### PR TITLE
Added support to switch between debug and release builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,14 @@ AM_MAINTAINER_MODE
 AC_CONFIG_HEADERS(config.h)
 
 dnl Do not set default CFLAGS and CXXFLAGS
-CXXFLAGS=" -O3 -Wall -std=c++11  $CXXFLAGS"
+CXXFLAGS=" -Wall -std=c++11  $CXXFLAGS"
+if test "$BUILD_TYPE" == "Debug" ; then 
+    # set up debug mode
+    CXXFLAGS="$CXXFLAGS -O0 -g3"
+else
+    # default is release mode
+    CXXFLAGS="$CXXFLAGS -O3"
+fi
 
 AC_ISC_POSIX
 AC_PROG_CPP


### PR DESCRIPTION
The environment variable BUILD_TYPE can be used when running ./configure to switch between debug and release builds. If set to "Debug" the debug mode will be used, otherwise release will be selected.

In debug mode, optimizations are disabled and debug symbols are integrated into the binaries.