### PR TITLE
Build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,14 +58,13 @@ pkg:
 	@test -d $(distdir) \
 		&& { echo "$(distdir) directory exists. (Re)move it before creating a MacOS package" 2>&1 && exit 1; } \
 		|| true
-	@which pkgbuild 2>&1 >/dev/null || { echo "pkgbuild not found" 2>&1 && exit 1; }
 	$(MAKE) distdir \
 		&& pushd $(distdir) \
-		&& $(MKDIR_P) `pwd`/osx \
-		&& ./configure --prefix `pwd`/osx \
+		&& $(MKDIR_P) `pwd`/pkg \
+		&& ./configure --prefix `pwd`/pkg \
 		&& $(MAKE) -j8 install \
-		&& pkgbuild \
-			--root `pwd`/osx \
+		&& $(PKGBUILD) \
+			--root `pwd`/pkg \
 			--identifier com.oracle.souffle \
 			--version $(VERSION) \
 			--install-location /usr/local \
@@ -73,6 +72,9 @@ pkg:
 			$(abs_top_builddir)/$(distdir).pkg \
 		&& popd \
 		&& rm -rf $(distdir)
+
+clean-local:
+	-rm -f $(abs_top_builddir)/$(distdir).pkg
 endif
 
 # Man pages

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,7 +81,13 @@ souffle_sources = \
               TypeSystem.cpp        TypeSystem.h        \
               PrecedenceGraph.cpp   PrecedenceGraph.h
 
-souffle_SOURCES = $(souffle_sources) main.cpp                                  
+# -- build souffle as a library so it can be reused in testing
+noinst_LIBRARIES = libsouffle.a
+libsouffle_a_SOURCES = $(souffle_sources)
+libsouffle_a_CXXFLAGS = $(souffle_CPPFLAGS)
+
+souffle_SOURCES = main.cpp
+souffle_LDADD = libsouffle.a
 
 dist_bin_SCRIPTS = souffle-compile souffle-config
 
@@ -111,11 +117,6 @@ $(builddir)/ParserDriver.cpp: $(builddir)/parser.hh
 ########## Unit Tests
 
 AM_COLOR_TESTS=always
-
-# -- build souffle as a library to not have a copy in each unit test --
-noinst_LIBRARIES = libsouffle.a
-libsouffle_a_SOURCES = $(souffle_sources)
-libsouffle_a_CXXFLAGS = $(souffle_CPPFLAGS)
 
 # -------------------------
 


### PR DESCRIPTION
The `Makefile` in `src` builds Soufflé from scratch but also compiles the library, which means that the same files are built twice. This merge requests suggests a change that builds the main Soufflé executable via a library as well, and thus reduces the build time of Soufflé (without tests that is).

Additionally, this merge request suggests small improvements to `pkg` target for building OSX packages.