### PR TITLE
Reporting bug

### DIFF
--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -56,6 +56,7 @@ namespace souffle {
 
 class AstTranslationUnit;
 
+
 bool AstSemanticChecker::transform(AstTranslationUnit &translationUnit) {
     const TypeEnvironment &typeEnv = translationUnit.getAnalysis<TypeEnvironmentAnalysis>()->getTypeEnvironment();
     TypeAnalysis *typeAnalysis = translationUnit.getAnalysis<TypeAnalysis>();
@@ -228,8 +229,14 @@ void AstSemanticChecker::checkProgram(ErrorReport &report, const AstProgram &pro
                 const AstLiteral *foundLiteral = nullptr;
                 bool hasNegation = hasClauseWithNegatedRelation(cyclicRelation, cur, &program, foundLiteral);
                 if (hasNegation || hasClauseWithAggregatedRelation(cyclicRelation, cur, &program, foundLiteral)) {
-                    std::string relationsListStr = toString(join(clique, ",", [](std::ostream& out, const AstRelation *rel) {
-                        out << rel->getName();
+                    std::set<std::string> rel_names;
+                    for(const AstRelation *x: clique) {
+                        std::stringstream os;
+                        os << x->getName();
+                        rel_names.insert(os.str());
+                    } 
+                    std::string relationsListStr = toString(join(rel_names, ",", [](std::ostream& out, const std::string &name) {
+                        out << name;
                     }));
                     std::vector<DiagnosticMessage> messages;
                     messages.push_back(DiagnosticMessage("Relation " + toString(cur->getName()), cur->getSrcLoc()));


### PR DESCRIPTION
The join() operations was enumerating items from an ordered pointer container; hence the order of the names was determined by the memory allocation and not deterministically using lexicographical order of the names. I fixed this single bug - perhaps join() needs to be reconsidered to enumerate in a sorted fashion. 

