### PR TITLE
Adding compiler prefix to deployed Debian packages and MD5 sums.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: cpp
 osx_image: xcode7.3
 before_install:
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get -y install debhelper devscripts build-essential g++ automake autoconf bison flex openjdk-7-jdk libboost-all-dev; fi
-  - if [ $TRAVIS_OS_NAME == osx ]; then brew update;brew install bison boost; brew link bison --force; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then brew update; brew install md5sha1sum bison boost; brew link bison --force; fi
 compiler:
 - gcc
 - clang
@@ -19,10 +19,10 @@ script:
 - sh ./bootstrap
 - ./configure
 - make 
-- make check
-- if [ $TRAVIS_OS_NAME == linux ]; then make deb; mkdir deploy; cd packaging; for d in *.deb; do cp $d "../deploy/$CXX_$d"; done; cd ..;  fi
-- if [ $TRAVIS_OS_NAME == osx ]; then make pkg; mkdir deploy; cp *.pkg deploy; fi
-
+- TESTSUITEFLAGS=-j3 make check
+- if [ $TRAVIS_OS_NAME == linux ]; then make deb; mkdir deploy; cd packaging; for d in *.deb; do cp $d ../deploy/"$CXX"_"$d"; md5sum <$d >"../deploy/"$CXX"_"$d".md5"; done; cd ..; fi
+- if [ $TRAVIS_OS_NAME == osx ]; then make pkg; mkdir deploy; for d in *.pkg; do cp $d deploy/; md5sum <$d >deploy/$d.md5; done; fi
+- ls deploy/*
 deploy:
   skip_cleanup: true
   provider: releases


### PR DESCRIPTION
.travis.yml generates packages in the deploy directory and the deploy mechanism pushes the packages into the release system of github. Unfortunately, the compiler prefix of the packages were not expanded properly and MD5sums were not computed. These changes fix the prefix issue and solve issue #90. 