### PR TITLE
FreeBSD: Compiler Flags for BOOST missing

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,7 @@ wave_SOURCES = wave.cpp wave.hpp	wave_trace_macro_expansion.hpp \
 		wave_config.hpp			wave_version.hpp \
 		wave_stop_watch.hpp
 
-wave_CPPFLAGS = 
+wave_CPPFLAGS = $(BOOST_CPPFLAGS)
 wave_LDFLAGS = 
 wave_LDADD = $(BOOST_LDFLAGS) \
              $(BOOST_FILESYSTEM_LIB) \


### PR DESCRIPTION
The compiler flags for BOOST where missing in src/Makefile.am. The build for FreeBSD failed.