### PR TITLE
License merge

### DIFF
--- a/prof/souffle-profile
+++ b/prof/souffle-profile
@@ -1,30 +1,10 @@
 #!/bin/bash
 #
+# Souffle version 0.0.0-25-g8be1361
 # Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
-#
-# The Universal Permissive License (UPL), Version 1.0
-#
-# Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
-# associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
-# Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
-# Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
-# 
-# (a) the Software, and
-# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
-# Work" to which the Software is contributed by such licensors),
-#
-# without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
-# distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
-# Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
-#
-# This license is subject to the following condition:
-# The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-# IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# Licensed under the Universal Permissive License v 1.0 as shown at:
+# - https://opensource.org/licenses/UPL
+# - souffle/LICENSE
 
 #
 # script that compiles a generated C++ program and executes it

--- a/prof/souffle-profile
+++ b/prof/souffle-profile
@@ -1,9 +1,30 @@
 #!/bin/bash
 #
-# Copyright (c) 2015, Oracle and/or its affiliates.
+# Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
 #
-# All rights reserved.
+# The Universal Permissive License (UPL), Version 1.0
 #
+# Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
+# associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
+# Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
+# Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+# 
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
+# Work" to which the Software is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
+# distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
+# Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+#
+# This license is subject to the following condition:
+# The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+# IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #
 # script that compiles a generated C++ program and executes it

--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -1,30 +1,10 @@
 #!/bin/sh
 #
+# Souffle version 0.0.0-25-g8be1361
 # Copyright (c) 2013-14, Oracle and/or its affiliates. All rights reserved.
-#
-# The Universal Permissive License (UPL), Version 1.0
-#
-# Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
-# associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
-# Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
-# Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
-# 
-# (a) the Software, and
-# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
-# Work" to which the Software is contributed by such licensors),
-#
-# without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
-# distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
-# Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
-#
-# This license is subject to the following condition:
-# The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-# IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# Licensed under the Universal Permissive License v 1.0 as shown at:
+# - https://opensource.org/licenses/UPL
+# - souffle/LICENSE
 
 #
 # script that compiles a generated C++ program and executes it

--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -1,10 +1,30 @@
-# Souffle version 0.0.0
-# Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved
-# Licensed under the Universal Permissive License v 1.0 as shown at:
-# - https://opensource.org/licenses/UPL
-# - souffle/LICENSE
-
 #!/bin/sh
+#
+# Copyright (c) 2013-14, Oracle and/or its affiliates. All rights reserved.
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
+# associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
+# Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
+# Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+# 
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
+# Work" to which the Software is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
+# distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
+# Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+#
+# This license is subject to the following condition:
+# The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+# IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #
 # script that compiles a generated C++ program and executes it

--- a/src/souffle-config.in
+++ b/src/souffle-config.in
@@ -1,30 +1,10 @@
 #!/bin/bash
 #
+# Souffle version 0.0.0-25-g8be1361
 # Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
-#
-# The Universal Permissive License (UPL), Version 1.0
-#
-# Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
-# associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
-# Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
-# Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
-# 
-# (a) the Software, and
-# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
-# Work" to which the Software is contributed by such licensors),
-#
-# without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
-# distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
-# Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
-#
-# This license is subject to the following condition:
-# The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-# IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# Licensed under the Universal Permissive License v 1.0 as shown at:
+# - https://opensource.org/licenses/UPL
+# - souffle/LICENSE
 #
 
 CXX=@CXX@

--- a/src/souffle-config.in
+++ b/src/souffle-config.in
@@ -1,8 +1,30 @@
 #!/bin/bash
 #
-# Copyright (c) 2015, Oracle and/or its affiliates.
+# Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
 #
-# All rights reserved.
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
+# associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
+# Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
+# Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+# 
+# (a) the Software, and
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
+# Work" to which the Software is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
+# distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
+# Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+#
+# This license is subject to the following condition:
+# The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+# IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
 CXX=@CXX@

--- a/tests/evaluation/nfsa2fsa/nfsa2fsa.dl
+++ b/tests/evaluation/nfsa2fsa/nfsa2fsa.dl
@@ -1,8 +1,28 @@
-/*
- * Copyright (c) 2013-14, Oracle and/or its affiliates.
- *
- * All rights reserved.
- */
+// Copyright (c) 2013-14, Oracle and/or its affiliates. All Rights reserved
+// 
+// The Universal Permissive License (UPL), Version 1.0
+// 
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
+// associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
+// Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+// 
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
+// Work" to which the Software is contributed by such licensors),
+// 
+// without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
+// distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
+// Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+// 
+// This license is subject to the following condition:
+// The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /* Conversion of non-deterministic FSA to deterministic FSA. 
  * Complex souffle example that demonstrates: components, 

--- a/tests/evaluation/nfsa2fsa/nfsa2fsa.dl
+++ b/tests/evaluation/nfsa2fsa/nfsa2fsa.dl
@@ -1,28 +1,8 @@
-// Copyright (c) 2013-14, Oracle and/or its affiliates. All Rights reserved
-// 
-// The Universal Permissive License (UPL), Version 1.0
-// 
-// Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
-// associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
-// Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
-// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
-// 
-// (a) the Software, and
-// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
-// Work" to which the Software is contributed by such licensors),
-// 
-// without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
-// distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
-// Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
-// 
-// This license is subject to the following condition:
-// The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
-// all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Souffle version 0.0.0-25-g8be1361
+// Copyright (c) 2013-14, Oracle and/or its affiliates. All rights reserved
+// Licensed under the Universal Permissive License v 1.0 as shown at:
+// - https://opensource.org/licenses/UPL
+// - souffle/LICENSE
 
 /* Conversion of non-deterministic FSA to deterministic FSA. 
  * Complex souffle example that demonstrates: components, 

--- a/tests/interface/insert_for/driver.cpp
+++ b/tests/interface/insert_for/driver.cpp
@@ -1,7 +1,29 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates.
- *
- * All rights reserved.
+ * Copyright (c) 2015, Oracle and/or its affiliates. All Rights reserved
+ * 
+ * The Universal Permissive License (UPL), Version 1.0
+ * 
+ * Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
+ * associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
+ * Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
+ * Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+ * 
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
+ * Work" to which the Software is contributed by such licensors),
+ * 
+ * without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
+ * distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
+ * Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+ * 
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 /************************************************************************

--- a/tests/interface/insert_for/driver.cpp
+++ b/tests/interface/insert_for/driver.cpp
@@ -1,29 +1,9 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All Rights reserved
- * 
- * The Universal Permissive License (UPL), Version 1.0
- * 
- * Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
- * associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
- * Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
- * Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
- * 
- * (a) the Software, and
- * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
- * Work" to which the Software is contributed by such licensors),
- * 
- * without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
- * distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
- * Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
- * 
- * This license is subject to the following condition:
- * The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
- * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Souffle version 0.0.0-25-g8be1361
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - souffle/LICENSE
  */
 
 /************************************************************************

--- a/tests/interface/insert_print/driver.cpp
+++ b/tests/interface/insert_print/driver.cpp
@@ -1,7 +1,29 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates.
- *
- * All rights reserved.
+ * Copyright (c) 2015, Oracle and/or its affiliates. All Rights reserved
+ * 
+ * The Universal Permissive License (UPL), Version 1.0
+ * 
+ * Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
+ * associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
+ * Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
+ * Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+ * 
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
+ * Work" to which the Software is contributed by such licensors),
+ * 
+ * without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
+ * distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
+ * Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+ * 
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 /************************************************************************

--- a/tests/interface/insert_print/driver.cpp
+++ b/tests/interface/insert_print/driver.cpp
@@ -1,29 +1,9 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All Rights reserved
- * 
- * The Universal Permissive License (UPL), Version 1.0
- * 
- * Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
- * associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
- * Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
- * Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
- * 
- * (a) the Software, and
- * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
- * Work" to which the Software is contributed by such licensors),
- * 
- * without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
- * distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
- * Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
- * 
- * This license is subject to the following condition:
- * The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
- * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Souffle version 0.0.0-25-g8be1361
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - souffle/LICENSE
  */
 
 /************************************************************************

--- a/tests/interface/load_print/driver.cpp
+++ b/tests/interface/load_print/driver.cpp
@@ -1,7 +1,29 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates.
- *
- * All rights reserved.
+ * Copyright (c) 2015, Oracle and/or its affiliates. All Rights reserved
+ * 
+ * The Universal Permissive License (UPL), Version 1.0
+ * 
+ * Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
+ * associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
+ * Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
+ * Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+ * 
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
+ * Work" to which the Software is contributed by such licensors),
+ * 
+ * without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
+ * distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
+ * Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+ * 
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 /************************************************************************

--- a/tests/interface/load_print/driver.cpp
+++ b/tests/interface/load_print/driver.cpp
@@ -1,29 +1,9 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All Rights reserved
- * 
- * The Universal Permissive License (UPL), Version 1.0
- * 
- * Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
- * associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
- * Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
- * Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
- * 
- * (a) the Software, and
- * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a "Larger
- * Work" to which the Software is contributed by such licensors),
- * 
- * without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
- * distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
- * Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
- * 
- * This license is subject to the following condition:
- * The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
- * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * Souffle version 0.0.0-25-g8be1361
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - souffle/LICENSE
  */
 
 /************************************************************************


### PR DESCRIPTION
This contains the patch from @nkeynes-oracle to the main oracle repo, applied on top of our fork.
I then shrunk the UPL license to the short form as-per the rest of our code base