### PR TITLE
Fixed CPP issues for FreeBSD

### DIFF
--- a/src/wavelib/Makefile.am
+++ b/src/wavelib/Makefile.am
@@ -81,6 +81,6 @@ libwave_a_SOURCES = instantiate_cpp_literalgrs.cpp \
                     instantiate_defined_grammar.cpp \
                     token_ids.cpp
 
-libwave_a_CXXFLAGS = -I@abs_top_srcdir@/src/
+libwave_a_CXXFLAGS = -I@abs_top_srcdir@/src/ $(BOOST_CPPFLAGS)
 
 

--- a/src/wavelib/cpplexer/re2clex/aq.cpp
+++ b/src/wavelib/cpplexer/re2clex/aq.cpp
@@ -10,9 +10,6 @@
 
 #define BOOST_WAVE_SOURCE 1
 
-// disable stupid compiler warnings
-#include <boost/config/warning_disable.hpp>
-
 #include <cstdlib>
 #include <cstring>
 

--- a/src/wavelib/cpplexer/re2clex/cpp_re.cpp
+++ b/src/wavelib/cpplexer/re2clex/cpp_re.cpp
@@ -14,9 +14,6 @@
 
 #define BOOST_WAVE_SOURCE 1
 
-// disable stupid compiler warnings
-#include <boost/config/warning_disable.hpp>
-
 #include <ctime>
 #include <cstdlib>
 #include <cstdio>

--- a/src/wavelib/instantiate_cpp_exprgrammar.cpp
+++ b/src/wavelib/instantiate_cpp_exprgrammar.cpp
@@ -9,8 +9,6 @@
 
 #define BOOST_WAVE_SOURCE 1
 
-// disable stupid compiler warnings
-#include <boost/config/warning_disable.hpp>
 #include <wavelib/wave_config.hpp>
 
 #if BOOST_WAVE_SEPARATE_GRAMMAR_INSTANTIATION != 0

--- a/src/wavelib/instantiate_cpp_grammar.cpp
+++ b/src/wavelib/instantiate_cpp_grammar.cpp
@@ -9,8 +9,6 @@
 
 #define BOOST_WAVE_SOURCE 1
 
-// disable stupid compiler warnings
-#include <boost/config/warning_disable.hpp>
 #include <wavelib/wave_config.hpp>
 
 #if BOOST_WAVE_SEPARATE_GRAMMAR_INSTANTIATION != 0

--- a/src/wavelib/instantiate_cpp_literalgrs.cpp
+++ b/src/wavelib/instantiate_cpp_literalgrs.cpp
@@ -9,8 +9,6 @@
 
 #define BOOST_WAVE_SOURCE 1
 
-// disable stupid compiler warnings
-#include <boost/config/warning_disable.hpp>
 #include <wavelib/wave_config.hpp>
 
 #if BOOST_WAVE_SEPARATE_GRAMMAR_INSTANTIATION != 0

--- a/src/wavelib/instantiate_defined_grammar.cpp
+++ b/src/wavelib/instantiate_defined_grammar.cpp
@@ -9,8 +9,6 @@
 
 #define BOOST_WAVE_SOURCE 1
 
-// disable stupid compiler warnings
-#include <boost/config/warning_disable.hpp>
 #include <wavelib/wave_config.hpp>
 
 #if BOOST_WAVE_SEPARATE_GRAMMAR_INSTANTIATION != 0

--- a/src/wavelib/instantiate_predef_macros.cpp
+++ b/src/wavelib/instantiate_predef_macros.cpp
@@ -9,8 +9,6 @@
 
 #define BOOST_WAVE_SOURCE 1
 
-// disable stupid compiler warnings
-#include <boost/config/warning_disable.hpp>
 #include <wavelib/wave_config.hpp>
 
 #if BOOST_WAVE_SEPARATE_GRAMMAR_INSTANTIATION != 0

--- a/src/wavelib/instantiate_re2c_lexer.cpp
+++ b/src/wavelib/instantiate_re2c_lexer.cpp
@@ -11,8 +11,6 @@
 
 #define BOOST_WAVE_SOURCE 1
 
-// disable stupid compiler warnings
-#include <boost/config/warning_disable.hpp>
 #include <wavelib/wave_config.hpp>          // configuration data
 
 #if BOOST_WAVE_SEPARATE_LEXER_INSTANTIATION != 0

--- a/src/wavelib/instantiate_re2c_lexer_str.cpp
+++ b/src/wavelib/instantiate_re2c_lexer_str.cpp
@@ -11,8 +11,6 @@
 
 #define BOOST_WAVE_SOURCE 1
 
-// disable stupid compiler warnings
-#include <boost/config/warning_disable.hpp>
 #include <wavelib/wave_config.hpp>          // configuration data
 
 #if BOOST_WAVE_SEPARATE_LEXER_INSTANTIATION != 0

--- a/src/wavelib/token_ids.cpp
+++ b/src/wavelib/token_ids.cpp
@@ -12,9 +12,6 @@
 
 #define BOOST_WAVE_SOURCE 1
 
-// disable stupid compiler warnings
-#include <boost/config/warning_disable.hpp>
-
 #include <string>
 #include <boost/assert.hpp>
 #include <boost/static_assert.hpp>

--- a/src/wavelib/wave_config_constant.cpp
+++ b/src/wavelib/wave_config_constant.cpp
@@ -11,9 +11,6 @@
 
 #define BOOST_WAVE_SOURCE 1
 
-// disable stupid compiler warnings
-#include <boost/config/warning_disable.hpp>
-
 #include <cstring>
 #include <boost/preprocessor/stringize.hpp>
 


### PR DESCRIPTION
FreeBSD requires the boost CPP flags in Makefile.am and the include file for disabling compiler warnings was not part of the boost distribution. 
This fix is related to issue #103.
