### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Follow the steps below to compile and install Soufflé on a UNIX system:
      brew update                
      brew reinstall gcc --without-multilib                
      brew install bison  
+     brew install boost
      brew link bison --force
      export CXX=/usr/local/bin/g++-5                
      export CXXFLAGS=-fopenmp                


### PR DESCRIPTION
Got this error on ./configure

```
checking for boostlib >= 1.54... configure: We could not detect the boost libraries (version 1.54 or higher). If you have a staged boost library (still not installed) please specify $BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.
configure: error: Souffle needs Boost, but it was not found.
```