### PR TITLE
Update install.sh

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -23,6 +23,6 @@ fi
 if [ $TRAVIS_OS_NAME == osx ]
 then
    brew update
-   brew install md5sha1sum bison boost
+   brew install md5sha1sum bison
    brew link bison --force
 fi


### PR DESCRIPTION
my previous pull request (commit #03f795c) is failing due to : 

==> Summary
....
Error: boost-1.60.0_2 already installed
To install this version, first `brew unlink boost`
The command "./.travis/install.sh" failed and exited with 1 during .

im trying to remove boost from the osx install in .travis/install.sh