### PR TITLE
 Added 'inline' to extern-C declaration.

### DIFF
--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -35,7 +35,7 @@
 namespace souffle {
 
 extern "C" {
-  souffle::SouffleProgram* getInstance(const char* p) { return souffle::ProgramFactory::newInstance(p); }
+  inline souffle::SouffleProgram* getInstance(const char* p) { return souffle::ProgramFactory::newInstance(p); }
 }
 
 /**


### PR DESCRIPTION
Omitting 'inline' leads to linker errors if target file is used in
multiple translation units