### PR TITLE
Revert " Added 'inline' to extern-C declaration."

### DIFF
--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -35,7 +35,7 @@
 namespace souffle {
 
 extern "C" {
-  inline souffle::SouffleProgram* getInstance(const char* p) { return souffle::ProgramFactory::newInstance(p); }
+  souffle::SouffleProgram* getInstance(const char* p) { return souffle::ProgramFactory::newInstance(p); }
 }
 
 /**


### PR DESCRIPTION
Reverts souffle-lang/souffle#220
this crashes the interface . If you inline the shared library get instance symbol cannot be found 