### PR TITLE
Fixed MAC OS X 10.12 configure issues for JNI

### DIFF
--- a/m4/ax_jni_include_dir.m4
+++ b/m4/ax_jni_include_dir.m4
@@ -67,7 +67,9 @@ fi
 
 case "$host_os" in
         darwin*)        _JTOPDIR=`echo "$_JTOPDIR" | sed -e 's:/[[^/]]*$::'`
-                        _JINC="$_JTOPDIR/Headers";;
+                        _JNIH=`find /Applications//Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/ -name jni.h`
+                        _JINC=`dirname $_JNIH`;;
+   
         *)              _JINC="$_JTOPDIR/include";;
 esac
 _AS_ECHO_LOG([_JTOPDIR=$_JTOPDIR])

--- a/m4/libtool.m4
+++ b/m4/libtool.m4
@@ -1,1 +1,0 @@
-/usr/share/aclocal/libtool.m4

--- a/m4/ltoptions.m4
+++ b/m4/ltoptions.m4
@@ -1,1 +1,0 @@
-/usr/share/aclocal/ltoptions.m4

--- a/m4/ltsugar.m4
+++ b/m4/ltsugar.m4
@@ -1,1 +1,0 @@
-/usr/share/aclocal/ltsugar.m4

--- a/m4/ltversion.m4
+++ b/m4/ltversion.m4
@@ -1,1 +1,0 @@
-/usr/share/aclocal/ltversion.m4

--- a/m4/lt~obsolete.m4
+++ b/m4/lt~obsolete.m4
@@ -1,1 +1,0 @@
-/usr/share/aclocal/lt~obsolete.m4

--- a/m4/m4_ax_prog_javah.m4
+++ b/m4/m4_ax_prog_javah.m4
@@ -38,6 +38,8 @@ AS_IF([test -n "$ac_cv_path_JAVAH"],
         AS_CASE([$build_os],
                 [cygwin*|mingw*],
                 [ac_machdep=win32],
+                [darwin*],
+                [_JNIH=`find /Applications//Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/ -name jni.h`;ac_dir=`dirname $_JNIH`]
                 [ac_machdep=`AS_ECHO($build_os) | sed 's,[[-0-9]].*,,'`])
         CPPFLAGS="$ac_save_CPPFLAGS -I$ac_dir -I$ac_dir/$ac_machdep"
         AC_TRY_CPP([#include <jni.h>],


### PR DESCRIPTION
The configure scripts were not able to find the header files jni.h on a MAC OS X 10.12 system.