### PR TITLE
Added cmath to the include list for CompiledSouffle.h

### DIFF
--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -20,6 +20,7 @@
 #include <regex>
 #include <map>
 #include <array>
+#include <cmath>
 #include "CompiledRamRelation.h"
 #include "CompiledRamRecord.h"
 #include "CompiledRamOptions.h"


### PR DESCRIPTION
Future versions of compilers (g++) do not implicitly include it anymore - causing failures in tests.