### PR TITLE
Prevent multiple runs of bison with parallel make

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -135,8 +135,10 @@ souffle_CPPFLAGS = -DPACKAGE_VERSION="\"${PACKAGE_VERSION}\""
 CLEANFILES = $(BUILT_SOURCES)  parser.cc scanner.cc parser.hh stack.hh
 
 # run Bison
-$(builddir)/parser.hh $(builddir)/parser.cc $(builddir)/stack.hh: $(srcdir)/parser.yy
+$(builddir)/parser.hh: $(srcdir)/parser.yy
 	$(BISON) -d -o parser.cc $(srcdir)/parser.yy
+
+$(builddir)/parser.cc $(builddir)/stack.hh: $(builddir)/parser.hh
 
 # and FLEX
 $(builddir)/scanner.cc: $(srcdir)/scanner.ll


### PR DESCRIPTION
Multiple runs of bison in parallel when building with -j30 caused the output of bison to be garbled. I rewrote the makefile according to https://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html to serialize the bison invocation, preventing the problem.