### PR TITLE
Add missing headers files to Makefile.am#soufflepublic_HEADERS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -127,7 +127,8 @@ soufflepublicdir = $(includedir)/souffle
 
 soufflepublic_HEADERS = CompiledRamOptions.h CompiledRamRelation.h CompiledRamTuple.h CompiledRamRecord.h CompiledSouffle.h \
 				  SouffleInterface.h ParallelUtils.h RamTypes.h BTree.h Trie.h Table.h Util.h IterUtils.h SymbolTable.h RamLogger.h \
-				  SqliteRelationWriter.h
+				  SqliteRelationWriter.h IOSystem.h ReadStream.h ReadStreamCSV.h SymbolMask.h ReadStreamSQLite.h WriteStream.h \
+                                  WriteStreamCSV.h WriteStreamSQLite.h
 
 souffle_CPPFLAGS = -DPACKAGE_VERSION="\"${PACKAGE_VERSION}\""
 


### PR DESCRIPTION
The souffle-compile script is unable to compile Souffle c++ programs as
a number of header files are not installed in /usr/local/include/souffle.

The problem is fixed by appeding soufflepublic_HEADERS with the missing header
files: IOSystem.h ReadStream.h ReadStreamCSV.h SymbolMask.h ReadStreamSQLite.h
WriteStream.h WriteStreamCSV.h WriteStreamSQLite.h