### PR TITLE
Combine fast tests to reduce jobs on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,7 @@ compiler:
 # The build takes about 4 minutes (2017016) before testsuite starts running
 env:
   - MAKEPACKAGE=1
-  - SOUFFLE_CATEGORY=Unit
-  - SOUFFLE_CATEGORY=Syntactic
-  - SOUFFLE_CATEGORY=Semantic
-  - SOUFFLE_CATEGORY=Interface
-  - SOUFFLE_CATEGORY=Profile
+  - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile
   - SOUFFLE_CATEGORY=Evaluation SOUFFLE_CONFS=",-j8,-p profile.log"
   - SOUFFLE_CATEGORY=Evaluation SOUFFLE_CONFS="-c -j8"
   - SOUFFLE_CATEGORY=Evaluation SOUFFLE_CONFS=-c


### PR DESCRIPTION
Travis is having serious OSX resource shortages. This change will reduce their effect by reducing the number of jobs run. Test output will be slightly less informative and slightly faster - and much, much faster when Travis having resource shortages.