### PR TITLE
Added tab completion and history to SouffleProf

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -22,7 +22,7 @@ then
         then
           sudo apt-get -y install debhelper devscripts
         fi
-        sudo apt-get -y install build-essential g++ automake autoconf bison flex openjdk-8-jdk lsb-release libtool libedit-dev
+        sudo apt-get -y install build-essential g++ automake autoconf bison flex openjdk-8-jdk lsb-release libtool
     fi
     # The following lines are hacked because travis stopped working around 5/12/16, if you can remove them and travis still works, then great
 #    source /opt/jdk_switcher/jdk_switcher.sh
@@ -37,6 +37,6 @@ fi
 if [ $TRAVIS_OS_NAME == osx ]
 then
    brew update
-   brew install md5sha1sum bison libtool homebrew/dupes/libedit
+   brew install md5sha1sum bison libtool
    brew link bison --force
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -259,7 +259,6 @@ AC_CHECK_HEADER(zlib.h,,[AC_MSG_ERROR([required library zlib missing])])
 AC_CHECK_LIB(z, compress,,
           [AC_MSG_ERROR([required library zlib missing])])
 
-PKG_CHECK_MODULES(LIBEDIT, libedit)
 
 dnl Enables OpenMP in the souffle compiler and interpreter
 AC_OPENMP

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,9 +35,11 @@ souffle_profile_SOURCES = souffle_prof.cpp profilerlib/Cell.hpp \
                           profilerlib/Table.hpp                 \
                           profilerlib/Tui.cpp                   \
                           profilerlib/Tui.hpp                   \
-                          profilerlib/html_string.hpp
+                          profilerlib/html_string.hpp           \
+                          profilerlib/UserInputReader.cpp       \
+                          profilerlib/UserInputReader.hpp
 
-souffle_profile_CXXFLAGS = $(souffle_CPPFLAGS) -ledit
+souffle_profile_CXXFLAGS = $(souffle_CPPFLAGS)
 
 nodist_souffle_mcpp_SOURCES = $(BUILT_SOURCES)
  

--- a/src/profilerlib/DataComparator.hpp
+++ b/src/profilerlib/DataComparator.hpp
@@ -15,7 +15,6 @@
 #include <memory>
 #include <vector>
 
-
 class DataComparator {
 public:
     /* descending order comparator used to sort rows */

--- a/src/profilerlib/Tui.cpp
+++ b/src/profilerlib/Tui.cpp
@@ -30,8 +30,11 @@ void Tui::runCommand(std::vector<std::string> c) {
     }
 
     if (alive) {
+        // remake tables to get new data
         rul_table_state = out.getRulTable();
         rel_table_state = out.getRelTable();
+
+        setupTabCompletion();
     }
 
     if (c[0].compare("top") == 0) {
@@ -86,7 +89,9 @@ void Tui::runProf() {
         top();
     }
 
-    rl_inhibit_completion = 1;
+    linereader = InputReader();
+    linereader.setPrompt("\n> ");
+    setupTabCompletion();
 
     while (true) {
         if (!loaded) {
@@ -96,19 +101,15 @@ void Tui::runProf() {
             }
         }
         std::string input;
-        char* x = readline("\n> ");
-        if ((x != NULL) && (x[0] == '\0')) {
-            input = "";
-        } else {
-            input = std::string(x);
-        }
+        input = linereader.getInput();
 
+        std::cout << std::endl;
         if (input.empty()) {
             std::cout << "Unknown command. Type help for a list of commands.\n";
             continue;
         }
 
-        add_history(input.c_str());
+        linereader.addHistory(input.c_str());
 
         std::vector<std::string> c = Tools::split(input, " ");
 
@@ -384,6 +385,26 @@ void Tui::load(std::string method, std::string load_file) {
     } else {
         std::cout << "Error: File not found\n";
     }
+}
+
+void Tui::setupTabCompletion() {
+    linereader.clearTabCompletion();
+
+    linereader.appendTabCompletion("rel");
+    linereader.appendTabCompletion("rul");
+    linereader.appendTabCompletion("rul id");
+    linereader.appendTabCompletion("graph ");
+    linereader.appendTabCompletion("top");
+    linereader.appendTabCompletion("help");
+
+    // add rel tab completes after the rest so users can see all commands first
+    for (auto& row : out.formatTable(rel_table_state, precision)) {
+        linereader.appendTabCompletion("rel "+row[5]);
+        linereader.appendTabCompletion("graph "+row[5]+" tot_t");
+        linereader.appendTabCompletion("graph "+row[5]+" copy_t");
+        linereader.appendTabCompletion("graph "+row[5]+" tuples");
+    }
+
 }
 
 void Tui::help() {

--- a/src/profilerlib/Tui.cpp
+++ b/src/profilerlib/Tui.cpp
@@ -399,12 +399,11 @@ void Tui::setupTabCompletion() {
 
     // add rel tab completes after the rest so users can see all commands first
     for (auto& row : out.formatTable(rel_table_state, precision)) {
-        linereader.appendTabCompletion("rel "+row[5]);
-        linereader.appendTabCompletion("graph "+row[5]+" tot_t");
-        linereader.appendTabCompletion("graph "+row[5]+" copy_t");
-        linereader.appendTabCompletion("graph "+row[5]+" tuples");
+        linereader.appendTabCompletion("rel " + row[5]);
+        linereader.appendTabCompletion("graph " + row[5] + " tot_t");
+        linereader.appendTabCompletion("graph " + row[5] + " copy_t");
+        linereader.appendTabCompletion("graph " + row[5] + " tuples");
     }
-
 }
 
 void Tui::help() {

--- a/src/profilerlib/Tui.hpp
+++ b/src/profilerlib/Tui.hpp
@@ -11,23 +11,15 @@
 #include <iostream>
 #include <string>
 #include <vector>
-
 #include <dirent.h>
 
-// TODO
-//#ifdef __linux__
-//#include <editline.h>
-//#endif
-//#ifdef __OpenBSD__
-//#include <readline/readline.h>
-//#endif
-#include <editline/readline.h>
 
 #include "DataComparator.hpp"
 #include "OutputProcessor.hpp"
 #include "Reader.hpp"
 #include "StringUtils.hpp"
 #include "html_string.hpp"
+#include "UserInputReader.hpp"
 
 class Tui {
 private:
@@ -40,6 +32,7 @@ private:
     Table rel_table_state;
     Table rul_table_state;
     std::shared_ptr<Reader> reader;
+    InputReader linereader;
 
 public:
     Tui(std::string filename, bool live, bool gui);
@@ -59,6 +52,8 @@ public:
     void load(std::string method, std::string load_file);
 
     static void help();
+
+    void setupTabCompletion();
 
     void top();
 

--- a/src/profilerlib/Tui.hpp
+++ b/src/profilerlib/Tui.hpp
@@ -13,13 +13,12 @@
 #include <vector>
 #include <dirent.h>
 
-
 #include "DataComparator.hpp"
 #include "OutputProcessor.hpp"
 #include "Reader.hpp"
 #include "StringUtils.hpp"
-#include "html_string.hpp"
 #include "UserInputReader.hpp"
+#include "html_string.hpp"
 
 class Tui {
 private:

--- a/src/profilerlib/UserInputReader.cpp
+++ b/src/profilerlib/UserInputReader.cpp
@@ -1,0 +1,296 @@
+/*
+* Souffle - A Datalog Compiler
+* Copyright (c) 2017, The Souffle Developers. All rights reserved
+* Licensed under the Universal Permissive License v 1.0 as shown at:
+* - https://opensource.org/licenses/UPL
+* - <souffle root>/licenses/SOUFFLE-UPL.txt
+*/
+
+//
+// Created by Dominic Romanowski on 13/2/17.
+//
+
+#include "UserInputReader.hpp"
+
+
+void InputReader::getch() {
+    char buf = 0;
+    struct termios old = {0};
+    if (tcgetattr(0, &old) < 0)
+        perror("tcsetattr()");
+    old.c_lflag &= ~ICANON;
+    old.c_lflag &= ~ECHO;
+    old.c_cc[VMIN] = 1;
+    old.c_cc[VTIME] = 0;
+    if (tcsetattr(0, TCSANOW, &old) < 0)
+        perror("tcsetattr ICANON");
+    if (read(0, &buf, 1) < 0)
+        perror ("read()");
+    old.c_lflag |= ICANON;
+    old.c_lflag |= ECHO;
+    if (tcsetattr(0, TCSADRAIN, &old) < 0)
+        perror ("tcsetattr ~ICANON");
+
+    current_char = buf;
+}
+
+
+std::string InputReader::getInput() {
+    output = "";
+    current_char = 0;
+    cursor_pos = 0;
+    hist_pos = 0;
+    tab_pos = 0;
+    in_tab_complete = false;
+    in_history = false;
+
+
+    std::cout << this->prompt << std::flush;
+    getch();
+
+    bool escaped = false;
+    bool arrow_key = false;
+
+    while (current_char != '\n') {
+        if (arrow_key) {
+            moveCursor(current_char);
+            escaped = false;
+            arrow_key = false;
+        } else if (escaped) {
+            if (current_char == '[') {
+                arrow_key = true;
+            }
+        } else {
+            if (current_char == 27) { // esc char for arrow keys
+                escaped = true;
+            } else if (current_char == '\t') {
+                tabComplete();
+            } else {
+                if (in_history) {
+                    output = current_hist_val;
+                    in_history = false;
+
+                } else if (in_tab_complete) {
+                    output = current_tab_val;
+                    in_tab_complete = false;
+                }
+
+                if (current_char == 127) {
+                    backspace();
+                } else {
+                    output.insert(output.begin() + (cursor_pos++), current_char);
+                    std::cout << current_char << std::flush;
+                    showFullText(output);
+                }
+
+            }
+        }
+
+        getch();
+    }
+
+    if (in_history) {
+        return current_hist_val;
+    }
+    if (in_tab_complete) {
+        return current_tab_val;
+    }
+
+    return output;
+}
+
+void InputReader::setPrompt(std::string prompt) {
+    this->prompt = prompt;
+}
+
+void InputReader::appendTabCompletion(std::vector<std::string> commands) {
+    tab_completion.insert(std::end(tab_completion),std::begin(commands),std::end(commands));
+}
+
+void InputReader::appendTabCompletion(std::string command) {
+    tab_completion.push_back(command);
+}
+
+void InputReader::tabComplete() {
+    if (in_history) {
+        output = current_hist_val;
+        in_history = false;
+    }
+    if (!in_tab_complete) {
+        current_tab_completes = std::vector<std::string>();
+        original_tab_val = output;
+        bool found_tab = false;
+        for (auto &a: tab_completion) {
+            if (a.find(original_tab_val)==0) {
+                current_tab_completes.push_back(a);
+                found_tab = true;
+            }
+        }
+        if (!found_tab) {
+            std::cout << '\a' << std::flush;
+            return;
+        } else {
+            in_tab_complete = true;
+            tab_pos = 0;
+            current_tab_val = current_tab_completes.at((unsigned)tab_pos);
+            clearPrompt(output.size());
+
+            cursor_pos = current_tab_val.size();
+            std::cout << current_tab_val << std::flush;
+        }
+    } else {
+        if (tab_pos+1>=current_tab_completes.size()) {
+            clearPrompt(current_tab_val.size());
+            current_tab_val = original_tab_val;
+            in_tab_complete = false;
+            cursor_pos = output.size();
+            std::cout << output << std::flush;
+        } else {
+            tab_pos++;
+
+            clearPrompt(current_tab_val.size());
+            current_tab_val = current_tab_completes.at((unsigned)tab_pos);
+
+            cursor_pos = current_tab_val.size();
+            std::cout << current_tab_val << std::flush;
+        }
+    }
+}
+
+void InputReader::clearTabCompletion() {
+    tab_completion = std::vector<std::string>();
+}
+
+void InputReader::clearHistory() {
+    history = std::vector<std::string>();
+}
+
+void InputReader::addHistory(std::string hist) {
+    for (auto &a: history) {
+        if (hist.compare(a)==0) {
+            return;
+        }
+    }
+    history.push_back(hist);
+}
+
+void InputReader::historyUp() {
+    if (history.empty()) {
+        std::cout << '\a' << std::flush;
+        return;
+    }
+    if (in_tab_complete) {
+        output = current_tab_val;
+        in_tab_complete = false;
+    }
+    if (!in_history) {
+        original_hist_val = output;
+        original_hist_cursor_pos = cursor_pos;
+        in_history = true;
+        clearPrompt(output.size());
+        hist_pos = history.size()-1;
+        current_hist_val = history.back();
+        cursor_pos = current_hist_val.size();
+        std::cout << current_hist_val << std::flush;
+    } else {
+        if (hist_pos > 0) {
+            hist_pos--;
+            clearPrompt(current_hist_val.size());
+            current_hist_val = history.at((unsigned)hist_pos);
+            cursor_pos = current_hist_val.size();
+            std::cout << current_hist_val << std::flush;
+        } else {
+            std::cout << '\a' << std::flush;
+        }
+    }
+}
+
+void InputReader::historyDown() {
+    if (in_history) {
+        clearPrompt(current_hist_val.size());
+        if (hist_pos+1 < history.size()) {
+            hist_pos++;
+            current_hist_val = history.at((unsigned)hist_pos);
+            cursor_pos = current_hist_val.size();
+            std::cout << current_hist_val << std::flush;
+        } else {
+            in_history = false;
+            cursor_pos = original_hist_cursor_pos;
+            std::cout << original_hist_val << std::flush;
+        }
+    } else {
+        std::cout << '\a' << std::flush;
+    }
+}
+
+void InputReader::moveCursor(char direction) {
+    switch (direction) {
+        case 'A':
+            historyUp();
+            break;
+        case 'B':
+            historyDown();
+            break;
+        case 'C':
+            moveCursorRight();
+            break;
+        case 'D':
+            moveCursorLeft();
+            break;
+        default:
+            break;
+    }
+
+}
+
+void InputReader::moveCursorRight() {
+    if (in_history) {
+        if (cursor_pos<current_hist_val.size()) {
+            cursor_pos++;
+            std::cout << (char) 27 << '[' << 'C' << std::flush;
+        }
+    } else if (in_tab_complete) {
+        if (cursor_pos<current_tab_val.size()) {
+            cursor_pos++;
+            std::cout << (char) 27 << '[' << 'C' << std::flush;
+        }
+    } else if (cursor_pos<output.size()) {
+        cursor_pos++;
+        std::cout << (char) 27 << '[' << 'C' << std::flush;
+    }
+}
+
+void InputReader::moveCursorLeft() {
+    if (cursor_pos > 0) {
+        cursor_pos--;
+        std::cout << (char) 27 << '[' << 'D' << std::flush;
+    }
+}
+
+void InputReader::backspace() {
+    if (cursor_pos > 0) {
+        output.erase(output.begin() + cursor_pos-1);
+        moveCursorLeft();
+        showFullText(output);
+    }
+}
+void InputReader::showFullText(std::string text) {
+    clearPrompt(text.size());
+    for (unsigned long i=0; i < text.size(); i++) {
+        std::cout << text.at(i) << std::flush;
+    }
+
+    for (unsigned long i=(unsigned)cursor_pos; i < text.size(); i++) {
+        std::cout << "\b" << std::flush;
+    }
+}
+
+
+void InputReader::clearPrompt(long text_len) {
+    for (unsigned long i=(unsigned)cursor_pos; i < text_len+1; i++) {
+        std::cout << (char) 27 << "[C" << std::flush;
+    }
+    for (unsigned long i=0; i < text_len+1; i++) {
+        std::cout << "\b \b" << std::flush;
+    }
+}

--- a/src/profilerlib/UserInputReader.hpp
+++ b/src/profilerlib/UserInputReader.hpp
@@ -6,16 +6,15 @@
 * - <souffle root>/licenses/SOUFFLE-UPL.txt
 */
 
-
 #pragma once
 
-#include <unistd.h>
-#include <termios.h>
-#include <stdio.h>
-#include <string>
-#include <sstream>
-#include <vector>
 #include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <stdio.h>
+#include <termios.h>
+#include <unistd.h>
 
 class InputReader {
 private:
@@ -36,9 +35,8 @@ private:
     std::vector<std::string> current_tab_completes;
     long original_hist_cursor_pos;
 
-
 public:
-    InputReader() : prompt("Input: "), in_tab_complete(false),in_history(false) {
+    InputReader() : prompt("Input: "), in_tab_complete(false), in_history(false) {
         clearTabCompletion();
         clearHistory();
     }
@@ -61,5 +59,3 @@ public:
     void clearPrompt(long text_len);
     void showFullText(std::string text);
 };
-
-

--- a/src/profilerlib/UserInputReader.hpp
+++ b/src/profilerlib/UserInputReader.hpp
@@ -1,0 +1,65 @@
+/*
+* Souffle - A Datalog Compiler
+* Copyright (c) 2017, The Souffle Developers. All rights reserved
+* Licensed under the Universal Permissive License v 1.0 as shown at:
+* - https://opensource.org/licenses/UPL
+* - <souffle root>/licenses/SOUFFLE-UPL.txt
+*/
+
+
+#pragma once
+
+#include <unistd.h>
+#include <termios.h>
+#include <stdio.h>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <iostream>
+
+class InputReader {
+private:
+    std::string prompt;
+    std::vector<std::string> tab_completion;
+    std::vector<std::string> history;
+    std::string output;
+    char current_char;
+    long cursor_pos;
+    long hist_pos;
+    long tab_pos;
+    bool in_tab_complete;
+    bool in_history;
+    std::string original_hist_val;
+    std::string current_hist_val;
+    std::string current_tab_val;
+    std::string original_tab_val;
+    std::vector<std::string> current_tab_completes;
+    long original_hist_cursor_pos;
+
+
+public:
+    InputReader() : prompt("Input: "), in_tab_complete(false),in_history(false) {
+        clearTabCompletion();
+        clearHistory();
+    }
+
+    void getch();
+    std::string getInput();
+    void setPrompt(std::string prompt);
+    void appendTabCompletion(std::vector<std::string> commands);
+    void appendTabCompletion(std::string command);
+    void clearTabCompletion();
+    void clearHistory();
+    void tabComplete();
+    void addHistory(std::string hist);
+    void historyUp();
+    void historyDown();
+    void moveCursor(char direction);
+    void moveCursorRight();
+    void moveCursorLeft();
+    void backspace();
+    void clearPrompt(long text_len);
+    void showFullText(std::string text);
+};
+
+


### PR DESCRIPTION
…making the libedit/editline library redundant

Built a standalone custom class (InputReader within UserInputReader.hpp) to read user input and handle tab/arrow keys to get input for souffleProf adding tab completion for commands that can use strings instead of ids.

Removed libedit from travis.

Removed -ledit flag from makefile (reducing number of warnings during compile time)