### PR TITLE
Update profiler CLI to ignore extra whitespace

### DIFF
--- a/src/profilerlib/Cli.cpp
+++ b/src/profilerlib/Cli.cpp
@@ -9,7 +9,7 @@
 #include "Cli.hpp"
 
 void Cli::error() {
-    std::cout << "souffle-profiler -v | -h | <log-file> [ -c <command> | -j | -l ]\n";
+    std::cout << "souffle-profile -v | -h | <log-file> [ -c <command> | -j | -l ]\n";
     exit(1);
 }
 
@@ -48,7 +48,7 @@ void Cli::parse() {
         }
     } else if (arg.compare("-h") == 0) {
         std::cout << "Souffle Profiler v3.0.1\n";
-        std::cout << "usage: souffle-profiler -v | -h | <log-file> [ -c <command> | -j | -l ]\n"
+        std::cout << "usage: souffle-profile -v | -h | <log-file> [ -c <command> | -j | -l ]\n"
                   << "<log-file>     the selected log file to profile\n"
                   << "-c <command>   run the given command on the log file (run -c \"help\" for a list of "
                      "profiler commands)\n"

--- a/src/profilerlib/StringUtils.cpp
+++ b/src/profilerlib/StringUtils.cpp
@@ -212,6 +212,20 @@ std::vector<std::string> Tools::splitAtSemiColon(std::string str) {
     return result;
 }
 
+std::string Tools::trimWhitespace(std::string str) {
+    std::string whitespace = " \t";
+    size_t first = str.find_first_not_of(whitespace);
+    if (first != std::string::npos) {
+        str.erase(0, first);
+        size_t last = str.find_last_not_of(whitespace);
+        str.erase(last+1);
+    } else {
+        str.clear();
+    }
+
+    return str;
+}
+
 std::string Tools::getworkingdir() {
     char cCurrentPath[FILENAME_MAX];
     if (!GetCurrentDir(cCurrentPath, sizeof(cCurrentPath))) {

--- a/src/profilerlib/StringUtils.cpp
+++ b/src/profilerlib/StringUtils.cpp
@@ -218,7 +218,7 @@ std::string Tools::trimWhitespace(std::string str) {
     if (first != std::string::npos) {
         str.erase(0, first);
         size_t last = str.find_last_not_of(whitespace);
-        str.erase(last+1);
+        str.erase(last + 1);
     } else {
         str.clear();
     }

--- a/src/profilerlib/StringUtils.hpp
+++ b/src/profilerlib/StringUtils.hpp
@@ -52,6 +52,8 @@ std::vector<std::string> split(std::string str, std::string split_reg);
 
 std::vector<std::string> splitAtSemiColon(std::string str);
 
+std::string trimWhitespace(std::string str);
+
 inline bool file_exists(const std::string& name) {
     std::ifstream f(name.c_str());
     return f.good();

--- a/src/profilerlib/Tui.cpp
+++ b/src/profilerlib/Tui.cpp
@@ -100,7 +100,7 @@ void Tui::runProf() {
         if ((x != NULL) && (x[0] == '\0')) {
             input = "";
         } else {
-            input = std::string(x);
+            input = Tools::trimWhitespace(std::string(x));
         }
 
         if (input.empty()) {


### PR DESCRIPTION
Prior to this fix the profiler CLI would crash when a command contained preceding or trailing whitespace.