### PR TITLE
Fix paths given to compiled executables

### DIFF
--- a/src/AstRelation.h
+++ b/src/AstRelation.h
@@ -212,9 +212,12 @@ public:
         auto res = new AstRelation();
         res->name = name;
         res->setSrcLoc(getSrcLoc());
-        for (const auto& cur : attributes)
+        for (const auto& cur : attributes) {
             res->attributes.push_back(std::unique_ptr<AstAttribute>(cur->clone()));
-        for (const auto& cur : clauses) res->clauses.push_back(std::unique_ptr<AstClause>(cur->clone()));
+        }
+        for (const auto& cur : clauses) {
+            res->clauses.push_back(std::unique_ptr<AstClause>(cur->clone()));
+        }
         for (const auto& cur : ioDirectives) {
             res->ioDirectives.push_back(std::unique_ptr<AstIODirective>(cur->clone()));
         }
@@ -295,7 +298,10 @@ public:
         } else if (directive->isPrintSize()) {
             qualifier |= PRINTSIZE_RELATION;
         }
-        ioDirectives.push_back(std::move(directive));
+        // Fall back on default behaviour for empty directives.
+        if (!directive->getIODirectiveMap().empty()) {
+            ioDirectives.push_back(std::move(directive));
+        }
     }
 
     std::vector<AstIODirective*> getIODirectives() const {

--- a/src/RamExecutor.cpp
+++ b/src/RamExecutor.cpp
@@ -2156,13 +2156,10 @@ std::string RamCompiler::generateCode(
             for (IODirectives ioDirectives : store->getRelation().getOutputDirectives()) {
                 os << "try {";
                 os << "std::map<std::string, std::string> directiveMap(" << ioDirectives << ");\n";
-                // If a directory has been specified then don't try to change it
-                if (!Global::config().has("output-dir")) {
-                    os << "if (!dirname.empty() && directiveMap[\"IO\"] == \"file\" && ";
-                    os << "directiveMap[\"filename\"].front() != '/') {";
-                    os << "directiveMap[\"filename\"] = dirname + \"/\" + directiveMap[\"filename\"];";
-                    os << "}";
-                }
+                os << "if (!dirname.empty() && directiveMap[\"IO\"] == \"file\" && ";
+                os << "directiveMap[\"filename\"].front() != '/') {";
+                os << "directiveMap[\"filename\"] = dirname + \"/\" + directiveMap[\"filename\"];";
+                os << "}";
                 os << "IODirectives ioDirectives(directiveMap);\n";
                 os << "IOSystem::getInstance().getWriter(";
                 os << "SymbolMask({" << store->getRelation().getSymbolMask() << "})";
@@ -2191,13 +2188,10 @@ std::string RamCompiler::generateCode(
         os << "try {";
         os << "std::map<std::string, std::string> directiveMap(";
         os << load.getRelation().getInputDirectives() << ");\n";
-        // If a directory has been specified then don't try to change it
-        if (!Global::config().has("fact-dir")) {
-            os << "if (!dirname.empty() && directiveMap[\"IO\"] == \"file\" && ";
-            os << "directiveMap[\"filename\"].front() != '/') {";
-            os << "directiveMap[\"filename\"] = dirname + \"/\" + directiveMap[\"filename\"];";
-            os << "}";
-        }
+        os << "if (!dirname.empty() && directiveMap[\"IO\"] == \"file\" && ";
+        os << "directiveMap[\"filename\"].front() != '/') {";
+        os << "directiveMap[\"filename\"] = dirname + \"/\" + directiveMap[\"filename\"];";
+        os << "}";
         os << "IODirectives ioDirectives(directiveMap);\n";
         os << "IOSystem::getInstance().getReader(";
         os << "SymbolMask({" << load.getRelation().getSymbolMask() << "})";
@@ -2274,8 +2268,8 @@ std::string RamCompiler::generateCode(
     // parse arguments
     os << "souffle::CmdOptions opt(";
     os << "R\"(" << Global::config().get("") << ")\",\n";
-    os << "R\"(" << Global::config().get("fact-dir") << ")\",\n";
-    os << "R\"(" << Global::config().get("output-dir") << ")\",\n";
+    os << "R\"(.)\",\n";
+    os << "R\"(.)\",\n";
     if (Global::config().has("profile")) {
         os << "true,\n";
         os << "R\"(" << Global::config().get("profile") << ")\",\n";

--- a/src/RamRelation.cpp
+++ b/src/RamRelation.cpp
@@ -19,7 +19,6 @@
 
 #include "RamRelation.h"
 #include "RamIndex.h"
-#include "StringPool.h"
 #include "SymbolMask.h"
 #include "SymbolTable.h"
 


### PR DESCRIPTION
Only build default directives once.
I/O paths have a default, non-empty, value; we now use that instead of assuming it is empty.
Fixes the path issue that #329 didn't finish fixing.