### PR TITLE
optimize writing to CSV files

### DIFF
--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -149,7 +149,7 @@ public:
     const char* unsafeResolve(const size_t idx) const {
         return numToStr[idx];
     }
-    
+
     /* Return the size of the symbol table, being the number of symbols it currently holds. */
     const size_t size() const {
         return numToStr.size();

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -146,6 +146,10 @@ public:
         return numToStr[idx];
     }
 
+    const char* unsafeResolve(const size_t idx) const {
+        return numToStr[idx];
+    }
+    
     /* Return the size of the symbol table, being the number of symbols it currently holds. */
     const size_t size() const {
         return numToStr.size();

--- a/src/WriteStreamCSV.h
+++ b/src/WriteStreamCSV.h
@@ -56,6 +56,30 @@ public:
         out << "\n";
     }
 
+    // optimizing, unsafe version. Doesn't lock, doesn't bound-check.
+    void writeNextTupleUnsafe(const RamDomain* tuple) {
+        size_t arity = symbolMask.getArity();
+        if (arity == 0) {
+            out << "()\n";
+            return;
+        }
+
+        if (symbolMask.isSymbol(0)) {
+            out << symbolTable.unsafeResolve(tuple[0]);
+        } else {
+            out << static_cast<int32_t>(tuple[0]);
+        }
+        for (size_t col = 1; col < arity; ++col) {
+            out << delimiter;
+            if (symbolMask.isSymbol(col)) {
+                out << symbolTable.unsafeResolve(tuple[col]);
+            } else {
+                out << static_cast<int32_t>(tuple[col]);
+            }
+        }
+        out << "\n";
+    }
+
     ~WriteStreamCSV() override = default;
 
 private:
@@ -71,7 +95,7 @@ public:
             char delimiter = '\t')
             : file(filename), writeStream(file, symbolMask, symbolTable, delimiter) {}
     void writeNextTuple(const RamDomain* tuple) override {
-        writeStream.writeNextTuple(tuple);
+        writeStream.writeNextTupleUnsafe(tuple);
     }
 
     ~WriteFileCSV() override = default;


### PR DESCRIPTION
I don't know if you want to consider a faster yet less-safe exporting to CSV files. I've pushed sample code in this branch. On our analysis of the facebook android app (v.86; stats: analysis time 45 mins, export time 48 mins) it results in significant speedup (39 vs. 48 mins for export of a 918GB database).