### PR TITLE
Fixed ODR violation

### DIFF
--- a/src/WriteStream.h
+++ b/src/WriteStream.h
@@ -46,7 +46,7 @@ public:
 };
 
 template <>
-void WriteStream::writeNext(const RamDomain* tuple) {
+inline void WriteStream::writeNext(const RamDomain* tuple) {
     writeNextTuple(tuple);
 }
 


### PR DESCRIPTION
Fixed One Definition Rule violation caused by explicit template specialization in header file.

The problem occurs when multiple compilation units which should be linked (transitively) include the header file with the definition.