### PR TITLE
Check new relations created for aggregates have unique names.

### DIFF
--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -570,6 +570,9 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
             // -- create a new clause --
 
             auto relName = "__agg_rel_" + toString(counter++);
+            while (program.getRelation(relName) != nullptr) {
+                relName = "__agg_rel_" + toString(counter++);
+            }
 
             AstAtom* head = new AstAtom();
             head->setName(relName);


### PR DESCRIPTION
Fix #393 