### PR TITLE
Only run bison once. (again)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -186,7 +186,7 @@ souffle_CPPFLAGS = -DPACKAGE_VERSION="\"${PACKAGE_VERSION}\""
 CLEANFILES = $(BUILT_SOURCES)  parser.cc scanner.cc parser.hh stack.hh
 
 # run Bison
-$(builddir)/parser.cc $(builddir)/parser.hh $(builddir)/stack.hh: $(srcdir)/parser.yy
+$(builddir)/parser.hh $(builddir)/stack.hh: $(srcdir)/parser.yy
 	$(BISON) -Wall -Werror -v -d -o parser.cc $(srcdir)/parser.yy
 
 # and FLEX


### PR DESCRIPTION
PR #369 added a dependency from a generated file to a generated file, thus leading to to multiple bison runs and breaking of parallel make runs in some cases. This PR fixes that problem.