### PR TITLE
Unshallow the standard shallow git clone to get all tags.

### DIFF
--- a/.travis/init.sh
+++ b/.travis/init.sh
@@ -13,7 +13,7 @@ then
   then
     # Ensure we have the tags before attempting to use them
     # Avoids issues with shallow clones not finding tags.
-    git fetch --tags
+    git fetch --tags --unshallow
     echo -n "Version: "
     git describe --tags --abbrev=0 --always
 


### PR DESCRIPTION
More fixes for the make package test. Unshallows the clone as well as fetching the tags as in #410. The final fix?