### PR TITLE
Fixed negation issues for naive provenance

### DIFF
--- a/src/Explain.h
+++ b/src/Explain.h
@@ -344,9 +344,14 @@ private:
 
                     // construct vector of proof references
                     for (size_t i = 1; i < tuple.size(); i++) {
-                        plabel l;
-                        tuple >> l;
-                        refs.push_back(l);
+                        if (*(rel->getAttrType(i)) == 'i' || *(rel->getAttrType(i)) == 'r') {
+                            plabel n;
+                            tuple >> n;
+                            refs.push_back(n);
+                        } else if (*(rel->getAttrType(i)) == 's') {
+                            std::string s;
+                            tuple >> s;
+                        }
                     }
 
                     labelToProof.insert({std::make_pair(rel->getName(), label), refs});
@@ -492,7 +497,11 @@ private:
                 for (size_t i = 0; i < provInfo.getInfo(infoKey).size(); i++) {
                     auto rel = provInfo.getInfo(infoKey)[i];
                     auto newLab = provInfo.getSubproofs(internalRelName, label)[i];
-                    inner->add_child(explainLabel(rel, newLab, depth - 1));
+                    if (std::regex_match(rel, std::regex("negated_.*"))) {
+                        inner->add_child(std::unique_ptr<TreeNode>(new leaf_node(rel)));
+                    } else {
+                        inner->add_child(explainLabel(rel, newLab, depth - 1));
+                    }
                 }
                 return std::move(inner);
 

--- a/src/Explain.h
+++ b/src/Explain.h
@@ -187,9 +187,9 @@ public:
 /***
  * Concrete class for leafs
  */
-class leaf_node : public TreeNode {
+class LeafNode : public TreeNode {
 public:
-    leaf_node(const std::string& t = "") : TreeNode(t) {}
+    LeafNode(const std::string& t = "") : TreeNode(t) {}
 
     // place leaf node
     void place(uint32_t x, uint32_t y) {
@@ -455,15 +455,16 @@ private:
 
         // check that relation is in the program
         if (!found) {
-            return std::unique_ptr<TreeNode>(new leaf_node("Relation " + relName + " not found"));
+            return std::unique_ptr<TreeNode>(new LeafNode("Relation " + relName + " not found"));
         }
 
         // if EDB relation, make a leaf node in the tree
         if (prog.getRelation(relName) != nullptr && isEDB) {
             std::string lab = relName + provInfo.getTuple(relName + "-output", label).getRepresentation();
-            return std::unique_ptr<TreeNode>(new leaf_node(lab));
+            return std::unique_ptr<TreeNode>(new LeafNode(lab));
         } else {
-            if (depth > 0) {
+            std::cout << "depth " << depth << std::endl;
+            if (depth > 1) {
                 std::string internalRelName;
 
                 // find correct relation
@@ -479,7 +480,7 @@ private:
                 }
 
                 if (internalRelName == "") {
-                    return std::unique_ptr<TreeNode>(new leaf_node("Relation " + relName + " not found"));
+                    return std::unique_ptr<TreeNode>(new LeafNode("Relation " + relName + " not found"));
                 }
 
                 // label and rule number for node
@@ -498,7 +499,7 @@ private:
                     auto rel = provInfo.getInfo(infoKey)[i];
                     auto newLab = provInfo.getSubproofs(internalRelName, label)[i];
                     if (std::regex_match(rel, std::regex("negated_.*"))) {
-                        inner->add_child(std::unique_ptr<TreeNode>(new leaf_node(rel)));
+                        inner->add_child(std::unique_ptr<TreeNode>(new LeafNode(rel)));
                     } else {
                         inner->add_child(explainLabel(rel, newLab, depth - 1));
                     }
@@ -508,7 +509,7 @@ private:
                 // add subproof label if depth limit is exceeded
             } else {
                 std::string lab = "subproof " + relName + "(" + std::to_string(label) + ")";
-                return std::unique_ptr<TreeNode>(new leaf_node(lab));
+                return std::unique_ptr<TreeNode>(new LeafNode(lab));
             }
         }
     }
@@ -517,7 +518,7 @@ private:
         auto lab = provInfo.getLabel(relName + "-output", tuple_elements);
         if (lab == -1) {
             return std::unique_ptr<TreeNode>(
-                    new leaf_node("Tuple " + relName + tuple_elements.getRepresentation() + " not found"));
+                    new LeafNode("Tuple " + relName + tuple_elements.getRepresentation() + " not found"));
         }
 
         return explainLabel(relName, lab, depthLimit);
@@ -697,6 +698,7 @@ public:
                     continue;
                 }
                 printStr("Depth is now " + std::to_string(depthLimit) + "\n");
+                provTree.setDepth(depthLimit);
             } else if (command[0] == "explain") {
                 std::pair<std::string, std::vector<std::string>> query;
                 if (command.size() > 1) {

--- a/src/Explain.h
+++ b/src/Explain.h
@@ -463,7 +463,6 @@ private:
             std::string lab = relName + provInfo.getTuple(relName + "-output", label).getRepresentation();
             return std::unique_ptr<TreeNode>(new LeafNode(lab));
         } else {
-            std::cout << "depth " << depth << std::endl;
             if (depth > 1) {
                 std::string internalRelName;
 
@@ -479,8 +478,14 @@ private:
                     }
                 }
 
+                // must be fact or not found
                 if (internalRelName == "") {
-                    return std::unique_ptr<TreeNode>(new LeafNode("Relation " + relName + " not found"));
+                    auto fact = provInfo.getTuple(relName + "-output", label);
+                    if (fact != defaultElement) {
+                        return std::unique_ptr<TreeNode>(new LeafNode(relName + fact.getRepresentation()));
+                    } else {
+                        return std::unique_ptr<TreeNode>(new LeafNode("Relation " + relName + " not found"));
+                    }
                 }
 
                 // label and rule number for node

--- a/src/ProvenanceTransformer.cpp
+++ b/src/ProvenanceTransformer.cpp
@@ -160,7 +160,8 @@ void ProvenanceTransformedClause::makeProvenanceRelation(AstRelation* recordRela
     provenanceClauseHead->addArgument(std::unique_ptr<AstArgument>(makeNewRecordInit(args)));
 
     // visit all body literals and add to provenance clause
-    for (auto lit : originalClause.getBodyLiterals()) {
+    for (size_t i = 0; i < originalClause.getBodyLiterals().size(); i++) {
+        auto lit = originalClause.getBodyLiterals()[i];
         const AstAtom* atom = lit->getAtom();
         if (atom != nullptr) {  // literal is atom or negation
             std::string relName = identifierToString(atom->getName());
@@ -175,8 +176,8 @@ void ProvenanceTransformedClause::makeProvenanceRelation(AstRelation* recordRela
 
             if (dynamic_cast<const AstAtom*>(lit)) {
                 // add atom to head as a record
-                provenanceRelation->addAttribute(std::unique_ptr<AstAttribute>(
-                        new AstAttribute("prov_" + relName, relationToTypeMap[atom->getName()])));
+                provenanceRelation->addAttribute(std::unique_ptr<AstAttribute>(new AstAttribute(
+                        "prov_" + relName + "_" + std::to_string(i), relationToTypeMap[atom->getName()])));
                 provenanceClauseHead->addArgument(std::unique_ptr<AstArgument>(makeNewRecordInit(args)));
 
                 // add argument to body corresponding to provenance info for atom
@@ -184,8 +185,8 @@ void ProvenanceTransformedClause::makeProvenanceRelation(AstRelation* recordRela
                 provenanceClause->addToBody(std::move(newBody));
             } else if (dynamic_cast<const AstNegation*>(lit)) {
                 // add a marker signifying a negation
-                provenanceRelation->addAttribute(std::unique_ptr<AstAttribute>(
-                        new AstAttribute("prov_" + relName, AstTypeIdentifier("symbol"))));
+                provenanceRelation->addAttribute(std::unique_ptr<AstAttribute>(new AstAttribute(
+                        "prov_" + relName + "_" + std::to_string(i), AstTypeIdentifier("symbol"))));
                 provenanceClauseHead->addArgument(std::unique_ptr<AstArgument>(new AstStringConstant(
                         translationUnit.getSymbolTable(), ("negated_" + relName).c_str())));
 
@@ -411,6 +412,7 @@ bool NaiveProvenanceTransformer::transform(AstTranslationUnit& translationUnit) 
         program->addRelation(transformedRelation->getRecordRelation());
         program->addRelation(transformedRelation->getOutputRelation());
     }
+
     return changed;
 }
 

--- a/tests/provenance.at
+++ b/tests/provenance.at
@@ -5,4 +5,6 @@
 # - <souffle root>/licenses/SOUFFLE-UPL.txt
 
 POSITIVE_TEST_IN([path],[provenance])
+POSITIVE_TEST_IN([negation],[provenance])
+
 dnl NEGATIVE_TEST_IN([test2],[provenance])

--- a/tests/provenance/negation/animal.csv
+++ b/tests/provenance/negation/animal.csv
@@ -1,0 +1,2 @@
+tomothy_the_cat
+ollie_the_doggo

--- a/tests/provenance/negation/negation.dl
+++ b/tests/provenance/negation/negation.dl
@@ -8,12 +8,16 @@
 
 .pragma "provenance" "2"
 
-.decl edge(x:symbol, y:symbol)
-edge("a", "b").
-edge("b", "c").
-edge("c", "d").
+.decl person(x:symbol)
+person("john").
+person("jim").
+person("tim").
 
-.decl path(x:symbol, y:symbol)
-path(x, y) :- edge(x, y).
-path(x, z) :- edge(x, y), path(y, z).
-.output path()
+.decl being(x:symbol)
+being(x) :- person(x).
+being("tomothy_the_cat").
+being("ollie_the_doggo").
+
+.decl animal(x:symbol)
+animal(x) :- being(x), !person(x).
+.output animal

--- a/tests/provenance/negation/negation.in
+++ b/tests/provenance/negation/negation.in
@@ -1,0 +1,2 @@
+explain animal(ollie_the_doggo)
+exit

--- a/tests/provenance/negation/negation.out
+++ b/tests/provenance/negation/negation.out
@@ -1,0 +1,5 @@
+Explain is invoked.
+Enter command > being(ollie_the_doggo) negated_person     
+--------------------------------------(R0)
+         animal(ollie_the_doggo)          
+Enter command > 


### PR DESCRIPTION
- Fixed issues with displaying derivation trees for programs with negation.
- Fixed display of derivation trees for relations with both facts and rules
- Fixed changing of depth limit for derivation tree display, which now works correctly
- Renamed some classes for consistency