### PR TITLE
Fix race condition for profile output.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,11 +48,26 @@ AS_VAR_APPEND(LIBS, ["$CURSES_LIB"])
 dnl Do not set default CFLAGS and CXXFLAGS
 CXXFLAGS=" -Wall -std=c++11  $CXXFLAGS"
 
+# Enable sanitise memory mode
+AC_ARG_ENABLE(
+  [sanitise-memory],
+  [AS_HELP_STRING([--enable-sanitise-memory], [Enable sanitise memory mode])]
+)
+AS_IF([test "x$enable_sanitise_memory" = "xyes"], [CXXFLAGS="$CXXFLAGS -fsanitize=address,leak"])
+
+# Enable sanitise threads mode
+AC_ARG_ENABLE(
+  [sanitise-thread],
+  [AS_HELP_STRING([--enable-sanitise-thread], [Enable sanitise thread mode])]
+)
+AS_IF([test "x$enable_sanitise_thread" = "xyes"], [CXXFLAGS="$CXXFLAGS -fsanitize=thread"])
+
 # Enable debug mode
 AC_ARG_ENABLE(
   [debug],
   [AS_HELP_STRING([--enable-debug], [Enable debug mode])]
 )
+
 AS_IF([test "x$enable_debug" = "xyes"], [CXXFLAGS="$CXXFLAGS -O0 -g3"],
   [test "x$enable_debug" != "xyes"], [CXXFLAGS="$CXXFLAGS -O3"]
 )

--- a/src/RamExecutor.cpp
+++ b/src/RamExecutor.cpp
@@ -706,11 +706,15 @@ void run(const QueryExecutionStrategy& executor, std::ostream* report, std::ostr
         }
 
         bool visitPrintSize(const RamPrintSize& print) override {
+            auto lease = getOutputLock().acquire();
+            (void)lease;
             std::cout << print.getLabel() << env.getRelation(print.getRelation()).size() << "\n";
             return true;
         }
 
         bool visitLogSize(const RamLogSize& print) override {
+            auto lease = getOutputLock().acquire();
+            (void)lease;
             *profile << print.getLabel() << env.getRelation(print.getRelation()).size() << "\n";
             return true;
         }
@@ -808,6 +812,8 @@ void run(const QueryExecutionStrategy& executor, std::ostream* report, std::ostr
         // -- safety net --
 
         bool visitNode(const RamNode& node) override {
+            auto lease = getOutputLock().acquire();
+            (void)lease;
             std::cerr << "Unsupported node type: " << typeid(node).name() << "\n";
             assert(false && "Unsupported Node Type!");
             return false;
@@ -1208,7 +1214,8 @@ public:
 
             // print log entry
             out << "{ auto lease = getOutputLock().acquire(); ";
-            out << "profile << R\"(#" << label << ";)\" << num_failed_proofs << \"\\n\";\n";
+            out << "(void)lease;\n";
+            out << "profile << R\"(#" << label << ";)\" << num_failed_proofs << std::endl;\n";
             out << "}";
         }
 
@@ -1238,10 +1245,11 @@ public:
 
     void visitLogSize(const RamLogSize& print, std::ostream& out) override {
         out << "{ auto lease = getOutputLock().acquire(); \n";
+        out << "(void)lease;\n";
         out << "profile << R\"(" << print.getLabel() << ")\" <<  ";
         out << getRelationName(print.getRelation());
         out << "->"
-            << "size() << \"\\n\";\n"
+            << "size() << std::endl;\n"
             << "}";
     }
 
@@ -2197,9 +2205,10 @@ std::string RamCompiler::generateCode(
             }
         } else if (auto print = dynamic_cast<const RamPrintSize*>(&node)) {
             os << "{ auto lease = getOutputLock().acquire(); \n";
+            os << "(void)lease;\n";
             os << "std::cout << R\"(" << print->getLabel() << ")\" <<  ";
             os << getRelationName(print->getRelation()) << "->"
-               << "size() << \"\\n\";\n";
+               << "size() << std::endl;\n";
             os << "}";
         }
     });


### PR DESCRIPTION
Adds locks around interpreter output. Before this fix, with current code and compiled with gcc 6 or clang 5, errors would show roughly every 40 runs of the profile tests. With the fix over 400 runs have been done without error.

This PR also adds configure flags (--enable-sanitise-memory, --enable-sanitise-thread) to enable compiler sanitise checks for memory and thread issues to help with debugging.