### PR TITLE
Add error message to configure script for missing ncurses lib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,7 @@ AM_CONDITIONAL([JAVAI], [test "x$enable_jni" = "xyes"])
 # Enable curses library
 AX_WITH_CURSES
 AS_VAR_APPEND(LIBS, ["$CURSES_LIB"])
+AS_IF([test "x$ax_cv_ncurses" != "xyes"],[AC_MSG_ERROR([required library ncurses missing])])
 
 dnl Do not set default CFLAGS and CXXFLAGS
 CXXFLAGS=" -Wall -std=c++11  $CXXFLAGS"


### PR DESCRIPTION
Without this PR, if you do not have ncurses an error message is incorrectly shown that says zlib is missing.