### PR TITLE
Stop processing compiled souffle on first error

### DIFF
--- a/src/RamExecutor.cpp
+++ b/src/RamExecutor.cpp
@@ -831,8 +831,7 @@ void RamGuidedInterpreter::applyOn(const RamStatement& stmt, RamEnvironment& env
         // open output stream
         std::ofstream os(fname);
         if (!os.is_open()) {
-            // TODO: use different error reporting here!!
-            std::cerr << "Cannot open fact file " << fname << " for profiling\n";
+            throw std::invalid_argument("Cannot open profile log file <" + fname + ">");
         }
         os << "@start-debug\n";
         run(queryStrategy, report, &os, stmt, env, data);
@@ -2402,7 +2401,7 @@ std::string RamCompiler::compileToBinary(const SymbolTable& symTable, const RamS
 
     // run executable
     if (system(cmd.c_str()) != 0) {
-        std::cerr << "failed to compile C++ source " << binary << "\n";
+        throw std::invalid_argument("failed to compile C++ source <" + source + ">");
     }
 
     // done
@@ -2420,7 +2419,7 @@ void RamCompiler::applyOn(const RamStatement& stmt, RamEnvironment& env, RamData
 
     // check whether the executable exists
     if (!isExecutable(binary)) {
-        std::cerr << "failed to run executable " << binary << "\n";
+        throw std::invalid_argument("Generated executable <" + binary + "> could not be found");
     }
 
     // run executable

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -393,22 +393,26 @@ int main(int argc, char** argv) {
             executor = std::unique_ptr<RamExecutor>(new RamInterpreter());
         }
     }
-
-    // check if this is code generation only
     std::unique_ptr<RamEnvironment> env;
-    if (Global::config().has("generate")) {
-        // just generate, no compile, no execute
-        static_cast<const RamCompiler*>(executor.get())
-                ->generateCode(translationUnit->getSymbolTable(), *ramProg, Global::config().get("generate"));
+    try {
+        // check if this is code generation only
+        if (Global::config().has("generate")) {
+            // just generate, no compile, no execute
+            static_cast<const RamCompiler*>(executor.get())
+                    ->generateCode(
+                            translationUnit->getSymbolTable(), *ramProg, Global::config().get("generate"));
 
-        // check if this is a compile only
-    } else if (Global::config().has("compile") && Global::config().has("dl-program")) {
-        // just compile, no execute
-        static_cast<const RamCompiler*>(executor.get())
-                ->compileToBinary(translationUnit->getSymbolTable(), *ramProg);
-    } else {
-        // run executor
-        env = executor->execute(translationUnit->getSymbolTable(), *ramProg);
+            // check if this is a compile only
+        } else if (Global::config().has("compile") && Global::config().has("dl-program")) {
+            // just compile, no execute
+            static_cast<const RamCompiler*>(executor.get())
+                    ->compileToBinary(translationUnit->getSymbolTable(), *ramProg);
+        } else {
+            // run executor
+            env = executor->execute(translationUnit->getSymbolTable(), *ramProg);
+        }
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
     }
 
     /* Report overall run-time in verbose mode */

--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -37,6 +37,9 @@ error() {
   fi
 }
 
+#Exit on error
+set -e
+
 ## set environment variables
 
 # set by autoconf

--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -44,6 +44,7 @@ set -e
 
 # set by autoconf
 CXX=@CXX@
+CPPFLAGS="@CPPFLAGS@"
 CXXFLAGS="@CXXFLAGS@"
 LDFLAGS="@LDFLAGS@"
 LIBS="@LIBS@"
@@ -111,7 +112,7 @@ then
   rm $dir/$exe.$$.ccerr
 else
   echo "compiler error: cannot compile source file $1" 1>&2
-  echo "$CXX $CXXFLAGS -o$dir/$exe $1 $LIBS -I$HEADER_DIR $OMP_FLAG"
+  echo "$CXX $CXXFLAGS $CPPFLAGS -o$dir/$exe $1 $LIBS -I$HEADER_DIR $OMP_FLAG"
   cat $dir/$exe.$$.ccerr 1>&2
   rm -f $dir/$exe.$$.ccerr
   exit 1

--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -18,7 +18,7 @@ Usage:
   souffle-compile [options] <FILE>.cpp
 Options:
   -h           show usage
-  -s           compile a program with OpenMP support
+  -s           compile a program without OpenMP support
   -v           verbose output
   -w           enable warnings\n"
   exit 1;


### PR DESCRIPTION
Currently if an error generating or executing compiled code is encountered, souffle keeps going, e.g., trying to execute a binary despite the binary not being generated. This PR is intended to stop on the first error.

Fixes #446 