### PR TITLE
Add configure option to disable provenance.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,13 +41,21 @@ AS_IF([test "x$enable_jni" = "xyes"], [
 ])
 AM_CONDITIONAL([JAVAI], [test "x$enable_jni" = "xyes"])
 
-# Enable curses library
-AX_WITH_CURSES
-AS_VAR_APPEND(LIBS, ["$CURSES_LIB"])
-AS_IF([test "x$ax_cv_ncurses" != "xyes"],[AC_MSG_ERROR([required library ncurses missing])])
-
 dnl Do not set default CFLAGS and CXXFLAGS
 CXXFLAGS=" -Wall -std=c++11  $CXXFLAGS"
+
+# Disable provenance
+AC_ARG_ENABLE(
+  [provenance],
+  AS_HELP_STRING([--disable-provenance], [Disable provenance display])
+)
+AS_IF([test "x$enable_provenance" != "xno"], [
+  AX_WITH_CURSES
+  AS_IF([test "x$ax_cv_ncurses" != "xyes"],[AC_MSG_ERROR([required library ncurses missing])])
+  AS_VAR_APPEND(LIBS, ["$CURSES_LIB"])
+  AS_VAR_APPEND(CXXFLAGS, [" -DUSE_PROVENANCE "])
+])
+AM_CONDITIONAL([PROVENANCE], [test "x$enable_provenance" != "xno"])
 
 # Enable sanitise memory mode
 AC_ARG_ENABLE(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,9 @@
 #include "AstUtils.h"
 #include "BddbddbBackend.h"
 #include "ComponentModel.h"
+#ifdef USE_PROVENANCE
 #include "Explain.h"
+#endif
 #include "Global.h"
 #include "ParserDriver.h"
 #include "PrecedenceGraph.h"
@@ -127,9 +129,11 @@ int main(int argc, char** argv) {
                                     "Enable profiling and write profile data to <FILE>."},
                             {"bddbddb", 'b', "FILE", "", false, "Convert input into bddbddb file format."},
                             {"debug-report", 'r', "FILE", "", false, "Write HTML debug report to <FILE>."},
+#ifdef USE_PROVENANCE
                             {"provenance", 't', "EXPLAIN", "", false,
                                     "Enable provenance information (<EXPLAIN> can be 0 for no explain, 1 for "
                                     "explain with ncurses, 2 for explain with stdout)."},
+#endif
                             {"verbose", 'v', "", "", false, "Verbose output."},
                             {"help", 'h', "", "", false, "Display this help message."}};
                     return std::vector<MainOption>(std::begin(opts), std::end(opts));
@@ -291,11 +295,12 @@ int main(int argc, char** argv) {
     if (Global::config().has("auto-schedule")) {
         transforms.push_back(std::unique_ptr<AstTransformer>(new AutoScheduleTransformer()));
     }
-
+#if USE_PROVENANCE
     // Add provenance information by transforming to records
     if (Global::config().has("provenance")) {
         transforms.push_back(std::unique_ptr<AstTransformer>(new NaiveProvenanceTransformer()));
     }
+#endif
     if (!Global::config().get("debug-report").empty()) {
         auto parser_end = std::chrono::high_resolution_clock::now();
         std::string runtimeStr =
@@ -421,7 +426,7 @@ int main(int argc, char** argv) {
         std::cout << "Total Time: " << std::chrono::duration<double>(souffle_end - souffle_start).count()
                   << "sec\n";
     }
-
+#ifdef USE_PROVENANCE
     if (Global::config().has("provenance") && env != nullptr) {
         // construct SouffleProgram from env
         SouffleInterpreterInterface interface(*env, translationUnit->getSymbolTable());
@@ -432,7 +437,7 @@ int main(int argc, char** argv) {
             explain(interface, false);
         }
     }
-
+#endif
     return 0;
 }
 


### PR DESCRIPTION
This PR adds the option to disable provenance
./configure --disable-provenance
This is useful in minimal environments where provenance is not needed and especially if its dependencies are not present.