### PR TITLE
Add stracktrace to failed Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ aliases:
         packages:
         - *linux_deps
         - clang-4.0
+        - gdb
     install: ".travis/linux/clang_install.sh"
     before_script: ".travis/init_test.sh"
     script: ".travis/run_test.sh"

--- a/.travis/after_failure.sh
+++ b/.travis/after_failure.sh
@@ -72,6 +72,12 @@ for EXTENSION in $RELEVANT_EXTENSIONS; do
     done
 done
 
+if [ -e "$TEST_ROOT/$CANDIDATE/core" ]
+then
+    pretty_print "Core dump found"
+    gdb -batch -ex 'bt' ./src/souffle "$TEST_ROOT/$CANDIDATE/core"
+fi
+
 if [ $TRAVIS_OS_NAME == osx ]
 then
     pretty_print "OSX Diagnostic Reports"

--- a/.travis/linux/clang_install.sh
+++ b/.travis/linux/clang_install.sh
@@ -9,3 +9,7 @@ set -x
 sudo add-apt-repository -y "deb http://ftp.us.debian.org/debian unstable main contrib non-free"
 sudo apt-get -qq update
 sudo apt-get -y --force-yes install libomp-dev
+
+
+# While we are using a sudo-enabled build, let's also enable coredumps
+sudo bash -c "echo 'core' > /proc/sys/kernel/core_pattern"

--- a/.travis/osx/install_withgcc.sh
+++ b/.travis/osx/install_withgcc.sh
@@ -10,3 +10,6 @@ rm /usr/local/include/c++
 brew install md5sha1sum bison libtool gcc
 brew link bison --force
 g++-7 --version
+
+rm /Users/travis/Library/Logs/DiagnosticReports/*
+

--- a/.travis/osx/install_withgcc.sh
+++ b/.travis/osx/install_withgcc.sh
@@ -12,4 +12,3 @@ brew link bison --force
 g++-7 --version
 
 rm /Users/travis/Library/Logs/DiagnosticReports/*
-

--- a/.travis/run_test.sh
+++ b/.travis/run_test.sh
@@ -5,6 +5,7 @@
 set -e
 set -x
 
+ulimit -c unlimited -S
 # Run from the test directory if we don't need the unit tests
 if [[ "$SOUFFLE_CATEGORY" != *"Unit"* ]]
 then


### PR DESCRIPTION
This is for linux clang only, as travis doesn't support coredumps on containerised builds