### PR TITLE
Added support for profiling hint hit/miss rates.

### DIFF
--- a/src/BTree.h
+++ b/src/BTree.h
@@ -1151,7 +1151,6 @@ private:
 
     // an aggregation of statistical values of the hint utilization
     struct hint_statistics {
-
         // the counter for insertion operations
         CacheAccessCounter inserts;
 
@@ -1163,7 +1162,6 @@ private:
 
         // the counter for upper_bound operations
         CacheAccessCounter upper_bound;
-
     };
 
     // the hint statistic of this b-tree instance

--- a/src/BTree.h
+++ b/src/BTree.h
@@ -1147,6 +1147,28 @@ private:
     // a pointer to the left-most node of this tree (initial note for iteration)
     leaf_node* leftmost;
 
+    /* -------------- operator hint statistics ----------------- */
+
+    // an aggregation of statistical values of the hint utilization
+    struct hint_statistics {
+
+        // the counter for insertion operations
+        CacheAccessCounter inserts;
+
+        // the counter for contains operations
+        CacheAccessCounter contains;
+
+        // the counter for lower_bound operations
+        CacheAccessCounter lower_bound;
+
+        // the counter for upper_bound operations
+        CacheAccessCounter upper_bound;
+
+    };
+
+    // the hint statistic of this b-tree instance
+    mutable hint_statistics hint_stats;
+
 public:
     enum {
         // the maximum number of keys stored per node
@@ -1269,7 +1291,15 @@ public:
                     cur = hints.last_insert;
                     // and keep lease
                     cur_lease = hint_lease;
+                    // register this as a hit
+                    hint_stats.inserts.addHit();
+                } else {
+                    // register this as a miss
+                    hint_stats.inserts.addMiss();
                 }
+            } else {
+                // register this as a miss
+                hint_stats.inserts.addMiss();
             }
         }
 
@@ -1470,6 +1500,9 @@ public:
         // test last insert
         if (hints.last_insert && covers(hints.last_insert, k)) {
             cur = hints.last_insert;
+            hint_stats.inserts.addHit();
+        } else {
+            hint_stats.inserts.addMiss();
         }
 
         while (true) {
@@ -1641,6 +1674,11 @@ public:
         // test last location searched (temporal locality)
         if (hints.last_find_end && covers(hints.last_find_end, k)) {
             cur = hints.last_find_end;
+            // register it as a hit
+            hint_stats.contains.addHit();
+        } else {
+            // register it as a miss
+            hint_stats.contains.addMiss();
         }
 
         // an iterative implementation (since 2/7 faster than recursive)
@@ -1691,6 +1729,9 @@ public:
         // test last searched node
         if (hints.last_lower_bound_end && covers(hints.last_lower_bound_end, k)) {
             cur = hints.last_lower_bound_end;
+            hint_stats.lower_bound.addHit();
+        } else {
+            hint_stats.lower_bound.addMiss();
         }
 
         iterator res = end();
@@ -1743,6 +1784,9 @@ public:
         // test last search node
         if (hints.last_upper_bound_end && coversUpperBound(hints.last_upper_bound_end, k)) {
             cur = hints.last_upper_bound_end;
+            hint_stats.upper_bound.addHit();
+        } else {
+            hint_stats.upper_bound.addMiss();
         }
 
         iterator res = end();
@@ -1864,6 +1908,11 @@ public:
         return sizeof(*this) + (empty() ? 0 : root->getMemoryUsage());
     }
 
+    // Obtains a reference to the internally maintained hint statistics
+    const hint_statistics& getHintStatistics() const {
+        return hint_stats;
+    }
+
     /*
      * Prints a textual representation of this tree to the given
      * output stream (mostly for debugging and tuning).
@@ -1899,6 +1948,17 @@ public:
         out << "  avg keys / node:  " << (size() / (double)nodes) << "\n";
         out << "  avg filling rate: " << ((size() / (double)nodes) / node::maxKeys) << "\n";
         out << "---------------------------------\n";
+        if (isHintsProfilingEnabled()) {
+            out << "         insert hint hits: " << hint_stats.inserts.getHits() << "\n";
+            out << "       insert hint misses: " << hint_stats.inserts.getMisses() << "\n";
+            out << "       contains hint hits: " << hint_stats.contains.getHits() << "\n";
+            out << "     contains hint misses: " << hint_stats.contains.getMisses() << "\n";
+            out << "    lower_bound hint hits: " << hint_stats.lower_bound.getHits() << "\n";
+            out << "  lower_bound hint misses: " << hint_stats.lower_bound.getMisses() << "\n";
+            out << "    upper_bound hint hits: " << hint_stats.upper_bound.getHits() << "\n";
+            out << "  upper_bound hint misses: " << hint_stats.upper_bound.getMisses() << "\n";
+            out << "---------------------------------\n";
+        }
     }
 
     /**

--- a/src/CompiledRamIndexUtils.h
+++ b/src/CompiledRamIndexUtils.h
@@ -652,6 +652,30 @@ public:
     static void printDescription(std::ostream& out) {
         out << "direct-btree-index(" << Index() << ")";
     }
+
+    void printHintStatistics(std::ostream& out, const std::string& prefix) const {
+        const auto& stats = index.getHintStatistics();
+        out << prefix << "Direct B-Tree Index: (Hits/Misses/Total)\n";
+        out << prefix << "       Insert: "
+                << stats.inserts.getHits()   << "/"
+                << stats.inserts.getMisses() << "/"
+                << stats.inserts.getAccesses() << "\n";
+
+        out << prefix << "     Contains: "
+                << stats.contains.getHits()   << "/"
+                << stats.contains.getMisses() << "/"
+                << stats.contains.getAccesses() << "\n";
+
+        out << prefix << "  lower bound: "
+                << stats.lower_bound.getHits() << "/"
+                << stats.lower_bound.getMisses() << "/"
+                << stats.lower_bound.getAccesses() << "\n";
+
+        out << prefix << "  upper bound: "
+                << stats.upper_bound.getHits() << "/"
+                << stats.upper_bound.getMisses() << "/"
+                << stats.upper_bound.getAccesses() << "\n";
+    }
 };
 
 /**
@@ -758,6 +782,30 @@ public:
 
     static void printDescription(std::ostream& out) {
         out << "indirect-btree-index(" << Index() << ")";
+    }
+
+    void printHintStatistics(std::ostream& out, const std::string& prefix) const {
+        const auto& stats = index.getHintStatistics();
+        out << prefix << "Indirect B-Tree Index: (Hits/Misses/Total)\n";
+        out << prefix << "       Insert: "
+                << stats.inserts.getHits()   << "/"
+                << stats.inserts.getMisses() << "/"
+                << stats.inserts.getAccesses() << "\n";
+
+        out << prefix << "     Contains: "
+                << stats.contains.getHits()   << "/"
+                << stats.contains.getMisses() << "/"
+                << stats.contains.getAccesses() << "\n";
+
+        out << prefix << "  lower bound: "
+                << stats.lower_bound.getHits() << "/"
+                << stats.lower_bound.getMisses() << "/"
+                << stats.lower_bound.getAccesses() << "\n";
+
+        out << prefix << "  upper bound: "
+                << stats.upper_bound.getHits() << "/"
+                << stats.upper_bound.getMisses() << "/"
+                << stats.upper_bound.getAccesses() << "\n";
     }
 };
 
@@ -931,6 +979,26 @@ public:
 
     static void printDescription(std::ostream& out) {
         out << "trie-index(" << Index() << ")";
+    }
+
+    void printHintStatistics(std::ostream& out, const std::string& prefix) const {
+        const auto& stats = data.getHintStatistics();
+        out << prefix << "Trie-Index: (Hits/Misses/Total)\n";
+        out << prefix << "      Insert: "
+                << stats.inserts.getHits()   << "/"
+                << stats.inserts.getMisses() << "/"
+                << stats.inserts.getAccesses() << "\n";
+
+        out << prefix << "    Contains: "
+                << stats.contains.getHits()   << "/"
+                << stats.contains.getMisses() << "/"
+                << stats.contains.getAccesses() << "\n";
+
+        out << prefix << "  RangeQuery: "
+                << stats.get_boundaries.getHits() << "/"
+                << stats.get_boundaries.getMisses() << "/"
+                << stats.get_boundaries.getAccesses() << "\n";
+
     }
 
 private:
@@ -1113,6 +1181,10 @@ public:
 
     static void printDescription(std::ostream& out) {
         out << "disjoint-set-index(" << Index() << ")";
+    }
+
+    void printHintStatistics(std::ostream& out, const std::string& prefix) const {
+        out << prefix << "Disjoint Set Index: no hint statistics supported\n";
     }
 
 private:
@@ -1329,6 +1401,17 @@ public:
         nested.printDescription(out);
         return out;
     }
+
+
+    void printHintStatistics(std::ostream& out, const std::string& prefix) const {
+        out << prefix << "Multi-Index Relation:\n";
+        printHintStatisticsInternal(out, prefix + "  ");
+    }
+
+    void printHintStatisticsInternal(std::ostream& out, const std::string& prefix) const {
+        index.printHintStatistics(out,prefix);
+        nested.printHintStatisticsInternal(out,prefix);
+    }
 };
 
 /* The based-case of indices containing no more nested indices. */
@@ -1394,6 +1477,10 @@ public:
 
     std::ostream& printDescription(std::ostream& out = std::cout) const {
         return out;
+    }
+
+    void printHintStatisticsInternal(std::ostream&, const std::string&) const {
+        // nothing to do here
     }
 };
 }  // namespace index_utils

--- a/src/CompiledRamIndexUtils.h
+++ b/src/CompiledRamIndexUtils.h
@@ -343,7 +343,7 @@ template <unsigned i, unsigned arity, typename Index>
 struct extend_to_full_index_aux {
     typedef typename extend_to_full_index_aux<i + 1, arity,
             typename std::conditional<(Index::template covers<i>::value), Index,
-                                                      typename extend<Index, i>::type>::type>::type type;
+                    typename extend<Index, i>::type>::type>::type type;
 };
 
 template <unsigned arity, typename Index>
@@ -1214,9 +1214,9 @@ struct index_factory<T, Index, true> {
     // pick direct or indirect indexing based on size of tuple
     typedef typename std::conditional<sizeof(T) <= 2 * sizeof(void*),  // if tuple is not bigger than a bound
             typename direct_index_factory<T, Index,
-                                              true>::type,  // use a direct index
+                    true>::type,  // use a direct index
             IndirectIndex<T,
-                                              Index>  // otherwise use an indirect, pointer based index
+                    Index>  // otherwise use an indirect, pointer based index
             >::type type;
 };
 

--- a/src/CompiledRamIndexUtils.h
+++ b/src/CompiledRamIndexUtils.h
@@ -343,7 +343,7 @@ template <unsigned i, unsigned arity, typename Index>
 struct extend_to_full_index_aux {
     typedef typename extend_to_full_index_aux<i + 1, arity,
             typename std::conditional<(Index::template covers<i>::value), Index,
-                    typename extend<Index, i>::type>::type>::type type;
+                                                      typename extend<Index, i>::type>::type>::type type;
 };
 
 template <unsigned arity, typename Index>
@@ -656,25 +656,17 @@ public:
     void printHintStatistics(std::ostream& out, const std::string& prefix) const {
         const auto& stats = index.getHintStatistics();
         out << prefix << "Direct B-Tree Index: (Hits/Misses/Total)\n";
-        out << prefix << "       Insert: "
-                << stats.inserts.getHits()   << "/"
-                << stats.inserts.getMisses() << "/"
-                << stats.inserts.getAccesses() << "\n";
+        out << prefix << "       Insert: " << stats.inserts.getHits() << "/" << stats.inserts.getMisses()
+            << "/" << stats.inserts.getAccesses() << "\n";
 
-        out << prefix << "     Contains: "
-                << stats.contains.getHits()   << "/"
-                << stats.contains.getMisses() << "/"
-                << stats.contains.getAccesses() << "\n";
+        out << prefix << "     Contains: " << stats.contains.getHits() << "/" << stats.contains.getMisses()
+            << "/" << stats.contains.getAccesses() << "\n";
 
-        out << prefix << "  lower bound: "
-                << stats.lower_bound.getHits() << "/"
-                << stats.lower_bound.getMisses() << "/"
-                << stats.lower_bound.getAccesses() << "\n";
+        out << prefix << "  lower bound: " << stats.lower_bound.getHits() << "/"
+            << stats.lower_bound.getMisses() << "/" << stats.lower_bound.getAccesses() << "\n";
 
-        out << prefix << "  upper bound: "
-                << stats.upper_bound.getHits() << "/"
-                << stats.upper_bound.getMisses() << "/"
-                << stats.upper_bound.getAccesses() << "\n";
+        out << prefix << "  upper bound: " << stats.upper_bound.getHits() << "/"
+            << stats.upper_bound.getMisses() << "/" << stats.upper_bound.getAccesses() << "\n";
     }
 };
 
@@ -787,25 +779,17 @@ public:
     void printHintStatistics(std::ostream& out, const std::string& prefix) const {
         const auto& stats = index.getHintStatistics();
         out << prefix << "Indirect B-Tree Index: (Hits/Misses/Total)\n";
-        out << prefix << "       Insert: "
-                << stats.inserts.getHits()   << "/"
-                << stats.inserts.getMisses() << "/"
-                << stats.inserts.getAccesses() << "\n";
+        out << prefix << "       Insert: " << stats.inserts.getHits() << "/" << stats.inserts.getMisses()
+            << "/" << stats.inserts.getAccesses() << "\n";
 
-        out << prefix << "     Contains: "
-                << stats.contains.getHits()   << "/"
-                << stats.contains.getMisses() << "/"
-                << stats.contains.getAccesses() << "\n";
+        out << prefix << "     Contains: " << stats.contains.getHits() << "/" << stats.contains.getMisses()
+            << "/" << stats.contains.getAccesses() << "\n";
 
-        out << prefix << "  lower bound: "
-                << stats.lower_bound.getHits() << "/"
-                << stats.lower_bound.getMisses() << "/"
-                << stats.lower_bound.getAccesses() << "\n";
+        out << prefix << "  lower bound: " << stats.lower_bound.getHits() << "/"
+            << stats.lower_bound.getMisses() << "/" << stats.lower_bound.getAccesses() << "\n";
 
-        out << prefix << "  upper bound: "
-                << stats.upper_bound.getHits() << "/"
-                << stats.upper_bound.getMisses() << "/"
-                << stats.upper_bound.getAccesses() << "\n";
+        out << prefix << "  upper bound: " << stats.upper_bound.getHits() << "/"
+            << stats.upper_bound.getMisses() << "/" << stats.upper_bound.getAccesses() << "\n";
     }
 };
 
@@ -984,21 +968,14 @@ public:
     void printHintStatistics(std::ostream& out, const std::string& prefix) const {
         const auto& stats = data.getHintStatistics();
         out << prefix << "Trie-Index: (Hits/Misses/Total)\n";
-        out << prefix << "      Insert: "
-                << stats.inserts.getHits()   << "/"
-                << stats.inserts.getMisses() << "/"
-                << stats.inserts.getAccesses() << "\n";
+        out << prefix << "      Insert: " << stats.inserts.getHits() << "/" << stats.inserts.getMisses()
+            << "/" << stats.inserts.getAccesses() << "\n";
 
-        out << prefix << "    Contains: "
-                << stats.contains.getHits()   << "/"
-                << stats.contains.getMisses() << "/"
-                << stats.contains.getAccesses() << "\n";
+        out << prefix << "    Contains: " << stats.contains.getHits() << "/" << stats.contains.getMisses()
+            << "/" << stats.contains.getAccesses() << "\n";
 
-        out << prefix << "  RangeQuery: "
-                << stats.get_boundaries.getHits() << "/"
-                << stats.get_boundaries.getMisses() << "/"
-                << stats.get_boundaries.getAccesses() << "\n";
-
+        out << prefix << "  RangeQuery: " << stats.get_boundaries.getHits() << "/"
+            << stats.get_boundaries.getMisses() << "/" << stats.get_boundaries.getAccesses() << "\n";
     }
 
 private:
@@ -1237,9 +1214,9 @@ struct index_factory<T, Index, true> {
     // pick direct or indirect indexing based on size of tuple
     typedef typename std::conditional<sizeof(T) <= 2 * sizeof(void*),  // if tuple is not bigger than a bound
             typename direct_index_factory<T, Index,
-                    true>::type,  // use a direct index
+                                              true>::type,  // use a direct index
             IndirectIndex<T,
-                    Index>  // otherwise use an indirect, pointer based index
+                                              Index>  // otherwise use an indirect, pointer based index
             >::type type;
 };
 
@@ -1402,15 +1379,14 @@ public:
         return out;
     }
 
-
     void printHintStatistics(std::ostream& out, const std::string& prefix) const {
         out << prefix << "Multi-Index Relation:\n";
         printHintStatisticsInternal(out, prefix + "  ");
     }
 
     void printHintStatisticsInternal(std::ostream& out, const std::string& prefix) const {
-        index.printHintStatistics(out,prefix);
-        nested.printHintStatisticsInternal(out,prefix);
+        index.printHintStatistics(out, prefix);
+        nested.printHintStatisticsInternal(out, prefix);
     }
 };
 

--- a/src/CompiledRamRelation.h
+++ b/src/CompiledRamRelation.h
@@ -225,6 +225,13 @@ struct RelationBase {
         return out.str();
     }
 
+    // -- Hint Profiling --
+
+    /* Prints a summary of the hint statistic of this relation */
+    void printHintStatistics(std::ostream& out, const std::string& prefix = "") const {
+        static_cast<const Derived*>(this)->printHintStatistics(out, prefix);
+    }
+
 private:
     /* Provides type-save access to the members of the derived class. */
     Derived& asDerived() {
@@ -410,6 +417,11 @@ public:
         out << " ] where " << primary_index() << " is the primary index";
         return out;
     }
+
+    /* Prints a summary of the hint statistic of this relation */
+    void printHintStatistics(std::ostream& out, const std::string& prefix = "") const {
+        indices.printHintStatistics(out,prefix);
+    }
 };
 
 /**
@@ -556,6 +568,11 @@ public:
         indices.printDescription(out);
         out << " ] where " << primary_index() << " is the primary index";
         return out;
+    }
+
+    /* Prints a summary of the hint statistic of this relation */
+    void printHintStatistics(std::ostream& out, const std::string& prefix = "") const {
+        indices.printHintStatistics(out,prefix);
     }
 };
 
@@ -744,6 +761,11 @@ public:
     std::ostream& printDescription(std::ostream& out = std::cout) const {
         return out << "Nullary Relation";
     }
+
+    /* Prints a summary of the hint statistic of this relation */
+    void printHintStatistics(std::ostream& out, const std::string& prefix = "") const {
+        out << prefix << " -- no hints used in nullary relation --\n";
+    }
 };
 
 /**
@@ -881,6 +903,11 @@ public:
         out << "Index-Organized Relation of arity=" << arity << " based on a ";
         table_t::printDescription(out);
         return out;
+    }
+
+    /* Prints a summary of the hint statistic of this relation */
+    void printHintStatistics(std::ostream& out, const std::string& prefix = "") const {
+        data.printHintStatistics(out,prefix);
     }
 };
 

--- a/src/CompiledRamRelation.h
+++ b/src/CompiledRamRelation.h
@@ -420,7 +420,7 @@ public:
 
     /* Prints a summary of the hint statistic of this relation */
     void printHintStatistics(std::ostream& out, const std::string& prefix = "") const {
-        indices.printHintStatistics(out,prefix);
+        indices.printHintStatistics(out, prefix);
     }
 };
 
@@ -572,7 +572,7 @@ public:
 
     /* Prints a summary of the hint statistic of this relation */
     void printHintStatistics(std::ostream& out, const std::string& prefix = "") const {
-        indices.printHintStatistics(out,prefix);
+        indices.printHintStatistics(out, prefix);
     }
 };
 
@@ -907,7 +907,7 @@ public:
 
     /* Prints a summary of the hint statistic of this relation */
     void printHintStatistics(std::ostream& out, const std::string& prefix = "") const {
-        data.printHintStatistics(out,prefix);
+        data.printHintStatistics(out, prefix);
     }
 };
 

--- a/src/RamExecutor.cpp
+++ b/src/RamExecutor.cpp
@@ -2298,6 +2298,18 @@ std::string RamCompiler::generateCode(
     } else {
         genCode(os, *(prog.getMain()), indices);
     }
+
+    // add code printing hint statistics
+    os << "\n// -- relation hint statistics --\n";
+    os << "if(isHintsProfilingEnabled()) {\n";
+    os << "std::cout << \" -- Operation Hint Statistics --\\n\";\n";
+    visitDepthFirst(*(prog.getMain()), [&](const RamCreate& create) {
+        auto name = getRelationName(create.getRelation());
+        os << "std::cout << \"Relation " << name << ":\\n\";\n";
+        os << name << "->printHintStatistics(std::cout,\"  \");\n";
+        os << "std::cout << \"\\n\";\n";
+    });
+    os << "}\n";
     os << "}\n";  // end of run() method
 
     // issue printAll method

--- a/src/Trie.h
+++ b/src/Trie.h
@@ -1845,7 +1845,6 @@ public:
 
     // an aggregation of statistical values of the hint utilization
     struct hint_statistics {
-
         // the counter for insertion operations
         CacheAccessCounter inserts;
 
@@ -1854,21 +1853,17 @@ public:
 
         // the counter for get_boundaries operations
         CacheAccessCounter get_boundaries;
-
     };
 
 protected:
-
     // the hint statistic of this b-tree instance
     mutable hint_statistics hint_stats;
 
 public:
-
     // Obtains a reference to the internally maintained hint statistics
     const hint_statistics& getHintStatistics() const {
         return hint_stats;
     }
-
 };
 
 /**

--- a/src/Util.h
+++ b/src/Util.h
@@ -18,11 +18,11 @@
 
 #include "Macro.h"
 
-#include <atomic>
 #include <algorithm>
+#include <atomic>
 #include <chrono>
-#include <cstdlib>
 #include <condition_variable>
+#include <cstdlib>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -609,8 +609,8 @@ ostream& operator<<(ostream& out, const set<K, C, A>& s) {
 template <typename K, typename T, typename C, typename A>
 ostream& operator<<(ostream& out, const map<K, T, C, A>& m) {
     return out << "{" << souffle::join(m, ",", [](ostream& out, const pair<K, T>& cur) {
-        out << cur.first << "->" << cur.second;
-    }) << "}";
+               out << cur.first << "->" << cur.second;
+           }) << "}";
 }
 
 }  // end namespace std
@@ -1116,7 +1116,6 @@ public:
 
 /* end http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2406.html#shared_mutex */
 
-
 // -------------------------------------------------------------------------------
 //                           Hint / Cache Profiling
 // -------------------------------------------------------------------------------
@@ -1133,18 +1132,16 @@ inline bool isHintsProfilingEnabled() {
  * A utility class to keep track of cache hits/misses.
  */
 class CacheAccessCounter {
-
     bool active;
     std::atomic<std::size_t> hits;
     std::atomic<std::size_t> misses;
 
 public:
-
-    CacheAccessCounter(bool active = isHintsProfilingEnabled())
-        : active(active), hits(0), misses(0) {}
+    CacheAccessCounter(bool active = isHintsProfilingEnabled()) : active(active), hits(0), misses(0) {}
 
     CacheAccessCounter(const CacheAccessCounter& other)
-        : active(other.active), hits((active)?other.getHits():0), misses((active)?other.getMisses():0) {}
+            : active(other.active), hits((active) ? other.getHits() : 0),
+              misses((active) ? other.getMisses() : 0) {}
 
     void addHit() {
         if (active) hits.fetch_add(1, std::memory_order_relaxed);
@@ -1174,8 +1171,6 @@ public:
         misses = 0;
     }
 };
-
-
 
 }  // end namespace souffle
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -609,8 +609,8 @@ ostream& operator<<(ostream& out, const set<K, C, A>& s) {
 template <typename K, typename T, typename C, typename A>
 ostream& operator<<(ostream& out, const map<K, T, C, A>& m) {
     return out << "{" << souffle::join(m, ",", [](ostream& out, const pair<K, T>& cur) {
-               out << cur.first << "->" << cur.second;
-           }) << "}";
+        out << cur.first << "->" << cur.second;
+    }) << "}";
 }
 
 }  // end namespace std

--- a/src/Util.h
+++ b/src/Util.h
@@ -18,8 +18,10 @@
 
 #include "Macro.h"
 
+#include <atomic>
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
 #include <condition_variable>
 #include <iostream>
 #include <map>
@@ -1113,6 +1115,67 @@ public:
 };
 
 /* end http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2406.html#shared_mutex */
+
+
+// -------------------------------------------------------------------------------
+//                           Hint / Cache Profiling
+// -------------------------------------------------------------------------------
+
+/**
+ * A utility function to determine whether hints-profiling is enabled or
+ * disabled;
+ */
+inline bool isHintsProfilingEnabled() {
+    return std::getenv("SOUFFLE_PROFILE_HINTS");
+}
+
+/**
+ * A utility class to keep track of cache hits/misses.
+ */
+class CacheAccessCounter {
+
+    bool active;
+    std::atomic<std::size_t> hits;
+    std::atomic<std::size_t> misses;
+
+public:
+
+    CacheAccessCounter(bool active = isHintsProfilingEnabled())
+        : active(active), hits(0), misses(0) {}
+
+    CacheAccessCounter(const CacheAccessCounter& other)
+        : active(other.active), hits((active)?other.getHits():0), misses((active)?other.getMisses():0) {}
+
+    void addHit() {
+        if (active) hits.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void addMiss() {
+        if (active) misses.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    std::size_t getHits() const {
+        ASSERT(active);
+        return hits;
+    }
+
+    std::size_t getMisses() const {
+        ASSERT(active);
+        return misses;
+    }
+
+    std::size_t getAccesses() const {
+        ASSERT(active);
+        return getHits() + getMisses();
+    }
+
+    void reset() {
+        hits = 0;
+        misses = 0;
+    }
+};
+
+
 
 }  // end namespace souffle
 


### PR DESCRIPTION
A compiled analysis will automatically track and print operation hint statistics in case the `SOUFFLE_PROFILE_HINTS` environment variable is set.