### PR TITLE
Make substr error messages consistent between interpreted and compiled

### DIFF
--- a/src/RamExecutor.cpp
+++ b/src/RamExecutor.cpp
@@ -271,7 +271,7 @@ RamDomain eval(const RamValue& value, RamEnvironment& env, const EvalContext& ct
                         sub_str = str.substr(idx, len);
                     } catch (...) {
                         std::cerr << "warning: wrong index position provided by substr(\"";
-                        std::cerr << str << "\"," << idx << "," << len << ") functor.\n";
+                        std::cerr << str << "\"," << (int32_t)idx << "," << (int32_t)len << ") functor.\n";
                     }
                     return env.getSymbolTable().lookup(sub_str.c_str());
                 }
@@ -2277,7 +2277,8 @@ std::string RamCompiler::generateCode(const SymbolTable& symTable, const RamProg
     os << "   std::string sub_str, result; \n";
     os << "   try { result = std::string(str).substr(idx,len); } catch(...) { \n";
     os << "     std::cerr << \"warning: wrong index position provided by substr(\\\"\";\n";
-    os << "     std::cerr << str << \"\\\",\" << idx << \",\" << len << \") functor.\\n\";\n";
+    os << "     std::cerr << str << \"\\\",\" << (int32_t)idx << \",\" << (int32_t)len << \") "
+          "functor.\\n\";\n";
     os << "   } return result;\n";
     os << "}\n";
 


### PR DESCRIPTION
Error messages for substr use signed for interpreted and unsigned (auto) for compiled. Both are arguably correct. This PR casts the input position and length as a signed integer when reporting errors. This is most likely to be what the user needs (e.g. a position found using `strlen("") - 1 => -1`)

Fixes #464 