### PR TITLE
Memory leak fixes

### DIFF
--- a/src/ProvenanceTransformer.cpp
+++ b/src/ProvenanceTransformer.cpp
@@ -24,18 +24,18 @@ namespace souffle {
 const std::string identifierToString(const AstRelationIdentifier& name) {
     std::stringstream ss;
     ss << name;
-    return *(new std::string(ss.str()));
+    return ss.str();
 }
 
 inline AstRelationIdentifier makeRelationName(
         const AstRelationIdentifier& orig, const std::string& type, int num = -1) {
-    auto newName = new AstRelationIdentifier(identifierToString(orig));
-    newName->append(type);
+    AstRelationIdentifier newName(identifierToString(orig));
+    newName.append(type);
     if (num != -1) {
-        newName->append((const std::string&)std::to_string(num));
+        newName.append((const std::string&)std::to_string(num));
     }
 
-    return *newName;
+    return newName;
 }
 
 std::unique_ptr<AstRelation> makeInfoRelation(

--- a/src/RamExecutor.cpp
+++ b/src/RamExecutor.cpp
@@ -76,13 +76,12 @@ namespace {
 
 class EvalContext {
     std::vector<const RamDomain*> data;
-    std::vector<RamDomain>* returnValues;
-    std::vector<bool>* returnErrors;
-    const std::vector<RamDomain>* args;
+    std::vector<RamDomain>* returnValues = nullptr;
+    std::vector<bool>* returnErrors = nullptr;
+    const std::vector<RamDomain>* args = nullptr;
 
 public:
-    EvalContext(size_t size = 0, const std::vector<RamDomain>* args = new std::vector<RamDomain>())
-            : data(size), args(args) {}
+    EvalContext(size_t size = 0) : data(size) {}
 
     const RamDomain*& operator[](size_t index) {
         return data[index];
@@ -123,7 +122,7 @@ public:
     }
 
     RamDomain getArgument(size_t i) const {
-        assert(i < args->size() && "argument out of range");
+        assert(args != nullptr && i < args->size() && "argument out of range");
         return (*args)[i];
     }
 };

--- a/src/RamTranslator.cpp
+++ b/src/RamTranslator.cpp
@@ -350,35 +350,35 @@ std::unique_ptr<RamValue> translateValue(const AstArgument* arg, const ValueInde
     if (const AstVariable* var = dynamic_cast<const AstVariable*>(arg)) {
         ASSERT(index.isDefined(*var) && "variable not grounded");
         const Location& loc = index.getDefinitionPoint(*var);
-        val = std::unique_ptr<RamValue>(new RamElementAccess(loc.level, loc.component, loc.name));
+        val = std::make_unique<RamElementAccess>(loc.level, loc.component, loc.name);
     } else if (dynamic_cast<const AstUnnamedVariable*>(arg)) {
-        return nullptr;  // utilized to identify _ values
+        return nullptr;  // utilised to identify _ values
     } else if (const AstConstant* c = dynamic_cast<const AstConstant*>(arg)) {
-        val = std::unique_ptr<RamValue>(new RamNumber(c->getIndex()));
+        val = std::make_unique<RamNumber>(c->getIndex());
     } else if (const AstUnaryFunctor* uf = dynamic_cast<const AstUnaryFunctor*>(arg)) {
         val = std::unique_ptr<RamValue>(
                 new RamUnaryOperator(uf->getFunction(), translateValue(uf->getOperand(), index)));
     } else if (const AstBinaryFunctor* bf = dynamic_cast<const AstBinaryFunctor*>(arg)) {
-        val = std::unique_ptr<RamValue>(new RamBinaryOperator(
-                bf->getFunction(), translateValue(bf->getLHS(), index), translateValue(bf->getRHS(), index)));
+        val = std::make_unique<RamBinaryOperator>(
+                bf->getFunction(), translateValue(bf->getLHS(), index), translateValue(bf->getRHS(), index));
     } else if (const AstTernaryFunctor* tf = dynamic_cast<const AstTernaryFunctor*>(arg)) {
         val = std::unique_ptr<RamValue>(
                 new RamTernaryOperator(tf->getFunction(), translateValue(tf->getArg(0), index),
                         translateValue(tf->getArg(1), index), translateValue(tf->getArg(2), index)));
     } else if (dynamic_cast<const AstCounter*>(arg)) {
-        val = std::unique_ptr<RamValue>(new RamAutoIncrement());
+        val = std::make_unique<RamAutoIncrement>();
     } else if (const AstRecordInit* init = dynamic_cast<const AstRecordInit*>(arg)) {
         std::vector<std::unique_ptr<RamValue>> values;
         for (const auto& cur : init->getArguments()) {
             values.push_back(translateValue(cur, index));
         }
-        val = std::unique_ptr<RamValue>(new RamPack(std::move(values)));
+        val = std::make_unique<RamPack>(std::move(values));
     } else if (const AstAggregator* agg = dynamic_cast<const AstAggregator*>(arg)) {
         // here we look up the location the aggregation result gets bound
         auto loc = index.getAggregatorLocation(*agg);
-        val = std::unique_ptr<RamValue>(new RamElementAccess(loc.level, loc.component, loc.name));
+        val = std::make_unique<RamElementAccess>(loc.level, loc.component, loc.name);
     } else if (const AstSubroutineArgument* subArg = dynamic_cast<const AstSubroutineArgument*>(arg)) {
-        val = std::unique_ptr<RamValue>(new RamArgument(subArg->getNumber()));
+        val = std::make_unique<RamArgument>(subArg->getNumber());
     } else {
         std::cout << "Unsupported node type of " << arg << ": " << typeid(*arg).name() << "\n";
         ASSERT(false && "unknown AST node type not permissible");
@@ -579,7 +579,7 @@ std::unique_ptr<RamStatement> RamTranslator::translateClause(const AstClause& cl
 
         // check existence for original tuple if we have provenance
         if (Global::config().has("provenance")) {
-            auto uniquenessEnforcement = new RamNotExists(getRelation(&head));
+            auto uniquenessEnforcement = std::make_unique<RamNotExists>(getRelation(&head));
             auto arity = head.getArity() - 2;
 
             bool add = true;
@@ -601,7 +601,7 @@ std::unique_ptr<RamStatement> RamTranslator::translateClause(const AstClause& cl
             uniquenessEnforcement->addArg(nullptr);
 
             if (add) {
-                project->addCondition(std::unique_ptr<RamCondition>(uniquenessEnforcement), project);
+                project->addCondition(std::move(uniquenessEnforcement), project);
             }
         }
 

--- a/src/RamTranslator.cpp
+++ b/src/RamTranslator.cpp
@@ -1123,6 +1123,7 @@ void createAndLoad(std::unique_ptr<RamStatement>& current, const AstRelation* re
     }
     RamRelationIdentifier rrel = getRamRelationIdentifier(
             mrel, &typeEnv, getRelationName(mrel->getName()), mrel->getArity(), false, dir, ext);
+    delete mrel;
     // create and load the relation at the start
     appendStmt(current, std::make_unique<RamCreate>(rrel));
 
@@ -1151,7 +1152,7 @@ void printSizeStore(std::unique_ptr<RamStatement>& current, const AstRelation* r
     }
     RamRelationIdentifier rrel = getRamRelationIdentifier(
             mrel, &typeEnv, getRelationName(mrel->getName()), mrel->getArity(), false, dir, ext);
-
+    delete mrel;
     if (rel->isPrintSize()) {
         appendStmt(current, std::make_unique<RamPrintSize>(rrel));
     }


### PR DESCRIPTION
Fix a few small memory leaks.
Use make_unique instead of new in a few places to simplify leak debugging, and hopefully improve clarity.