### PR TITLE
Remove pthread dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -311,10 +311,6 @@ DIST_PACKAGING([debian ubuntu],[DEBIAN_PACKAGE],[DEBUILD],[debuild])
 DIST_PACKAGING([osx],[OSX_PACKAGE],[PKGBUILD],[pkgbuild])
 DIST_PACKAGING([bsd],[BSD_PACKAGE],[PKGBUILD],[pkgbuild])
 
-dnl Enable pthread library
-AC_CHECK_LIB(pthread, pthread_create,,
-          [AC_MSG_ERROR([required library pthread missing])])
-
 dnl Enables OpenMP in the souffle compiler and interpreter
 AC_OPENMP
 AS_VAR_APPEND(CXXFLAGS, [" $OPENMP_CFLAGS "])

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -21,11 +21,12 @@
 #include "RamNode.h"
 #include "RamOperation.h"
 #include "RamRelation.h"
+#include "RamValue.h"
 
-#include <map>
-#include <set>
-
-#include <pthread.h>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
 
 namespace souffle {
 


### PR DESCRIPTION
Remove pthread dependency by refactoring the interpreter's pthread mutex to instead use ParallelUtils Lock class (std::mutex).
The speed seems to be near identical, at least with the current interpreter's limited use of parallel code.