### PR TITLE
Update brew to work around travis issues.

### DIFF
--- a/.travis/osx/install.sh
+++ b/.travis/osx/install.sh
@@ -6,6 +6,7 @@ set -e
 set -x
 
 # Install requirements of MAC OS X
+brew update
 brew install md5sha1sum bison libtool
 brew link bison --force
 

--- a/.travis/osx/install_withgcc.sh
+++ b/.travis/osx/install_withgcc.sh
@@ -7,6 +7,7 @@ set -x
 
 # Install requirements of MAC OS X
 rm /usr/local/include/c++
+brew update
 brew install md5sha1sum bison libtool gcc
 brew link bison --force
 g++-7 --version


### PR DESCRIPTION
homebrew has had an update since the travis osx images were made which breaks brew operations unless update is run. This PR simply runs brew update before using brew.