### PR TITLE
Missing include file in CompiledSouffle.h

### DIFF
--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -26,6 +26,7 @@
 #include "SouffleInterface.h"
 #include "SymbolTable.h"
 
+#include <fstream>
 #include <array>
 #include <cmath>
 #include <iostream>

--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -26,9 +26,9 @@
 #include "SouffleInterface.h"
 #include "SymbolTable.h"
 
-#include <fstream>
 #include <array>
 #include <cmath>
+#include <fstream>
 #include <iostream>
 #include <map>
 #include <regex>


### PR DESCRIPTION
C++ Interface breaks without the <fstream> include