### PR TITLE
Continue executing if the debug directory has no files to delete.

### DIFF
--- a/.travis/osx/install.sh
+++ b/.travis/osx/install.sh
@@ -10,4 +10,4 @@ brew update
 brew install md5sha1sum bison libtool
 brew link bison --force
 
-rm /Users/travis/Library/Logs/DiagnosticReports/*
+rm /Users/travis/Library/Logs/DiagnosticReports/* || true

--- a/.travis/osx/install_withgcc.sh
+++ b/.travis/osx/install_withgcc.sh
@@ -12,4 +12,4 @@ brew install md5sha1sum bison libtool gcc
 brew link bison --force
 g++-7 --version
 
-rm /Users/travis/Library/Logs/DiagnosticReports/*
+rm /Users/travis/Library/Logs/DiagnosticReports/* || true


### PR DESCRIPTION
Currently on startup of a job we delete the contents of the osx debug directory so that all crash reports are from running tests. This fails if the debug directory is empty, which happens in some rare cases.

This PR is a simple change to prevent failure if there are no debug files to delete.