### PR TITLE
Handle Windows line endings on non-Windows systems.

### DIFF
--- a/src/ReadStreamCSV.h
+++ b/src/ReadStreamCSV.h
@@ -67,6 +67,10 @@ protected:
         if (!getline(file, line)) {
             return nullptr;
         }
+        // Handle Windows line endings on non-Windows systems
+        if (line.back() == '\r') {
+            line = line.substr(0, line.length() - 1);
+        }
         ++lineNumber;
 
         size_t start = 0, end = 0, columnsFilled = 0;


### PR DESCRIPTION
If Windows line endings are used on a non-Windows system, and the last column in an input csv file is a symbol, the \r was added to the symbol. This PR strips \r from the end of each input line.

Fixes #495 