### PR TITLE
Fix eqrel segfaults.

### DIFF
--- a/src/BinaryRelation.h
+++ b/src/BinaryRelation.h
@@ -106,8 +106,8 @@ public:
         // and this is not normal souffle behaviour
         // statesLock.lock_shared();
 
-        orderedStates.erase(x);
-        orderedStates.erase(y);
+        orderedStates.erase(sds.readOnlyFindNode(x));
+        orderedStates.erase(sds.readOnlyFindNode(y));
         sds.unionNodes(x, y);
 
         bool retval = contains(x, y);


### PR DESCRIPTION
When inserting new tuples erase stored tries for representative nodes, rather than actual nodes. This prevents re-use of stale tries.

Fixes #501 