### PR TITLE
Disable linux clang omp on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ aliases:
     os: linux
     # enable sudo for libomp-dev in debian-sid repository
     # It clashes with the existing repo if we add it here.
-    sudo: required
+    # sudo: required
     addons:
       apt:
         sources:
@@ -38,7 +38,7 @@ aliases:
         - *linux_deps
         - clang-4.0
         - gdb
-    install: ".travis/linux/clang_install.sh"
+    #install: ".travis/linux/clang_install.sh"
     before_script: ".travis/init_test.sh"
     script: ".travis/run_test.sh"
   - &linuxpackage


### PR DESCRIPTION
Travis uses Ubuntu 14.04 which is making newer (years old) dependencies fragile. This patch will disable clang until a better solution is found.