### PR TITLE
Clang/Linux build uses old version of G++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ aliases:
         - *linux_deps
         - clang-4.0
         - gdb
+        - g++-7
     #install: ".travis/linux/clang_install.sh"
     before_script: ".travis/init_test.sh"
     script: ".travis/run_test.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ aliases:
         - *linux_deps
         - clang-4.0
         - gdb
-        - g++-7
+        - g++-4.9
     #install: ".travis/linux/clang_install.sh"
     before_script: ".travis/init_test.sh"
     script: ".travis/run_test.sh"


### PR DESCRIPTION
Make sure that libtool uses a newer version of the G++ library >=4.9 for the clang/linux build