### PR TITLE
Update libstdc++ for clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,11 @@ aliases:
       apt:
         sources:
         - llvm-toolchain-trusty-4.0
+        - ubuntu-toolchain-r-test
         packages:
         - *linux_deps
         - clang-4.0
-        - gdb
+        - libstdc++-7-dev
     #install: ".travis/linux/clang_install.sh"
     before_script: ".travis/init_test.sh"
     script: ".travis/run_test.sh"

--- a/configure.ac
+++ b/configure.ac
@@ -291,6 +291,10 @@ DIST_PACKAGING([debian ubuntu],[DEBIAN_PACKAGE],[DEBUILD],[debuild])
 DIST_PACKAGING([osx],[OSX_PACKAGE],[PKGBUILD],[pkgbuild])
 DIST_PACKAGING([bsd],[BSD_PACKAGE],[PKGBUILD],[pkgbuild])
 
+dnl Enable pthread library
+AC_CHECK_LIB(pthread, pthread_create,,
+    [AC_MSG_ERROR([required library pthread missing])])
+
 dnl Enables OpenMP in the souffle compiler and interpreter
 AC_OPENMP
 AS_VAR_APPEND(CXXFLAGS, [" $OPENMP_CFLAGS "])


### PR DESCRIPTION
This PR fixes two related issues:
1. Clang uses an outdated libstdc++ on travis which lacks full support for regex
2. If we do have a more recent library, and clang does not use omp, it fails to build because it requires a pthread library. This issue could affect users more widely.
