### PR TITLE
Respect LDFLAGS given to configure for compiled souffle.

### DIFF
--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -101,7 +101,7 @@ cd "$OLDPWD"
 
 # Compile
 rm -f $dir/$exe
-$CXX $CXXFLAGS $CPPFLAGS -o$dir/$exe $1 $LIBS -I$HEADER_DIR $OMP_FLAG 2> $dir/$exe.$$.ccerr
+$CXX $CXXFLAGS $CPPFLAGS -o$dir/$exe $1 $LIBS -I$HEADER_DIR $OMP_FLAG $LDFLAGS 2> $dir/$exe.$$.ccerr
 if test -f $dir/$exe
 then
   if [ "$WARNINGS" = 1 ]


### PR DESCRIPTION
Currently souffle-compile does not use LDFLAGS, so any linker flags passed to the configure script are ignored when using `-c`. This PR fixes that.

This is useful if the user needs custom flags for their setup, such as for building on a different system such as FreeBSD or with a customised environment.