### PR TITLE
Defer execution of lsb_release to configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,7 +149,7 @@ if test -n "$SOUFFLE_PACKAGING"; then
       # Check for bison
       AC_CHECK_PROG(LSB_RELEASE, lsb_release, lsb_release)
       AS_IF([test -z "$LSB_RELEASE"], [AC_MSG_ERROR([lsb_release required to detect LINUX distribution not found.])])
-      DISTRIBUTION=m4_esyscmd([lsb_release -i | sed 's/^.*:[ \t]\+//' | tr [A-Z] [a-z]])
+      DISTRIBUTION=[`lsb_release -i | sed 's/^.*:[ \t]\+//' | tr '[A-Z]' '[a-z]'`]
     ;;
     *BSD*)
       DISTRIBUTION=bsd


### PR DESCRIPTION
m4_esyscmd was running lsb_release at the time autoconf was run so
DISTRIBUTION was being set according to the place that autoconf was
run, not where configure was run. Also quoted the arguments to tr to
avoid possible shell globbing.