### PR TITLE
64bit fixes

### DIFF
--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -111,7 +111,7 @@ void AstSemanticChecker::checkProgram(ErrorReport& report, const AstProgram& pro
             report.addError("Number constant (type mismatch)", cnst.getSrcLoc());
         }
         AstDomain idx = cnst.getIndex();
-        if (idx > 2147483647 || idx < -2147483648) {
+        if (idx > MAX_AST_DOMAIN || idx < MIN_AST_DOMAIN) {
             report.addError("Number constant not in range [-2^31, 2^31-1]", cnst.getSrcLoc());
         }
     });

--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -112,7 +112,9 @@ void AstSemanticChecker::checkProgram(ErrorReport& report, const AstProgram& pro
         }
         AstDomain idx = cnst.getIndex();
         if (idx > MAX_AST_DOMAIN || idx < MIN_AST_DOMAIN) {
-            report.addError("Number constant out of range", cnst.getSrcLoc());
+            report.addError("Number constant not in range [" + std::to_string(MIN_AST_DOMAIN) + ", " +
+                                    std::to_string(MAX_AST_DOMAIN) + "]",
+                    cnst.getSrcLoc());
         }
     });
 

--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -112,7 +112,7 @@ void AstSemanticChecker::checkProgram(ErrorReport& report, const AstProgram& pro
         }
         AstDomain idx = cnst.getIndex();
         if (idx > MAX_AST_DOMAIN || idx < MIN_AST_DOMAIN) {
-            report.addError("Number constant not in range [-2^31, 2^31-1]", cnst.getSrcLoc());
+            report.addError("Number constant out of range", cnst.getSrcLoc());
         }
     });
 

--- a/src/AstTypes.h
+++ b/src/AstTypes.h
@@ -20,14 +20,15 @@
 
 namespace souffle {
 
-/** ast domain to mimic ram domain */
+/** ast domain that contains ram domain */
 #ifdef AST_DOMAIN_TYPE
 typedef AST_DOMAIN_TYPE AstDomain;
 #else
 typedef int64_t AstDomain;
 #endif
 
-/** lower and upper boundaries for the ast domain **/
-#define MIN_AST_DOMAIN (std::numeric_limits<AstDomain>::min())
-#define MAX_AST_DOMAIN (std::numeric_limits<AstDomain>::max())
+/** Lower and upper boundaries for the AST domain. The range must be able to be stored in a RamDomain. By
+ *  default, RamDomain is uint32_t and the allowed AstDomain range is that of a int32_t. **/
+#define MIN_AST_DOMAIN (std::numeric_limits<int32_t>::min())
+#define MAX_AST_DOMAIN (std::numeric_limits<int32_t>::max())
 }  // namespace souffle

--- a/src/AstTypes.h
+++ b/src/AstTypes.h
@@ -29,5 +29,5 @@ typedef int64_t AstDomain;
 
 /** lower and upper boundaries for the ast domain **/
 #define MIN_AST_DOMAIN (std::numeric_limits<AstDomain>::min())
-#define MAX_Ast_DOMAIN (std::numeric_limits<AstDomain>::max())
+#define MAX_AST_DOMAIN (std::numeric_limits<AstDomain>::max())
 }  // namespace souffle

--- a/src/RamTypes.h
+++ b/src/RamTypes.h
@@ -28,8 +28,11 @@ namespace souffle {
  * Default type is int32_t; may be overridden by user
  * defining RAM_DOMAIN_TYPE.
  */
-#ifdef RAM_DOMAIN_TYPE
-typedef RAM_DOMAIN_TYPE RamDomain;
+
+#define RAM_DOMAIN_SIZE 32
+
+#if RAM_DOMAIN_SIZE == 64
+typedef int64_t RamDomain;
 #else
 typedef int32_t RamDomain;
 #endif

--- a/src/ReadStreamCSV.h
+++ b/src/ReadStreamCSV.h
@@ -111,8 +111,8 @@ protected:
                 } catch (...) {
                     if (!error) {
                         std::stringstream errorMessage;
-                        errorMessage << "Error converting number in column " << column + 1 << " in line "
-                                     << lineNumber << "; ";
+                        errorMessage << "Error converting number <" + element + "> in column " << column + 1
+                                     << " in line " << lineNumber << "; ";
                         throw std::invalid_argument(errorMessage.str());
                     }
                 }

--- a/src/ReadStreamCSV.h
+++ b/src/ReadStreamCSV.h
@@ -103,7 +103,11 @@ protected:
                 tuple[inputMap[column]] = symbolTable.unsafeLookup(element.c_str());
             } else {
                 try {
+#if RAM_DOMAIN_SIZE == 64
+                    tuple[inputMap[column]] = std::stoll(element.c_str());
+#else
                     tuple[inputMap[column]] = std::stoi(element.c_str());
+#endif
                 } catch (...) {
                     if (!error) {
                         std::stringstream errorMessage;

--- a/src/ReadStreamSQLite.h
+++ b/src/ReadStreamSQLite.h
@@ -70,7 +70,11 @@ protected:
                 tuple[column] = symbolTable.unsafeLookup(element.c_str());
             } else {
                 try {
+#if RAM_DOMAIN_SIZE == 64
+                    tuple[column] = std::stoll(element.c_str());
+#else
                     tuple[column] = std::stoi(element.c_str());
+#endif
                 } catch (...) {
                     std::stringstream errorMessage;
                     errorMessage << "Error converting number in column " << (column) + 1;

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1003,7 +1003,7 @@ public:
     // -- values --
     void visitNumber(const RamNumber& num, std::ostream& out) override {
         PRINT_BEGIN_COMMENT(out);
-        out << num.getConstant();
+        out << "RamDomain(" << num.getConstant() << ")";
         PRINT_END_COMMENT(out);
     }
 

--- a/src/WriteStreamCSV.h
+++ b/src/WriteStreamCSV.h
@@ -67,14 +67,14 @@ protected:
         if (symbolMask.isSymbol(0)) {
             file << symbolTable.unsafeResolve(tuple[0]);
         } else {
-            file << static_cast<int32_t>(tuple[0]);
+            file << tuple[0];
         }
         for (size_t col = 1; col < arity; ++col) {
             file << delimiter;
             if (symbolMask.isSymbol(col)) {
                 file << symbolTable.unsafeResolve(tuple[col]);
             } else {
-                file << static_cast<int32_t>(tuple[col]);
+                file << tuple[col];
             }
         }
         file << "\n";
@@ -116,14 +116,14 @@ protected:
         if (symbolMask.isSymbol(0)) {
             file << symbolTable.unsafeResolve(tuple[0]);
         } else {
-            file << static_cast<int32_t>(tuple[0]);
+            file << tuple[0];
         }
         for (size_t col = 1; col < arity; ++col) {
             file << delimiter;
             if (symbolMask.isSymbol(col)) {
                 file << symbolTable.unsafeResolve(tuple[col]);
             } else {
-                file << static_cast<int32_t>(tuple[col]);
+                file << tuple[col];
             }
         }
         file << "\n";
@@ -166,14 +166,14 @@ protected:
         if (symbolMask.isSymbol(0)) {
             std::cout << symbolTable.unsafeResolve(tuple[0]);
         } else {
-            std::cout << static_cast<int32_t>(tuple[0]);
+            std::cout << tuple[0];
         }
         for (size_t col = 1; col < arity; ++col) {
             std::cout << delimiter;
             if (symbolMask.isSymbol(col)) {
                 std::cout << symbolTable.unsafeResolve(tuple[col]);
             } else {
-                std::cout << static_cast<int32_t>(tuple[col]);
+                std::cout << tuple[col];
             }
         }
         std::cout << "\n";

--- a/src/WriteStreamSQLite.h
+++ b/src/WriteStreamSQLite.h
@@ -59,13 +59,17 @@ protected:
         }
 
         for (size_t i = 0; i < arity; i++) {
-            int32_t value;
+            RamDomain value;
             if (symbolMask.isSymbol(i)) {
                 value = getSymbolTableID(tuple[i]);
             } else {
-                value = (int32_t)tuple[i];
+                value = tuple[i];
             }
+#if RAM_DOMAIN_SIZE == 64
+            if (sqlite3_bind_int64(insertStatement, i + 1, value) != SQLITE_OK) {
+#else
             if (sqlite3_bind_int(insertStatement, i + 1, value) != SQLITE_OK) {
+#endif
                 throwError("SQLite error in sqlite3_bind_text: ");
             }
         }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -47,6 +47,7 @@
     #include "AstParserUtils.h"
 
     #include "AstSrcLocation.h"
+    #include "AstTypes.h"
 
     using namespace souffle;
 
@@ -171,7 +172,7 @@
 %token LOG                       "log"
 %token EXP                       "exp"
 
-%type <int>                              qualifiers
+%type <uint32_t>                         qualifiers
 %type <AstTypeIdentifier *>              type_id
 %type <AstRelationIdentifier *>          rel_id
 %type <AstType *>                        type

--- a/tests/semantic/load3/load3.err
+++ b/tests/semantic/load3/load3.err
@@ -1,1 +1,1 @@
-Error converting number in column 2 in line 2; cannot parse fact file A.facts!
+Error converting number <AA> in column 2 in line 2; cannot parse fact file A.facts!

--- a/tests/semantic/number_constants/number_constants.err
+++ b/tests/semantic/number_constants/number_constants.err
@@ -1,22 +1,22 @@
-Error: Number constant not in range [-2^31, 2^31-1] in file number_constants.dl at line 13
+Error: Number constant not in range [-2147483648, 2147483647] in file number_constants.dl at line 13
 R(2147483648). // error: out of range
 --^-----------------------------------
-Error: Number constant not in range [-2^31, 2^31-1] in file number_constants.dl at line 18
+Error: Number constant not in range [-2147483648, 2147483647] in file number_constants.dl at line 18
 R(-2147483649). // error: out of range
 ---^-----------------------------------
-Error: Number constant not in range [-2^31, 2^31-1] in file number_constants.dl at line 19
+Error: Number constant not in range [-2147483648, 2147483647] in file number_constants.dl at line 19
 R(- 2147483649). // error: out of range
 ----^-----------------------------------
-Error: Number constant not in range [-2^31, 2^31-1] in file number_constants.dl at line 30
+Error: Number constant not in range [-2147483648, 2147483647] in file number_constants.dl at line 30
 R(2147483647-2147483648). // error: out of range
 -------------^-----------------------------------
-Error: Number constant not in range [-2^31, 2^31-1] in file number_constants.dl at line 31
+Error: Number constant not in range [-2147483648, 2147483647] in file number_constants.dl at line 31
 R(2147483647- 2147483648). // error: out of range
 --------------^-----------------------------------
-Error: Number constant not in range [-2^31, 2^31-1] in file number_constants.dl at line 32
+Error: Number constant not in range [-2147483648, 2147483647] in file number_constants.dl at line 32
 R(2147483647 -2147483648). // error: out of range
 --------------^-----------------------------------
-Error: Number constant not in range [-2^31, 2^31-1] in file number_constants.dl at line 33
+Error: Number constant not in range [-2147483648, 2147483647] in file number_constants.dl at line 33
 R(2147483647 - 2147483648). // error: out of range
 ---------------^-----------------------------------
 7 errors generated, evaluation aborted


### PR DESCRIPTION
Support for 64 bit RamDomains has been questionable for some time. This PR is intended to make Souffle work when 64 bit RamDomains are enabled in RamTypes.h.

Fixes #559.