### PR TITLE
Only create github documentation if required token exists.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,6 +132,8 @@ jobs:
     - *gcc_environment
     before_deploy:
       - .travis/bintray_json.sh
+    # deploy to bintray if we're in the souffle-lang repo
+    # https://docs.travis-ci.com/user/deployment/bintray
     deploy:
       - provider: bintray
         skip-cleanup: true
@@ -163,6 +165,8 @@ jobs:
         - doxygen
         - graphviz
     script: "./bootstrap && ./configure && make doxygen-doc"
+    # update the gh-pages branch with doxygen output if the required github token has been set
+    # https://pages.github.com/
     deploy:
       provider: pages
       skip-cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -171,6 +171,7 @@ jobs:
       local-dir: doc/html
       on:
         branch: master
+        condition: -v $GHPAGES_TOKEN
 
 after_failure:
   - ".travis/after_failure.sh"


### PR DESCRIPTION
This PR is to fix travis build failurs for forks of souffle-lang. Behaviour is unchanged for souffle-lang.

The build requires a token to be set in travis so that the doxygen pages can be pushed, and breaks if the token does not exist.. This is fine for souffle-lang, which has a token, or any fork that wants documentation and generates their own token. For anyone else that forks, and enables travis, the build fails.