### PR TITLE
Permit functors to be grounded if their arguments are grounded.

### DIFF
--- a/src/AstTypeAnalysis.cpp
+++ b/src/AstTypeAnalysis.cpp
@@ -389,6 +389,31 @@ std::map<const AstArgument*, bool> getGroundedTerms(const AstClause& clause) {
         void visitAggregator(const AstAggregator& c) override {
             addConstraint(isTrue(getVar(c)));
         }
+
+        // #8 - functors with grounded values are grounded values
+        void visitUnaryFunctor(const AstUnaryFunctor& cur) override {
+            auto fun = getVar(cur);
+            auto arg = getVar(cur.getOperand());
+
+            addConstraint(imply(arg, fun));
+        }
+
+        void visitBinaryFunctor(const AstBinaryFunctor& cur) override {
+            auto fun = getVar(cur);
+            auto lhs = getVar(cur.getLHS());
+            auto rhs = getVar(cur.getRHS());
+
+            addConstraint(imply({lhs, rhs}, fun));
+        }
+
+        void visitTernaryFunctor(const AstTernaryFunctor& cur) override {
+            auto fun = getVar(cur);
+            auto a0 = getVar(cur.getArg(0));
+            auto a1 = getVar(cur.getArg(1));
+            auto a2 = getVar(cur.getArg(2));
+
+            addConstraint(imply({a0, a1, a2}, fun));
+        }
     };
 
     // run analysis on given clause

--- a/tests/semantic/rule_grounded/rule_grounded.dl
+++ b/tests/semantic/rule_grounded/rule_grounded.dl
@@ -18,3 +18,17 @@ A(x,z) :- B(x,y), C(y,z), !C(y,l).
 
 // l in constraint is not grounded
 A(x,z) :- B(x,y), C(y,z), y > l.
+
+.decl N (a:T, b:number)
+
+// unary functor ord(x) grounded if x grounded
+N(x,z) :- B(x,y), z = ord(y).
+
+// binary functor cat(x, y) grounded if x and y grounded
+A(x,z) :- B(x,y), z = cat(x, y).
+
+// ternary functor substr(y, 0, 1) grounded if y, 0, and 1 are grounded
+A(x,z) :- B(x,y), z = substr(y, 0, 1).
+
+// binary functor cat(x, y) not grounded if y not grounded
+A(x,z) :- B(x, _), z = cat(x, y).

--- a/tests/semantic/rule_grounded/rule_grounded.err
+++ b/tests/semantic/rule_grounded/rule_grounded.err
@@ -37,4 +37,13 @@ A(x,z) :- B(x,y), C(y,z), y > l.
 Warning: Variable l only occurs once in file rule_grounded.dl at line 20
 A(x,z) :- B(x,y), C(y,z), y > l.
 ------------------------------^--
-8 errors generated, evaluation aborted
+Error: Ungrounded variable z in file rule_grounded.dl at line 34
+A(x,z) :- B(x, _), z = cat(x, y).
+----^-----------------------------
+Error: Ungrounded variable y in file rule_grounded.dl at line 34
+A(x,z) :- B(x, _), z = cat(x, y).
+------------------------------^---
+Warning: Variable y only occurs once in file rule_grounded.dl at line 34
+A(x,z) :- B(x, _), z = cat(x, y).
+------------------------------^---
+10 errors generated, evaluation aborted


### PR DESCRIPTION
I recently ran into an issue where I wanted to do something like the following:

    Predicate(x, y, z) :-
        Domain(x, y),
        // synthesize a new symbol from x and y
        z = cat(cat(x, y), "/new-symbol")

Souffle currently concludes that `z` is ungrounded in the predicate above, even though it seems (to me at least) that it should be grounded: because the only non-constant inputs (`x` and `y`) are grounded, and the result is a function of those inputs, the result should be grounded as well.

This PR changes the groundedness analysis to incorporate constraints that enable this behavior, and adds a few test cases as well.

I'm not sure if you have a higher-level process to discuss or standardize language changes, and this does change semantics (the set of accepted programs should be a superset of what was accepted previously, though), so please let me know if there's some other way I should go about doing this! Thanks!