### PR TITLE
Add configure flag for `--enable-64bit-domain` option.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -186,7 +186,7 @@ AS_IF([test "x$enable_intel_rtm" = "xyes"], [
 
 AC_ARG_ENABLE(
   [64bit-domain],
-  [AS_HELP_STRING([--enable-64bit-domain], [Enable 64-bit number values in Datalog records])]
+  [AS_HELP_STRING([--enable-64bit-domain], [Enable 64-bit number values in Datalog tuples])]
 )
 AS_IF([test "x$enable_64bit_domain" = "xyes"], [
   AS_VAR_APPEND(CXXFLAGS, [" -DRAM_DOMAIN_SIZE=64"])

--- a/configure.ac
+++ b/configure.ac
@@ -184,6 +184,14 @@ AS_IF([test "x$enable_intel_rtm" = "xyes"], [
   AS_VAR_APPEND(CXXFLAGS, [" -mrtm -DHAS_TSX"])
 ])
 
+AC_ARG_ENABLE(
+  [64bit-domain],
+  [AS_HELP_STRING([--enable-64bit-domain], [Enable 64-bit number values in Datalog records])]
+)
+AS_IF([test "x$enable_64bit_domain" = "xyes"], [
+  AS_VAR_APPEND(CXXFLAGS, [" -DRAM_DOMAIN_SIZE=64"])
+])
+
 dnl Check for the program(s), define a variable and perform substitution in the
 dnl Makefiles if found.  Bail with an error message otherwise
 dnl   $1 -- Variable

--- a/src/AstTypes.h
+++ b/src/AstTypes.h
@@ -18,6 +18,8 @@
 
 #include <stdint.h>
 
+#include "RamTypes.h"
+
 namespace souffle {
 
 /** ast domain that contains ram domain */
@@ -28,14 +30,8 @@ typedef int64_t AstDomain;
 #endif
 
 /** Lower and upper boundaries for the AST domain. The range must be able to be
- * stored in a RamDomain. By default, RamDomain is int32_t and the allowed
- * AstDomain range is that of a int32_t. The 64-bit case is active if the
- * user configured the build accordingly (with --enable-64bit-domain). **/
-#if RAM_DOMAIN_SIZE == 64
-#define MIN_AST_DOMAIN (std::numeric_limits<int64_t>::min())
-#define MAX_AST_DOMAIN (std::numeric_limits<int64_t>::max())
-#else
-#define MIN_AST_DOMAIN (std::numeric_limits<int32_t>::min())
-#define MAX_AST_DOMAIN (std::numeric_limits<int32_t>::max())
-#endif
+ * stored in a RamDomain, so we simply compute the limits of that type. **/
+#define MIN_AST_DOMAIN (std::numeric_limits<RamDomain>::min())
+#define MAX_AST_DOMAIN (std::numeric_limits<RamDomain>::max())
+
 }  // namespace souffle

--- a/src/AstTypes.h
+++ b/src/AstTypes.h
@@ -27,8 +27,15 @@ typedef AST_DOMAIN_TYPE AstDomain;
 typedef int64_t AstDomain;
 #endif
 
-/** Lower and upper boundaries for the AST domain. The range must be able to be stored in a RamDomain. By
- *  default, RamDomain is uint32_t and the allowed AstDomain range is that of a int32_t. **/
-#define MIN_AST_DOMAIN (std::numeric_limits<AstDomain>::min())
-#define MAX_AST_DOMAIN (std::numeric_limits<AstDomain>::max())
+/** Lower and upper boundaries for the AST domain. The range must be able to be
+ * stored in a RamDomain. By default, RamDomain is int32_t and the allowed
+ * AstDomain range is that of a int32_t. The 64-bit case is active if the
+ * user configured the build accordingly (with --enable-64bit-domain). **/
+#if RAM_DOMAIN_SIZE == 64
+#define MIN_AST_DOMAIN (std::numeric_limits<int64_t>::min())
+#define MAX_AST_DOMAIN (std::numeric_limits<int64_t>::max())
+#else
+#define MIN_AST_DOMAIN (std::numeric_limits<int32_t>::min())
+#define MAX_AST_DOMAIN (std::numeric_limits<int32_t>::max())
+#endif
 }  // namespace souffle

--- a/src/AstTypes.h
+++ b/src/AstTypes.h
@@ -29,6 +29,6 @@ typedef int64_t AstDomain;
 
 /** Lower and upper boundaries for the AST domain. The range must be able to be stored in a RamDomain. By
  *  default, RamDomain is uint32_t and the allowed AstDomain range is that of a int32_t. **/
-#define MIN_AST_DOMAIN (std::numeric_limits<int32_t>::min())
-#define MAX_AST_DOMAIN (std::numeric_limits<int32_t>::max())
+#define MIN_AST_DOMAIN (std::numeric_limits<AstDomain>::min())
+#define MAX_AST_DOMAIN (std::numeric_limits<AstDomain>::max())
 }  // namespace souffle

--- a/src/RamTypes.h
+++ b/src/RamTypes.h
@@ -29,7 +29,9 @@ namespace souffle {
  * defining RAM_DOMAIN_TYPE.
  */
 
+#ifndef RAM_DOMAIN_SIZE
 #define RAM_DOMAIN_SIZE 32
+#endif
 
 #if RAM_DOMAIN_SIZE == 64
 typedef int64_t RamDomain;


### PR DESCRIPTION
This PR adds a flag to the `configure` script so that 64-bit domain support can be enabled without editing the source code. It is (still) off by default.

It also fixes a minor issue with 64-bit domain support: namely, it ensures that the AST integer-constant range checks are using the configured range, rather than a hard-coded `int32_t`.

This lets me use upstream Souffle without a one-line patch, so it makes my life a bit easier, but if you'd like more tests for 64-bit domains or whatnot before exposing an option to the user, I understand that too. Thanks either way!