### PR TITLE
Improve handling user input in provenance browser

### DIFF
--- a/src/Explain.h
+++ b/src/Explain.h
@@ -183,7 +183,10 @@ public:
                 prefresh(treePad, 0, 0, 0, 0, maxy - 3, maxx - 1);
             } else {
                 std::cout << "Enter command > ";
-                getline(std::cin, line);
+                if (!getline(std::cin, line)) {
+                    printStr("Exiting explain\n");
+                    break;
+                }
             }
 
             std::vector<std::string> command = split(line, ' ', 1);

--- a/src/Explain.h
+++ b/src/Explain.h
@@ -129,6 +129,7 @@ private:
             } else if (ch == KEY_DOWN) {
                 if (y < MAX_TREE_HEIGHT - 1) y += 1;
             } else {
+                ungetch(ch);
                 break;
             }
 
@@ -240,7 +241,10 @@ public:
                     printStr("Usage: printrel <relation name>\n");
                     continue;
                 }
-            } else if (command[0] == "help") {
+            } else if (command[0] == "exit") {
+                printStr("Exiting explain\n");
+                break;
+            } else {
                 printStr(
                         "\n----------\n"
                         "Commands:\n"
@@ -252,9 +256,6 @@ public:
                         "rule <rule number>: Prints a rule\n"
                         "printrel <relation name>: Prints the tuples of a relation\n"
                         "exit: Exits this interface\n\n");
-            } else if (command[0] == "exit") {
-                printStr("Exiting explain\n");
-                break;
             }
 
             // refresh treePad and allow scrolling


### PR DESCRIPTION
Ctrl+D exits the std::cin provenance browser
Exiting the scroll function puts back the non-scroll key. i.e. the first letter of a new command is not discarded.
Any invalid commands show the help function.

Fixes #585 