### PR TITLE
Add test compilation error output to after_failure logs.

### DIFF
--- a/.travis/after_failure.sh
+++ b/.travis/after_failure.sh
@@ -25,7 +25,7 @@ pretty_print () {
 }
 
 TEST_ROOT=`find . -type d -name "testsuite.dir" | head -1`
-RELEVANT_EXTENSIONS=".out .err .log"
+RELEVANT_EXTENSIONS=".out .err .log .ccerr"
 MAXIMUM_LINES="200"
 
 # Show the current directory, and the contents of each direct subdirectory


### PR DESCRIPTION
With this (tiny) PR, the `after_failure` script on travis will show the output of failed compilation when using `-c`. This is helpful with more obscure, environment dependent, c++ compilation bugs