### PR TITLE
Added type analysis to the debug report.

### DIFF
--- a/src/AstTypeAnalysis.h
+++ b/src/AstTypeAnalysis.h
@@ -67,11 +67,14 @@ public:
 class TypeAnalysis : public AstAnalysis {
 private:
     std::map<const AstArgument*, TypeSet> argumentTypes;
+    std::vector<std::unique_ptr<AstClause>> annotatedClauses;
 
 public:
     static constexpr const char* name = "type-analysis";
 
     void run(const AstTranslationUnit& translationUnit) override;
+
+    void print(std::ostream& os) const override;
 
     /**
      * Get the computed types for the given argument.

--- a/src/DebugReport.cpp
+++ b/src/DebugReport.cpp
@@ -16,6 +16,7 @@
 
 #include "DebugReport.h"
 #include "AstTranslationUnit.h"
+#include "AstTypeAnalysis.h"
 #include "MagicSet.h"
 #include "PrecedenceGraph.h"
 
@@ -214,6 +215,10 @@ void DebugReporter::generateDebugReport(
 
     DebugReportSection datalogSection = getCodeSection(id + "-dl", "Datalog", datalogSpec.str());
 
+    std::stringstream typeAnalysis;
+    translationUnit.getAnalysis<TypeAnalysis>()->print(typeAnalysis);
+    DebugReportSection typeAnalysisSection = getCodeSection(id + "-ta", "Type Analysis", typeAnalysis.str());
+
     std::stringstream precGraphDot;
     translationUnit.getAnalysis<PrecedenceGraph>()->print(precGraphDot);
     DebugReportSection precedenceGraphSection =
@@ -230,7 +235,9 @@ void DebugReporter::generateDebugReport(
             getCodeSection(id + "-topsort-scc-graph", "SCC Topological Sort Order", topsortSCCGraph.str());
 
     translationUnit.getDebugReport().addSection(DebugReportSection(id, title,
-            {datalogSection, precedenceGraphSection, sccGraphSection, topsortSCCGraphSection}, ""));
+            {datalogSection, typeAnalysisSection, precedenceGraphSection, sccGraphSection,
+                    topsortSCCGraphSection},
+            ""));
 }
 
 }  // end of namespace souffle


### PR DESCRIPTION
Added a section in the debug report that displays type analysis information after each transformation in the form of annotated clauses, where each variable x is renamed to x&isin;{\<type-set\>}.

E.g. the following program:
```
.number_type mild_num
.number_type EXTREME_NUM
.type text

.decl a(x:mild_num, y:text, z:EXTREME_NUM)
a(1, "hello", 1000).
a(x,y,z) :- a(x,y,z), b(x,_).

.decl b(x:mild_num, y:text)
b(1, "bye").
```

will display the following variable type analysis summary after the parsing stage in the debug report:
```
a(1,"hello",1000).
a(x∈{mild_num},y∈{text},z∈{EXTREME_NUM}) :- 
   a(x∈{mild_num},y∈{text},z∈{EXTREME_NUM}),
   b(x∈{mild_num},_∈{text}).
b(1,"bye").
```
