### PR TITLE
Fix compilation error in 64bit mode

### DIFF
--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -239,7 +239,8 @@ public:
 
         iterator(const InterpreterRelation* const relation)
                 : relation(relation), index(0),
-                  tuple(relation->arity == 0 ? reinterpret_cast<RamDomain*>(this) : &relation->blockList[0][0]) {}
+                  tuple(relation->arity == 0 ? reinterpret_cast<RamDomain*>(this)
+                                             : &relation->blockList[0][0]) {}
 
         const RamDomain* operator*() {
             return tuple;

--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -239,7 +239,7 @@ public:
 
         iterator(const InterpreterRelation* const relation)
                 : relation(relation), index(0),
-                  tuple(relation->arity == 0 ? reinterpret_cast<int*>(this) : &relation->blockList[0][0]) {}
+                  tuple(relation->arity == 0 ? reinterpret_cast<RamDomain*>(this) : &relation->blockList[0][0]) {}
 
         const RamDomain* operator*() {
             return tuple;


### PR DESCRIPTION
An compilation error occurs when `--enable-64bit-domain` is enabled.
Compiler Version: `gcc version 6.3.0 20170516 (Debian 6.3.0-18)`
Error message:
```
InterpreterRelation.h:242:104: error: conditional expression between distinct pointer types 'int*' and 'long int*' lacks a cast [-fpermissive]
tuple(relation->arity == 0 ? reinterpret_cast<int*>(this) : &relation->blockList[0][0]) {}
```