### PR TITLE
Add tests compiled with 64bit ramdomains.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,13 @@ jobs:
     - *gcc_environment
     - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile,Provenance SOUFFLE_CONFS="-j8,-c -j8"
 
+# Testing stage with 64bit RamDomains (-j8,-c -j8, no 32bit Semantic tests)
+  - <<: *linuxgcc
+    before_script: ".travis/init_test_64bit.sh" 
+    env:
+    - *gcc_environment
+    - SOUFFLE_CATEGORY=Unit,Syntactic,Interface,Profile,Provenance SOUFFLE_CONFS="-j8,-c -j8"
+
 # Testing stage (-j8,-c -j8)
   - <<: *linuxgcc
     env:

--- a/.travis/init_test_64bit.sh
+++ b/.travis/init_test_64bit.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+# Enable debugging and logging of shell operations
+# that are executed.
+set -e
+set -x
+
+# configure project
+
+# create configure files
+./bootstrap
+./configure --enable-64bit-domain
+make -j2
+


### PR DESCRIPTION
This PR adds tests using 64 bit RamDomains so we don't break support again.

Semantic tests are not included since they contain tests that specifically test 32bit RamDomain handling.