### PR TITLE
Refactor SymbolTable

### DIFF
--- a/src/AstArgument.h
+++ b/src/AstArgument.h
@@ -201,16 +201,16 @@ protected:
  * Subclass of Argument that represents a datalog constant value
  */
 class AstStringConstant : public AstConstant {
-    SymbolTable* symTable;
-    AstStringConstant(SymbolTable* symTable, size_t index) : AstConstant(index), symTable(symTable) {}
+    SymbolTable& symTable;
+    AstStringConstant(SymbolTable& symTable, size_t index) : AstConstant(index), symTable(symTable) {}
 
 public:
-    AstStringConstant(SymbolTable& symTable, const char* c)
-            : AstConstant(symTable.lookup(c)), symTable(&symTable) {}
+    AstStringConstant(SymbolTable& symTable, const std::string& c)
+            : AstConstant(symTable.lookup(c)), symTable(symTable) {}
 
     /** @return String representation of this Constant */
-    const std::string getConstant() const {
-        return symTable->resolve(getIndex());
+    const std::string& getConstant() const {
+        return symTable.resolve(getIndex());
     }
 
     /**  Print argument to the given output stream */

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -81,7 +81,7 @@ RamDomain Interpreter::evalVal(const RamValue& value, const InterpreterContext& 
                 case UnaryOp::ORD:
                     return arg;
                 case UnaryOp::STRLEN:
-                    return strlen(interpreter.getSymbolTable().resolve(arg));
+                    return interpreter.getSymbolTable().resolve(arg).size();
                 default:
                     assert(0 && "unsupported operator");
                     return 0;

--- a/src/MagicSet.cpp
+++ b/src/MagicSet.cpp
@@ -991,7 +991,7 @@ AstArgument* extractConstant(SymbolTable& symbolTable, std::string normalisedCon
 
     if (indicatorChar == 's') {
         // string argument
-        return new AstStringConstant(symbolTable, stringRep.c_str());
+        return new AstStringConstant(symbolTable, stringRep);
     } else if (indicatorChar == 'n') {
         // numeric argument
         return new AstNumberConstant(stoi(stringRep));

--- a/src/ProvenanceTransformer.cpp
+++ b/src/ProvenanceTransformer.cpp
@@ -66,11 +66,11 @@ std::unique_ptr<AstRelation> makeInfoRelation(
                     new AstAttribute(std::string("rel_") + std::to_string(i), AstTypeIdentifier("symbol"))));
 
             if (dynamic_cast<AstAtom*>(lit)) {
-                infoClauseHead->addArgument(std::unique_ptr<AstArgument>(
-                        new AstStringConstant(translationUnit.getSymbolTable(), relName.c_str())));
+                infoClauseHead->addArgument(
+                        std::make_unique<AstStringConstant>(translationUnit.getSymbolTable(), relName));
             } else if (dynamic_cast<AstNegation*>(lit)) {
-                infoClauseHead->addArgument(std::unique_ptr<AstArgument>(
-                        new AstStringConstant(translationUnit.getSymbolTable(), ("!" + relName).c_str())));
+                infoClauseHead->addArgument(std::make_unique<AstStringConstant>(
+                        translationUnit.getSymbolTable(), ("!" + relName)));
             }
         }
     }
@@ -80,8 +80,8 @@ std::unique_ptr<AstRelation> makeInfoRelation(
     originalClause.print(ss);
 
     infoRelation->addAttribute(std::make_unique<AstAttribute>("clause_repr", AstTypeIdentifier("symbol")));
-    infoClauseHead->addArgument(std::unique_ptr<AstArgument>(
-            new AstStringConstant(translationUnit.getSymbolTable(), ss.str().c_str())));
+    infoClauseHead->addArgument(
+            std::make_unique<AstStringConstant>(translationUnit.getSymbolTable(), ss.str()));
 
     // set clause head and add clause to info relation
     infoClause->setHead(std::unique_ptr<AstAtom>(infoClauseHead));

--- a/src/ReadStreamCSV.h
+++ b/src/ReadStreamCSV.h
@@ -100,13 +100,13 @@ protected:
             }
             ++columnsFilled;
             if (symbolMask.isSymbol(column)) {
-                tuple[inputMap[column]] = symbolTable.unsafeLookup(element.c_str());
+                tuple[inputMap[column]] = symbolTable.unsafeLookup(element);
             } else {
                 try {
 #if RAM_DOMAIN_SIZE == 64
-                    tuple[inputMap[column]] = std::stoll(element.c_str());
+                    tuple[inputMap[column]] = std::stoll(element);
 #else
-                    tuple[inputMap[column]] = std::stoi(element.c_str());
+                    tuple[inputMap[column]] = std::stoi(element);
 #endif
                 } catch (...) {
                     if (!error) {

--- a/src/ReadStreamSQLite.h
+++ b/src/ReadStreamSQLite.h
@@ -67,13 +67,13 @@ protected:
                 element = "n/a";
             }
             if (symbolMask.isSymbol(column)) {
-                tuple[column] = symbolTable.unsafeLookup(element.c_str());
+                tuple[column] = symbolTable.unsafeLookup(element);
             } else {
                 try {
 #if RAM_DOMAIN_SIZE == 64
-                    tuple[column] = std::stoll(element.c_str());
+                    tuple[column] = std::stoll(element);
 #else
-                    tuple[column] = std::stoi(element.c_str());
+                    tuple[column] = std::stoi(element);
 #endif
                 } catch (...) {
                     std::stringstream errorMessage;

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -36,10 +36,10 @@ namespace souffle {
  * SymbolTable stores Datalog symbols and converts them to numbers and vice versa.
  */
 class SymbolTable {
+private:
     /** A lock to synchronize parallel accesses */
     mutable Lock access;
 
-private:
     /** Map indices to strings. */
     std::deque<std::string> numToStr;
 

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -20,11 +20,11 @@
 #include "RamTypes.h"
 #include "Util.h"
 
+#include <deque>
 #include <iostream>
 #include <set>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 namespace souffle {
 
@@ -41,7 +41,7 @@ class SymbolTable {
 
 private:
     /** Map indices to strings. */
-    std::vector<std::string> numToStr;
+    std::deque<std::string> numToStr;
 
     /** Map strings to indices. */
     std::unordered_map<std::string, size_t> strToNum;
@@ -154,7 +154,6 @@ public:
         auto lease = access.acquire();
         (void)lease;  // avoid warning;
         strToNum.reserve(size() + symbols.size());
-        numToStr.reserve(size() + symbols.size());
         for (auto& symbol : symbols) {
             newSymbol(symbol);
         }

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -128,19 +128,20 @@ public:
 
     /** Find a symbol in the table by its index, note that this gives an error if the index is out of bounds.
      */
-    const std::string& resolve(const size_t index) const {
+    const std::string& resolve(const RamDomain index) const {
         auto lease = access.acquire();
         (void)lease;  // avoid warning;
-        if (index >= size()) {
+        size_t pos = static_cast<size_t>(index);
+        if (pos >= size()) {
             // TODO: use different error reporting here!!
             std::cerr << "Error index out of bounds in call to SymbolTable::resolve.\n";
             exit(1);
         }
-        return numToStr[index];
+        return numToStr[pos];
     }
 
-    const std::string& unsafeResolve(const size_t index) const {
-        return numToStr[index];
+    const std::string& unsafeResolve(const RamDomain index) const {
+        return numToStr[static_cast<size_t>(index)];
     }
 
     /* Return the size of the symbol table, being the number of symbols it currently holds. */

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -22,7 +22,6 @@
 
 #include <deque>
 #include <iostream>
-#include <set>
 #include <string>
 #include <unordered_map>
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1089,9 +1089,9 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                     out << "symTable.lookup(";
                     out << "symTable.resolve(";
                     visit(op.getLHS(), out);
-                    out << ") + std::string(symTable.resolve(";
+                    out << ") + symTable.resolve(";
                     visit(op.getRHS(), out);
-                    out << ")))";
+                    out << "))";
                     break;
                 }
                 default:

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -949,9 +949,9 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                     visit(op.getValue(), out);
                     break;
                 case UnaryOp::STRLEN:
-                    out << "strlen(symTable.resolve((size_t)";
+                    out << "symTable.resolve((size_t)";
                     visit(op.getValue(), out);
-                    out << "))";
+                    out << ").size()";
                     break;
                 case UnaryOp::NEG:
                     out << "(-(";
@@ -1086,12 +1086,12 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 
                 // strings
                 case BinaryOp::CAT: {
-                    out << "(RamDomain)symTable.lookup(";
-                    out << "(std::string(symTable.resolve((size_t)";
+                    out << "symTable.lookup(";
+                    out << "symTable.resolve(";
                     visit(op.getLHS(), out);
-                    out << ")) + std::string(symTable.resolve((size_t)";
+                    out << ") + std::string(symTable.resolve(";
                     visit(op.getRHS(), out);
-                    out << "))).c_str())";
+                    out << ")))";
                     break;
                 }
                 default:
@@ -1105,13 +1105,13 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             switch (op.getOperator()) {
                 case TernaryOp::SUBSTR:
                     out << "(RamDomain)symTable.lookup(";
-                    out << "(substr_wrapper(symTable.resolve((size_t)";
+                    out << "substr_wrapper(symTable.resolve(";
                     visit(op.getArg(0), out);
                     out << "),(";
                     visit(op.getArg(1), out);
                     out << "),(";
                     visit(op.getArg(2), out);
-                    out << ")).c_str()))";
+                    out << ")))";
                     break;
                 default:
                     assert(0 && "Unsupported Operation!");
@@ -1197,9 +1197,9 @@ void Synthesiser::generateCode(const RamTranslationUnit& unit, std::ostream& os,
           "<< text << \"\\\")\\n\";\n}\n";
     os << "   return result;\n";
     os << "}\n";
-    os << "static inline std::string substr_wrapper(const char *str, size_t idx, size_t len) {\n";
-    os << "   std::string sub_str, result; \n";
-    os << "   try { result = std::string(str).substr(idx,len); } catch(...) { \n";
+    os << "static inline std::string substr_wrapper(const std::string& str, size_t idx, size_t len) {\n";
+    os << "   std::string result; \n";
+    os << "   try { result = str.substr(idx,len); } catch(...) { \n";
     os << "     std::cerr << \"warning: wrong index position provided by substr(\\\"\";\n";
     os << "     std::cerr << str << \"\\\",\" << (int32_t)idx << \",\" << (int32_t)len << \") "
           "functor.\\n\";\n";
@@ -1299,12 +1299,12 @@ void Synthesiser::generateCode(const RamTranslationUnit& unit, std::ostream& os,
 
     if (symTable.size() > 0) {
         os << "// -- initialize symbol table --\n";
-        os << "static const char *symbols[]={\n";
+        os << "static const std::vector<std::string> symbols = {\n";
         for (size_t i = 0; i < symTable.size(); i++) {
             os << "\tR\"(" << symTable.resolve(i) << ")\",\n";
         }
         os << "};\n";
-        os << "symTable.insert(symbols," << symTable.size() << ");\n";
+        os << "symTable.insert(symbols);\n";
         os << "\n";
     }
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -845,35 +845,35 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 
                 // strings
                 case BinaryConstraintOp::MATCH: {
-                    out << "regex_wrapper(symTable.resolve((size_t)";
+                    out << "regex_wrapper(symTable.resolve(";
                     visit(rel.getLHS(), out);
-                    out << "),symTable.resolve((size_t)";
+                    out << "),symTable.resolve(";
                     visit(rel.getRHS(), out);
                     out << "))";
                     break;
                 }
                 case BinaryConstraintOp::NOT_MATCH: {
-                    out << "!regex_wrapper(symTable.resolve((size_t)";
+                    out << "!regex_wrapper(symTable.resolve(";
                     visit(rel.getLHS(), out);
-                    out << "),symTable.resolve((size_t)";
+                    out << "),symTable.resolve(";
                     visit(rel.getRHS(), out);
                     out << "))";
                     break;
                 }
                 case BinaryConstraintOp::CONTAINS: {
-                    out << "(std::string(symTable.resolve((size_t)";
+                    out << "(symTable.resolve(";
                     visit(rel.getRHS(), out);
-                    out << ")).find(symTable.resolve((size_t)";
+                    out << ").find(symTable.resolve(";
                     visit(rel.getLHS(), out);
-                    out << "))!=std::string::npos)";
+                    out << ")) != std::string::npos)";
                     break;
                 }
                 case BinaryConstraintOp::NOT_CONTAINS: {
-                    out << "(std::string(symTable.resolve((size_t)";
+                    out << "(symTable.resolve(";
                     visit(rel.getRHS(), out);
-                    out << ")).find(symTable.resolve((size_t)";
+                    out << ").find(symTable.resolve(";
                     visit(rel.getLHS(), out);
-                    out << "))==std::string::npos)";
+                    out << ")) == std::string::npos)";
                     break;
                 }
                 default:
@@ -1104,7 +1104,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             PRINT_BEGIN_COMMENT(out);
             switch (op.getOperator()) {
                 case TernaryOp::SUBSTR:
-                    out << "(RamDomain)symTable.lookup(";
+                    out << "symTable.lookup(";
                     out << "substr_wrapper(symTable.resolve(";
                     visit(op.getArg(0), out);
                     out << "),(";
@@ -1190,7 +1190,7 @@ void Synthesiser::generateCode(const RamTranslationUnit& unit, std::ostream& os,
     // print wrapper for regex
     os << "class " << classname << " : public SouffleProgram {\n";
     os << "private:\n";
-    os << "static inline bool regex_wrapper(const char *pattern, const char *text) {\n";
+    os << "static inline bool regex_wrapper(const std::string& pattern, const std::string& text) {\n";
     os << "   bool result = false; \n";
     os << "   try { result = std::regex_match(text, std::regex(pattern)); } catch(...) { \n";
     os << "     std::cerr << \"warning: wrong pattern provided for match(\\\"\" << pattern << \"\\\",\\\"\" "

--- a/src/WriteStreamSQLite.h
+++ b/src/WriteStreamSQLite.h
@@ -104,7 +104,7 @@ private:
     }
 
     uint64_t getSymbolTableIDFromDB(int index) {
-        if (sqlite3_bind_text(symbolSelectStatement, 1, symbolTable.unsafeResolve(index), -1,
+        if (sqlite3_bind_text(symbolSelectStatement, 1, symbolTable.unsafeResolve(index).c_str(), -1,
                     SQLITE_TRANSIENT) != SQLITE_OK) {
             throwError("SQLite error in sqlite3_bind_text: ");
         }
@@ -121,7 +121,7 @@ private:
             return dbSymbolTable[index];
         }
 
-        if (sqlite3_bind_text(symbolInsertStatement, 1, symbolTable.unsafeResolve(index), -1,
+        if (sqlite3_bind_text(symbolInsertStatement, 1, symbolTable.unsafeResolve(index).c_str(), -1,
                     SQLITE_TRANSIENT) != SQLITE_OK) {
             throwError("SQLite error in sqlite3_bind_text: ");
         }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -499,7 +499,7 @@ iodirective
 /* Atom */
 arg
   : STRING {
-        $$ = new AstStringConstant(driver.getSymbolTable(), $1.c_str());
+        $$ = new AstStringConstant(driver.getSymbolTable(), $1);
         $$->setSrcLoc(@$);
     }
   | UNDERSCORE {

--- a/src/test/symbol_table_test.cpp
+++ b/src/test/symbol_table_test.cpp
@@ -103,17 +103,18 @@ TEST(SymbolTable, Inserts) {
     T N = 10000000;  // number of symbols to insert
 
     SymbolTable X;
-    char* x;
+    std::string x;
 
-    char** A = new char*[N];  // create an array of symbols
+    std::vector<std::string> A;
+    A.reserve(N);
 
     for (T i = 0; i < N; ++i) {
-        x = reinterpret_cast<char*>(&i);
+        x = std::to_string(i) + "string";
         start = now();
         X.insert(x);  // insert one at a time
         end = now();
         n += duration_in_ns(start, end);  // record the time
-        A[i] = x;                         // also put in the array
+        A.push_back(x);                   // also put in the array
     }
 
     if (ECHO_TIME)
@@ -122,7 +123,7 @@ TEST(SymbolTable, Inserts) {
 
     // try inserting all the elements that were just inserted
     start = now();
-    X.insert((const char**)A, N);
+    X.insert(A);
     end = now();
     n = duration_in_ns(start, end);
 
@@ -132,13 +133,11 @@ TEST(SymbolTable, Inserts) {
 
     // test insert for elements that don't exist yet
     start = now();
-    Y.insert((const char**)A, N);
+    Y.insert(A);
     end = now();
     n = duration_in_ns(start, end);
 
     if (ECHO_TIME) std::cout << "Time to insert " << N << " new elements: " << n << " ns" << std::endl;
-
-    delete[] A;
 }
 
 }  // end namespace test

--- a/src/test/symbol_table_test.cpp
+++ b/src/test/symbol_table_test.cpp
@@ -53,9 +53,8 @@ TEST(SymbolTable, Copy) {
     EXPECT_STREQ("Hello", a->resolve(a_idx));
     EXPECT_STREQ("Hello", b->resolve(b_idx));
 
-    // should be different string references but the same actual string
+    // should be the same actual string
     EXPECT_STREQ(a->resolve(a_idx), b->resolve(b_idx));
-    EXPECT_NE(a->resolve(a_idx), b->resolve(b_idx));
 
     // b should survive
     delete a;
@@ -84,11 +83,6 @@ TEST(SymbolTable, Assign) {
     EXPECT_STREQ("Hello", a->resolve(a_idx));
     EXPECT_STREQ("Hello", b.resolve(b_idx));
     EXPECT_STREQ("Hello", c.resolve(c_idx));
-
-    // should be different strings
-    EXPECT_NE(a->resolve(a_idx), b.resolve(b_idx));
-    EXPECT_NE(a->resolve(a_idx), c.resolve(c_idx));
-    EXPECT_NE(b.resolve(b_idx), c.resolve(c_idx));
 
     // b and c should survive
     delete a;


### PR DESCRIPTION
Refactor SymbolTable to use std::string instead of char*

Using strings proves to be faster when deleting the SymbolTable, a significant time cost with large text input. There is also some improvement in string operations during execution since we have fewer conversions between string and char*.