### PR TITLE
Fix for potential compilation and test errors

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -198,7 +198,7 @@ souffle_CPPFLAGS = -DPACKAGE_VERSION="\"${PACKAGE_VERSION}\""
 CLEANFILES = $(BUILT_SOURCES)  parser.cc scanner.cc parser.hh stack.hh
 
 # run Bison
-$(builddir)/parser.hh $(builddir)/stack.hh: $(srcdir)/parser.yy
+$(builddir)/parser.hh: $(srcdir)/parser.yy
 	$(BISON) -Wall -Werror -v -d -o parser.cc $(srcdir)/parser.yy
 
 # and FLEX
@@ -206,8 +206,8 @@ $(builddir)/scanner.cc: $(srcdir)/scanner.ll
 	$(FLEX) -o scanner.cc $(srcdir)/scanner.ll
 
 # driver depends on the generated header
-$(builddir)/parser.cc $(builddir)/scanner.cc $(builddir)/main.cpp $(builddir)/ParserDriver.cpp: \
-	$(builddir)/parser.hh
+$(builddir)/parser.cc $(builddir)/stack.hh $(builddir)/scanner.cc \
+        $(builddir)/main.cpp $(builddir)/ParserDriver.cpp: $(builddir)/parser.hh
 
 ########## Unit Tests
 

--- a/src/test/file_format_converter_test.cpp
+++ b/src/test/file_format_converter_test.cpp
@@ -16,7 +16,7 @@
 
 #include "FileFormatConverter.h"
 #include "test.h"
-
+#include <cstdio>
 #include <sstream>
 
 namespace souffle {
@@ -1103,6 +1103,9 @@ TEST(FileFormatConverter, fromLogToCsv) {
         // test for config with headers as first row and quotes around columns
         runTestCase(LOG.FILE_PATH, CSV.FILE_PATH, CSV.CONFIG_WITH.HEADERS_AND_QUOTES,
                 CSV.DATA_WITH.HEADERS_AND_QUOTES);
+
+        remove(LOG.FILE_PATH.c_str());
+        remove(CSV.FILE_PATH.c_str());
     }
 }
 


### PR DESCRIPTION
It's still possible for bison to be run twice. Simplifying the rules that run bison avoid the problem.
Also remove files left behind by tests (these can be problematic with some docker setups)