### PR TITLE
Profiler logging fixes

### DIFF
--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -769,11 +769,11 @@ void Interpreter::executeMain() {
             throw std::invalid_argument("Cannot open profile log file <" + fname + ">");
         }
         // Enable profiling for execution of main
-        ProfileEventSingleton::instance().startTimer();
+        os << AstLogStatement::startDebug() << std::endl;
         ProfileEventSingleton::instance().setLog(&os);
+        ProfileEventSingleton::instance().startTimer();
         evalStmt(main);
         ProfileEventSingleton::instance().stopTimer();
-        os << AstLogStatement::startDebug() << std::endl;
     }
     SignalHandler::instance()->reset();
 }

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -50,6 +50,7 @@ public:
 
     ~Logger() {
         event->stop();
+        ProfileEventSingleton::instance().print(event);
     }
 };
 

--- a/src/ProfileEvent.h
+++ b/src/ProfileEvent.h
@@ -139,11 +139,8 @@ private:
     /** end point */
     ProfileTimePoint end;
 
-    /** output stream for live timing */
-    std::ostream* out;
-
 public:
-    ProfileTimingEvent(const std::string& txt, std::ostream* out = nullptr) : ProfileEvent(txt), out(out) {}
+    ProfileTimingEvent(const std::string& txt) : ProfileEvent(txt) {}
 
     /** Stop timing event */
     void stop() {
@@ -242,7 +239,7 @@ public:
 
     /** Make new time event */
     ProfileTimingEvent* makeTimingEvent(const std::string& txt) {
-        auto e = new ProfileTimingEvent(txt, out);
+        auto e = new ProfileTimingEvent(txt);
         std::lock_guard<std::mutex> guard(eventMutex);
         events.push_back(e);
         return e;

--- a/src/profilerlib/Iteration.cpp
+++ b/src/profilerlib/Iteration.cpp
@@ -13,26 +13,21 @@
 void Iteration::addRule(std::vector<std::string> data, std::string rec_id) {
     std::string strTemp = data[4] + data[3] + data[2];
 
+    std::shared_ptr<Rule> rul_rec = nullptr;
+    if (rul_rec_map.find(strTemp) == rul_rec_map.end()) {
+        rul_rec = std::make_shared<Rule>(Rule(data[4], std::stoi(data[2]), rec_id));
+        rul_rec->setRuntime(0);
+        rul_rec_map[strTemp] = rul_rec;
+    } else {
+        rul_rec = rul_rec_map[strTemp];
+    }
+
     if (data[0].at(0) == 't') {
-        if (rul_rec_map.find(strTemp) != rul_rec_map.end()) {
-            std::shared_ptr<Rule> rul_rec = rul_rec_map[strTemp];
-            rul_rec->setRuntime(std::stod(data[5]) + rul_rec->getRuntime());
-        } else {
-            std::shared_ptr<Rule> rul_rec = std::make_shared<Rule>(Rule(data[4], std::stoi(data[2]), rec_id));
-            rul_rec->setRuntime(std::stod(data[5]));
-            rul_rec->setLocator(data[3]);
-            rul_rec_map[strTemp] = rul_rec;
-        }
-
+        rul_rec->setRuntime(std::stod(data[5]) + rul_rec->getRuntime());
+        rul_rec->setLocator(data[3]);
     } else if (data[0].at(0) == 'n') {
-        std::unordered_map<std::string, std::shared_ptr<Rule>>::const_iterator got =
-                rul_rec_map.find(strTemp);
-
-        assert(got != rul_rec_map.end() && "missing t tag");
-        std::shared_ptr<Rule> rul_rec = rul_rec_map[strTemp];
         rul_rec->setNum_tuples(std::stol(data[5]) - prev_num_tuples);
         this->prev_num_tuples = std::stol(data[5]);
-        rul_rec_map[strTemp] = rul_rec;
     }
 }
 


### PR DESCRIPTION
The asynchronous logging led to issues with concurrency, and problems with timers. This PR makes the logging look more like the old synchronous style.

In future we will either enhance the profiler and redo all the logging, or revisit this to make simpler logging more efficient.