### PR TITLE
Improving escaping of SymbolTable initialiser in generated C++.

### DIFF
--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1229,7 +1229,7 @@ void Synthesiser::generateCode(const RamTranslationUnit& unit, std::ostream& os,
     if (symTable.size() > 0) {
         os << "{\n";
         for (size_t i = 0; i < symTable.size(); i++) {
-            os << "\t\"" << stringify(symTable.resolve(i)) << "\",\n";
+            os << "\tR\"_(" << symTable.resolve(i) << ")_\",\n";
         }
         os << "}";
     }


### PR DESCRIPTION
The strings added to the synthesised C++ must be parsed from the input datalog. The characters to escape `R"_( ... )_"` aren't valid in the input file so raw literals are safer than stringified strings in quotes.