### PR TITLE
Refactor includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ Makefile
 Makefile.in
 
 aclocal.m4
-libtool.m4
 lt*.m4
 autom4te.cache
 config.*
@@ -12,7 +11,6 @@ env
 *.o
 *.a
 *~
-stamp-h1
 compile
 depcomp
 install-sh
@@ -21,7 +19,6 @@ libtool
 ltmain.sh
 /include
 test-driver
-interfaces/souffle-compilelib
 warn.log
 packaging/*
 
@@ -31,18 +28,11 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 
-build_*
-
 debian/changelog
-souffle-*.*.*
 
-src/souffle-mcpp
-src/souffle-profile
-src/profilerlib/.dirstamp
 profiler_html/
 
 doc
-prof
 
 .idea/
 cmake-build-debug/

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,11 +1,9 @@
 .deps
 
-souffle.dSYM
 souffle
 souffle-compile
 souffle-config
-souffle-wave
-souffle-prof
+souffle-profile
 souffle2lb
 souffle2bdd
 
@@ -17,6 +15,3 @@ libsouffle*
 *.output
 
 test-suite.log
-wavelib/cpplexer/re2clex/.dirstamp
-
-souffle.dSYM

--- a/src/AstArgument.h
+++ b/src/AstArgument.h
@@ -19,24 +19,24 @@
 #pragma once
 
 #include "AstNode.h"
-#include "AstType.h"
+#include "AstTypes.h"
 #include "BinaryFunctorOps.h"
 #include "SymbolTable.h"
 #include "TernaryFunctorOps.h"
-#include "TypeSystem.h"
 #include "UnaryFunctorOps.h"
-
+#include "Util.h"
 #include <array>
-#include <list>
+#include <cassert>
+#include <cstddef>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace souffle {
 
 /* Forward declarations */
-class AstClause;
-class AstVariable;
 class AstLiteral;
 
 /**

--- a/src/AstArgument.h
+++ b/src/AstArgument.h
@@ -81,7 +81,7 @@ public:
         os << name;
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstVariable* clone() const override {
         AstVariable* res = new AstVariable(name);
         res->setSrcLoc(getSrcLoc());
@@ -115,7 +115,7 @@ public:
         os << "_";
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstUnnamedVariable* clone() const override {
         auto* res = new AstUnnamedVariable();
         res->setSrcLoc(getSrcLoc());
@@ -219,7 +219,7 @@ public:
         os << "\"" << getConstant() << "\"";
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstStringConstant* clone() const override {
         auto* res = new AstStringConstant(symTable, getIndex());
         res->setSrcLoc(getSrcLoc());
@@ -239,7 +239,7 @@ public:
         os << idx;
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstNumberConstant* clone() const override {
         auto* res = new AstNumberConstant(getIndex());
         res->setSrcLoc(getSrcLoc());
@@ -259,7 +259,7 @@ public:
         os << '-';
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstNullConstant* clone() const override {
         auto* res = new AstNullConstant();
         res->setSrcLoc(getSrcLoc());
@@ -562,7 +562,7 @@ public:
         os << "[" << join(args, ",", print_deref<std::unique_ptr<AstArgument>>()) << "]";
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstRecordInit* clone() const override {
         auto res = new AstRecordInit();
         for (auto& cur : args) {
@@ -630,7 +630,7 @@ public:
         return res;
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstTypeCast* clone() const override {
         auto res = new AstTypeCast(std::unique_ptr<AstArgument>(value->clone()), type);
         res->setSrcLoc(getSrcLoc());
@@ -714,7 +714,7 @@ public:
     /** Obtains a list of all embedded child nodes */
     std::vector<const AstNode*> getChildNodes() const override;
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstAggregator* clone() const override;
 
     /** Mutates this node */
@@ -757,7 +757,7 @@ public:
         os << "arg_" << number;
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstSubroutineArgument* clone() const override {
         auto* res = new AstSubroutineArgument(number);
         res->setSrcLoc(getSrcLoc());

--- a/src/AstAttribute.h
+++ b/src/AstAttribute.h
@@ -64,7 +64,7 @@ public:
         os << name << ":" << typeName;
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstAttribute* clone() const override {
         AstAttribute* res = new AstAttribute(name, typeName);
         res->setSrcLoc(getSrcLoc());

--- a/src/AstClause.cpp
+++ b/src/AstClause.cpp
@@ -17,18 +17,13 @@
 
 #include "AstClause.h"
 #include "AstLiteral.h"
-#include "AstProgram.h"
-#include "AstRelation.h"
 #include "AstVisitor.h"
-
-#include <set>
-#include <sstream>
-#include <string>
-
-#include <cstdlib>
-#include <cstring>
+#include "Macro.h"
+#include <algorithm>
 
 namespace souffle {
+
+class AstAggregator;
 
 /*
  * Clause

--- a/src/AstClause.h
+++ b/src/AstClause.h
@@ -384,7 +384,7 @@ public:
     /** Print this clause to a given stream */
     void print(std::ostream& os) const override;
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstClause* clone() const override {
         auto res = new AstClause();
         res->setSrcLoc(getSrcLoc());

--- a/src/AstClause.h
+++ b/src/AstClause.h
@@ -17,19 +17,18 @@
 
 #pragma once
 
-#include "AstArgument.h"
 #include "AstLiteral.h"
-#include "AstRelationIdentifier.h"
+#include "AstNode.h"
 #include "Util.h"
-
+#include <cassert>
+#include <cstddef>
+#include <map>
 #include <memory>
-#include <set>
-#include <string>
+#include <ostream>
+#include <utility>
 #include <vector>
 
 namespace souffle {
-
-class AstProgram;
 
 /**
  * An execution order for atoms within a clause.

--- a/src/AstComponentChecker.cpp
+++ b/src/AstComponentChecker.cpp
@@ -17,14 +17,21 @@
 #include "AstComponentChecker.h"
 #include "AstComponent.h"
 #include "AstProgram.h"
+#include "AstRelation.h"
+#include "AstRelationIdentifier.h"
 #include "AstTranslationUnit.h"
+#include "AstType.h"
 #include "ComponentModel.h"
-
+#include "ErrorReport.h"
+#include "SrcLocation.h"
+#include "Util.h"
 #include <functional>
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
 
 namespace souffle {
-
-class AstTranslationUnit;
 
 bool AstComponentChecker::transform(AstTranslationUnit& translationUnit) {
     AstProgram& program = *translationUnit.getProgram();

--- a/src/AstComponentChecker.h
+++ b/src/AstComponentChecker.h
@@ -17,11 +17,11 @@
 #pragma once
 
 #include "AstTransformer.h"
+#include <string>
 
 namespace souffle {
 
 class AstComponent;
-class AstComponentScope;
 class AstComponentType;
 class AstComponentInit;
 class AstProgram;

--- a/src/AstLiteral.h
+++ b/src/AstLiteral.h
@@ -50,7 +50,7 @@ public:
     /** Obtains the atom referenced by this literal - if any */
     virtual const AstAtom* getAtom() const = 0;
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstLiteral* clone() const override = 0;
 };
 
@@ -134,7 +134,7 @@ public:
         os << ")";
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstAtom* clone() const override {
         auto res = new AstAtom(name);
         res->setSrcLoc(getSrcLoc());
@@ -199,7 +199,7 @@ public:
         atom->print(os);
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstNegation* clone() const override {
         AstNegation* res = new AstNegation(std::unique_ptr<AstAtom>(atom->clone()));
         res->setSrcLoc(getSrcLoc());
@@ -358,7 +358,7 @@ public:
         rhs->print(os);
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstBinaryConstraint* clone() const override {
         AstBinaryConstraint* res = new AstBinaryConstraint(operation,
                 std::unique_ptr<AstArgument>(lhs->clone()), std::unique_ptr<AstArgument>(rhs->clone()));

--- a/src/AstParserUtils.cpp
+++ b/src/AstParserUtils.cpp
@@ -16,8 +16,11 @@
 
 #include "AstParserUtils.h"
 #include "AstClause.h"
-
+#include "AstNode.h"
+#include "Util.h"
 #include <memory>
+#include <ostream>
+#include <utility>
 #include <vector>
 
 namespace souffle {

--- a/src/AstParserUtils.h
+++ b/src/AstParserUtils.h
@@ -17,12 +17,14 @@
 #pragma once
 
 #include "AstLiteral.h"
-#include "Util.h"
 
+#include <iosfwd>
 #include <memory>
 #include <vector>
 
 namespace souffle {
+
+class AstClause;
 
 class RuleBody {
     // a struct to represent literals

--- a/src/AstPragma.cpp
+++ b/src/AstPragma.cpp
@@ -15,6 +15,7 @@
  ***********************************************************************/
 
 #include "AstPragma.h"
+#include "AstProgram.h"
 #include "AstTranslationUnit.h"
 #include "AstVisitor.h"
 #include "Global.h"

--- a/src/AstPragma.h
+++ b/src/AstPragma.h
@@ -18,11 +18,15 @@
 
 #include "AstNode.h"
 #include "AstTransformer.h"
-
+#include <ostream>
 #include <string>
 #include <utility>
+#include <vector>
+#include <assert.h>
 
 namespace souffle {
+
+class AstTranslationUnit;
 
 /**
  * @class AstPragma

--- a/src/AstProgram.cpp
+++ b/src/AstProgram.cpp
@@ -18,19 +18,12 @@
 #include "AstProgram.h"
 #include "AstClause.h"
 #include "AstComponent.h"
+#include "AstLiteral.h"
 #include "AstRelation.h"
-#include "AstTypeAnalysis.h"
-#include "AstUtils.h"
-#include "AstVisitor.h"
 #include "ErrorReport.h"
-#include "GraphUtils.h"
+#include "Macro.h"
 #include "Util.h"
-
-#include <list>
 #include <sstream>
-
-#include <cstdarg>
-#include <cstdlib>
 
 namespace souffle {
 

--- a/src/AstProgram.h
+++ b/src/AstProgram.h
@@ -182,7 +182,7 @@ public:
 
     // -- Manipulation ---------------------------------------------------------
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstProgram* clone() const override;
 
     /** Mutates this node */

--- a/src/AstProgram.h
+++ b/src/AstProgram.h
@@ -18,25 +18,24 @@
 #pragma once
 
 #include "AstComponent.h"
+#include "AstNode.h"
 #include "AstPragma.h"
-#include "AstRelation.h"
-#include "ErrorReport.h"
-#include "TypeSystem.h"
+#include "AstRelationIdentifier.h"
+#include "AstType.h"
 #include "Util.h"
-
-#include <list>
+#include <cassert>
+#include <cstddef>
+#include <iosfwd>
 #include <map>
 #include <memory>
-#include <set>
-#include <string>
+#include <utility>
+#include <vector>
 
 namespace souffle {
 
 class AstClause;
+class AstIODirective;
 class AstRelation;
-class AstLiteral;
-class AstAtom;
-class AstArgument;
 
 /**
  *  Intermediate representation of a datalog program
@@ -44,10 +43,9 @@ class AstArgument;
  */
 class AstProgram : public AstNode {
     // TODO: Check whether this is needed
-    friend class ParserDriver;
     friend class ComponentInstantiationTransformer;
+    friend class ParserDriver;
     friend class ProvenanceTransformer;
-    friend class AstBuilder;
 
     /** Program types  */
     std::map<AstTypeIdentifier, std::unique_ptr<AstType>> types;

--- a/src/AstRelation.h
+++ b/src/AstRelation.h
@@ -263,7 +263,7 @@ public:
         }
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstRelation* clone() const override {
         auto res = new AstRelation();
         res->name = name;

--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -15,24 +15,41 @@
  ***********************************************************************/
 
 #include "AstSemanticChecker.h"
+#include "AstArgument.h"
+#include "AstAttribute.h"
 #include "AstClause.h"
+#include "AstIODirective.h"
+#include "AstLiteral.h"
+#include "AstNode.h"
 #include "AstProgram.h"
 #include "AstRelation.h"
+#include "AstRelationIdentifier.h"
 #include "AstTranslationUnit.h"
+#include "AstType.h"
 #include "AstTypeAnalysis.h"
+#include "AstTypes.h"
 #include "AstUtils.h"
 #include "AstVisitor.h"
+#include "BinaryConstraintOps.h"
+#include "ErrorReport.h"
 #include "Global.h"
 #include "GraphUtils.h"
+#include "Macro.h"
 #include "PrecedenceGraph.h"
+#include "SrcLocation.h"
+#include "TypeSystem.h"
 #include "Util.h"
-
+#include <cassert>
+#include <cstddef>
+#include <iostream>
+#include <map>
+#include <memory>
 #include <set>
+#include <typeinfo>
+#include <utility>
 #include <vector>
 
 namespace souffle {
-
-class AstTranslationUnit;
 
 bool AstSemanticChecker::transform(AstTranslationUnit& translationUnit) {
     const TypeEnvironment& typeEnv =

--- a/src/AstSemanticChecker.h
+++ b/src/AstSemanticChecker.h
@@ -16,27 +16,26 @@
 #pragma once
 
 #include "AstTransformer.h"
+#include <string>
 
 namespace souffle {
 
-class AstTranslationUnit;
-class ErrorReport;
-class AstProgram;
-class AstAtom;
-class AstLiteral;
 class AstAggregator;
 class AstArgument;
+class AstAtom;
 class AstClause;
-class AstRelation;
-class SrcLocation;
-class TypeBinding;
-class AstUnionType;
+class AstLiteral;
+class AstProgram;
 class AstRecordType;
+class AstRelation;
+class AstTranslationUnit;
 class AstType;
-class TypeEnvironment;
-class TypeAnalysis;
+class AstUnionType;
+class ErrorReport;
 class PrecedenceGraph;
 class RecursiveClauses;
+class TypeAnalysis;
+class TypeEnvironment;
 
 class AstSemanticChecker : public AstTransformer {
 private:

--- a/src/AstTransformer.cpp
+++ b/src/AstTransformer.cpp
@@ -16,6 +16,10 @@
 
 #include "AstTransformer.h"
 #include "AstTranslationUnit.h"
+#include "ErrorReport.h"
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
 
 namespace souffle {
 

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -15,12 +15,28 @@
  ***********************************************************************/
 
 #include "AstTransforms.h"
-
+#include "AstAttribute.h"
+#include "AstClause.h"
+#include "AstLiteral.h"
+#include "AstNode.h"
+#include "AstProgram.h"
+#include "AstRelation.h"
+#include "AstRelationIdentifier.h"
 #include "AstTypeAnalysis.h"
+#include "AstTypes.h"
 #include "AstUtils.h"
 #include "AstVisitor.h"
+#include "BinaryConstraintOps.h"
+#include "GraphUtils.h"
 #include "PrecedenceGraph.h"
+#include "TypeSystem.h"
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <map>
 #include <memory>
+#include <ostream>
+#include <set>
 
 namespace souffle {
 

--- a/src/AstTransforms.h
+++ b/src/AstTransforms.h
@@ -15,13 +15,22 @@
  ***********************************************************************/
 #pragma once
 
+#include "AstArgument.h"
 #include "AstTransformer.h"
 #include "AstTranslationUnit.h"
-
+#include "DebugReport.h"
+#include "Util.h"
 #include <functional>
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace souffle {
+
+class AstClause;
+class AstProgram;
+class AstRelation;
 
 /**
  * Transformation pass to eliminate grounded aliases.

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -15,28 +15,54 @@
  ***********************************************************************/
 
 #include "AstTranslator.h"
+#include "AstArgument.h"
+#include "AstAttribute.h"
 #include "AstClause.h"
 #include "AstIODirective.h"
+#include "AstLiteral.h"
+#include "AstNode.h"
 #include "AstProgram.h"
 #include "AstRelation.h"
+#include "AstTranslationUnit.h"
 #include "AstTypeAnalysis.h"
 #include "AstUtils.h"
 #include "AstVisitor.h"
 #include "BinaryConstraintOps.h"
+#include "DebugReport.h"
 #include "Global.h"
+#include "IODirectives.h"
 #include "LogStatement.h"
+#include "Macro.h"
 #include "PrecedenceGraph.h"
+#include "RamCondition.h"
+#include "RamNode.h"
+#include "RamOperation.h"
+#include "RamProgram.h"
 #include "RamRelation.h"
 #include "RamStatement.h"
-#include "RamVisitor.h"
+#include "RamTranslationUnit.h"
+#include "RamValue.h"
+#include "SrcLocation.h"
+#include "SymbolMask.h"
+#include "TypeSystem.h"
 #include "Util.h"
-
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cstddef>
 #include <fstream>
+#include <functional>
 #include <iostream>
+#include <map>
 #include <memory>
+#include <typeinfo>
 #include <utility>
+#include <vector>
 
 namespace souffle {
+
+class ErrorReport;
+class SymbolTable;
 
 namespace {
 

--- a/src/AstTranslator.h
+++ b/src/AstTranslator.h
@@ -16,25 +16,24 @@
 
 #pragma once
 
-#include "AstTranslationUnit.h"
-#include "RamProgram.h"
-#include "RamRelation.h"
-#include "RamTranslationUnit.h"
-
+#include "AstRelationIdentifier.h"
 #include <map>
-#include <vector>
+#include <memory>
+#include <set>
+#include <string>
 
 namespace souffle {
 
 // forward declarations
-class AstRelation;
-class AstAtom;
 class AstClause;
 class AstProgram;
-
+class AstRelation;
+class AstTranslationUnit;
+class RamProgram;
 class RamStatement;
-
+class RamTranslationUnit;
 class RecursiveClauses;
+class TypeEnvironment;
 
 /**
  * A utility class capable of conducting the conversion between AST

--- a/src/AstType.h
+++ b/src/AstType.h
@@ -138,7 +138,7 @@ public:
         return {};
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstType* clone() const override = 0;
 
     /** Mutates this node */
@@ -175,7 +175,7 @@ public:
         os << ".type " << getName() << (num ? "= number" : "");
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstPrimitiveType* clone() const override {
         return new AstPrimitiveType(getName(), num);
     }
@@ -217,7 +217,7 @@ public:
         os << ".type " << getName() << " = " << join(types, " | ");
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstUnionType* clone() const override {
         auto res = new AstUnionType();
         res->setName(getName());
@@ -285,7 +285,7 @@ public:
         os << "]";
     }
 
-    /** Creates a clone if this AST sub-structure */
+    /** Creates a clone of this AST sub-structure */
     AstRecordType* clone() const override {
         auto res = new AstRecordType();
         res->setName(getName());

--- a/src/AstTypeAnalysis.cpp
+++ b/src/AstTypeAnalysis.cpp
@@ -15,13 +15,27 @@
  ***********************************************************************/
 
 #include "AstTypeAnalysis.h"
-
+#include "AstArgument.h"
+#include "AstAttribute.h"
+#include "AstLiteral.h"
+#include "AstNode.h"
+#include "AstProgram.h"
+#include "AstRelation.h"
+#include "AstTranslationUnit.h"
+#include "AstType.h"
 #include "AstUtils.h"
 #include "AstVisitor.h"
 #include "BinaryConstraintOps.h"
 #include "Constraints.h"
 #include "Global.h"
+#include "Macro.h"
 #include "Util.h"
+#include <cstddef>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <string>
+#include <typeinfo>
 #include <utility>
 
 namespace souffle {

--- a/src/AstTypeAnalysis.h
+++ b/src/AstTypeAnalysis.h
@@ -16,17 +16,20 @@
 #pragma once
 
 #include "AstAnalysis.h"
-#include "AstTranslationUnit.h"
 #include "TypeSystem.h"
+#include <cassert>
+#include <iosfwd>
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace souffle {
 
-class AstNode;
-class AstProgram;
 class AstArgument;
 class AstClause;
-class AstVariable;
-class AstRelation;
+class AstProgram;
+class AstTranslationUnit;
 
 /**
  * Analyse the given clause and computes for each contained argument

--- a/src/AstUtils.cpp
+++ b/src/AstUtils.cpp
@@ -15,10 +15,12 @@
  ***********************************************************************/
 
 #include "AstUtils.h"
+#include "AstArgument.h"
+#include "AstClause.h"
+#include "AstLiteral.h"
+#include "AstProgram.h"
+#include "AstRelation.h"
 #include "AstVisitor.h"
-#include "Constraints.h"
-#include "TypeSystem.h"
-#include "Util.h"
 
 namespace souffle {
 

--- a/src/AstUtils.h
+++ b/src/AstUtils.h
@@ -16,20 +16,19 @@
 
 #pragma once
 
-#include <map>
 #include <set>
 #include <vector>
 
 namespace souffle {
 
 // some forward declarations
-class AstNode;
-class AstVariable;
-class AstRelation;
 class AstAtom;
 class AstClause;
-class AstProgram;
 class AstLiteral;
+class AstNode;
+class AstProgram;
+class AstRelation;
+class AstVariable;
 
 // ---------------------------------------------------------------
 //                      General Utilities

--- a/src/CompiledIndexUtils.h
+++ b/src/CompiledIndexUtils.h
@@ -21,17 +21,15 @@
 #include "BinaryRelation.h"
 #include "CompiledTuple.h"
 #include "IterUtils.h"
-#include "ParallelUtils.h"
-#include "SymbolTable.h"
-#include "Table.h"
+#include "RamTypes.h"
 #include "Trie.h"
 #include "Util.h"
-
+#include <cassert>
 #include <iterator>
-#include <mutex>
+#include <ostream>
+#include <string>
 #include <type_traits>
-
-#include <libgen.h>
+#include <vector>
 
 namespace souffle {
 

--- a/src/CompiledRelation.h
+++ b/src/CompiledRelation.h
@@ -17,22 +17,21 @@
 
 #pragma once
 
-#include "BTree.h"
 #include "CompiledIndexUtils.h"
 #include "CompiledTuple.h"
-#include "IOSystem.h"
-#include "IterUtils.h"
 #include "ParallelUtils.h"
+#include "RamTypes.h"
 #include "Table.h"
-#include "Trie.h"
 #include "Util.h"
-
+#include <iostream>
 #include <iterator>
 #include <mutex>
+#include <set>
+#include <string>
 #include <type_traits>
 #include <unordered_set>
-
-#include <libgen.h>
+#include <vector>
+#include <assert.h>
 
 namespace souffle {
 

--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -16,23 +16,38 @@
 
 #pragma once
 
-#include "AstTypes.h"
-#include "CompiledOptions.h"
-#include "CompiledRecord.h"
-#include "CompiledRelation.h"
-#include "Logger.h"
-#include "ParallelUtils.h"
-#include "ProfileEvent.h"
-#include "SignalHandler.h"
-#include "SouffleInterface.h"
-#include "SymbolTable.h"
-
+#include "souffle/AstTypes.h"
+#include "souffle/CompiledIndexUtils.h"
+#include "souffle/CompiledOptions.h"
+#include "souffle/CompiledRecord.h"
+#include "souffle/CompiledRelation.h"
+#include "souffle/CompiledTuple.h"
+#include "souffle/IODirectives.h"
+#include "souffle/IOSystem.h"
+#include "souffle/Logger.h"
+#include "souffle/ParallelUtils.h"
+#include "souffle/ProfileEvent.h"
+#include "souffle/RamTypes.h"
+#include "souffle/SignalHandler.h"
+#include "souffle/SouffleInterface.h"
+#include "souffle/SymbolMask.h"
+#include "souffle/SymbolTable.h"
+#include "souffle/Trie.h"
+#include "souffle/Util.h"
+#include "souffle/WriteStream.h"
 #include <array>
+#include <atomic>
+#include <cassert>
 #include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
 #include <iostream>
-#include <map>
+#include <memory>
 #include <regex>
+#include <string>
 #include <utility>
+#include <vector>
 
 #if defined(_OPENMP)
 #include <omp.h>

--- a/src/CompiledTuple.h
+++ b/src/CompiledTuple.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include "RamTypes.h"
-
 #include <iostream>
 
 namespace souffle {

--- a/src/ComponentModel.cpp
+++ b/src/ComponentModel.cpp
@@ -13,12 +13,24 @@
  ***********************************************************************/
 
 #include "ComponentModel.h"
+#include "AstAttribute.h"
+#include "AstClause.h"
 #include "AstComponent.h"
+#include "AstIODirective.h"
+#include "AstLiteral.h"
 #include "AstProgram.h"
+#include "AstRelation.h"
+#include "AstRelationIdentifier.h"
+#include "AstTranslationUnit.h"
 #include "AstVisitor.h"
 #include "ErrorReport.h"
+#include "Util.h"
+#include <algorithm>
+#include <memory>
 
 namespace souffle {
+
+class AstNode;
 
 void ComponentLookup::run(const AstTranslationUnit& translationUnit) {
     const AstProgram* program = translationUnit.getProgram();

--- a/src/ComponentModel.h
+++ b/src/ComponentModel.h
@@ -15,17 +15,18 @@
 #pragma once
 
 #include "AstAnalysis.h"
-#include "AstComponent.h"
-#include "AstRelation.h"
-#include "AstTranslationUnit.h"
-
-#include <memory>
+#include "AstTransformer.h"
+#include "AstType.h"
+#include <cstddef>
+#include <map>
+#include <set>
 #include <string>
 #include <vector>
 
 namespace souffle {
 
-class ErrorReport;
+class AstComponent;
+class AstTranslationUnit;
 
 /**
  * Class that encapsulates std::map of types binding that comes from .init c = Comp<MyType>

--- a/src/DebugReport.cpp
+++ b/src/DebugReport.cpp
@@ -17,10 +17,10 @@
 #include "DebugReport.h"
 #include "AstTranslationUnit.h"
 #include "AstTypeAnalysis.h"
-#include "MagicSet.h"
 #include "PrecedenceGraph.h"
-
+#include <chrono>
 #include <cstdio>
+#include <ostream>
 #include <sstream>
 #include <utility>
 

--- a/src/Global.cpp
+++ b/src/Global.cpp
@@ -1,4 +1,12 @@
 #include "Global.h"
+#include "Macro.h"
+#include <cassert>
+#include <cctype>
+#include <cstdio>
+#include <memory>
+#include <sstream>
+#include <utility>
+#include <getopt.h>
 
 namespace souffle {
 

--- a/src/Global.h
+++ b/src/Global.h
@@ -1,15 +1,9 @@
 #pragma once
 
-#include "Util.h"
-
 #include <iostream>
 #include <map>
-#include <sstream>
 #include <string>
 #include <vector>
-
-#include <cctype>
-#include <getopt.h>
 
 namespace souffle {
 
@@ -53,11 +47,11 @@ public:
         return (has(key)) ? _data.at(key) : value;
     }
     /* Check the table has the specified key. */
-    const bool has(const K& key) const {
+    bool has(const K& key) const {
         return _data.find(key) != _data.end();
     }
     /* Check the table has the specified key and the specified value for that key. */
-    const bool has(const K& key, const V& value) const {
+    bool has(const K& key, const V& value) const {
         return has(key) && _data.at(key) == value;
     }
     /* Set the entry in the table for the specified key to an object of the value class called with an empty

--- a/src/IndexSetAnalysis.cpp
+++ b/src/IndexSetAnalysis.cpp
@@ -17,12 +17,14 @@
 #include "IndexSetAnalysis.h"
 #include "Global.h"
 #include "RamCondition.h"
+#include "RamNode.h"
 #include "RamOperation.h"
 #include "RamTranslationUnit.h"
-#include "RamValue.h"
 #include "RamVisitor.h"
-
-#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <iterator>
 #include <queue>
 
 #ifdef _OPENMP

--- a/src/IndexSetAnalysis.h
+++ b/src/IndexSetAnalysis.h
@@ -16,14 +16,20 @@
 
 #pragma once
 
+#include "Macro.h"
 #include "RamAnalysis.h"
 #include "RamRelation.h"
 #include "RamTypes.h"
-#include "Util.h"
-
-#include <cstring>
+#include <cassert>
+#include <cstdlib>
+#include <functional>
+#include <iosfwd>
+#include <limits>
+#include <map>
+#include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #define NIL 0
@@ -33,6 +39,8 @@
 #define M_UNIT_TEST
 
 namespace souffle {
+
+class RamTranslationUnit;
 
 /**
  * Computes a maximum matching with Hopcroft-Karp algorithm

--- a/src/InlineRelationsTransformer.cpp
+++ b/src/InlineRelationsTransformer.cpp
@@ -1,7 +1,24 @@
-#include <utility>
-
+#include "AstArgument.h"
+#include "AstClause.h"
+#include "AstLiteral.h"
+#include "AstNode.h"
+#include "AstProgram.h"
+#include "AstRelation.h"
+#include "AstRelationIdentifier.h"
 #include "AstTransforms.h"
+#include "AstTranslationUnit.h"
 #include "AstVisitor.h"
+#include "BinaryConstraintOps.h"
+#include "BinaryFunctorOps.h"
+#include "Util.h"
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace souffle {
 

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -18,29 +18,37 @@
 #include "BinaryConstraintOps.h"
 #include "BinaryFunctorOps.h"
 #include "Global.h"
+#include "IODirectives.h"
 #include "IOSystem.h"
+#include "InterpreterIndex.h"
 #include "InterpreterRecords.h"
 #include "LogStatement.h"
 #include "Logger.h"
 #include "Macro.h"
+#include "ParallelUtils.h"
 #include "ProfileEvent.h"
+#include "RamNode.h"
+#include "RamOperation.h"
+#include "RamValue.h"
 #include "RamVisitor.h"
+#include "ReadStream.h"
 #include "SignalHandler.h"
-#include "TypeSystem.h"
+#include "SymbolTable.h"
+#include "TernaryFunctorOps.h"
 #include "UnaryFunctorOps.h"
-
+#include "WriteStream.h"
 #include <algorithm>
-#include <chrono>
 #include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <fstream>
+#include <iostream>
 #include <memory>
 #include <regex>
+#include <stdexcept>
+#include <typeinfo>
 #include <utility>
-
-#include <unistd.h>
-
-#ifdef _OPENMP
-#include <omp.h>
-#endif
 
 namespace souffle {
 

--- a/src/Interpreter.h
+++ b/src/Interpreter.h
@@ -18,17 +18,23 @@
 
 #include "InterpreterContext.h"
 #include "InterpreterRelation.h"
+#include "RamCondition.h"
+#include "RamRelation.h"
+#include "RamStatement.h"
 #include "RamTranslationUnit.h"
-#include "SymbolTable.h"
+#include "RamTypes.h"
 
+#include <cassert>
 #include <map>
-#include <memory>
-#include <ostream>
+#include <string>
 #include <vector>
 
 namespace souffle {
 
 class InterpreterProgInterface;
+class RamOperation;
+class RamValue;
+class SymbolTable;
 
 /**
  * Interpreter executing a RAM translation unit

--- a/src/InterpreterRecords.cpp
+++ b/src/InterpreterRecords.cpp
@@ -15,9 +15,7 @@
  ***********************************************************************/
 
 #include "InterpreterRecords.h"
-#include "Util.h"
-
-#include <iostream>
+#include <cassert>
 #include <limits>
 #include <map>
 #include <vector>

--- a/src/MagicSet.cpp
+++ b/src/MagicSet.cpp
@@ -15,12 +15,24 @@
  ***********************************************************************/
 
 #include "MagicSet.h"
-
+#include "AstAttribute.h"
+#include "AstIODirective.h"
+#include "AstNode.h"
+#include "AstProgram.h"
+#include "AstRelation.h"
+#include "AstTransforms.h"
+#include "AstTranslationUnit.h"
+#include "BinaryConstraintOps.h"
 #include "Global.h"
 #include "IODirectives.h"
+#include "SrcLocation.h"
+#include <cassert>
 #include <utility>
 
 namespace souffle {
+
+class SymbolTable;
+
 /* general functions */
 
 // checks whether the adorned version of two predicates is equal

--- a/src/MagicSet.h
+++ b/src/MagicSet.h
@@ -16,14 +16,26 @@
 
 #pragma once
 
-#include "AstTransforms.h"
+#include "AstAnalysis.h"
+#include "AstArgument.h"
+#include "AstClause.h"
+#include "AstLiteral.h"
+#include "AstRelationIdentifier.h"
 #include "AstVisitor.h"
-
+#include "Util.h"
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
 
 namespace souffle {
+
+class AstTranslationUnit;
+
 class AdornedPredicate {
 private:
     AstRelationIdentifier predicateName;

--- a/src/ParserDriver.cpp
+++ b/src/ParserDriver.cpp
@@ -15,11 +15,19 @@
  ***********************************************************************/
 
 #include "ParserDriver.h"
-
+#include "AstClause.h"
+#include "AstComponent.h"
+#include "AstIODirective.h"
+#include "AstPragma.h"
 #include "AstProgram.h"
+#include "AstRelation.h"
+#include "AstRelationIdentifier.h"
 #include "AstTranslationUnit.h"
+#include "AstType.h"
 #include "ErrorReport.h"
+#include "Util.h"
 #include <memory>
+#include <utility>
 
 using YY_BUFFER_STATE = struct yy_buffer_state*;
 extern YY_BUFFER_STATE yy_scan_string(const char*, yyscan_t scanner);

--- a/src/ParserDriver.h
+++ b/src/ParserDriver.h
@@ -15,19 +15,22 @@
  ***********************************************************************/
 #pragma once
 
+#include "SrcLocation.h"
 #include "parser.hh"
-
 #include <memory>
-
-#define YY_DECL yy::parser::symbol_type yylex(ParserDriver& driver, yyscan_t yyscanner)
-YY_DECL;
+#include <string>
+#include <stdio.h>
 
 namespace souffle {
 
-class AstTranslationUnit;
+class AstClause;
+class AstComponent;
+class AstComponentInit;
+class AstIODirective;
+class AstPragma;
 class AstRelation;
+class AstTranslationUnit;
 class AstType;
-class AstProgram;
 class DebugReport;
 class ErrorReport;
 class SymbolTable;
@@ -77,3 +80,6 @@ public:
 };
 
 }  // end of namespace souffle
+
+#define YY_DECL yy::parser::symbol_type yylex(souffle::ParserDriver& driver, yyscan_t yyscanner)
+YY_DECL;

--- a/src/PrecedenceGraph.cpp
+++ b/src/PrecedenceGraph.cpp
@@ -18,13 +18,20 @@
 
 #include "PrecedenceGraph.h"
 #include "AstClause.h"
+#include "AstLiteral.h"
+#include "AstProgram.h"
 #include "AstRelation.h"
+#include "AstRelationIdentifier.h"
+#include "AstTranslationUnit.h"
 #include "AstUtils.h"
 #include "AstVisitor.h"
 #include "Global.h"
-
+#include "Macro.h"
+#include "Util.h"
 #include <algorithm>
+#include <iterator>
 #include <set>
+#include <string>
 
 namespace souffle {
 

--- a/src/PrecedenceGraph.h
+++ b/src/PrecedenceGraph.h
@@ -19,19 +19,20 @@
 #pragma once
 
 #include "AstAnalysis.h"
-#include "AstProgram.h"
-#include "AstTranslationUnit.h"
+#include "AstRelation.h"
 #include "GraphUtils.h"
-
+#include <cstddef>
 #include <iostream>
-#include <list>
 #include <map>
+#include <set>
 #include <stack>
-#include <string>
 #include <utility>
 #include <vector>
 
 namespace souffle {
+
+class AstClause;
+class AstTranslationUnit;
 
 /**
  * Analysis pass computing the precedence graph of the relations of the datalog progam.

--- a/src/ProvenanceTransformer.cpp
+++ b/src/ProvenanceTransformer.cpp
@@ -14,9 +14,25 @@
  *
  ***********************************************************************/
 
-#include <memory>
-
+#include "AstArgument.h"
+#include "AstAttribute.h"
+#include "AstClause.h"
+#include "AstLiteral.h"
+#include "AstNode.h"
+#include "AstProgram.h"
+#include "AstRelation.h"
+#include "AstRelationIdentifier.h"
 #include "AstTransforms.h"
+#include "AstTranslationUnit.h"
+#include "AstType.h"
+#include "BinaryFunctorOps.h"
+#include "Util.h"
+#include <cassert>
+#include <cstddef>
+#include <iosfwd>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace souffle {
 

--- a/src/RamOperation.cpp
+++ b/src/RamOperation.cpp
@@ -17,11 +17,11 @@
  ***********************************************************************/
 
 #include "RamOperation.h"
+#include "BinaryConstraintOps.h"
 #include "RamCondition.h"
 #include "RamRelation.h"
-
+#include <cstddef>
 #include <iostream>
-#include <list>
 #include <memory>
 #include <string>
 

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -16,12 +16,20 @@
 
 #pragma once
 
+#include "Macro.h"
 #include "RamCondition.h"
 #include "RamNode.h"
 #include "RamRelation.h"
-
+#include "RamTypes.h"
+#include "RamValue.h"
+#include "Util.h"
+#include <cassert>
+#include <cstddef>
+#include <iosfwd>
 #include <memory>
-#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace souffle {
 

--- a/src/SrcLocation.cpp
+++ b/src/SrcLocation.cpp
@@ -16,15 +16,11 @@
 
 #include "SrcLocation.h"
 #include "Util.h"
-
-#include <cstring>
+#include <cctype>
 #include <fstream>
-#include <iostream>
 #include <limits>
 #include <sstream>
-
-#include <libgen.h>
-#include <unistd.h>
+#include <stdio.h>
 
 namespace souffle {
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -15,35 +15,34 @@
  ***********************************************************************/
 
 #include "Synthesiser.h"
-#include "AstRelation.h"
-#include "AstVisitor.h"
 #include "BinaryConstraintOps.h"
 #include "BinaryFunctorOps.h"
 #include "Global.h"
-#include "IOSystem.h"
+#include "IODirectives.h"
 #include "IndexSetAnalysis.h"
 #include "LogStatement.h"
-#include "Logger.h"
-#include "Macro.h"
-#include "ProfileEvent.h"
+#include "RamCondition.h"
+#include "RamNode.h"
+#include "RamOperation.h"
+#include "RamProgram.h"
 #include "RamRelation.h"
+#include "RamTranslationUnit.h"
+#include "RamValue.h"
 #include "RamVisitor.h"
-#include "SignalHandler.h"
-#include "TypeSystem.h"
+#include "SymbolMask.h"
+#include "SymbolTable.h"
+#include "TernaryFunctorOps.h"
 #include "UnaryFunctorOps.h"
-
+#include "Util.h"
 #include <algorithm>
-#include <chrono>
-#include <cmath>
-#include <memory>
-#include <regex>
+#include <cassert>
+#include <cctype>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <typeinfo>
 #include <utility>
-
-#include <unistd.h>
-
-#ifdef _OPENMP
-#include <omp.h>
-#endif
+#include <vector>
 
 namespace souffle {
 

--- a/src/Synthesiser.h
+++ b/src/Synthesiser.h
@@ -17,18 +17,18 @@
 #pragma once
 
 #include "IndexSetAnalysis.h"
-#include "RamProgram.h"
-#include "RamRelation.h"
-#include "RamTranslationUnit.h"
-#include "SymbolTable.h"
-
 #include "RamStatement.h"
-
+#include "RamTypes.h"
+#include <map>
 #include <ostream>
+#include <set>
 #include <string>
-#include <vector>
 
 namespace souffle {
+
+class RamOperation;
+class RamRelation;
+class RamTranslationUnit;
 
 /**
  * A RAM synthesiser: synthesises a C++ program from a RAM program.

--- a/src/Trie.h
+++ b/src/Trie.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "CompiledTuple.h"
+#include "RamTypes.h"
 #include "Util.h"
 
 #include <atomic>

--- a/src/TypeSystem.cpp
+++ b/src/TypeSystem.cpp
@@ -15,8 +15,8 @@
  ***********************************************************************/
 
 #include "TypeSystem.h"
+#include "Macro.h"
 #include "Util.h"
-
 #include <cassert>
 
 namespace souffle {

--- a/src/TypeSystem.h
+++ b/src/TypeSystem.h
@@ -19,8 +19,7 @@
 #include "AstType.h"
 #include "IterUtils.h"
 #include "Util.h"
-
-#include <initializer_list>
+#include <cassert>
 #include <iostream>
 #include <map>
 #include <set>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,52 +14,45 @@
  *
  ***********************************************************************/
 
-#include "AstAnalysis.h"
 #include "AstComponentChecker.h"
 #include "AstPragma.h"
-#include "AstProgram.h"
 #include "AstSemanticChecker.h"
-#include "AstTransformer.h"
 #include "AstTransforms.h"
 #include "AstTranslationUnit.h"
 #include "AstTranslator.h"
-#include "AstUtils.h"
 #include "ComponentModel.h"
+#include "DebugReport.h"
+#include "ErrorReport.h"
 #include "Global.h"
 #include "Interpreter.h"
 #include "InterpreterInterface.h"
+#include "Macro.h"
 #include "ParserDriver.h"
-#include "PrecedenceGraph.h"
+#include "RamProgram.h"
 #include "RamSemanticChecker.h"
-#include "RamStatement.h"
 #include "RamTransformer.h"
 #include "RamTranslationUnit.h"
 #include "SymbolTable.h"
 #include "Synthesiser.h"
 #include "Util.h"
+#include "config.h"
 
 #ifdef USE_PROVENANCE
 #include "Explain.h"
 #endif
 
+#include <cassert>
 #include <chrono>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <list>
+#include <iterator>
 #include <memory>
+#include <stdexcept>
 #include <string>
-
-#include "config.h"
-#include <cctype>
-#include <cerrno>
-#include <climits>
-#include <cstdarg>
-#include <cstdlib>
-#include <cstring>
-#include <getopt.h>
-#include <libgen.h>
-#include <sys/stat.h>
-#include <unistd.h>
+#include <utility>
+#include <vector>
+#include <stdio.h>
 
 namespace souffle {
 

--- a/src/profilerlib/Cell.h
+++ b/src/profilerlib/Cell.h
@@ -20,6 +20,7 @@ class Cell : public CellInterface {
 public:
     T val;
     Cell(T value) : val(value){};
+    virtual ~Cell() {}
 };
 
 template <>

--- a/src/profilerlib/CellInterface.h
+++ b/src/profilerlib/CellInterface.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <string>
+
 class CellInterface {
 public:
     virtual std::string toString(int precision) = 0;
@@ -17,4 +19,6 @@ public:
     virtual long getLongVal() = 0;
 
     virtual std::string getStringVal() = 0;
+
+    virtual ~CellInterface() {}
 };

--- a/src/profilerlib/Cli.cpp
+++ b/src/profilerlib/Cli.cpp
@@ -7,7 +7,12 @@
  */
 
 #include "Cli.h"
-#include "../FileFormatConverter.h"
+#include "FileFormatConverter.h"
+#include "profilerlib/StringUtils.h"
+#include "profilerlib/Tui.h"
+#include <cstdlib>
+#include <iostream>
+#include <map>
 
 // TODO: should move everything in the profiler library to namespace souffle
 using namespace souffle;

--- a/src/profilerlib/Cli.h
+++ b/src/profilerlib/Cli.h
@@ -8,12 +8,8 @@
 
 #pragma once
 
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <vector>
-
-#include "Tui.h"
 
 /*
  * CLI to parse command line arguments and start up the TUI to either run a single command,

--- a/src/profilerlib/Iteration.cpp
+++ b/src/profilerlib/Iteration.cpp
@@ -6,9 +6,10 @@
  * - <souffle root>/licenses/SOUFFLE-UPL.txt
  */
 
-#include "Iteration.h"
-
-#include <iostream>
+#include "profilerlib/Iteration.h"
+#include "profilerlib/Rule.h"
+#include <memory>
+#include <sstream>
 
 void Iteration::addRule(std::vector<std::string> data, std::string rec_id) {
     std::string strTemp = data[4] + data[3] + data[2];

--- a/src/profilerlib/Iteration.h
+++ b/src/profilerlib/Iteration.h
@@ -8,14 +8,12 @@
 
 #pragma once
 
-#include <cassert>
-#include <iomanip>
+#include "profilerlib/Rule.h"
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include "Rule.h"
 /*
  * Represents recursive profile data
  */

--- a/src/profilerlib/OutputProcessor.cpp
+++ b/src/profilerlib/OutputProcessor.cpp
@@ -6,7 +6,17 @@
  * - <souffle root>/licenses/SOUFFLE-UPL.txt
  */
 
-#include "OutputProcessor.h"
+#include "profilerlib/OutputProcessor.h"
+#include "profilerlib/Cell.h"
+#include "profilerlib/CellInterface.h"
+#include "profilerlib/Iteration.h"
+#include "profilerlib/ProgramRun.h"
+#include "profilerlib/Relation.h"
+#include "profilerlib/Row.h"
+#include "profilerlib/Rule.h"
+#include "profilerlib/Table.h"
+#include <memory>
+#include <unordered_map>
 
 /*
  * rel table :

--- a/src/profilerlib/OutputProcessor.h
+++ b/src/profilerlib/OutputProcessor.h
@@ -8,15 +8,12 @@
 
 #pragma once
 
+#include "profilerlib/ProgramRun.h"
+#include "profilerlib/StringUtils.h"
+#include "profilerlib/Table.h"
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "Cell.h"
-#include "ProgramRun.h"
-#include "Row.h"
-#include "StringUtils.h"
-#include "Table.h"
 
 /*
  * Class to format profiler data structures into tables

--- a/src/profilerlib/ProgramRun.cpp
+++ b/src/profilerlib/ProgramRun.cpp
@@ -6,7 +6,8 @@
  * - <souffle root>/licenses/SOUFFLE-UPL.txt
  */
 
-#include "ProgramRun.h"
+#include "profilerlib/ProgramRun.h"
+#include <sstream>
 
 std::string ProgramRun::toString() {
     std::ostringstream output;

--- a/src/profilerlib/ProgramRun.h
+++ b/src/profilerlib/ProgramRun.h
@@ -8,12 +8,13 @@
 
 #pragma once
 
-#include "Relation.h"
-#include "StringUtils.h"
-
+#include "profilerlib/Relation.h"
+#include "profilerlib/StringUtils.h"
+#include "profilerlib/Table.h"
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 /*
  * Stores the relations of the program

--- a/src/profilerlib/Reader.cpp
+++ b/src/profilerlib/Reader.cpp
@@ -6,7 +6,21 @@
  * - <souffle root>/licenses/SOUFFLE-UPL.txt
  */
 
-#include "Reader.h"
+#include "profilerlib/Reader.h"
+#include "profilerlib/Iteration.h"
+#include "profilerlib/ProgramRun.h"
+#include "profilerlib/Relation.h"
+#include "profilerlib/Rule.h"
+#include "profilerlib/StringUtils.h"
+#include <cassert>
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <dirent.h>
+#include <sys/stat.h>
 
 void Reader::readFile() {
     if (isLive()) {

--- a/src/profilerlib/Reader.h
+++ b/src/profilerlib/Reader.h
@@ -8,22 +8,13 @@
 
 #pragma once
 
-#include <cassert>
-#include <exception>
+#include "profilerlib/ProgramRun.h"
+#include "profilerlib/Relation.h"
 #include <fstream>
-#include <iostream>
 #include <memory>
-#include <regex>
-#include <thread>
+#include <string>
 #include <unordered_map>
-
-#include <dirent.h>
-
-#include "Iteration.h"
-#include "ProgramRun.h"
-#include "Relation.h"
-#include "Rule.h"
-#include "StringUtils.h"
+#include <vector>
 
 /*
  * Input reader and processor for log files

--- a/src/profilerlib/Relation.cpp
+++ b/src/profilerlib/Relation.cpp
@@ -7,6 +7,10 @@
  */
 
 #include "Relation.h"
+#include "profilerlib/Iteration.h"
+#include "profilerlib/Rule.h"
+#include <memory>
+#include <sstream>
 
 std::vector<std::shared_ptr<Rule>> Relation::getRuleRecList() {
     std::vector<std::shared_ptr<Rule>> temp = std::vector<std::shared_ptr<Rule>>();

--- a/src/profilerlib/Relation.h
+++ b/src/profilerlib/Relation.h
@@ -8,14 +8,13 @@
 
 #pragma once
 
+#include "profilerlib/Iteration.h"
+#include "profilerlib/Rule.h"
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include "Iteration.h"
-#include "Rule.h"
 
 /*
  * Stores the iterations and rules of a given relation

--- a/src/profilerlib/Rule.cpp
+++ b/src/profilerlib/Rule.cpp
@@ -6,7 +6,8 @@
  * - <souffle root>/licenses/SOUFFLE-UPL.txt
  */
 
-#include "Rule.h"
+#include "profilerlib/Rule.h"
+#include <sstream>
 
 std::string Rule::toString() {
     std::ostringstream output;

--- a/src/profilerlib/Rule.h
+++ b/src/profilerlib/Rule.h
@@ -8,10 +8,7 @@
 
 #pragma once
 
-#include <iomanip>
-#include <iostream>
 #include <map>
-#include <sstream>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/src/profilerlib/StringUtils.cpp
+++ b/src/profilerlib/StringUtils.cpp
@@ -6,7 +6,15 @@
  * - <souffle root>/licenses/SOUFFLE-UPL.txt
  */
 
-#include "StringUtils.h"
+#include "profilerlib/StringUtils.h"
+#include "profilerlib/CellInterface.h"
+#include "profilerlib/Row.h"
+#include "profilerlib/Table.h"
+#include <cmath>
+#include <cstdio>
+#include <iomanip>
+#include <memory>
+#include <sstream>
 
 /*
  * Convert a number into a shorthand notation

--- a/src/profilerlib/StringUtils.h
+++ b/src/profilerlib/StringUtils.h
@@ -8,32 +8,14 @@
 
 #pragma once
 
+#include "profilerlib/Table.h"
+#include <fstream>
+#include <ios>
 #include <string>
 #include <vector>
-
-#include <cmath>
-#include <fstream>
-#include <iomanip>
-#include <ios>
-#include <iostream>
-#include <sstream>
-
-#include <sys/stat.h>
-#include <sys/types.h>  // required for stat.h
-
-#include <cstdio> /* defines FILENAME_MAX */
-
-#if defined(_WIN32) || defined(_WIN64) || defined(WINDOWS)
-#include <direct.h>
-#define GetCurrentDir _getcwd
-#else
-
 #include <unistd.h>
 
 #define GetCurrentDir getcwd
-#endif
-
-#include "Table.h"
 
 /*
  * A series of functions necessary throughout the code

--- a/src/profilerlib/Table.cpp
+++ b/src/profilerlib/Table.cpp
@@ -6,7 +6,9 @@
  * - <souffle root>/licenses/SOUFFLE-UPL.txt
  */
 
-#include "Table.h"
+#include "profilerlib/Table.h"
+#include "profilerlib/DataComparator.h"
+#include <algorithm>
 
 void Table::sort(int col_num) {
     switch (col_num) {

--- a/src/profilerlib/Table.h
+++ b/src/profilerlib/Table.h
@@ -8,12 +8,8 @@
 
 #pragma once
 
-#include <algorithm>
-#include <string>
-#include <vector>
-
-#include "DataComparator.h"
 #include "Row.h"
+#include <vector>
 
 /*
  * Table class for holding a vector of rows

--- a/src/profilerlib/Tui.cpp
+++ b/src/profilerlib/Tui.cpp
@@ -7,6 +7,27 @@
  */
 
 #include "Tui.h"
+#include "profilerlib/CellInterface.h"
+#include "profilerlib/Iteration.h"
+#include "profilerlib/OutputProcessor.h"
+#include "profilerlib/ProgramRun.h"
+#include "profilerlib/Reader.h"
+#include "profilerlib/Relation.h"
+#include "profilerlib/Row.h"
+#include "profilerlib/Rule.h"
+#include "profilerlib/StringUtils.h"
+#include "profilerlib/UserInputReader.h"
+#include "profilerlib/html_string.h"
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <dirent.h>
+#include <sys/stat.h>
 
 Tui::Tui(std::string filename, bool live, bool gui) {
     this->f_name = filename;
@@ -343,8 +364,6 @@ void Tui::loadMenu() {
     std::cout << "Please 'load' a file or 'open' from Previous Runs.\n";
     std::cout << "Previous Runs:\n";
 
-    // http://stackoverflow.com/a/612176
-    // TODO: check cross-platform capability
     DIR* dir;
     struct dirent* ent;
     if ((dir = opendir("./old_runs")) != NULL) {

--- a/src/profilerlib/Tui.h
+++ b/src/profilerlib/Tui.h
@@ -8,17 +8,12 @@
 
 #pragma once
 
-#include <iostream>
+#include "profilerlib/OutputProcessor.h"
+#include "profilerlib/Reader.h"
+#include "profilerlib/Table.h"
+#include "profilerlib/UserInputReader.h"
 #include <string>
 #include <vector>
-#include <dirent.h>
-
-#include "DataComparator.h"
-#include "OutputProcessor.h"
-#include "Reader.h"
-#include "StringUtils.h"
-#include "UserInputReader.h"
-#include "html_string.h"
 
 /*
  * Text User interface for SouffleProf

--- a/src/profilerlib/UserInputReader.cpp
+++ b/src/profilerlib/UserInputReader.cpp
@@ -11,10 +11,14 @@
 //
 
 #include "UserInputReader.h"
+#include <iostream>   // for operator<<, flush, basic_ostream, cout, ostream
+#include <iterator>   // for end, begin
+#include <termios.h>  // for termios, tcsetattr, tcgetattr, ECHO, ICANON, cc_t
+#include <unistd.h>   // for read
 
 void InputReader::getch() {
     char buf = 0;
-    struct termios old = {0};
+    struct termios old = {};
     if (tcgetattr(0, &old) < 0) perror("tcsetattr()");
     old.c_lflag &= ~ICANON;
     old.c_lflag &= ~ECHO;

--- a/src/profilerlib/UserInputReader.h
+++ b/src/profilerlib/UserInputReader.h
@@ -8,9 +8,6 @@
 
 #pragma once
 
-#include <cstdio>
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <vector>
 #include <termios.h>

--- a/src/souffle2bdd.cpp
+++ b/src/souffle2bdd.cpp
@@ -18,8 +18,11 @@
  ***********************************************************************/
 
 #include "AstArgument.h"
+#include "AstAttribute.h"
+#include "AstClause.h"
 #include "AstComponentChecker.h"
 #include "AstLiteral.h"
+#include "AstNode.h"
 #include "AstPragma.h"
 #include "AstProgram.h"
 #include "AstRelation.h"
@@ -27,23 +30,34 @@
 #include "AstSemanticChecker.h"
 #include "AstTransforms.h"
 #include "AstTranslationUnit.h"
-#include "AstType.h"
 #include "AstVisitor.h"
+#include "BinaryConstraintOps.h"
+#include "BinaryFunctorOps.h"
 #include "ComponentModel.h"
 #include "DebugReport.h"
 #include "ErrorReport.h"
 #include "Global.h"
 #include "Macro.h"
 #include "ParserDriver.h"
+#include "RamTypes.h"
 #include "SymbolTable.h"
 #include "Util.h"
+#include "config.h"
+#include <algorithm>
+#include <cassert>
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
 #include <exception>
 #include <fstream>
 #include <iostream>
+#include <iterator>
+#include <limits>
+#include <memory>
 #include <sstream>
+#include <string>
+#include <utility>
 #include <vector>
-#include <assert.h>
 
 namespace souffle {
 

--- a/src/souffle2lb.cpp
+++ b/src/souffle2lb.cpp
@@ -17,17 +17,12 @@
  *
  ***********************************************************************/
 
-#include <chrono>
-#include <exception>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <vector>
-#include <assert.h>
-
 #include "AstArgument.h"
+#include "AstAttribute.h"
+#include "AstClause.h"
 #include "AstComponentChecker.h"
 #include "AstLiteral.h"
+#include "AstNode.h"
 #include "AstPragma.h"
 #include "AstProgram.h"
 #include "AstRelation.h"
@@ -37,6 +32,8 @@
 #include "AstTranslationUnit.h"
 #include "AstType.h"
 #include "AstVisitor.h"
+#include "BinaryConstraintOps.h"
+#include "BinaryFunctorOps.h"
 #include "ComponentModel.h"
 #include "DebugReport.h"
 #include "ErrorReport.h"
@@ -45,6 +42,20 @@
 #include "ParserDriver.h"
 #include "SymbolTable.h"
 #include "Util.h"
+#include "config.h"
+#include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace souffle {
 

--- a/src/souffle_prof.cpp
+++ b/src/souffle_prof.cpp
@@ -9,7 +9,6 @@
 #include "profilerlib/Cli.h"
 
 #include <iostream>
-#include <string>
 
 int main(int argc, char* argv[]) {
     Cli cli_obj = Cli(argc, argv);


### PR DESCRIPTION
Mostly using the include-what-you-use tool, this PR refactors the headers to include what we use and remove what we don't.

While I was touching everything I also fixed a typo, removed some redundant const qualifiers to non-ref return types, and modified the instantiation of a struct that was not completely initialised.