### PR TITLE
Remove redundant tests.

### DIFF
--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -182,9 +182,7 @@ m4_define([NEGATIVE_TEST],[
 dnl Defines most relevant Souffle flag configurations for testing.
 dnl NOTE: This is the default configuration that can be overridden
 dnl using SOUFFLE_CONFS environment variable.
-m4_define([DEFAULT_CONFS], [[],      dnl run interpreter
-  [-c],                              dnl compile, then execute
-  [-j8],                             dnl run interpreter in parallel
+m4_define([DEFAULT_CONFS], [[-j8],   dnl run interpreter in parallel
   [-c -j8],                          dnl compile, then execute in parallel
   [-c -j8 -efile]                    dnl compile, then execute in parallel with file communication engine
 ])


### PR DESCRIPTION
In the current implementation -j1/default uses the same code paths as -j8 so testing both is redundant.

Tests for non-parallel implementations need a non-parallel environment/configuration, such as the OSX clang environment on Travis.