### PR TITLE
Update gcc version used on travis osx to match homebrew.

### DIFF
--- a/.travis/osx/install_withgcc.sh
+++ b/.travis/osx/install_withgcc.sh
@@ -8,8 +8,12 @@ set -x
 # Install requirements of MAC OS X
 rm /usr/local/include/c++
 brew update
-brew install md5sha1sum bison libtool gcc mcpp
+
+# Install gcc instead of gcc-x.x if a current version is preferred
+brew install md5sha1sum bison libtool gcc@7 mcpp
 brew link bison --force
+
+# Using 'g++' will call the xcode link to clang
 g++-7 --version
 
 rm /Users/travis/Library/Logs/DiagnosticReports/* || true


### PR DESCRIPTION
Homebrew has updated their version of g++ so our travis tests need to be updated to match.