### PR TITLE
Add rule evaluation logging when verbose output is enabled

### DIFF
--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -784,6 +784,9 @@ void Interpreter::evalStmt(const RamStatement& stmt) {
 /** Execute main program of a translation unit */
 void Interpreter::executeMain() {
     SignalHandler::instance()->set();
+    if (Global::config().has("verbose")) {
+        SignalHandler::instance()->enableLogging();
+    }
     const RamStatement& main = *translationUnit.getP().getMain();
 
     if (!Global::config().has("profile")) {

--- a/src/SignalHandler.h
+++ b/src/SignalHandler.h
@@ -88,15 +88,19 @@ public:
     }
     // set signal message
     void setMsg(const char* m) {
-        if (m != nullptr && logMessages) {
-            static std::mutex logMutex;
+        if (logMessages && m != nullptr) {
+            static std::mutex outputMutex;
             std::string outputMessage(m);
-            for (char& c : outputMessage) {
+            for (size_t pos = 0; pos < outputMessage.size(); ++pos) {
+                char& c = outputMessage[pos];
                 if (c == '\n' || c == '\t') {
                     c = ' ';
+                } else if (c == '.') {
+                    outputMessage = outputMessage.substr(0, pos + 1);
+                    break;
                 }
             }
-            std::lock_guard<std::mutex> guard(logMutex);
+            std::lock_guard<std::mutex> guard(outputMutex);
             std::cout << "Starting work on " << outputMessage << std::endl;
         }
         msg = m;

--- a/src/SignalHandler.h
+++ b/src/SignalHandler.h
@@ -15,10 +15,12 @@
  ***********************************************************************/
 
 #pragma once
+
 #include <atomic>
 #include <cassert>
 #include <csignal>
 #include <iostream>
+#include <mutex>
 #include <string>
 
 namespace souffle {
@@ -35,6 +37,8 @@ private:
 
     // state of signal handler
     bool isSet = false;
+
+    bool logMessages = false;
 
     // previous signal handler routines
     void (*prevFpeHandler)(int) = nullptr;
@@ -78,8 +82,23 @@ public:
         return &singleton;
     }
 
+    // Enable logging
+    void enableLogging() {
+        logMessages = true;
+    }
     // set signal message
     void setMsg(const char* m) {
+        if (m != nullptr && logMessages) {
+            static std::mutex logMutex;
+            std::string outputMessage(m);
+            for (char& c : outputMessage) {
+                if (c == '\n' || c == '\t') {
+                    c = ' ';
+                }
+            }
+            std::lock_guard<std::mutex> guard(logMutex);
+            std::cout << "Starting work on " << outputMessage << std::endl;
+        }
         msg = m;
     }
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1358,6 +1358,9 @@ void Synthesiser::generateCode(const RamTranslationUnit& unit, std::ostream& os,
           "std::string outputDirectory = \".\", size_t stratumIndex = (size_t) -1) {\n";
 
     os << "SignalHandler::instance()->set();\n";
+    if (Global::config().has("verbose")) {
+        os << "SignalHandler::instance()->enableLogging();\n";
+    }
 
     // initialize counter
     os << "// -- initialize counter --\n";


### PR DESCRIPTION
This PR adds rule evaluation to verbose output, e.g.,
```
Starting work on B(x) :-     A(x),    C(x).
Starting work on A(x) :-     B(x),    C(x).
```