### PR TITLE
Don't remove input relations.

### DIFF
--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -471,7 +471,7 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(AstProgram& program) 
 
     // search for relations only defined by a single rule ..
     for (AstRelation* rel : program.getRelations()) {
-        if (!rel->isComputed() && rel->getClauses().size() == 1u) {
+        if (!rel->isInput() && !rel->isComputed() && rel->getClauses().size() == 1u) {
             // .. of shape r(x,y,..) :- s(x,y,..)
             AstClause* cl = rel->getClause(0);
             if (!cl->isFact() && cl->getBodySize() == 1u && cl->getAtoms().size() == 1u) {


### PR DESCRIPTION
Fixes issue #675 

Currently relations are removed if they are not computed and have a single rule that copies another relation. This removes relations that have both input and that single rule. This PR is to also keep input relations.