### PR TITLE
Add build dependencies for souffle converters.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -218,7 +218,8 @@ $(builddir)/scanner.cc: $(srcdir)/scanner.ll
 
 # driver depends on the generated header
 $(builddir)/parser.cc $(builddir)/stack.hh $(builddir)/scanner.cc \
-        $(builddir)/main.cpp $(builddir)/ParserDriver.cpp: $(builddir)/parser.hh
+    $(builddir)/souffle2bdd.cpp $(builddir)/souffle2lb.cpp \
+    $(builddir)/main.cpp $(builddir)/ParserDriver.cpp: $(builddir)/parser.hh
 
 ########## Unit Tests
 


### PR DESCRIPTION
Builds with sufficient threads failed due to transitive dependencies on generated header file. This PR adds the needed dependency.