### PR TITLE
Use better formatting for lambdas & namespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ aliases:
     addons:
       apt:
         sources:
-        - llvm-toolchain-trusty-4.0
+        - llvm-toolchain-trusty-6.0
         - ubuntu-toolchain-r-test
         packages:
         - *linux_deps
-        - clang-4.0
+        - clang-6.0
         - libstdc++-7-dev
     #install: ".travis/linux/clang_install.sh"
     before_script: ".travis/init_test.sh"
@@ -77,7 +77,7 @@ aliases:
     before_script: ".travis/init_make_package.sh"
     script: ".travis/osx/make_package.sh"
   - &gcc_environment CC=gcc-7 CXX=g++-7
-  - &clang_environment CC=clang-4.0 CXX=clang++-4.0
+  - &clang_environment CC=clang-6.0 CXX=clang++-6.0
 
 jobs:
   include:
@@ -88,9 +88,11 @@ jobs:
     addons:
       apt:
         sources:
-        - llvm-toolchain-trusty-4.0
+        - llvm-toolchain-trusty-6.0
+        - ubuntu-toolchain-r-test
         packages:
-        - clang-format-4.0
+        - clang-format-6.0
+        - libstdc++-7-dev
     script: ".travis/run_test_format.sh"
 
 # Testing stage (-j8,-c -j8)

--- a/.travis/checkStyle.sh
+++ b/.travis/checkStyle.sh
@@ -3,7 +3,7 @@
 # Find the changed lines in the diff. Arguments 1 and 2 are appended to the
 #git diff command
 
-CLANGFORMAT=clang-format-4.0
+CLANGFORMAT=clang-format-6.0
 
 changedLines() {
   range_start=-1

--- a/.travis/checkStyle.sh
+++ b/.travis/checkStyle.sh
@@ -5,31 +5,6 @@
 
 CLANGFORMAT=clang-format-6.0
 
-changedLines() {
-  range_start=-1
-  
-  for m in $(git diff -U0 $1 $2|grep '^@@'|sed -r 's/^@@.* \+([0-9][0-9]*),?([0-9]*) .*$/_\1 _\2/'); do
-    n=${m:1};
-    if (( range_start > -1 )) ; then
-      if [[ "$n" == "" ]]
-      then
-        echo -n " -lines=$range_start:$range_start"
-      else
-        if (( n > 0 )) ; then
-            echo -n " -lines=$range_start:$((n + range_start - 1))"
-        fi
-      fi
-      range_start=-1
-    else
-      range_start=$n
-    fi
-  done
-  
-  if (( range_start > -1 )) ; then
-    echo -n " -lines=$range_start:$range_start"
-  fi
-}
-
 # Move to the root of the repo if we aren't there already so the paths returned
 # by git are correct.
 cd "$(git rev-parse --show-toplevel)"

--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -135,7 +135,6 @@ void AstSemanticChecker::checkProgram(ErrorReport& report, const AstProgram& pro
 
     // all null constants are used as records
     visitDepthFirst(nodes, [&](const AstNullConstant& cnst) {
-
         // TODO (#467) remove the next line to enable subprogram compilation for record types
         Global::config().unset("engine");
         TypeSet types = typeAnalysis.getTypes(&cnst);
@@ -1129,27 +1128,27 @@ void AstSemanticChecker::checkInlining(
     // Returns the pair (isValid, lastSrcLoc) where:
     //  - isValid is true if and only if the node contains an invalid underscore, and
     //  - lastSrcLoc is the source location of the last visited node
-    std::function<std::pair<bool, SrcLocation>(const AstNode*)> checkInvalidUnderscore = [&](
-            const AstNode* node) {
-        if (dynamic_cast<const AstUnnamedVariable*>(node)) {
-            // Found an invalid underscore
-            return std::make_pair(true, node->getSrcLoc());
-        } else if (dynamic_cast<const AstAggregator*>(node)) {
-            // Don't care about underscores within aggregators
-            return std::make_pair(false, node->getSrcLoc());
-        }
+    std::function<std::pair<bool, SrcLocation>(const AstNode*)> checkInvalidUnderscore =
+            [&](const AstNode* node) {
+                if (dynamic_cast<const AstUnnamedVariable*>(node)) {
+                    // Found an invalid underscore
+                    return std::make_pair(true, node->getSrcLoc());
+                } else if (dynamic_cast<const AstAggregator*>(node)) {
+                    // Don't care about underscores within aggregators
+                    return std::make_pair(false, node->getSrcLoc());
+                }
 
-        // Check if any children nodes use invalid underscores
-        for (const AstNode* child : node->getChildNodes()) {
-            std::pair<bool, SrcLocation> childStatus = checkInvalidUnderscore(child);
-            if (childStatus.first) {
-                // Found an invalid underscore
-                return childStatus;
-            }
-        }
+                // Check if any children nodes use invalid underscores
+                for (const AstNode* child : node->getChildNodes()) {
+                    std::pair<bool, SrcLocation> childStatus = checkInvalidUnderscore(child);
+                    if (childStatus.first) {
+                        // Found an invalid underscore
+                        return childStatus;
+                    }
+                }
 
-        return std::make_pair(false, node->getSrcLoc());
-    };
+                return std::make_pair(false, node->getSrcLoc());
+            };
 
     // Perform the check
     visitDepthFirst(program, [&](const AstNegation& negation) {

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -193,11 +193,12 @@ public:
 
     /** A print function (for debugging) */
     void print(std::ostream& out) const {
-        out << "{" << join(map, ",",
-                              [](std::ostream& out,
-                                      const std::pair<const std::string, std::unique_ptr<AstArgument>>& cur) {
-                                  out << cur.first << " -> " << *cur.second;
-                              })
+        out << "{"
+            << join(map, ",",
+                       [](std::ostream& out,
+                               const std::pair<const std::string, std::unique_ptr<AstArgument>>& cur) {
+                           out << cur.first << " -> " << *cur.second;
+                       })
             << "}";
     }
 

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -1071,8 +1071,9 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
     std::unique_ptr<RamParallel> loopSeq(new RamParallel());
 
     // create a utility to check SCC membership
-    auto isInSameSCC = [&](
-            const AstRelation* rel) { return std::find(scc.begin(), scc.end(), rel) != scc.end(); };
+    auto isInSameSCC = [&](const AstRelation* rel) {
+        return std::find(scc.begin(), scc.end(), rel) != scc.end();
+    };
 
     /* Compute temp for the current tables */
     for (const AstRelation* rel : scc) {
@@ -1273,8 +1274,7 @@ std::unique_ptr<RamProgram> AstTranslator::translateProgram(const AstTranslation
 
     // a function to create relations
     const auto& makeRamCreate = [&](std::unique_ptr<RamStatement>& current, const AstRelation* relation,
-            const std::string relationNamePrefix) {
-
+                                        const std::string relationNamePrefix) {
         appendStmt(
                 current, std::make_unique<RamCreate>(std::unique_ptr<RamRelation>(getRamRelation(relation,
                                  &typeEnv, relationNamePrefix + getRelationName(relation->getName()),
@@ -1283,8 +1283,7 @@ std::unique_ptr<RamProgram> AstTranslator::translateProgram(const AstTranslation
 
     // a function to load relations
     const auto& makeRamLoad = [&](std::unique_ptr<RamStatement>& current, const AstRelation* relation,
-            const std::string& inputDirectory, const std::string& fileExtension) {
-
+                                      const std::string& inputDirectory, const std::string& fileExtension) {
         std::unique_ptr<RamStatement> statement =
                 std::make_unique<RamLoad>(std::unique_ptr<RamRelation>(getRamRelation(relation, &typeEnv,
                                                   getRelationName(relation->getName()), relation->getArity(),
@@ -1300,7 +1299,6 @@ std::unique_ptr<RamProgram> AstTranslator::translateProgram(const AstTranslation
 
     // a function to print the size of relations
     const auto& makeRamPrintSize = [&](std::unique_ptr<RamStatement>& current, const AstRelation* relation) {
-
         appendStmt(current, std::make_unique<RamPrintSize>(std::unique_ptr<RamRelation>(
                                     getRamRelation(relation, &typeEnv, getRelationName(relation->getName()),
                                             relation->getArity(), false, relation->isHashset()))));
@@ -1308,8 +1306,7 @@ std::unique_ptr<RamProgram> AstTranslator::translateProgram(const AstTranslation
 
     // a function to store relations
     const auto& makeRamStore = [&](std::unique_ptr<RamStatement>& current, const AstRelation* relation,
-            const std::string& outputDirectory, const std::string& fileExtension) {
-
+                                       const std::string& outputDirectory, const std::string& fileExtension) {
         std::unique_ptr<RamStatement> statement =
                 std::make_unique<RamStore>(std::unique_ptr<RamRelation>(getRamRelation(relation, &typeEnv,
                                                    getRelationName(relation->getName()), relation->getArity(),
@@ -1333,25 +1330,24 @@ std::unique_ptr<RamProgram> AstTranslator::translateProgram(const AstTranslation
 
 #ifdef USE_MPI
     const auto& makeRamSend = [&](std::unique_ptr<RamStatement>& current, const AstRelation* relation,
-            const std::set<size_t> destinationStrata) {
+                                      const std::set<size_t> destinationStrata) {
         appendStmt(current, std::make_unique<RamSend>(
                                     getRamRelation(relation, &typeEnv, getRelationName(relation->getName()),
                                             relation->getArity(), false, relation->isHashset()),
                                     destinationStrata));
-
     };
 
-    const auto& makeRamRecv = [&](
-            std::unique_ptr<RamStatement>& current, const AstRelation* relation, const size_t sourceStrata) {
+    const auto& makeRamRecv = [&](std::unique_ptr<RamStatement>& current, const AstRelation* relation,
+                                      const size_t sourceStrata) {
         appendStmt(current, std::make_unique<RamRecv>(
                                     getRamRelation(relation, &typeEnv, getRelationName(relation->getName()),
                                             relation->getArity(), false, relation->isHashset()),
                                     sourceStrata));
-
     };
 
-    const auto& makeRamNotify = [&](
-            std::unique_ptr<RamStatement>& current) { appendStmt(current, std::make_unique<RamNotify>()); };
+    const auto& makeRamNotify = [&](std::unique_ptr<RamStatement>& current) {
+        appendStmt(current, std::make_unique<RamNotify>());
+    };
 
     const auto& makeRamWait = [&](std::unique_ptr<RamStatement>& current, const size_t count) {
         appendStmt(current, std::make_unique<RamWait>(count));

--- a/src/AstVisitor.h
+++ b/src/AstVisitor.h
@@ -64,7 +64,7 @@ struct AstVisitor : public ast_visitor_tag {
      * @param args a list of extra parameters to be forwarded
      */
     virtual R visit(const AstNode& node, Params... args) {
-// dispatch node processing based on dynamic type
+        // dispatch node processing based on dynamic type
 
 #define FORWARD(Kind) \
     if (const auto* n = dynamic_cast<const Ast##Kind*>(&node)) return visit##Kind(*n, args...);

--- a/src/Mpi.h
+++ b/src/Mpi.h
@@ -107,7 +107,7 @@ template <>
 inline const MPI_Datatype datatype<char>() {
     return MPI_BYTE;
 }
-}
+}  // namespace
 
 /* getCount */
 namespace {
@@ -119,7 +119,7 @@ inline int getCount(std::unique_ptr<MPI_Status>& status) {
     MPI_Get_count(status.get(), datatype<T>(), &count);
     return count;
 }
-}
+}  // namespace
 
 /* pack */
 namespace {
@@ -157,7 +157,7 @@ inline void pack<std::vector<std::string>>(
     MPI_Pack(&last[0], (int)last.size(), lastType, &newData[0], (int)newData.capacity(), &position,
             MPI_COMM_WORLD);
 }
-}
+}  // namespace
 
 /* unpack */
 namespace {
@@ -185,7 +185,7 @@ inline void unpack<std::vector<std::string>>(
         from = to;
     }
 }
-}
+}  // namespace
 
 /* init */
 namespace {
@@ -193,7 +193,7 @@ inline int init(int argc, char* argv[]) {
     auto flag = MPI_Init(&argc, &argv);
     return flag;
 }
-}
+}  // namespace
 
 /* finalize */
 namespace {
@@ -201,7 +201,7 @@ namespace {
 inline void finalize() {
     MPI_Finalize();
 }
-}
+}  // namespace
 
 /* commSize */
 namespace {
@@ -211,7 +211,7 @@ inline int commSize() {
 
     return size;
 }
-}
+}  // namespace
 
 /* commRank */
 namespace {
@@ -221,7 +221,7 @@ inline int commRank() {
 
     return rank;
 }
-}
+}  // namespace
 
 /* probe */
 namespace {
@@ -240,7 +240,7 @@ inline Status probe() {
 inline Status probe(const Status& status) {
     return probe(status->MPI_SOURCE, status->MPI_TAG);
 }
-}
+}  // namespace
 
 /* iprobe */
 namespace {
@@ -259,7 +259,7 @@ inline Status iprobe() {
 inline Status iprobe(const Status& status) {
     return iprobe(status->MPI_SOURCE, status->MPI_TAG);
 }
-}
+}  // namespace
 
 /* send */
 namespace {
@@ -361,7 +361,7 @@ inline void send(const T& data, const size_t length, const std::set<int>& destin
         send((!data.empty()), destinations, tag);
     }
 }
-}
+}  // namespace
 
 /* recv */
 namespace {
@@ -465,6 +465,6 @@ inline void recv(T& data, const size_t length, Status& status) {
         }
     }
 }
-}
+}  // namespace
 }  // end of namespace mpi
 }  // end of namespace souffle

--- a/src/PrecedenceGraph.cpp
+++ b/src/PrecedenceGraph.cpp
@@ -485,8 +485,9 @@ std::vector<std::set<const AstRelation*>> RelationSchedule::computeRelationExpir
         /* Compute expired relations in reverse topological order using the set difference of the alive sets
            between steps. */
         std::set_difference(alive[orderedSCC].begin(), alive[orderedSCC].end(), alive[orderedSCC - 1].begin(),
-                alive[orderedSCC - 1].end(), std::inserter(relationExpirySchedule[numSCCs - orderedSCC],
-                                                     relationExpirySchedule[numSCCs - orderedSCC].end()));
+                alive[orderedSCC - 1].end(),
+                std::inserter(relationExpirySchedule[numSCCs - orderedSCC],
+                        relationExpirySchedule[numSCCs - orderedSCC].end()));
     }
 
     return relationExpirySchedule;

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -245,14 +245,15 @@ public:
 
     /** Print */
     void print(std::ostream& os) const override {
-        os << "(" << join(values, ",",
-                             [](std::ostream& out, const std::unique_ptr<RamValue>& value) {
-                                 if (!value) {
-                                     out << "_";
-                                 } else {
-                                     out << *value;
-                                 }
-                             })
+        os << "("
+           << join(values, ",",
+                      [](std::ostream& out, const std::unique_ptr<RamValue>& value) {
+                          if (!value) {
+                              out << "_";
+                          } else {
+                              out << *value;
+                          }
+                      })
            << ") ∉ " << relation->getName();
     }
 

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -377,10 +377,11 @@ public:
 #endif
         {
             out << "SymbolTable: {\n\t";
-            out << join(strToNum, "\n\t", [](std::ostream& out,
-                                                  const std::pair<std::string, std::size_t>& entry) {
-                out << entry.first << "\t => " << entry.second;
-            }) << "\n";
+            out << join(strToNum, "\n\t",
+                           [](std::ostream& out, const std::pair<std::string, std::size_t>& entry) {
+                               out << entry.first << "\t => " << entry.second;
+                           })
+                << "\n";
             out << "}\n";
         }
     }

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1409,8 +1409,9 @@ void Synthesiser::generateCode(const RamTranslationUnit& unit, std::ostream& os,
         tempType = (rel.isTemp() && raw_name.find("@delta") != std::string::npos)
                            ? getRelationType(rel, rel.getArity(), idxAnalysis->getIndexes(rel))
                            : tempType;
-        const std::string& type = (rel.isTemp()) ? tempType : getRelationType(rel, rel.getArity(),
-                                                                      idxAnalysis->getIndexes(rel));
+        const std::string& type =
+                (rel.isTemp()) ? tempType
+                               : getRelationType(rel, rel.getArity(), idxAnalysis->getIndexes(rel));
 
         // defining table
         os << "// -- Table: " << raw_name << "\n";
@@ -1722,8 +1723,9 @@ void Synthesiser::generateCode(const RamTranslationUnit& unit, std::ostream& os,
         for (auto& sub : prog.getSubroutines()) {
             // method header
             os << "void "
-               << "subproof_" << subroutineNum << "(const std::vector<RamDomain>& args, "
-                                                  "std::vector<RamDomain>& ret, std::vector<bool>& err) {\n";
+               << "subproof_" << subroutineNum
+               << "(const std::vector<RamDomain>& args, "
+                  "std::vector<RamDomain>& ret, std::vector<bool>& err) {\n";
 
             // generate code for body
             emitCode(os, *sub.second);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ void executeBinary(const std::string& binaryFilename
         ,
         const int numberOfProcesses
 #endif
-        ) {
+) {
     assert(!binaryFilename.empty() && "binary filename cannot be blank");
 
     // check whether the executable exists
@@ -563,7 +563,7 @@ int main(int argc, char** argv) {
                             ,
                             ((int)astTranslationUnit->getAnalysis<SCCGraph>()->getNumberOfSCCs()) + 1
 #endif
-                            );
+                    );
                 }
             }
         } catch (std::exception& e) {

--- a/src/profile/htmlCssChartist.h
+++ b/src/profile/htmlCssChartist.h
@@ -848,5 +848,5 @@ th[role=columnheader]:not(.no-sort):hover:after {
 }
 )___";
 }
-}
-}
+}  // namespace profile
+}  // namespace souffle

--- a/src/profile/htmlCssStyle.h
+++ b/src/profile/htmlCssStyle.h
@@ -651,5 +651,5 @@ button {
 }
 )___";
 }
-}
-}
+}  // namespace profile
+}  // namespace souffle

--- a/src/profile/htmlJsChartistMin.h
+++ b/src/profile/htmlJsChartistMin.h
@@ -17,5 +17,5 @@ std::string jsChartistMin = R"___(
 
 )___";
 }
-}
-}
+}  // namespace profile
+}  // namespace souffle

--- a/src/profile/htmlJsChartistPlugin.h
+++ b/src/profile/htmlJsChartistPlugin.h
@@ -221,5 +221,5 @@ std::string jsChartistPlugin = R"___(
 
 )___";
 }
-}
-}
+}  // namespace profile
+}  // namespace souffle

--- a/src/profile/htmlJsMain.h
+++ b/src/profile/htmlJsMain.h
@@ -4,7 +4,7 @@
  * Licensed under the Universal Permissive License v 1.0 as shown at:
  * - https://opensource.org/licenses/UPL
  * - <souffle root>/licenses/SOUFFLE-UPL.txt
-*/
+ */
 
 #include <string>
 
@@ -515,5 +515,5 @@ function init() {
 init();
     )___";
 }
-}
-}
+}  // namespace profile
+}  // namespace souffle

--- a/src/profile/htmlJsTableSort.h
+++ b/src/profile/htmlJsTableSort.h
@@ -266,5 +266,5 @@ std::string jsTableSort = R"___(
 
 )___";
 }
-}
-}
+}  // namespace profile
+}  // namespace souffle

--- a/src/profile/htmlJsUtil.h
+++ b/src/profile/htmlJsUtil.h
@@ -157,5 +157,5 @@ function minify_numbers(num) {
 
 )___";
 }
-}
-}
+}  // namespace profile
+}  // namespace souffle

--- a/src/profile/htmlMain.h
+++ b/src/profile/htmlMain.h
@@ -182,6 +182,6 @@ std::string htmlBodyBottom = R"___(
 </html>
 
 )___";
-}
-}
-}
+}  // namespace html
+}  // namespace profile
+}  // namespace souffle

--- a/src/test/mpi_test.cpp
+++ b/src/test/mpi_test.cpp
@@ -31,5 +31,5 @@ TEST(mpi, mpi) {
         EXPECT_EQ(mpi::commSize(), 1);
     }
 }
-}
-}
+}  // namespace test
+}  // namespace souffle


### PR DESCRIPTION
clang-6.0, and clang-format-6.0, are widespread now, and clang-format-6.0 handles lambdas in keeping with our style. This PR is to change the automated tests, and the code, to match the 'new' style, and the clang version to match the commonly installed version.

