### PR TITLE
Integration of flexible operator hints into btree implementation.

### DIFF
--- a/src/BTree.h
+++ b/src/BTree.h
@@ -1110,13 +1110,12 @@ public:
     };
 
     /**
-	 * A collection of operation hints speeding up some of the involved operations
-	 * by exploiting temporal locality.
-	 */
-    template<unsigned size = 1>
+     * A collection of operation hints speeding up some of the involved operations
+     * by exploiting temporal locality.
+     */
+    template <unsigned size = 1>
     struct btree_operation_hints {
-
-        using node_cache = LRUCache<node*,size>;
+        using node_cache = LRUCache<node*, size>;
 
         // the node where the last insertion terminated
         node_cache last_insert;
@@ -1316,29 +1315,29 @@ public:
         // test last insert hints
         lock_type::Lease cur_lease;
 
-        auto checkHint = [&](node* last_insert){
-        	// ignore null pointer
-        	if (!last_insert) return false;
-        	// get a read lease on indicated node
-			auto hint_lease = last_insert->lock.start_read();
-			// check whether it covers the key
-			if (!covers(last_insert, k)) return false;
-			// and if there was no concurrent modification
-			if (!last_insert->lock.validate(hint_lease)) return false;
-			// use hinted location
-			cur = last_insert;
-			// and keep lease
-			cur_lease = hint_lease;
-			// we found a hit
-			return true;
+        auto checkHint = [&](node* last_insert) {
+            // ignore null pointer
+            if (!last_insert) return false;
+            // get a read lease on indicated node
+            auto hint_lease = last_insert->lock.start_read();
+            // check whether it covers the key
+            if (!covers(last_insert, k)) return false;
+            // and if there was no concurrent modification
+            if (!last_insert->lock.validate(hint_lease)) return false;
+            // use hinted location
+            cur = last_insert;
+            // and keep lease
+            cur_lease = hint_lease;
+            // we found a hit
+            return true;
         };
 
         if (hints.last_insert.any(checkHint)) {
-    		// register this as a hit
-			hint_stats.inserts.addHit();
+            // register this as a hit
+            hint_stats.inserts.addHit();
         } else {
-        	// register this as a miss
-			hint_stats.inserts.addMiss();
+            // register this as a miss
+            hint_stats.inserts.addMiss();
         }
 
         // if there is no valid hint ..
@@ -1543,10 +1542,10 @@ public:
         node* cur = root;
 
         auto checkHints = [&](node* last_insert) {
-        	if (!last_insert) return false;
-        	if (!covers(last_insert,k)) return false;
-        	cur = last_insert;
-        	return true;
+            if (!last_insert) return false;
+            if (!covers(last_insert, k)) return false;
+            cur = last_insert;
+            return true;
         };
 
         // test last insert
@@ -1733,10 +1732,10 @@ public:
         node* cur = root;
 
         auto checkHints = [&](node* last_find_end) {
-        	if (!last_find_end) return false;
-        	if (!covers(last_find_end,k)) return false;
-        	cur = last_find_end;
-        	return true;
+            if (!last_find_end) return false;
+            if (!covers(last_find_end, k)) return false;
+            cur = last_find_end;
+            return true;
         };
 
         // test last location searched (temporal locality)
@@ -1794,11 +1793,11 @@ public:
         node* cur = root;
 
         auto checkHints = [&](node* last_lower_bound_end) {
-			if (!last_lower_bound_end) return false;
-			if (!covers(last_lower_bound_end,k)) return false;
-			cur = last_lower_bound_end;
-			return true;
-		};
+            if (!last_lower_bound_end) return false;
+            if (!covers(last_lower_bound_end, k)) return false;
+            cur = last_lower_bound_end;
+            return true;
+        };
 
         // test last searched node
         if (hints.last_lower_bound_end.any(checkHints)) {
@@ -1855,11 +1854,11 @@ public:
         node* cur = root;
 
         auto checkHints = [&](node* last_upper_bound_end) {
-			if (!last_upper_bound_end) return false;
-			if (!coversUpperBound(last_upper_bound_end,k)) return false;
-			cur = last_upper_bound_end;
-			return true;
-		};
+            if (!last_upper_bound_end) return false;
+            if (!coversUpperBound(last_upper_bound_end, k)) return false;
+            cur = last_upper_bound_end;
+            return true;
+        };
 
         // test last search node
         if (hints.last_upper_bound_end.any(checkHints)) {

--- a/src/BTree.h
+++ b/src/BTree.h
@@ -1110,35 +1110,39 @@ public:
     };
 
     /**
-     * A collection of operation hints speeding up some of the involved operations
-     * by exploiting temporal locality.
-     */
-    struct operation_hints {
+	 * A collection of operation hints speeding up some of the involved operations
+	 * by exploiting temporal locality.
+	 */
+    template<unsigned size = 1>
+    struct btree_operation_hints {
+
+        using node_cache = LRUCache<node*,size>;
+
         // the node where the last insertion terminated
-        node* last_insert;
+        node_cache last_insert;
 
         // the node where the last find-operation terminated
-        node* last_find_end;
+        node_cache last_find_end;
 
         // the node where the last lower-bound operation terminated
-        node* last_lower_bound_end;
+        node_cache last_lower_bound_end;
 
         // the node where the last upper-bound operation terminated
-        node* last_upper_bound_end;
+        node_cache last_upper_bound_end;
 
         // default constructor
-        operation_hints()
-                : last_insert(nullptr), last_find_end(nullptr), last_lower_bound_end(nullptr),
-                  last_upper_bound_end(nullptr) {}
+        btree_operation_hints() {}
 
         // resets all hints (to be triggered e.g. when deleting nodes)
         void clear() {
-            last_insert = nullptr;
-            last_find_end = nullptr;
-            last_lower_bound_end = nullptr;
-            last_upper_bound_end = nullptr;
+            last_insert.clear(nullptr);
+            last_find_end.clear(nullptr);
+            last_lower_bound_end.clear(nullptr);
+            last_upper_bound_end.clear(nullptr);
         }
     };
+
+    using operation_hints = btree_operation_hints<4>;
 
 private:
 #if defined(IS_PARALLEL) && !defined(HAS_TSX)
@@ -1300,7 +1304,7 @@ public:
             // operation complete => we can release the root lock
             root_lock.end_write();
 
-            hints.last_insert = leftmost;
+            hints.last_insert.access(leftmost);
 
             return true;
         }
@@ -1309,30 +1313,32 @@ public:
 
         node* cur = nullptr;
 
-        // test last insert
+        // test last insert hints
         lock_type::Lease cur_lease;
 
-        if (hints.last_insert) {
-            // get a read lease on indicated node
-            auto hint_lease = hints.last_insert->lock.start_read();
-            // check whether it covers the key
-            if (covers(hints.last_insert, k)) {
-                // and if there was no concurrent modification
-                if (hints.last_insert->lock.validate(hint_lease)) {
-                    // use hinted location
-                    cur = hints.last_insert;
-                    // and keep lease
-                    cur_lease = hint_lease;
-                    // register this as a hit
-                    hint_stats.inserts.addHit();
-                } else {
-                    // register this as a miss
-                    hint_stats.inserts.addMiss();
-                }
-            } else {
-                // register this as a miss
-                hint_stats.inserts.addMiss();
-            }
+        auto checkHint = [&](node* last_insert){
+        	// ignore null pointer
+        	if (!last_insert) return false;
+        	// get a read lease on indicated node
+			auto hint_lease = last_insert->lock.start_read();
+			// check whether it covers the key
+			if (!covers(last_insert, k)) return false;
+			// and if there was no concurrent modification
+			if (!last_insert->lock.validate(hint_lease)) return false;
+			// use hinted location
+			cur = last_insert;
+			// and keep lease
+			cur_lease = hint_lease;
+			// we found a hit
+			return true;
+        };
+
+        if (hints.last_insert.any(checkHint)) {
+    		// register this as a hit
+			hint_stats.inserts.addHit();
+        } else {
+        	// register this as a miss
+			hint_stats.inserts.addMiss();
         }
 
         // if there is no valid hint ..
@@ -1419,7 +1425,7 @@ public:
             // upgrade to write-permission
             if (!cur->lock.try_upgrade_to_write(cur_lease)) {
                 // something has changed => restart
-                hints.last_insert = cur;
+                hints.last_insert.access(cur);
                 return insert(k, hints);
             }
 
@@ -1502,7 +1508,7 @@ public:
             cur->lock.end_write();
 
             // remember last insertion position
-            hints.last_insert = cur;
+            hints.last_insert.access(cur);
             return true;
         }
 #else
@@ -1524,7 +1530,7 @@ public:
             leftmost->keys[0] = k;
             root = leftmost;
 
-            hints.last_insert = leftmost;
+            hints.last_insert.access(leftmost);
 
 #ifdef HAS_TSX
             // end hardware transaction
@@ -1536,9 +1542,15 @@ public:
         // insert using iterative implementation
         node* cur = root;
 
+        auto checkHints = [&](node* last_insert) {
+        	if (!last_insert) return false;
+        	if (!covers(last_insert,k)) return false;
+        	cur = last_insert;
+        	return true;
+        };
+
         // test last insert
-        if (hints.last_insert && covers(hints.last_insert, k)) {
-            cur = hints.last_insert;
+        if (hints.last_insert.any(checkHints)) {
             hint_stats.inserts.addHit();
         } else {
             hint_stats.inserts.addMiss();
@@ -1610,7 +1622,7 @@ public:
             cur->numElements++;
 
             // remember last insertion position
-            hints.last_insert = cur;
+            hints.last_insert.access(cur);
 
 #ifdef HAS_TSX
             // end hardware transaction
@@ -1720,9 +1732,15 @@ public:
 
         node* cur = root;
 
+        auto checkHints = [&](node* last_find_end) {
+        	if (!last_find_end) return false;
+        	if (!covers(last_find_end,k)) return false;
+        	cur = last_find_end;
+        	return true;
+        };
+
         // test last location searched (temporal locality)
-        if (hints.last_find_end && covers(hints.last_find_end, k)) {
-            cur = hints.last_find_end;
+        if (hints.last_find_end.any(checkHints)) {
             // register it as a hit
             hint_stats.contains.addHit();
         } else {
@@ -1739,12 +1757,12 @@ public:
             auto pos = search(k, a, b, comp);
 
             if (pos < b && equal(*pos, k)) {
-                hints.last_find_end = cur;
+                hints.last_find_end.access(cur);
                 return iterator(cur, pos - a);
             }
 
             if (!cur->inner) {
-                hints.last_find_end = cur;
+                hints.last_find_end.access(cur);
                 return end();
             }
 
@@ -1775,9 +1793,15 @@ public:
 
         node* cur = root;
 
+        auto checkHints = [&](node* last_lower_bound_end) {
+			if (!last_lower_bound_end) return false;
+			if (!covers(last_lower_bound_end,k)) return false;
+			cur = last_lower_bound_end;
+			return true;
+		};
+
         // test last searched node
-        if (hints.last_lower_bound_end && covers(hints.last_lower_bound_end, k)) {
-            cur = hints.last_lower_bound_end;
+        if (hints.last_lower_bound_end.any(checkHints)) {
             hint_stats.lower_bound.addHit();
         } else {
             hint_stats.lower_bound.addMiss();
@@ -1792,7 +1816,7 @@ public:
             auto idx = pos - a;
 
             if (!cur->inner) {
-                hints.last_lower_bound_end = cur;
+                hints.last_lower_bound_end.access(cur);
                 return (pos != b) ? iterator(cur, idx) : res;
             }
 
@@ -1830,9 +1854,15 @@ public:
 
         node* cur = root;
 
+        auto checkHints = [&](node* last_upper_bound_end) {
+			if (!last_upper_bound_end) return false;
+			if (!coversUpperBound(last_upper_bound_end,k)) return false;
+			cur = last_upper_bound_end;
+			return true;
+		};
+
         // test last search node
-        if (hints.last_upper_bound_end && coversUpperBound(hints.last_upper_bound_end, k)) {
-            cur = hints.last_upper_bound_end;
+        if (hints.last_upper_bound_end.any(checkHints)) {
             hint_stats.upper_bound.addHit();
         } else {
             hint_stats.upper_bound.addMiss();
@@ -1847,7 +1877,7 @@ public:
             auto idx = pos - a;
 
             if (!cur->inner) {
-                hints.last_upper_bound_end = cur;
+                hints.last_upper_bound_end.access(cur);
                 return (pos != b) ? iterator(cur, idx) : res;
             }
 

--- a/src/BTree.h
+++ b/src/BTree.h
@@ -1141,7 +1141,7 @@ public:
         }
     };
 
-    using operation_hints = btree_operation_hints<4>;
+    using operation_hints = btree_operation_hints<1>;
 
 private:
 #if defined(IS_PARALLEL) && !defined(HAS_TSX)

--- a/src/Util.h
+++ b/src/Util.h
@@ -1266,9 +1266,6 @@ inline bool isTransactionProfilingEnabled() {
  * to be accessed and iterated through in their LRU order.
  */
 template <typename T, unsigned size = 1>
-class LRUCache;
-
-template <typename T, unsigned size>
 class LRUCache {
     // the list of pointers maintained
     std::array<T, size> entries;
@@ -1365,20 +1362,19 @@ public:
     bool any(const Op& op) const {
         return forEachInOrder(op);
     }
-
-    // --- print support ---
-
-    friend std::ostream& operator<<(std::ostream& out, const LRUCache& cache) {
-        bool first = true;
-        cache.forEachInOrder([&](const T& val) {
-            if (!first) out << ",";
-            first = false;
-            out << val;
-            return false;
-        });
-        return out;
-    }
 };
+
+template <typename T, unsigned size>
+std::ostream& operator<<(std::ostream& out, const LRUCache<T, size>& cache) {
+    bool first = true;
+    cache.forEachInOrder([&](const T& val) {
+        if (!first) out << ",";
+        first = false;
+        out << val;
+        return false;
+    });
+    return out;
+}
 
 // a specialization for a single-entry cache
 template <typename T>

--- a/src/Util.h
+++ b/src/Util.h
@@ -19,6 +19,7 @@
 #include "RamTypes.h"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -1255,6 +1256,224 @@ inline bool isTransactionProfilingEnabled() {
     const static bool res = std::getenv("SOUFFLE_PROFILE_TRANSACTIONS");
     return res;
 }
+
+
+
+// -------------------------------------------------------------------------------
+//                              Hint / Cache
+// -------------------------------------------------------------------------------
+
+/**
+ * An Least-Recently-Used cache for arbitrary element types. Elements can be signaled
+ * to be accessed and iterated through in their LRU order.
+ */
+template<typename T, unsigned size = 1>
+class LRUCache {
+
+	// the list of pointers maintained
+	std::array<T,size> entries;
+
+	// pointer to predecessor / successor in the entries list
+	std::array<std::size_t,size> priv;		// < predecessor of element i
+	std::array<std::size_t,size> post;		// < successor of element i
+
+	std::size_t first;		// < index of the first element
+	std::size_t last;		// < index of the last element
+
+public:
+
+	// creates a new, empty cache
+	LRUCache(const T& val = T()) : entries(), first(0), last(size-1) {
+		for(unsigned i=0; i<size; i++) {
+			entries[i] = val;
+			priv[i] = i-1;
+			post[i] = i+1;
+		}
+		priv[first] = last;
+		post[last] = first;
+	}
+
+	// clears the content of this cache
+	void clear(const T& val = T()) {
+		for(auto& cur : entries) {
+			cur = val;
+		}
+	}
+
+	// registers an access to the given element
+	void access(const T& val) {
+		// test whether it is contained
+		for(std::size_t i = 0; i<size; i++) {
+			if (entries[i] != val) continue;
+
+			// -- move this one to the front --
+
+			// if it is the first, nothing to handle
+			if (i == first) return;
+
+			// if this is the last, just first and last need to change
+			if (i == last) {
+				auto tmp = last;
+				last = priv[last];
+				first = tmp;
+				return;
+			}
+
+			// otherwise we need to update the linked list
+
+			// remove from current position
+			post[priv[i]] = post[i];
+			priv[post[i]] = priv[i];
+
+			// insert in first position
+			post[i] = first;
+			priv[i] = last;
+			priv[first] = i;
+			post[last] = i;
+
+			// update first pointer
+			first = i;
+			return;
+		}
+		// not present => drop last, make it first
+		entries[last] = val;
+		auto tmp = last;
+		last = priv[last];
+		first = tmp;
+	}
+
+	/**
+	 * Iterates over the elements within this cache in LRU order.
+	 * The operator is applied on each element. If the operation
+	 * returns false, iteration is continued. If the operator return
+	 * true, iteration is stopped -- similar to the any operator.
+	 *
+	 * @param op the operator to be applied on every element
+	 * @return true if op returned true for any entry, false otherwise
+	 */
+	template<typename Op>
+	bool forEachInOrder(const Op& op) const {
+		std::size_t i = first;
+		while(i != last) {
+			if (op(entries[i])) return true;
+			i = post[i];
+		}
+		return op(entries[i]);
+	}
+
+	// equivalent to forEachInOrder
+	template<typename Op>
+	bool any(const Op& op) const {
+		return forEachInOrder(op);
+	}
+
+
+	// --- print support ---
+
+	friend std::ostream& operator<<(std::ostream& out, const LRUCache& cache) {
+		bool first = true;
+		cache.forEachInOrder([&](const T& val){
+			if (!first) out << ",";
+			first = false;
+			out << val;
+			return false;
+		});
+		return out;
+	}
+
+};
+
+// a specialization for a single-entry cache
+template<typename T>
+class LRUCache<T,1> {
+
+	// the single entry in this cache
+	T entry;
+
+public:
+
+	// creates a new, empty cache
+	LRUCache() : entry() {}
+
+	// creates a new, empty cache storing the given value
+	LRUCache(const T& val) : entry(val) {}
+
+	// clears the content of this cache
+	void clear(const T& val = T()) {
+		entry = val;
+	}
+
+	// registers an access to the given element
+	void access(const T& val) {
+		entry = val;
+	}
+
+	/**
+	 * See description in most general case.
+	 */
+	template<typename Op>
+	bool forEachInOrder(const Op& op) const {
+		return op(entry);
+	}
+
+	// equivalent to forEachInOrder
+	template<typename Op>
+	bool any(const Op& op) const {
+		return forEachInOrder(op);
+	}
+
+
+	// --- print support ---
+
+	friend std::ostream& operator<<(std::ostream& out, const LRUCache& cache) {
+		return out << cache.entry;
+	}
+
+};
+
+
+// a specialization for no-entry caches.
+template<typename T>
+class LRUCache<T,0> {
+
+public:
+
+	// creates a new, empty cache
+	LRUCache(const T& = T()) {}
+
+	// clears the content of this cache
+	void clear(const T& = T()) {
+		// nothing to do
+	}
+
+	// registers an access to the given element
+	void access(const T&) {
+		// nothing to do
+	}
+
+	/**
+	 * Always returns false.
+	 */
+	template<typename Op>
+	bool forEachInOrder(const Op&) const {
+		return false;
+	}
+
+	// equivalent to forEachInOrder
+	template<typename Op>
+	bool any(const Op& op) const {
+		return forEachInOrder(op);
+	}
+
+
+	// --- print support ---
+
+	friend std::ostream& operator<<(std::ostream& out, const LRUCache& cache) {
+		return out << "-empty-";
+	}
+
+};
+
 
 // -------------------------------------------------------------------------------
 //                           Hint / Cache Profiling

--- a/src/Util.h
+++ b/src/Util.h
@@ -1257,8 +1257,6 @@ inline bool isTransactionProfilingEnabled() {
     return res;
 }
 
-
-
 // -------------------------------------------------------------------------------
 //                              Hint / Cache
 // -------------------------------------------------------------------------------
@@ -1267,213 +1265,199 @@ inline bool isTransactionProfilingEnabled() {
  * An Least-Recently-Used cache for arbitrary element types. Elements can be signaled
  * to be accessed and iterated through in their LRU order.
  */
-template<typename T, unsigned size = 1>
+template <typename T, unsigned size = 1>
 class LRUCache {
+    // the list of pointers maintained
+    std::array<T, size> entries;
 
-	// the list of pointers maintained
-	std::array<T,size> entries;
+    // pointer to predecessor / successor in the entries list
+    std::array<std::size_t, size> priv;  // < predecessor of element i
+    std::array<std::size_t, size> post;  // < successor of element i
 
-	// pointer to predecessor / successor in the entries list
-	std::array<std::size_t,size> priv;		// < predecessor of element i
-	std::array<std::size_t,size> post;		// < successor of element i
-
-	std::size_t first;		// < index of the first element
-	std::size_t last;		// < index of the last element
+    std::size_t first;  // < index of the first element
+    std::size_t last;   // < index of the last element
 
 public:
+    // creates a new, empty cache
+    LRUCache(const T& val = T()) : entries(), first(0), last(size - 1) {
+        for (unsigned i = 0; i < size; i++) {
+            entries[i] = val;
+            priv[i] = i - 1;
+            post[i] = i + 1;
+        }
+        priv[first] = last;
+        post[last] = first;
+    }
 
-	// creates a new, empty cache
-	LRUCache(const T& val = T()) : entries(), first(0), last(size-1) {
-		for(unsigned i=0; i<size; i++) {
-			entries[i] = val;
-			priv[i] = i-1;
-			post[i] = i+1;
-		}
-		priv[first] = last;
-		post[last] = first;
-	}
+    // clears the content of this cache
+    void clear(const T& val = T()) {
+        for (auto& cur : entries) {
+            cur = val;
+        }
+    }
 
-	// clears the content of this cache
-	void clear(const T& val = T()) {
-		for(auto& cur : entries) {
-			cur = val;
-		}
-	}
+    // registers an access to the given element
+    void access(const T& val) {
+        // test whether it is contained
+        for (std::size_t i = 0; i < size; i++) {
+            if (entries[i] != val) continue;
 
-	// registers an access to the given element
-	void access(const T& val) {
-		// test whether it is contained
-		for(std::size_t i = 0; i<size; i++) {
-			if (entries[i] != val) continue;
+            // -- move this one to the front --
 
-			// -- move this one to the front --
+            // if it is the first, nothing to handle
+            if (i == first) return;
 
-			// if it is the first, nothing to handle
-			if (i == first) return;
+            // if this is the last, just first and last need to change
+            if (i == last) {
+                auto tmp = last;
+                last = priv[last];
+                first = tmp;
+                return;
+            }
 
-			// if this is the last, just first and last need to change
-			if (i == last) {
-				auto tmp = last;
-				last = priv[last];
-				first = tmp;
-				return;
-			}
+            // otherwise we need to update the linked list
 
-			// otherwise we need to update the linked list
+            // remove from current position
+            post[priv[i]] = post[i];
+            priv[post[i]] = priv[i];
 
-			// remove from current position
-			post[priv[i]] = post[i];
-			priv[post[i]] = priv[i];
+            // insert in first position
+            post[i] = first;
+            priv[i] = last;
+            priv[first] = i;
+            post[last] = i;
 
-			// insert in first position
-			post[i] = first;
-			priv[i] = last;
-			priv[first] = i;
-			post[last] = i;
+            // update first pointer
+            first = i;
+            return;
+        }
+        // not present => drop last, make it first
+        entries[last] = val;
+        auto tmp = last;
+        last = priv[last];
+        first = tmp;
+    }
 
-			// update first pointer
-			first = i;
-			return;
-		}
-		// not present => drop last, make it first
-		entries[last] = val;
-		auto tmp = last;
-		last = priv[last];
-		first = tmp;
-	}
+    /**
+     * Iterates over the elements within this cache in LRU order.
+     * The operator is applied on each element. If the operation
+     * returns false, iteration is continued. If the operator return
+     * true, iteration is stopped -- similar to the any operator.
+     *
+     * @param op the operator to be applied on every element
+     * @return true if op returned true for any entry, false otherwise
+     */
+    template <typename Op>
+    bool forEachInOrder(const Op& op) const {
+        std::size_t i = first;
+        while (i != last) {
+            if (op(entries[i])) return true;
+            i = post[i];
+        }
+        return op(entries[i]);
+    }
 
-	/**
-	 * Iterates over the elements within this cache in LRU order.
-	 * The operator is applied on each element. If the operation
-	 * returns false, iteration is continued. If the operator return
-	 * true, iteration is stopped -- similar to the any operator.
-	 *
-	 * @param op the operator to be applied on every element
-	 * @return true if op returned true for any entry, false otherwise
-	 */
-	template<typename Op>
-	bool forEachInOrder(const Op& op) const {
-		std::size_t i = first;
-		while(i != last) {
-			if (op(entries[i])) return true;
-			i = post[i];
-		}
-		return op(entries[i]);
-	}
+    // equivalent to forEachInOrder
+    template <typename Op>
+    bool any(const Op& op) const {
+        return forEachInOrder(op);
+    }
 
-	// equivalent to forEachInOrder
-	template<typename Op>
-	bool any(const Op& op) const {
-		return forEachInOrder(op);
-	}
+    // --- print support ---
 
-
-	// --- print support ---
-
-	friend std::ostream& operator<<(std::ostream& out, const LRUCache& cache) {
-		bool first = true;
-		cache.forEachInOrder([&](const T& val){
-			if (!first) out << ",";
-			first = false;
-			out << val;
-			return false;
-		});
-		return out;
-	}
-
+    friend std::ostream& operator<<(std::ostream& out, const LRUCache& cache) {
+        bool first = true;
+        cache.forEachInOrder([&](const T& val) {
+            if (!first) out << ",";
+            first = false;
+            out << val;
+            return false;
+        });
+        return out;
+    }
 };
 
 // a specialization for a single-entry cache
-template<typename T>
-class LRUCache<T,1> {
-
-	// the single entry in this cache
-	T entry;
+template <typename T>
+class LRUCache<T, 1> {
+    // the single entry in this cache
+    T entry;
 
 public:
+    // creates a new, empty cache
+    LRUCache() : entry() {}
 
-	// creates a new, empty cache
-	LRUCache() : entry() {}
+    // creates a new, empty cache storing the given value
+    LRUCache(const T& val) : entry(val) {}
 
-	// creates a new, empty cache storing the given value
-	LRUCache(const T& val) : entry(val) {}
+    // clears the content of this cache
+    void clear(const T& val = T()) {
+        entry = val;
+    }
 
-	// clears the content of this cache
-	void clear(const T& val = T()) {
-		entry = val;
-	}
+    // registers an access to the given element
+    void access(const T& val) {
+        entry = val;
+    }
 
-	// registers an access to the given element
-	void access(const T& val) {
-		entry = val;
-	}
+    /**
+     * See description in most general case.
+     */
+    template <typename Op>
+    bool forEachInOrder(const Op& op) const {
+        return op(entry);
+    }
 
-	/**
-	 * See description in most general case.
-	 */
-	template<typename Op>
-	bool forEachInOrder(const Op& op) const {
-		return op(entry);
-	}
+    // equivalent to forEachInOrder
+    template <typename Op>
+    bool any(const Op& op) const {
+        return forEachInOrder(op);
+    }
 
-	// equivalent to forEachInOrder
-	template<typename Op>
-	bool any(const Op& op) const {
-		return forEachInOrder(op);
-	}
+    // --- print support ---
 
-
-	// --- print support ---
-
-	friend std::ostream& operator<<(std::ostream& out, const LRUCache& cache) {
-		return out << cache.entry;
-	}
-
+    friend std::ostream& operator<<(std::ostream& out, const LRUCache& cache) {
+        return out << cache.entry;
+    }
 };
-
 
 // a specialization for no-entry caches.
-template<typename T>
-class LRUCache<T,0> {
-
+template <typename T>
+class LRUCache<T, 0> {
 public:
+    // creates a new, empty cache
+    LRUCache(const T& = T()) {}
 
-	// creates a new, empty cache
-	LRUCache(const T& = T()) {}
+    // clears the content of this cache
+    void clear(const T& = T()) {
+        // nothing to do
+    }
 
-	// clears the content of this cache
-	void clear(const T& = T()) {
-		// nothing to do
-	}
+    // registers an access to the given element
+    void access(const T&) {
+        // nothing to do
+    }
 
-	// registers an access to the given element
-	void access(const T&) {
-		// nothing to do
-	}
+    /**
+     * Always returns false.
+     */
+    template <typename Op>
+    bool forEachInOrder(const Op&) const {
+        return false;
+    }
 
-	/**
-	 * Always returns false.
-	 */
-	template<typename Op>
-	bool forEachInOrder(const Op&) const {
-		return false;
-	}
+    // equivalent to forEachInOrder
+    template <typename Op>
+    bool any(const Op& op) const {
+        return forEachInOrder(op);
+    }
 
-	// equivalent to forEachInOrder
-	template<typename Op>
-	bool any(const Op& op) const {
-		return forEachInOrder(op);
-	}
+    // --- print support ---
 
-
-	// --- print support ---
-
-	friend std::ostream& operator<<(std::ostream& out, const LRUCache& cache) {
-		return out << "-empty-";
-	}
-
+    friend std::ostream& operator<<(std::ostream& out, const LRUCache& cache) {
+        return out << "-empty-";
+    }
 };
-
 
 // -------------------------------------------------------------------------------
 //                           Hint / Cache Profiling

--- a/src/Util.h
+++ b/src/Util.h
@@ -1266,6 +1266,9 @@ inline bool isTransactionProfilingEnabled() {
  * to be accessed and iterated through in their LRU order.
  */
 template <typename T, unsigned size = 1>
+class LRUCache;
+
+template <typename T, unsigned size>
 class LRUCache {
     // the list of pointers maintained
     std::array<T, size> entries;

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -74,3 +74,159 @@ TEST(Util, NullStream) {
     out = &nullstream;
     (*out) << "Hello World!\n";
 }
+
+TEST(Util, LRUCache) {
+
+	using cache = LRUCache<int,4>;
+	cache c;
+
+	// check initial state
+	EXPECT_EQ("0,0,0,0",toString(c));
+
+	// fill cache with new entries
+	c.access(4);
+	EXPECT_EQ("4,0,0,0",toString(c));
+
+	c.access(3);
+	EXPECT_EQ("3,4,0,0",toString(c));
+
+	c.access(7);
+	EXPECT_EQ("7,3,4,0",toString(c));
+
+	c.access(2);
+	EXPECT_EQ("2,7,3,4",toString(c));
+
+	c.access(5);
+	EXPECT_EQ("5,2,7,3",toString(c));
+
+
+	// access elements present
+	c.access(5);
+	EXPECT_EQ("5,2,7,3",toString(c));
+
+	c.access(2);
+	EXPECT_EQ("2,5,7,3",toString(c));
+
+	c.access(7);
+	EXPECT_EQ("7,2,5,3",toString(c));
+
+	c.access(3);
+	EXPECT_EQ("3,7,2,5",toString(c));
+
+	c.access(2);
+	EXPECT_EQ("2,3,7,5",toString(c));
+
+
+	// test clearing
+	c.clear();
+	EXPECT_EQ("0,0,0,0",toString(c));
+
+	c.clear(5);
+	EXPECT_EQ("5,5,5,5",toString(c));
+
+}
+
+
+TEST(Util, LRUCache_S2) {
+
+	using cache = LRUCache<int,2>;
+	cache c;
+
+	// check initial state
+	EXPECT_EQ("0,0",toString(c));
+
+	// fill cache with new entries
+	c.access(4);
+	EXPECT_EQ("4,0",toString(c));
+
+	c.access(3);
+	EXPECT_EQ("3,4",toString(c));
+
+	c.access(7);
+	EXPECT_EQ("7,3",toString(c));
+
+
+	// access elements present
+	c.access(7);
+	EXPECT_EQ("7,3",toString(c));
+
+	c.access(3);
+	EXPECT_EQ("3,7",toString(c));
+
+	c.access(7);
+	EXPECT_EQ("7,3",toString(c));
+
+	// test clearing
+	c.clear();
+	EXPECT_EQ("0,0",toString(c));
+
+	c.clear(5);
+	EXPECT_EQ("5,5",toString(c));
+
+}
+
+
+TEST(Util, LRUCache_S1) {
+
+	using cache = LRUCache<int,1>;
+	cache c;
+
+	// check initial state
+	EXPECT_EQ("0",toString(c));
+
+	// fill cache with new entries
+	c.access(4);
+	EXPECT_EQ("4",toString(c));
+
+	c.access(3);
+	EXPECT_EQ("3",toString(c));
+
+	// access elements present
+	c.access(3);
+	EXPECT_EQ("3",toString(c));
+
+	// and again not present
+	c.access(2);
+	EXPECT_EQ("2",toString(c));
+
+	// test clearing
+	c.clear();
+	EXPECT_EQ("0",toString(c));
+
+	c.clear(5);
+	EXPECT_EQ("5",toString(c));
+
+}
+
+
+TEST(Util, LRUCache_S0) {
+
+	using cache = LRUCache<int,0>;
+	cache c;
+
+	// check initial state
+	EXPECT_EQ("-empty-",toString(c));
+
+	// fill cache with new entries
+	c.access(4);
+	EXPECT_EQ("-empty-",toString(c));
+
+	c.access(3);
+	EXPECT_EQ("-empty-",toString(c));
+
+	// access elements present
+	c.access(3);
+	EXPECT_EQ("-empty-",toString(c));
+
+	// and again not present
+	c.access(2);
+	EXPECT_EQ("-empty-",toString(c));
+
+	// test clearing
+	c.clear();
+	EXPECT_EQ("-empty-",toString(c));
+
+	c.clear(5);
+	EXPECT_EQ("-empty-",toString(c));
+
+}

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -76,157 +76,143 @@ TEST(Util, NullStream) {
 }
 
 TEST(Util, LRUCache) {
+    using cache = LRUCache<int, 4>;
+    cache c;
 
-	using cache = LRUCache<int,4>;
-	cache c;
+    // check initial state
+    EXPECT_EQ("0,0,0,0", toString(c));
 
-	// check initial state
-	EXPECT_EQ("0,0,0,0",toString(c));
+    // fill cache with new entries
+    c.access(4);
+    EXPECT_EQ("4,0,0,0", toString(c));
 
-	// fill cache with new entries
-	c.access(4);
-	EXPECT_EQ("4,0,0,0",toString(c));
+    c.access(3);
+    EXPECT_EQ("3,4,0,0", toString(c));
 
-	c.access(3);
-	EXPECT_EQ("3,4,0,0",toString(c));
+    c.access(7);
+    EXPECT_EQ("7,3,4,0", toString(c));
 
-	c.access(7);
-	EXPECT_EQ("7,3,4,0",toString(c));
+    c.access(2);
+    EXPECT_EQ("2,7,3,4", toString(c));
 
-	c.access(2);
-	EXPECT_EQ("2,7,3,4",toString(c));
+    c.access(5);
+    EXPECT_EQ("5,2,7,3", toString(c));
 
-	c.access(5);
-	EXPECT_EQ("5,2,7,3",toString(c));
+    // access elements present
+    c.access(5);
+    EXPECT_EQ("5,2,7,3", toString(c));
 
+    c.access(2);
+    EXPECT_EQ("2,5,7,3", toString(c));
 
-	// access elements present
-	c.access(5);
-	EXPECT_EQ("5,2,7,3",toString(c));
+    c.access(7);
+    EXPECT_EQ("7,2,5,3", toString(c));
 
-	c.access(2);
-	EXPECT_EQ("2,5,7,3",toString(c));
+    c.access(3);
+    EXPECT_EQ("3,7,2,5", toString(c));
 
-	c.access(7);
-	EXPECT_EQ("7,2,5,3",toString(c));
+    c.access(2);
+    EXPECT_EQ("2,3,7,5", toString(c));
 
-	c.access(3);
-	EXPECT_EQ("3,7,2,5",toString(c));
+    // test clearing
+    c.clear();
+    EXPECT_EQ("0,0,0,0", toString(c));
 
-	c.access(2);
-	EXPECT_EQ("2,3,7,5",toString(c));
-
-
-	// test clearing
-	c.clear();
-	EXPECT_EQ("0,0,0,0",toString(c));
-
-	c.clear(5);
-	EXPECT_EQ("5,5,5,5",toString(c));
-
+    c.clear(5);
+    EXPECT_EQ("5,5,5,5", toString(c));
 }
-
 
 TEST(Util, LRUCache_S2) {
+    using cache = LRUCache<int, 2>;
+    cache c;
 
-	using cache = LRUCache<int,2>;
-	cache c;
+    // check initial state
+    EXPECT_EQ("0,0", toString(c));
 
-	// check initial state
-	EXPECT_EQ("0,0",toString(c));
+    // fill cache with new entries
+    c.access(4);
+    EXPECT_EQ("4,0", toString(c));
 
-	// fill cache with new entries
-	c.access(4);
-	EXPECT_EQ("4,0",toString(c));
+    c.access(3);
+    EXPECT_EQ("3,4", toString(c));
 
-	c.access(3);
-	EXPECT_EQ("3,4",toString(c));
+    c.access(7);
+    EXPECT_EQ("7,3", toString(c));
 
-	c.access(7);
-	EXPECT_EQ("7,3",toString(c));
+    // access elements present
+    c.access(7);
+    EXPECT_EQ("7,3", toString(c));
 
+    c.access(3);
+    EXPECT_EQ("3,7", toString(c));
 
-	// access elements present
-	c.access(7);
-	EXPECT_EQ("7,3",toString(c));
+    c.access(7);
+    EXPECT_EQ("7,3", toString(c));
 
-	c.access(3);
-	EXPECT_EQ("3,7",toString(c));
+    // test clearing
+    c.clear();
+    EXPECT_EQ("0,0", toString(c));
 
-	c.access(7);
-	EXPECT_EQ("7,3",toString(c));
-
-	// test clearing
-	c.clear();
-	EXPECT_EQ("0,0",toString(c));
-
-	c.clear(5);
-	EXPECT_EQ("5,5",toString(c));
-
+    c.clear(5);
+    EXPECT_EQ("5,5", toString(c));
 }
-
 
 TEST(Util, LRUCache_S1) {
+    using cache = LRUCache<int, 1>;
+    cache c;
 
-	using cache = LRUCache<int,1>;
-	cache c;
+    // check initial state
+    EXPECT_EQ("0", toString(c));
 
-	// check initial state
-	EXPECT_EQ("0",toString(c));
+    // fill cache with new entries
+    c.access(4);
+    EXPECT_EQ("4", toString(c));
 
-	// fill cache with new entries
-	c.access(4);
-	EXPECT_EQ("4",toString(c));
+    c.access(3);
+    EXPECT_EQ("3", toString(c));
 
-	c.access(3);
-	EXPECT_EQ("3",toString(c));
+    // access elements present
+    c.access(3);
+    EXPECT_EQ("3", toString(c));
 
-	// access elements present
-	c.access(3);
-	EXPECT_EQ("3",toString(c));
+    // and again not present
+    c.access(2);
+    EXPECT_EQ("2", toString(c));
 
-	// and again not present
-	c.access(2);
-	EXPECT_EQ("2",toString(c));
+    // test clearing
+    c.clear();
+    EXPECT_EQ("0", toString(c));
 
-	// test clearing
-	c.clear();
-	EXPECT_EQ("0",toString(c));
-
-	c.clear(5);
-	EXPECT_EQ("5",toString(c));
-
+    c.clear(5);
+    EXPECT_EQ("5", toString(c));
 }
 
-
 TEST(Util, LRUCache_S0) {
+    using cache = LRUCache<int, 0>;
+    cache c;
 
-	using cache = LRUCache<int,0>;
-	cache c;
+    // check initial state
+    EXPECT_EQ("-empty-", toString(c));
 
-	// check initial state
-	EXPECT_EQ("-empty-",toString(c));
+    // fill cache with new entries
+    c.access(4);
+    EXPECT_EQ("-empty-", toString(c));
 
-	// fill cache with new entries
-	c.access(4);
-	EXPECT_EQ("-empty-",toString(c));
+    c.access(3);
+    EXPECT_EQ("-empty-", toString(c));
 
-	c.access(3);
-	EXPECT_EQ("-empty-",toString(c));
+    // access elements present
+    c.access(3);
+    EXPECT_EQ("-empty-", toString(c));
 
-	// access elements present
-	c.access(3);
-	EXPECT_EQ("-empty-",toString(c));
+    // and again not present
+    c.access(2);
+    EXPECT_EQ("-empty-", toString(c));
 
-	// and again not present
-	c.access(2);
-	EXPECT_EQ("-empty-",toString(c));
+    // test clearing
+    c.clear();
+    EXPECT_EQ("-empty-", toString(c));
 
-	// test clearing
-	c.clear();
-	EXPECT_EQ("-empty-",toString(c));
-
-	c.clear(5);
-	EXPECT_EQ("-empty-",toString(c));
-
+    c.clear(5);
+    EXPECT_EQ("-empty-", toString(c));
 }


### PR DESCRIPTION
Currently, it is set up to be equivalent to the old, single entry version. 

Have tested it on my system using a size of 2, 4, and 8 -- noticed some improvements in the hit rate in the unit tests. The integration test are still running, relying on travis :-)