### PR TITLE
Update license abbreviation to match bintray deployment.

### DIFF
--- a/.travis/bintray_json.sh
+++ b/.travis/bintray_json.sh
@@ -60,7 +60,7 @@ cat > ${3} <<EOF
         "vcs_url": "https://github.com/souffle-lang/souffle.git",
         "github_use_tag_release_notes": true,
         "github_release_notes_file": "debian/changelog",
-        "licenses": ["UPL"],
+        "licenses": ["UPL-1.0"],
         "public_download_numbers": false,
         "public_stats": false
     },


### PR DESCRIPTION
Bintray finally supports UPL as a license type, so now we can update our deployment script to match what they actually use.