### PR TITLE
Fix gh-pages deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -293,4 +293,4 @@ jobs:
       local-dir: doc/html
       on:
         branch: master
-        condition: -v $GHPAGES_TOKEN
+        condition: -n $GHPAGES_TOKEN


### PR DESCRIPTION
The doxygen documentation hasn't been updated since February. This PR re-enables the deployment.

`-v $GHPAGES_TOKEN` should be `-v GHPAGES_TOKEN`, but `-n $GHPAGES_TOKEN` works on older versions of bash and also covers empty, but set, tokens.