### PR TITLE
Add dependencies to debian package.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,13 +3,13 @@ Maintainer: Kostyantyn Vorobyov <k.a.vorobyov@gmail.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.5
-Build-Depends: autoconf, automake, bison, mcpp, debhelper (>= 9), flex, libsqlite3-dev, zlib1g-dev, libncurses5-dev
+Build-Depends: autoconf, automake, bison, debhelper (>= 9), flex, libsqlite3-dev, zlib1g-dev, libncurses5-dev
 Homepage: https://souffle-lang.org/
 Vcs-Git: https://github.com/souffle-lang/souffle.git
 
 Package: souffle
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, g++
+Depends: ${shlibs:Depends}, ${misc:Depends}, g++, mcpp, zlib1g-dev, libsqlite3-dev, libncurses5-dev
 Description: Translator of declarative Datalog programs into the C++ language.
  Soufflé is a translator of declarative Datalog programs into the C++ language.
  Soufflé is used as a domain-specific language for static program analysis, over


### PR DESCRIPTION
Fixes #708 
We only have mcpp as a build dependency, not as a dependency of the installed package. I've also added ncurses, sqlite, and zlib for synthesised souffle.