### PR TITLE
Remove NDEBUG flags (to use -g/-o instead)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ AC_ARG_ENABLE(
 )
 
 AS_IF([test "x$enable_debug" = "xyes"], [CXXFLAGS="$CXXFLAGS -O0 -g3"],
-  [test "x$enable_debug" != "xyes"], [CXXFLAGS="$CXXFLAGS -O3 -DNDEBUG"]
+  [test "x$enable_debug" != "xyes"], [CXXFLAGS="$CXXFLAGS -O3"]
 )
 
 if test "$BUILD_TYPE" == "Debug" ; then

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,13 +96,10 @@ void executeBinary(const std::string& binaryFilename
         exitCode = system(binaryFilename.c_str());
     }
 
-// only remove temp files if we are not configuring with --enable-debug
-#ifndef NDEBUG
     if (Global::config().get("dl-program").empty()) {
         remove(binaryFilename.c_str());
         remove((binaryFilename + ".cpp").c_str());
     }
-#endif
 
     // exit with same code as executable
     if (exitCode != 0) {


### PR DESCRIPTION
We're currently leaving behind our temporary files after running with `-c`. This can be fixed by changing the `#ifndef NDEBUG` in main.cpp to `#ifdef NDEBUG`, but we can actually run with `-o` or `-g` instead, removing the need for the #defines.

(If the MPI stuff added at the same time as the ifdefs needs -c, then the ifdef change would be better, of course.)