### PR TITLE
Save profile log when execution is interrupted

### DIFF
--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -834,6 +834,7 @@ void Interpreter::executeMain() {
     if (!Global::config().has("profile")) {
         evalStmt(main);
     } else {
+        ProfileEventSingleton::instance().setOutputFile(Global::config().get("profile"));
         // Prepare the frequency table for threaded use
         visitDepthFirst(main, [&](const RamSearch& node) {
             if (!node.getProfileText().empty()) {
@@ -865,15 +866,6 @@ void Interpreter::executeMain() {
             for (auto const& iter : cur.second) {
                 ProfileEventSingleton::instance().makeQuantityEvent(cur.first, iter.second, iter.first);
             }
-        }
-        // open output stream if we're logging the profile data to file
-        if (!Global::config().get("profile").empty()) {
-            std::string fname = Global::config().get("profile");
-            std::ofstream os(fname);
-            if (!os.is_open()) {
-                throw std::invalid_argument("Cannot open profile log file <" + fname + ">");
-            }
-            ProfileEventSingleton::instance().dump(os);
         }
     }
     SignalHandler::instance()->reset();

--- a/src/ProfileEvent.h
+++ b/src/ProfileEvent.h
@@ -44,12 +44,18 @@ namespace souffle {
 class ProfileEventSingleton {
     /** profile database */
     profile::ProfileDatabase database;
+    std::string filename{"souffle.profile"};
 
     ProfileEventSingleton() = default;
 
 public:
     ~ProfileEventSingleton() {
         stopTimer();
+        std::ofstream os(filename);
+        if (!os.is_open()) {
+            std::cerr << "Cannot open profile log file <" + filename + ">";
+        }
+        ProfileEventSingleton::instance().dump(os);
     }
 
     /** get instance */
@@ -109,6 +115,9 @@ public:
                 database, txt.c_str(), time, systemTime, userTime, maxRSS);
     }
 
+    void setOutputFile(std::string filename) {
+        this->filename = filename;
+    }
     /** Dump all events */
     void dump(std::ostream& os) {
         database.print(os);

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1532,6 +1532,9 @@ void Synthesiser::generateCode(const RamTranslationUnit& unit, std::ostream& os,
         }
     }
     os << "{\n";
+    if (Global::config().has("profile")) {
+        os << "ProfileEventSingleton::instance().setOutputFile(profiling_fname);\n";
+    }
     os << registerRel;
     os << "}\n";
     // -- destructor --
@@ -1639,9 +1642,6 @@ void Synthesiser::generateCode(const RamTranslationUnit& unit, std::ostream& os,
     if (Global::config().has("profile")) {
         os << "}\n";
         os << "dumpFreqs();\n";
-        os << "ProfileEventSingleton::instance().stopTimer();\n";
-        os << "std::ofstream profile(profiling_fname);\n";
-        os << "ProfileEventSingleton::instance().dump(profile);\n";
     }
 
     // add code printing hint statistics

--- a/src/profile/StringUtils.h
+++ b/src/profile/StringUtils.h
@@ -115,6 +115,17 @@ inline std::string formatNum(int precision, int64_t amount) {
     return nullptr;
 }
 
+inline std::string formatMemory(uint64_t kbytes) {
+    if (kbytes < 1024L * 2) {
+        return std::to_string(kbytes) + "kB";
+    } else if (kbytes < 1024L * 1024 * 2) {
+        return std::to_string(kbytes / 1024) + "MB";
+    } else if (kbytes < 1024L * 1024 * 1024 * 2) {
+        return std::to_string(kbytes / (1024 * 1024)) + "GB";
+    }
+    return std::to_string(kbytes / (1024 * 1024 * 1024)) + "TB";
+}
+
 inline std::string formatTime(double number) {
     if (std::isnan(number) || std::isinf(number)) {
         return "-";

--- a/tests/profile/lrg_attr_id/out/help.out
+++ b/tests/profile/lrg_attr_id/out/help.out
@@ -11,6 +11,7 @@ Available profiling commands:
   graph ver <rule id> <type>    -     graph recursive(C) rule versions by type(tot_t/copy_t/tuples).
   top                           -     display top-level summary of program run.
   usage [relation id|rule id]   -     display CPU usage graphs for a relation or rule.
+  memory                        -     display memory usage.
   help                          -     print this.
 
 Interactive mode only commands:

--- a/tests/profile/recursive/out/help.out
+++ b/tests/profile/recursive/out/help.out
@@ -11,6 +11,7 @@ Available profiling commands:
   graph ver <rule id> <type>    -     graph recursive(C) rule versions by type(tot_t/copy_t/tuples).
   top                           -     display top-level summary of program run.
   usage [relation id|rule id]   -     display CPU usage graphs for a relation or rule.
+  memory                        -     display memory usage.
   help                          -     print this.
 
 Interactive mode only commands:


### PR DESCRIPTION
Save profile log when execution is interrupted in a profile-enabled build.
Add a graph of memory use over time to the cli profiler.