### PR TITLE
Disable Intel specific settings on non-Intel hardware.

### DIFF
--- a/src/ParallelUtils.h
+++ b/src/ParallelUtils.h
@@ -186,7 +186,11 @@ public:
 namespace detail {
 
 /* Pause instruction to prevent excess processor bus usage */
+#ifdef __x86_64__
 #define cpu_relax() asm volatile("pause\n" : : : "memory")
+#else
+#define cpu_relax() asm volatile("" : : : "memory")
+#endif
 
 /**
  * A utility class managing waiting operations for spin locks.


### PR DESCRIPTION
This PR is to get souffle working for all our non-x86 using users. With this change, it compiles and runs on ARM hardware.