### PR TITLE
Added option to disable a set of AST transformations

### DIFF
--- a/src/AstTransformer.h
+++ b/src/AstTransformer.h
@@ -49,6 +49,9 @@ public:
     /* Enable high verbosity */
     virtual void setVerbosity(bool verbose) = 0;
 
+    /* Disable subtransformers */
+    virtual void disableTransformers(const std::set<std::string>& transforms) = 0;
+
     /* Apply a nested transformer */
     bool applySubtransformer(AstTranslationUnit& translationUnit, AstTransformer* transformer);
 };
@@ -64,6 +67,8 @@ public:
     void setDebugReport() override {}
 
     void setVerbosity(bool verbose) override {}
+
+    void disableTransformers(const std::set<std::string>& transforms) override {}
 
     std::string getName() const override {
         return "NullTransformer";

--- a/src/AstTransformer.h
+++ b/src/AstTransformer.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <set>
 #include <string>
 
 namespace souffle {
@@ -50,6 +51,23 @@ public:
 
     /* Apply a nested transformer */
     bool applySubtransformer(AstTranslationUnit& translationUnit, AstTransformer* transformer);
+};
+
+/**
+ * Transformer that does absolutely nothing
+ */
+class NullTransformer : public MetaTransformer {
+private:
+    bool transform(AstTranslationUnit& translationUnit) override;
+
+public:
+    void setDebugReport() override {}
+
+    void setVerbosity(bool verbose) override {}
+
+    std::string getName() const override {
+        return "NullTransformer";
+    }
 };
 
 }  // end of namespace souffle

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -40,6 +40,10 @@
 
 namespace souffle {
 
+bool NullTransformer::transform(AstTranslationUnit& translationUnit) {
+    return false;
+}
+
 bool PipelineTransformer::transform(AstTranslationUnit& translationUnit) {
     bool changed = false;
     for (auto& transformer : pipeline) {

--- a/src/AstTransforms.h
+++ b/src/AstTransforms.h
@@ -354,6 +354,16 @@ public:
         }
     }
 
+    void disableTransformers(const std::set<std::string>& transforms) override {
+        for (auto& i : pipeline) {
+            if (auto* mt = dynamic_cast<MetaTransformer*>(i.get())) {
+                mt->disableTransformers(transforms);
+            } else if (transforms.find(i->getName()) != transforms.end()) {
+                i = std::make_unique<NullTransformer>();
+            }
+        }
+    }
+
     std::string getName() const override {
         return "PipelineTransformer";
     }
@@ -387,6 +397,14 @@ public:
         this->verbose = verbose;
         if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
             mt->setVerbosity(verbose);
+        }
+    }
+
+    void disableTransformers(const std::set<std::string>& transforms) override {
+        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+            mt->disableTransformers(transforms);
+        } else if (transforms.find(transformer->getName()) != transforms.end()) {
+            transformer = std::make_unique<NullTransformer>();
         }
     }
 
@@ -426,6 +444,14 @@ public:
         }
     }
 
+    void disableTransformers(const std::set<std::string>& transforms) override {
+        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+            mt->disableTransformers(transforms);
+        } else if (transforms.find(transformer->getName()) != transforms.end()) {
+            transformer = std::make_unique<NullTransformer>();
+        }
+    }
+
     std::string getName() const override {
         return "WhileTransformer";
     }
@@ -454,6 +480,14 @@ public:
         this->verbose = verbose;
         if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
             mt->setVerbosity(verbose);
+        }
+    }
+
+    void disableTransformers(const std::set<std::string>& transforms) override {
+        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+            mt->disableTransformers(transforms);
+        } else if (transforms.find(transformer->getName()) != transforms.end()) {
+            transformer = std::make_unique<NullTransformer>();
         }
     }
 

--- a/src/DebugReport.h
+++ b/src/DebugReport.h
@@ -129,7 +129,7 @@ public:
         }
     }
 
-    void disableTransformers(const std::set<std::string>& transforms) {
+    void disableTransformers(const std::set<std::string>& transforms) override {
         if (auto* mt = dynamic_cast<MetaTransformer*>(wrappedTransformer.get())) {
             mt->disableTransformers(transforms);
         } else if (transforms.find(wrappedTransformer->getName()) != transforms.end()) {

--- a/src/DebugReport.h
+++ b/src/DebugReport.h
@@ -129,6 +129,14 @@ public:
         }
     }
 
+    void disableTransformers(const std::set<std::string>& transforms) {
+        if (auto* mt = dynamic_cast<MetaTransformer*>(wrappedTransformer.get())) {
+            mt->disableTransformers(transforms);
+        } else if (transforms.find(wrappedTransformer->getName()) != transforms.end()) {
+            wrappedTransformer = std::unique_ptr<AstTransformer>(new NullTransformer());
+        }
+    }
+
     std::string getName() const override {
         return "DebugReporter";
     }

--- a/src/Util.h
+++ b/src/Util.h
@@ -524,7 +524,7 @@ namespace detail {
 /**
  * A auxiliary class to be returned by the join function aggregating the information
  * required to print a list of elements as well as the implementation of the printing
- * itsefl.
+ * itself.
  */
 template <typename Iter, typename Printer>
 class joined_sequence {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,7 +189,8 @@ int main(int argc, char** argv) {
                             {"magic-transform", 'm', "RELATIONS", "", false,
                                     "Enable magic set transformation changes on the given relations, use '*' "
                                     "for all."},
-                            {"disable-transformers", 'z', "TRANSFORMERS", "", false, "Disable the given AST transformers."},
+                            {"disable-transformers", 'z', "TRANSFORMERS", "", false,
+                                    "Disable the given AST transformers."},
                             {"dl-program", 'o', "FILE", "", false,
                                     "Generate C++ source code, written to <FILE>, and compile this to a "
                                     "binary executable (without executing it)."},
@@ -437,14 +438,14 @@ int main(int argc, char** argv) {
             int begin = 0;
             for (size_t i = 0; i < str.size(); i++) {
                 if (str[i] == delimiter) {
-                    std::string token = str.substr(begin, (i-begin));
+                    std::string token = str.substr(begin, (i - begin));
                     parts.insert(token);
                     begin = i + 1;
                 }
             }
 
-            parts.insert(str.substr(begin)); // add in the last remaining token
-            parts.erase("");                 // remove empty tokens
+            parts.insert(str.substr(begin));  // add in the last remaining token
+            parts.erase("");                  // remove empty tokens
 
             return parts;
         };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,7 +189,7 @@ int main(int argc, char** argv) {
                             {"magic-transform", 'm', "RELATIONS", "", false,
                                     "Enable magic set transformation changes on the given relations, use '*' "
                                     "for all."},
-                            {"disable-transformers", 'z', "TRANSFORMERS", "", false, "Disable the given AST transformers"},
+                            {"disable-transformers", 'z', "TRANSFORMERS", "", false, "Disable the given AST transformers."},
                             {"dl-program", 'o', "FILE", "", false,
                                     "Generate C++ source code, written to <FILE>, and compile this to a "
                                     "binary executable (without executing it)."},
@@ -430,7 +430,7 @@ int main(int argc, char** argv) {
 
     // Disable unwanted transformations
     if (Global::config().has("disable-transformers")) {
-        // TODO (azreika): maybe push this into utils
+        // TODO (azreika): add splitter into utils
         auto split = [&](std::string str, char delimiter) {
             std::set<std::string> parts;
 
@@ -450,7 +450,6 @@ int main(int argc, char** argv) {
         };
 
         std::set<std::string> givenTransformers = split(Global::config().get("disable-transformers"), ',');
-
         pipeline->disableTransformers(givenTransformers);
     }
 


### PR DESCRIPTION
Added a new command-line option, `--disable-transformers=<TRANSFORMERS>` or `-z<TRANSFORMERS>`, where `<TRANSFORMERS>` is a comma-separated list of transformer names (as shown in the debug report).

Allows the user to disable any provided AST transformation. For example, to disable the InliningTransformer and PartitionBodyLiteralsTransformer transformations, one can use the command:

`souffle test.dl --disable-transformers="PartitionBodyLiteralsTransformer,InliningTransformer"`

or

`souffle test.dl -z"PartitionBodyLiterals,InliningTransformer"`

Should make testing certain configurations much faster.

