### PR TITLE
Reduce unnecessary travis log output

### DIFF
--- a/.travis/after_failure.sh
+++ b/.travis/after_failure.sh
@@ -29,17 +29,17 @@ RELEVANT_EXTENSIONS=".out .err .log .ccerr"
 MAXIMUM_LINES="200"
 
 # Show the current directory, and the contents of each direct subdirectory
-pretty_print "Current directory status"
-pwd
-ls -l
-for FI in */; do
-    pretty_print $FI
-    ls $FI
-done
+# pretty_print "Current directory status"
+# pwd
+# ls -l
+# for FI in */; do
+#     pretty_print $FI
+#     ls $FI
+# done
 
 # print some program data
 pretty_print "Installed tools"
-for exe in git java javac gcc g++ clang clang++ automake autoconf flex bison; do
+for exe in git gcc g++ clang clang++ automake autoconf flex bison; do
     which $exe
     ($exe --version 2>/dev/null >/dev/null && $exe --version ) || $exe -version
     echo

--- a/.travis/linux/install_centos_deps.sh
+++ b/.travis/linux/install_centos_deps.sh
@@ -21,15 +21,18 @@ travis_retry() {
   return $result
 }
 
+# Add our repo to get mcpp
 travis_retry yum install -y https://dl.bintray.com/souffle-lang/rpm-unstable/centos/7/x86_64/souffle-repo-centos-1.0-1.x86_64.rpm
 
-travis_retry yum install -y autoconf automake bison clang doxygen flex gcc gcc-c++ git kernel-devel ncurses-devel sqlite-devel libtool make mcpp python sqlite sudo zlib-devel
+# Build dependencies
+travis_retry yum install -y -q autoconf automake bison clang doxygen flex gcc gcc-c++ git kernel-devel ncurses-devel sqlite-devel libtool make mcpp python sqlite sudo zlib-devel
 
+# Set up a more recent gcc that supports C++11
 travis_retry yum install -y centos-release-scl
 travis_retry yum install -y devtoolset-7-gcc-c++
 
-travis_retry yum install -y ruby-devel gcc make rpm-build libffi-devel
-
+# Set up the package builder
+travis_retry yum install -y -q ruby-devel gcc make rpm-build libffi-devel
 travis_retry gem install --no-ri --no-rdoc fpm
 
 fpm --version

--- a/.travis/linux/install_debian_deps.sh
+++ b/.travis/linux/install_debian_deps.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-apt-get update
-apt-get install -y autoconf automake bison build-essential clang debhelper devscripts doxygen fakeroot flex g++ git graphviz libncurses5-dev libsqlite3-dev libtool make mcpp pkg-config python sqlite zlib1g-dev
+apt-get update -q
+apt-get install -y -q autoconf automake bison build-essential clang debhelper devscripts doxygen fakeroot flex g++ git graphviz libncurses5-dev libsqlite3-dev libtool make mcpp pkg-config python sqlite zlib1g-dev

--- a/.travis/linux/install_fedora_deps.sh
+++ b/.travis/linux/install_fedora_deps.sh
@@ -21,11 +21,11 @@ travis_retry() {
   return $result
 }
 
+# Build dependencies
+travis_retry yum install -y -q autoconf automake bison clang doxygen flex gcc gcc-c++ git kernel-devel ncurses-devel sqlite-devel libtool make mcpp pkg-config python sqlite sudo zlib-devel
 
-travis_retry yum install -y autoconf automake bison clang doxygen flex gcc gcc-c++ git kernel-devel ncurses-devel sqlite-devel libtool make mcpp pkg-config python sqlite sudo zlib-devel
-
-travis_retry yum install -y ruby-devel gcc make rpm-build libffi-devel
-
+# Set up the package builder
+travis_retry yum install -y -q ruby-devel gcc make rpm-build libffi-devel
 travis_retry gem install --no-ri --no-rdoc fpm
 
 fpm --version

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,7 +27,7 @@ package:
 	rm -rf $(dpkg_dir)
 	$(MKDIR_P) $(dpkg_dir)
 	$(MAKE) dist
-	tar -xvf $(dist_src) -C $(dpkg_dir)
+	tar -xf $(dist_src) -C $(dpkg_dir)
 	cp -r debian $(dpkg_dir)/$(distdir)
 	mv $(dist_src) $(dpkg_dir)/$(deb_src)
 	cd $(dpkg_dir)/$(distdir) && DEB_BUILD_OPTIONS=nocheck $(DEBUILD) -us -uc


### PR DESCRIPTION
This is a workaround for current travis logging issues that are blocking successful builds, but also improves log clarity by removing verbose success messages, and very rarely helpful logs (so rarely that it is more helpful to enable that logging only as needed).