### PR TITLE
Pragma Upgrade + Guided Literal Reordering Transformation

### DIFF
--- a/src/AstPragma.cpp
+++ b/src/AstPragma.cpp
@@ -33,7 +33,8 @@ bool AstPragmaChecker::transform(AstTranslationUnit& translationUnit) {
             size_t splitPoint = option.find(':');
 
             std::string optionName = option.substr(0, splitPoint);
-            std::string optionValue = (splitPoint == std::string::npos) ? "" : option.substr(splitPoint+1, option.length());
+            std::string optionValue =
+                    (splitPoint == std::string::npos) ? "" : option.substr(splitPoint + 1, option.length());
 
             if (!Global::config().has(optionName)) {
                 changed = true;

--- a/src/AstPragma.cpp
+++ b/src/AstPragma.cpp
@@ -19,21 +19,40 @@
 #include "AstTranslationUnit.h"
 #include "AstVisitor.h"
 #include "Global.h"
+#include "Util.h"
 
 namespace souffle {
 bool AstPragmaChecker::transform(AstTranslationUnit& translationUnit) {
     bool changed = false;
     AstProgram* program = translationUnit.getProgram();
 
+    // Take in pragma options from the command line
+    if (Global::config().has("pragma")) {
+        std::vector<std::string> configOptions = splitString(Global::config().get("pragma"), ',');
+        for (const std::string& option : configOptions) {
+            size_t splitPoint = option.find(':');
+
+            std::string optionName = option.substr(0, splitPoint);
+            std::string optionValue = (splitPoint == std::string::npos) ? "" : option.substr(splitPoint+1, option.length());
+
+            if (!Global::config().has(optionName)) {
+                changed = true;
+                Global::config().set(optionName, optionValue);
+            }
+        }
+    }
+
+    // Take in pragma options from the datalog file itself
     visitDepthFirst(*program, [&](const AstPragma& pragma) {
         std::pair<std::string, std::string> kvp = pragma.getkvp();
-        // command line options take precedence
-        // TODO (azreika): currently does not override default values if set
+
+        // Command line options take precedence
         if (!Global::config().has(kvp.first)) {
             changed = true;
             Global::config().set(kvp.first, kvp.second);
         }
     });
+
     return changed;
 }
 }  // end of namespace souffle

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1390,7 +1390,7 @@ bool isProposition(const AstLiteral* literal) {
     }
 
     bool isProp = true;
-    visitDepthFirst(*literal, [&](const AstVariable& var){
+    visitDepthFirst(*literal, [&](const AstVariable& var) {
         // Found a variable, therefore not a proposition
         isProp = false;
     });
@@ -1405,17 +1405,18 @@ bool isProposition(const AstLiteral* literal) {
  * For example, the 'max-bound' SIPS function will return the
  * atom in the clause with the maximum number of bound arguments.
  */
-std::function<unsigned int(std::vector<AstAtom*>, const std::set<std::string>&)> getSIPSfunction(const std::string& SIPSchosen) {
+std::function<unsigned int(std::vector<AstAtom*>, const std::set<std::string>&)> getSIPSfunction(
+        const std::string& SIPSchosen) {
     // Count the number of bound arguments in a given atom
     auto numBoundArguments = [&](const AstAtom* atom, const std::set<std::string>& boundVariables) {
         int count = 0;
         for (const AstArgument* arg : atom->getArguments()) {
             bool isBound = true;
             visitDepthFirst(*arg, [&](const AstVariable& var) {
-                    if (boundVariables.find(var.getName()) == boundVariables.end()) {
+                if (boundVariables.find(var.getName()) == boundVariables.end()) {
                     isBound = false;
-                    }
-                    });
+                }
+            });
 
             if (isBound) {
                 count++;
@@ -1485,11 +1486,11 @@ std::function<unsigned int(std::vector<AstAtom*>, const std::set<std::string>&)>
     } else if (SIPSchosen == "max-ratio") {
         // Order based on maximum ratio of bound to unbound
         getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
-            auto isLargerRatio = [&](std::pair<int,int> lhs, std::pair<int,int> rhs) {
+            auto isLargerRatio = [&](std::pair<int, int> lhs, std::pair<int, int> rhs) {
                 return (lhs.first * rhs.second > lhs.second * rhs.first);
             };
 
-            std::pair<int,int> currMaxRatio = std::pair<int,int>(-1,1);
+            std::pair<int, int> currMaxRatio = std::pair<int, int>(-1, 1);
             unsigned int currMaxIdx = 0;
 
             for (unsigned int i = 0; i < atoms.size(); i++) {
@@ -1530,10 +1531,10 @@ std::function<unsigned int(std::vector<AstAtom*>, const std::set<std::string>&)>
 
                 std::set<std::string> freeVars;
                 visitDepthFirst(*atoms[i], [&](const AstVariable& var) {
-                        if (boundVariables.find(var.getName()) == boundVariables.end()) {
+                    if (boundVariables.find(var.getName()) == boundVariables.end()) {
                         freeVars.insert(var.getName());
-                        }
-                        });
+                    }
+                });
 
                 int numFreeVars = freeVars.size();
                 if (currLeastFree == -1 || numFreeVars < currLeastFree) {
@@ -1568,7 +1569,7 @@ bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) 
     AstProgram& program = *translationUnit.getProgram();
 
     // --- Reordering --- : Prepend Propositions
-    auto prependPropositions = [&](AstClause* clause){
+    auto prependPropositions = [&](AstClause* clause) {
         const std::vector<AstAtom*>& atoms = clause->getAtoms();
 
         // Calculate the new ordering
@@ -1611,7 +1612,8 @@ bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) 
                 std::vector<AstAtom*> atoms = clause->getAtoms();
 
                 // Decide which SIPS to use
-                std::function<unsigned int(std::vector<AstAtom*>, const std::set<std::string>&)> getNextAtomSIPS = getSIPSfunction(Global::config().get("SIPS"));
+                std::function<unsigned int(std::vector<AstAtom*>, const std::set<std::string>&)>
+                        getNextAtomSIPS = getSIPSfunction(Global::config().get("SIPS"));
 
                 // Apply the SIPS to get a new ordering
                 std::set<std::string> boundVariables;
@@ -1621,9 +1623,8 @@ bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) 
                 while (numAdded < atoms.size()) {
                     int nextIdx = getNextAtomSIPS(atoms, boundVariables);
 
-                    visitDepthFirst(*atoms[nextIdx], [&](const AstVariable& var) {
-                        boundVariables.insert(var.getName());
-                    });
+                    visitDepthFirst(*atoms[nextIdx],
+                            [&](const AstVariable& var) { boundVariables.insert(var.getName()); });
 
                     newOrder[numAdded] = nextIdx;
                     atoms[nextIdx] = nullptr;

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1513,7 +1513,7 @@ bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) 
                             return (lhs.first * rhs.second > lhs.second * rhs.first);
                         };
 
-                        std::pair<int,int> currMaxRatio = std::pair<int,int>(0,1);
+                        std::pair<int,int> currMaxRatio = std::pair<int,int>(-1,1);
                         unsigned int currMaxIdx = 0;
 
                         for (unsigned int i = 0; i < atoms.size(); i++) {

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1375,6 +1375,10 @@ bool ReplaceSingletonVariablesTransformer::transform(AstTranslationUnit& transla
     return changed;
 }
 
+bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) {
+    return false;
+}
+
 bool NormaliseConstraintsTransformer::transform(AstTranslationUnit& translationUnit) {
     bool changed = false;
 

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1378,23 +1378,19 @@ bool ReplaceSingletonVariablesTransformer::transform(AstTranslationUnit& transla
 }
 
 /**
- * Checks whether the given literal is a 'proposition',
- * in the sense that it has no variables in its arguments,
- * and so will take a constant time to process and is
- * independent of the remainder of the clause.
+ * Checks that the given literal is a proposition - that is,
+ * an atom with no arguments, which is hence independent of the
+ * rest of the clause.
  */
 bool isProposition(const AstLiteral* literal) {
-    if (dynamic_cast<const AstAtom*>(literal) == nullptr) {
+    const AstAtom* correspondingAtom = dynamic_cast<const AstAtom*>(literal);
+    if (correspondingAtom == nullptr) {
         // Just a constraint with no associated atom
         return false;
     }
 
-    bool isProp = true;
-    visitDepthFirst(*literal, [&](const AstVariable& var) {
-        // Found a variable, therefore not a proposition
-        isProp = false;
-    });
-    return isProp;
+    // Check that it has no arguments
+    return correspondingAtom->getArguments().empty();
 }
 
 /**

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1619,6 +1619,10 @@ bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) 
                 while (numAdded < atoms.size()) {
                     int nextIdx = getNextAtomSIPS(atoms, boundVariables);
 
+                    if (nextIdx != numAdded) {
+                        changed = true;
+                    }
+
                     visitDepthFirst(*atoms[nextIdx],
                             [&](const AstVariable& var) { boundVariables.insert(var.getName()); });
 

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1377,23 +1377,197 @@ bool ReplaceSingletonVariablesTransformer::transform(AstTranslationUnit& transla
     return changed;
 }
 
+/**
+ * Checks whether the given literal is a 'proposition',
+ * in the sense that it has no variables in its arguments,
+ * and so will take a constant time to process and is
+ * independent of the remainder of the clause.
+ */
+bool isProposition(const AstLiteral* literal) {
+    if (dynamic_cast<const AstAtom*>(literal) == nullptr) {
+        // Just a constraint with no associated atom
+        return false;
+    }
+
+    bool isProp = true;
+    visitDepthFirst(*literal, [&](const AstVariable& var){
+        // Found a variable, therefore not a proposition
+        isProp = false;
+    });
+    return isProp;
+}
+
+/**
+ * Returns a SIPS function based on the SIPS option provided.
+ * The SIPS function will return the index of the appropriate atom in a clause
+ * given a goal.
+ *
+ * For example, the 'max-bound' SIPS function will return the
+ * atom in the clause with the maximum number of bound arguments.
+ */
+std::function<unsigned int(std::vector<AstAtom*>, const std::set<std::string>&)> getSIPSfunction(const std::string& SIPSchosen) {
+    // Count the number of bound arguments in a given atom
+    auto numBoundArguments = [&](const AstAtom* atom, const std::set<std::string>& boundVariables) {
+        int count = 0;
+        for (const AstArgument* arg : atom->getArguments()) {
+            bool isBound = true;
+            visitDepthFirst(*arg, [&](const AstVariable& var) {
+                    if (boundVariables.find(var.getName()) == boundVariables.end()) {
+                    isBound = false;
+                    }
+                    });
+
+            if (isBound) {
+                count++;
+            }
+        }
+        return count;
+    };
+
+    // --- Create the appropriate SIPS function. ---
+
+    // Each SIPS function has a priority metric (e.g. max-bound atoms). The function will typically
+    // take in the atom, and a set of variables bound so far, and return the index of the atom that
+    // maximises the priority metric.
+
+    // If an atom in the vector should be ignored, set it to be the nullpointer.
+    std::function<unsigned int(std::vector<AstAtom*>, const std::set<std::string>&)> getNextAtomSIPS;
+
+    if (SIPSchosen == "naive") {
+        // Choose the first predicate with at least one bound argument
+        getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
+            for (unsigned int i = 0; i < atoms.size(); i++) {
+                if (atoms[i] == nullptr) {
+                    // Already processed, move on
+                    continue;
+                }
+
+                if (isProposition(atoms[i]) || (numBoundArguments(atoms[i], boundVariables) >= 1)) {
+                    return i;
+                }
+            }
+
+            // None found, so just return the first non-null
+            for (unsigned int i = 0; i < atoms.size(); i++) {
+                if (atoms[i] != nullptr) {
+                    return i;
+                }
+            }
+
+            // Fall back to the first
+            return 0U;
+        };
+    } else if (SIPSchosen == "max-bound") {
+        // Order based on maximum number of bound variables
+        getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
+            int currMaxBound = -1;
+            unsigned int currMaxIdx = 0;
+
+            for (unsigned int i = 0; i < atoms.size(); i++) {
+                if (atoms[i] == nullptr) {
+                    // Already processed, move on
+                    continue;
+                }
+
+                if (isProposition(atoms[i])) {
+                    return i;
+                }
+
+                int numBound = numBoundArguments(atoms[i], boundVariables);
+                if (numBound > currMaxBound) {
+                    currMaxBound = numBound;
+                    currMaxIdx = i;
+                }
+            }
+
+            return currMaxIdx;
+        };
+    } else if (SIPSchosen == "max-ratio") {
+        // Order based on maximum ratio of bound to unbound
+        getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
+            auto isLargerRatio = [&](std::pair<int,int> lhs, std::pair<int,int> rhs) {
+                return (lhs.first * rhs.second > lhs.second * rhs.first);
+            };
+
+            std::pair<int,int> currMaxRatio = std::pair<int,int>(-1,1);
+            unsigned int currMaxIdx = 0;
+
+            for (unsigned int i = 0; i < atoms.size(); i++) {
+                if (atoms[i] == nullptr) {
+                    // Already processed, move on
+                    continue;
+                }
+
+                if (isProposition(atoms[i])) {
+                    return i;
+                }
+
+                int numBound = numBoundArguments(atoms[i], boundVariables);
+                int numArgs = atoms[i]->getArguments().size();
+                if (isLargerRatio(std::make_pair(numBound, numArgs), currMaxRatio)) {
+                    currMaxRatio = std::make_pair(numBound, numArgs);
+                    currMaxIdx = i;
+                }
+            }
+
+            return currMaxIdx;
+        };
+    } else if (SIPSchosen == "least-free-vars") {
+        // Order based on the least amount of free variables in the atom
+        getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
+            int currLeastFree = -1;
+            unsigned int currLeastIdx = 0;
+
+            for (unsigned int i = 0; i < atoms.size(); i++) {
+                if (atoms[i] == nullptr) {
+                    // Already processed, move on
+                    continue;
+                }
+
+                if (isProposition(atoms[i])) {
+                    return i;
+                }
+
+                std::set<std::string> freeVars;
+                visitDepthFirst(*atoms[i], [&](const AstVariable& var) {
+                        if (boundVariables.find(var.getName()) == boundVariables.end()) {
+                        freeVars.insert(var.getName());
+                        }
+                        });
+
+                int numFreeVars = freeVars.size();
+                if (currLeastFree == -1 || numFreeVars < currLeastFree) {
+                    currLeastFree = numFreeVars;
+                    currLeastIdx = i;
+                }
+            }
+
+            return currLeastIdx;
+        };
+    } else {
+        // Keep the same order - leftmost takes precedence
+        getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
+            for (unsigned int i = 0; i < atoms.size(); i++) {
+                if (atoms[i] == nullptr) {
+                    // Already processed, move on
+                    continue;
+                }
+
+                return i;
+            }
+
+            return 0U;
+        };
+    }
+
+    return getNextAtomSIPS;
+}
+
 bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) {
     bool changed = false;
     AstProgram& program = *translationUnit.getProgram();
 
     // --- Reordering --- : Prepend Propositions
-    auto isProposition = [&](const AstLiteral* literal) {
-        if (dynamic_cast<const AstAtom*>(literal) == nullptr) {
-            return false;
-        }
-
-        bool isProp = true;
-        visitDepthFirst(*literal, [&](const AstVariable& var){
-            isProp = false;
-        });
-        return isProp;
-    };
-
     auto prependPropositions = [&](AstClause* clause){
         const std::vector<AstAtom*>& atoms = clause->getAtoms();
 
@@ -1437,153 +1611,7 @@ bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) 
                 std::vector<AstAtom*> atoms = clause->getAtoms();
 
                 // Decide which SIPS to use
-                std::function<int(std::vector<AstAtom*>, const std::set<std::string>&)> getNextAtomSIPS;
-                std::string SIPSchosen = Global::config().get("SIPS");
-
-                // Count the number of bound arguments in a given atom
-                auto numBoundArguments = [&](const AstAtom* atom, const std::set<std::string>& boundVariables) {
-                    int count = 0;
-                    for (const AstArgument* arg : atom->getArguments()) {
-                        bool isBound = true;
-                        visitDepthFirst(*arg, [&](const AstVariable& var) {
-                            if (boundVariables.find(var.getName()) == boundVariables.end()) {
-                                isBound = false;
-                            }
-                        });
-
-                        if (isBound) {
-                            count++;
-                        }
-                    }
-                    return count;
-                };
-
-                if (SIPSchosen == "naive") {
-                    // Choose the first predicate with at least one bound argument
-                    getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
-                        for (unsigned int i = 0; i < atoms.size(); i++) {
-                            if (atoms[i] == nullptr) {
-                                // Already processed, move on
-                                continue;
-                            }
-
-                            if (isProposition(atoms[i]) || (numBoundArguments(atoms[i], boundVariables) >= 1)) {
-                                return i;
-                            }
-                        }
-
-                        // None found, so just return the first non-null
-                        for (unsigned int i = 0; i < atoms.size(); i++) {
-                            if (atoms[i] != nullptr) {
-                                return i;
-                            }
-                        }
-
-                        // Fall back to the first
-                        return 0U;
-                    };
-                } else if (SIPSchosen == "max-bound") {
-                    // Order based on maximum number of bound variables
-                    getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
-                        int currMaxBound = -1;
-                        unsigned int currMaxIdx = 0;
-
-                        for (unsigned int i = 0; i < atoms.size(); i++) {
-                            if (atoms[i] == nullptr) {
-                                // Already processed, move on
-                                continue;
-                            }
-
-                            if (isProposition(atoms[i])) {
-                                return i;
-                            }
-
-                            int numBound = numBoundArguments(atoms[i], boundVariables);
-                            if (numBound > currMaxBound) {
-                                currMaxBound = numBound;
-                                currMaxIdx = i;
-                            }
-                        }
-
-                        return currMaxIdx;
-                    };
-                } else if (SIPSchosen == "max-ratio") {
-                    // Order based on maximum ratio of bound to unbound
-                    getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
-                        auto isLargerRatio = [&](std::pair<int,int> lhs, std::pair<int,int> rhs) {
-                            return (lhs.first * rhs.second > lhs.second * rhs.first);
-                        };
-
-                        std::pair<int,int> currMaxRatio = std::pair<int,int>(-1,1);
-                        unsigned int currMaxIdx = 0;
-
-                        for (unsigned int i = 0; i < atoms.size(); i++) {
-                            if (atoms[i] == nullptr) {
-                                // Already processed, move on
-                                continue;
-                            }
-
-                            if (isProposition(atoms[i])) {
-                                return i;
-                            }
-
-                            int numBound = numBoundArguments(atoms[i], boundVariables);
-                            int numArgs = atoms[i]->getArguments().size();
-                            if (isLargerRatio(std::make_pair(numBound, numArgs), currMaxRatio)) {
-                                currMaxRatio = std::make_pair(numBound, numArgs);
-                                currMaxIdx = i;
-                            }
-                        }
-
-                        return currMaxIdx;
-                    };
-                } else if (SIPSchosen == "least-free-vars") {
-                    // Order based on the least amount of free variables in the atom
-                    getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
-                        int currLeastFree = -1;
-                        unsigned int currLeastIdx = 0;
-
-                        for (unsigned int i = 0; i < atoms.size(); i++) {
-                            if (atoms[i] == nullptr) {
-                                // Already processed, move on
-                                continue;
-                            }
-
-                            if (isProposition(atoms[i])) {
-                                return i;
-                            }
-
-                            std::set<std::string> freeVars;
-                            visitDepthFirst(*atoms[i], [&](const AstVariable& var) {
-                                if (boundVariables.find(var.getName()) == boundVariables.end()) {
-                                    freeVars.insert(var.getName());
-                                }
-                            });
-
-                            int numFreeVars = freeVars.size();
-                            if (currLeastFree == -1 || numFreeVars < currLeastFree) {
-                                currLeastFree = numFreeVars;
-                                currLeastIdx = i;
-                            }
-                        }
-
-                        return currLeastIdx;
-                    };
-                } else {
-                    // Keep the same order - left takes precedence
-                    getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
-                        for (unsigned int i = 0; i < atoms.size(); i++) {
-                            if (atoms[i] == nullptr) {
-                                // Already processed, move on
-                                continue;
-                            }
-
-                            return i;
-                        }
-
-                        return 0U;
-                    };
-                }
+                std::function<unsigned int(std::vector<AstAtom*>, const std::set<std::string>&)> getNextAtomSIPS = getSIPSfunction(Global::config().get("SIPS"));
 
                 // Apply the SIPS to get a new ordering
                 std::set<std::string> boundVariables;

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1394,15 +1394,15 @@ bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) 
     };
 
     auto prependPropositions = [&](AstClause* clause){
-        const std::vector<AstLiteral*>& bodyLiterals = clause->getBodyLiterals();
+        const std::vector<AstAtom*>& atoms = clause->getAtoms();
 
         // Calculate the new ordering
         std::vector<unsigned int> nonPropositionIndices;
         std::vector<unsigned int> newOrder;
 
         bool seenNonProp;
-        for (unsigned int i = 0; i < bodyLiterals.size(); i++) {
-            if (isProposition(bodyLiterals[i])) {
+        for (unsigned int i = 0; i < atoms.size(); i++) {
+            if (isProposition(atoms[i])) {
                 newOrder.push_back(i);
                 if (seenNonProp) {
                     changed = true;

--- a/src/AstTransforms.h
+++ b/src/AstTransforms.h
@@ -292,6 +292,19 @@ public:
 };
 
 /**
+ * Transformation pass to reorder body literals.
+ */
+class ReorderLiteralsTransformer : public AstTransformer {
+private:
+    bool transform(AstTranslationUnit& translationUnit) override;
+
+public:
+    std::string getName() const override {
+        return "ReorderLiteralsTransformer";
+    }
+}
+
+/**
  * Transformation pass to normalise constraints.
  * E.g.: a(x) :- b(x, 1). -> a(x) :- b(x, tmp0), tmp0=1.
  */

--- a/src/AstTransforms.h
+++ b/src/AstTransforms.h
@@ -302,7 +302,7 @@ public:
     std::string getName() const override {
         return "ReorderLiteralsTransformer";
     }
-}
+};
 
 /**
  * Transformation pass to normalise constraints.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -434,6 +434,7 @@ int main(int argc, char** argv) {
             std::make_unique<RemoveRelationCopiesTransformer>(), std::move(equivalencePipeline),
             std::make_unique<MaterializeAggregationQueriesTransformer>(),
             std::make_unique<RemoveEmptyRelationsTransformer>(),
+            std::make_unique<ReorderLiteralsTransformer>(),
             std::make_unique<RemoveRedundantRelationsTransformer>(), std::move(magicPipeline),
             std::make_unique<AstExecutionPlanChecker>(), std::move(provenancePipeline));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,6 +197,7 @@ int main(int argc, char** argv) {
                             {"profile", 'p', "FILE", "", false,
                                     "Enable profiling, and write profile data to <FILE>."},
                             {"debug-report", 'r', "FILE", "", false, "Write HTML debug report to <FILE>."},
+                            {"pragma", 'P', "OPTIONS", "", false, "Set pragma options."},
 #ifdef USE_PROVENANCE
                             {"provenance", 't', "EXPLAIN", "", false,
                                     "Enable provenance information via guided SLD."},


### PR DESCRIPTION
* Added a new transformation: `ReorderBodyLiteralsTransformer`
  * Reorders atoms in the clause so that propositions are pushed to the start of evaluation
    * Propositions will be evaluated prior to all other body atoms in the rules that they appear in. This is always better, as propositions are constant-time checks, and have already been evaluated (never recursive - see `ReduceExistentialsTransformer`).
  * If a Sideways-Information-Passing Strategy (SIPS) is given, then it reorders based on the given strategy.
  * SIPS can be provided using pragmas in the datalog file: `.pragma "SIPS" "<strategy-name>"`
  * Valid SIPS strategies are as follows (invalid options default to null):
    * `null` -- no SIPS
    * `naive` -- atoms with any number of bound atoms are prioritised, with left-to-right priority
    * `least-free-vars` -- atoms with the fewest number of introduced free variables are prioritised
    * `max-bound` -- atoms with a higher number of bound atoms are prioritised
    * `max-ratio` -- atoms with the highest bound-to-unbound variable ratio are prioritised

* Upgraded the pragma option
  * Previously, only allowed to be supplied in the Datalog file itself -- e.g. `.pragma "magic-transform" "somerelation, someotherrelation"`.
  * Now, can be supplied via the command-line to update config options (like the `SIPS` option above!)
    * Option is `--pragma || -p`.
    * Format: `--pragma="option1:value1,option2:value2,...,optionN:valueN"`
      * i.e. comma-separated list of "option:value" pairs, with no spaces
      * If, for instance, option1 does not need a value, then can just use `--pragma="option1,option2:value2,...,optionN:valueN`