### PR TITLE
Improve speed for nullary relations

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -695,11 +695,6 @@ std::unique_ptr<RamStatement> AstTranslator::translateClause(const AstClause& cl
             }
         }
 
-	// add stopping criteria for nullary relations
-	// (if it contains already the null tuple, don't re-compute)
-	if (head.getArity() == 0) {
-            project->addCondition(std::make_unique<RamEmpty>(getRelation(&origHead)), *project);
-	}
 
         // build up insertion call
         op = std::move(project);  // start with innermost
@@ -916,10 +911,18 @@ std::unique_ptr<RamStatement> AstTranslator::translateClause(const AstClause& cl
             std::cout << "Unsupported node type: " << typeid(*lit).name();
             assert(false && "Unsupported node type!");
         }
-    }
+    } 
 
+
+
+    // add stopping criteria for nullary relations
+    // (if it contains already the null tuple, don't re-compute)
+    std::unique_ptr<RamCondition> ramInsertCondition;
+    if(!ret && head.getArity() == 0) {
+        ramInsertCondition = std::make_unique<RamEmpty>(getRelation(&origHead));
+    }
     /* generate the final RAM Insert statement */
-    return std::make_unique<RamInsert>(std::move(op));
+    return std::make_unique<RamInsert>(std::move(op), std::move(ramInsertCondition));
 }
 
 /* utility for appending statements */

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -663,7 +663,6 @@ std::unique_ptr<RamStatement> AstTranslator::translateClause(const AstClause& cl
     } else {
         std::unique_ptr<RamProject> project = std::make_unique<RamProject>(getRelation(&head), level);
 
-
         for (AstArgument* arg : head.getArguments()) {
             project->addArg(translateValue(arg, valueIndex));
         }
@@ -694,7 +693,6 @@ std::unique_ptr<RamStatement> AstTranslator::translateClause(const AstClause& cl
                 project->addCondition(std::move(uniquenessEnforcement), *project);
             }
         }
-
 
         // build up insertion call
         op = std::move(project);  // start with innermost
@@ -911,14 +909,12 @@ std::unique_ptr<RamStatement> AstTranslator::translateClause(const AstClause& cl
             std::cout << "Unsupported node type: " << typeid(*lit).name();
             assert(false && "Unsupported node type!");
         }
-    } 
-
-
+    }
 
     // add stopping criteria for nullary relations
     // (if it contains already the null tuple, don't re-compute)
     std::unique_ptr<RamCondition> ramInsertCondition;
-    if(!ret && head.getArity() == 0) {
+    if (!ret && head.getArity() == 0) {
         ramInsertCondition = std::make_unique<RamEmpty>(getRelation(&origHead));
     }
     /* generate the final RAM Insert statement */

--- a/src/AstVisitor.h
+++ b/src/AstVisitor.h
@@ -64,7 +64,7 @@ struct AstVisitor : public ast_visitor_tag {
      * @param args a list of extra parameters to be forwarded
      */
     virtual R visit(const AstNode& node, Params... args) {
-        // dispatch node processing based on dynamic type
+    // dispatch node processing based on dynamic type
 
 #define FORWARD(Kind) \
     if (const auto* n = dynamic_cast<const Ast##Kind*>(&node)) return visit##Kind(*n, args...);

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -783,7 +783,10 @@ void Interpreter::evalStmt(const RamStatement& stmt) {
 
         bool visitInsert(const RamInsert& insert) override {
             // run generic query executor
-            interpreter.evalOp(insert.getOperation());
+
+            if(interpreter.evalCond(*insert.getCondition())) {
+               interpreter.evalOp(insert.getOperation());
+	    }
             return true;
         }
 

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -784,8 +784,14 @@ void Interpreter::evalStmt(const RamStatement& stmt) {
         bool visitInsert(const RamInsert& insert) override {
             // run generic query executor
 
-            if(interpreter.evalCond(*insert.getCondition())) {
-               interpreter.evalOp(insert.getOperation());
+	   
+	    const RamCondition *c = insert.getCondition();
+	    if(c != nullptr) { 
+               if(interpreter.evalCond(*insert.getCondition())) {
+                  interpreter.evalOp(insert.getOperation());
+	       }
+	    } else {
+                  interpreter.evalOp(insert.getOperation());
 	    }
             return true;
         }

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -784,15 +784,14 @@ void Interpreter::evalStmt(const RamStatement& stmt) {
         bool visitInsert(const RamInsert& insert) override {
             // run generic query executor
 
-	   
-	    const RamCondition *c = insert.getCondition();
-	    if(c != nullptr) { 
-               if(interpreter.evalCond(*insert.getCondition())) {
-                  interpreter.evalOp(insert.getOperation());
-	       }
-	    } else {
-                  interpreter.evalOp(insert.getOperation());
-	    }
+            const RamCondition* c = insert.getCondition();
+            if (c != nullptr) {
+                if (interpreter.evalCond(*insert.getCondition())) {
+                    interpreter.evalOp(insert.getOperation());
+                }
+            } else {
+                interpreter.evalOp(insert.getOperation());
+            }
             return true;
         }
 

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -460,7 +460,7 @@ public:
 
     /** Print */
     void print(std::ostream& os) const override {
-        os << relation->getName() << " ≠ ∅";
+        os << relation->getName() << " = ∅";
     }
 
     /** Obtain list of child nodes */

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -419,7 +419,8 @@ protected:
     std::unique_ptr<RamCondition> condition;
 
 public:
-    RamInsert(std::unique_ptr<RamOperation> o, std::unique_ptr<RamCondition> c=nullptr) : RamStatement(RN_Insert), operation(std::move(o)), condition(std::move(c)) {}
+    RamInsert(std::unique_ptr<RamOperation> o, std::unique_ptr<RamCondition> c = nullptr)
+            : RamStatement(RN_Insert), operation(std::move(o)), condition(std::move(c)) {}
 
     /** Get RAM operation */
     const RamOperation& getOperation() const {
@@ -429,18 +430,18 @@ public:
 
     /** Get RAM condition */
     const RamCondition* getCondition() const {
-	return condition.get();
+        return condition.get();
     }
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
         os << "INSERT ";
-	if (condition != nullptr) {
-		os << "WHERE ";
-		condition->print(os);
-	}
-	os << "\n";
+        if (condition != nullptr) {
+            os << "WHERE ";
+            condition->print(os);
+        }
+        os << "\n";
         operation->print(os, tabpos + 1);
     }
 
@@ -452,12 +453,12 @@ public:
     /** Create clone */
     RamInsert* clone() const override {
         RamInsert* res;
-	if (condition != nullptr) {
-           res = new RamInsert(std::unique_ptr<RamOperation>(operation->clone()));
-	} else {
-           res = new RamInsert(std::unique_ptr<RamOperation>(operation->clone()), 
-			       std::unique_ptr<RamCondition>(condition->clone()));
-	}
+        if (condition != nullptr) {
+            res = new RamInsert(std::unique_ptr<RamOperation>(operation->clone()));
+        } else {
+            res = new RamInsert(std::unique_ptr<RamOperation>(operation->clone()),
+                    std::unique_ptr<RamCondition>(condition->clone()));
+        }
         return res;
     }
 
@@ -472,8 +473,7 @@ protected:
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamInsert*>(&node));
         const auto& other = static_cast<const RamInsert&>(node);
-        return getOperation() == other.getOperation() &&
-	       getCondition() == other.getCondition();
+        return getOperation() == other.getOperation() && getCondition() == other.getCondition();
     }
 };
 

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -415,8 +415,11 @@ protected:
     /** RAM operation */
     std::unique_ptr<RamOperation> operation;
 
+    /** RAM condition */
+    std::unique_ptr<RamCondition> condition;
+
 public:
-    RamInsert(std::unique_ptr<RamOperation> o) : RamStatement(RN_Insert), operation(std::move(o)) {}
+    RamInsert(std::unique_ptr<RamOperation> o, std::unique_ptr<RamCondition> c=nullptr) : RamStatement(RN_Insert), operation(std::move(o)), condition(std::move(c)) {}
 
     /** Get RAM operation */
     const RamOperation& getOperation() const {
@@ -424,27 +427,44 @@ public:
         return *operation;
     }
 
+    /** Get RAM condition */
+    const RamCondition* getCondition() const {
+	return condition.get();
+    }
+
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
-        os << "INSERT \n";
+        os << "INSERT ";
+	if (condition != nullptr) {
+		os << "WHERE ";
+		condition->print(os);
+	}
+	os << "\n";
         operation->print(os, tabpos + 1);
     }
 
     /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
-        return toVector<const RamNode*>(operation.get());
+        return std::vector<const RamNode*>({operation.get(), condition.get()});
     }
 
     /** Create clone */
     RamInsert* clone() const override {
-        RamInsert* res = new RamInsert(std::unique_ptr<RamOperation>(operation->clone()));
+        RamInsert* res;
+	if (condition != nullptr) {
+           res = new RamInsert(std::unique_ptr<RamOperation>(operation->clone()));
+	} else {
+           res = new RamInsert(std::unique_ptr<RamOperation>(operation->clone()), 
+			       std::unique_ptr<RamCondition>(condition->clone()));
+	}
         return res;
     }
 
     /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         operation = map(std::move(operation));
+        condition = map(std::move(condition));
     }
 
 protected:
@@ -452,7 +472,8 @@ protected:
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamInsert*>(&node));
         const auto& other = static_cast<const RamInsert&>(node);
-        return getOperation() == other.getOperation();
+        return getOperation() == other.getOperation() &&
+	       getCondition() == other.getCondition();
     }
 };
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -264,6 +264,12 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 	    std::string projectRelName;
 	    int projectRelArity=-1; 
 
+	    if(insert.getCondition() != nullptr) {
+		    out << "if(";
+                    visit(*insert.getCondition(), out);
+		    out << ") {\n";
+	    }
+
             visitDepthFirst(insert, [&](const RamProject& project) { projectRelArity = project.getRelation().getArity();  
 			                                             projectRelName = project.getRelation().getName(); });
 
@@ -369,6 +375,10 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 #else
             out << "();";  // call lambda
 #endif
+	   if(insert.getCondition() != nullptr) {
+	    out << "}\n";
+	   }
+
             PRINT_END_COMMENT(out);
         }
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -261,37 +261,40 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             PRINT_BEGIN_COMMENT(out);
             // enclose operation with a check for an empty relation
             std::set<std::string> inputRelNames;
-	    std::string projectRelName;
-	    int projectRelArity=-1; 
+            std::string projectRelName;
+            int projectRelArity = -1;
 
-	    if(insert.getCondition() != nullptr) {
-		    out << "if(";
-                    visit(*insert.getCondition(), out);
-		    out << ") {\n";
-	    }
+            if (insert.getCondition() != nullptr) {
+                out << "if(";
+                visit(*insert.getCondition(), out);
+                out << ") {\n";
+            }
 
-            visitDepthFirst(insert, [&](const RamProject& project) { projectRelArity = project.getRelation().getArity();  
-			                                             projectRelName = project.getRelation().getName(); });
+            visitDepthFirst(insert, [&](const RamProject& project) {
+                projectRelArity = project.getRelation().getArity();
+                projectRelName = project.getRelation().getName();
+            });
 
-            visitDepthFirst(insert, [&](const RamScan& scan) { inputRelNames.insert(scan.getRelation().getName()); });
+            visitDepthFirst(
+                    insert, [&](const RamScan& scan) { inputRelNames.insert(scan.getRelation().getName()); });
 
             if (!inputRelNames.empty() || projectRelArity == 0) {
                 out << "if (";
-		if (!inputRelNames.empty()) { 
-	            out << join(inputRelNames, "&&", [&](std::ostream& os, const std::string relName) {
+                if (!inputRelNames.empty()) {
+                    out << join(inputRelNames, "&&", [&](std::ostream& os, const std::string relName) {
                         os << "!" << synthesiser.getRelationName(relName) << "->empty()";
                     });
-		} 
-		if(projectRelArity == 0) { 
-		    if (!inputRelNames.empty()) {
-			out << "&&"; 
-		    }
-		    out << synthesiser.getRelationName(projectRelName) << "->empty()";
-		}
-	        out << ") ";
+                }
+                if (projectRelArity == 0) {
+                    if (!inputRelNames.empty()) {
+                        out << "&&";
+                    }
+                    out << synthesiser.getRelationName(projectRelName) << "->empty()";
+                }
+                out << ") ";
             }
 
-            // outline each search operation to improve compilation time
+                // outline each search operation to improve compilation time
 #ifdef __clang__
 #if __clang_major > 3
             out << "[&]()";
@@ -375,9 +378,9 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 #else
             out << "();";  // call lambda
 #endif
-	   if(insert.getCondition() != nullptr) {
-	    out << "}\n";
-	   }
+            if (insert.getCondition() != nullptr) {
+                out << "}\n";
+            }
 
             PRINT_END_COMMENT(out);
         }

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -578,16 +578,16 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             auto ctxName = "READ_OP_CONTEXT(" + synthesiser.getOpContextName(rel) + ")";
             auto level = scan.getLevel();
 
-	    // construct empty condition for nullary relations
-	    std::string nullaryStopStmt;
-	    std::string nullaryCond;
+            // construct empty condition for nullary relations
+            std::string nullaryStopStmt;
+            std::string nullaryCond;
             visitDepthFirst(scan, [&](const RamProject& project) {
-                int arity =  project.getRelation().getArity();
-		std::string projectRelName = synthesiser.getRelationName(project.getRelation().getName());
-		if (arity == 0) {
-		   nullaryStopStmt = "if(!" +  projectRelName + "->empty()) break;";
-		   nullaryCond = projectRelName + "->empty()";
-		}
+                int arity = project.getRelation().getArity();
+                std::string projectRelName = synthesiser.getRelationName(project.getRelation().getName());
+                if (arity == 0) {
+                    nullaryStopStmt = "if(!" + projectRelName + "->empty()) break;";
+                    nullaryCond = projectRelName + "->empty()";
+                }
             });
 
             // if this search is a full scan
@@ -601,23 +601,23 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                     // make this loop parallel
                     // partition outermost relation
                     out << "pfor(auto it = part.begin(); it<part.end();++it){\n";
-		    if(nullaryCond.length() > 0) {
-			    out << "if(" << nullaryCond << ") {\n";
-		    }
+                    if (nullaryCond.length() > 0) {
+                        out << "if(" << nullaryCond << ") {\n";
+                    }
                     out << "try{";
                     out << "for(const auto& env0 : *it) {\n";
-		    out << nullaryStopStmt;
+                    out << nullaryStopStmt;
                     visitSearch(scan, out);
                     out << "}\n";
                     out << "} catch(std::exception &e) { SignalHandler::instance()->error(e.what());}\n";
-		    if(nullaryCond.length() > 0) {
-			    out << "}\n";
-		    }
-		    out << "}\n";
+                    if (nullaryCond.length() > 0) {
+                        out << "}\n";
+                    }
+                    out << "}\n";
                 } else {
                     out << "for(const auto& env" << level << " : "
                         << "*" << relName << ") {\n";
-		    out << nullaryStopStmt;
+                    out << nullaryStopStmt;
                     visitSearch(scan, out);
                     out << "}\n";
                 }
@@ -650,18 +650,18 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             if (scan.getLevel() == 0 && !scan.isPureExistenceCheck()) {
                 // make this loop parallel
                 out << "pfor(auto it = part.begin(); it<part.end(); ++it) { \n";
-		    if(nullaryCond.length() > 0) {
-			    out << "if(" << nullaryCond << ") {\n";
-		    }
+                if (nullaryCond.length() > 0) {
+                    out << "if(" << nullaryCond << ") {\n";
+                }
                 out << "try{";
                 out << "for(const auto& env0 : *it) {\n";
-		out << nullaryStopStmt;
+                out << nullaryStopStmt;
                 visitSearch(scan, out);
                 out << "}\n";
                 out << "} catch(std::exception &e) { SignalHandler::instance()->error(e.what());}\n";
-		    if(nullaryCond.length() > 0) {
-			    out << "}\n";
-		    }
+                if (nullaryCond.length() > 0) {
+                    out << "}\n";
+                }
                 out << "}\n";
                 return;
                 PRINT_END_COMMENT(out);
@@ -679,7 +679,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 out << "}\n";
             } else {
                 out << "for(const auto& env" << level << " : range) {\n";
-	        out << nullaryStopStmt;
+                out << nullaryStopStmt;
                 visitSearch(scan, out);
                 out << "}\n";
             }

--- a/src/Synthesiser.h
+++ b/src/Synthesiser.h
@@ -55,6 +55,9 @@ protected:
     /** Get relation name */
     const std::string getRelationName(const RamRelation& rel);
 
+    /** Get relation name */
+    const std::string getRelationName(const std::string& relName);
+
     /** Get context name */
     const std::string getOpContextName(const RamRelation& rel);
 


### PR DESCRIPTION
If nullary relations contain the empty tuple,  no further evaluations of rules are required for them. 
This change should improve the evaluation time for nullary relations.