### PR TITLE
Further compilation speed improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,8 @@ AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_MACRO_DIR([m4])
 
 dnl Do not set default CFLAGS and CXXFLAGS
-CXXFLAGS=" -Wall -std=c++11 $CXXFLAGS"
+ENV_CXXFLAGS="$CXXFLAGS"
+CXXFLAGS=" -Wall -std=c++11"
 
 # Disable provenance
 AC_ARG_ENABLE(
@@ -359,6 +360,10 @@ AC_FUNC_MMAP
 AC_FUNC_REALLOC
 AC_FUNC_STRERROR_R
 AC_CHECK_FUNCS([dup2 fchdir getcwd getpagesize gettimeofday isascii memset mkdir munmap pow regcomp rmdir setenv socket strcasecmp strchr strdup strerror strrchr strstr strtol strtoull])
+
+SOUFFLE_CXXFLAGS="$CXXFLAGS"
+AC_SUBST(SOUFFLE_CXXFLAGS)
+CXXFLAGS="$CXXFLAGS $ENV_CXXFLAGS"
 
 AC_OUTPUT(
   [ src/souffle-compile src/souffle-config debian/changelog ],

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1702,9 +1702,9 @@ void Synthesiser::generateCode(const RamTranslationUnit& unit, std::ostream& os,
             auto i = stratum.getIndex();
             os << "STRATUM_" << i << ":\n";
         }
-        os << "{\n";
+        os << "[&]() {\n";
         emitCode(os, stratum.getBody());
-        os << "}\n";
+        os << "}();\n";
         if (Global::config().has("engine")) {
             os << "if (stratumIndex != (size_t) -1) goto EXIT;\n";
         }

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -493,15 +493,10 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 
         void visitSwap(const RamSwap& swap, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
-            const std::string tempKnowledge = "rel_0";
             const std::string& deltaKnowledge = synthesiser.getRelationName(swap.getFirstRelation());
             const std::string& newKnowledge = synthesiser.getRelationName(swap.getSecondRelation());
 
-            // perform a triangular swap of pointers
-            out << "{\nauto " << tempKnowledge << " = " << deltaKnowledge << ";\n"
-                << deltaKnowledge << " = " << newKnowledge << ";\n"
-                << newKnowledge << " = " << tempKnowledge << ";\n"
-                << "}\n";
+            out << "std::swap(" << deltaKnowledge << ", " << newKnowledge << ");\n";
             PRINT_END_COMMENT(out);
         }
 

--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -18,6 +18,7 @@ Usage:
   souffle-compile [options] <FILE>.cpp
 Options:
   -h           show usage
+  -g           Build in debug mode
   -v           verbose output
   -w           enable warnings\n"
   exit 1;
@@ -42,12 +43,12 @@ set -e
 ## set environment variables
 
 # set by autoconf
-CXX=@CXX@
-CPPFLAGS="@CPPFLAGS@"
-CXXFLAGS="@CXXFLAGS@"
-LDFLAGS="@LDFLAGS@"
-LIBS="@LIBS@"
-OMP_FLAG="@OPENMP_CFLAGS@"
+CXX="$(printenv CXX || true)"
+test -z "$CXX" && CXX=@CXX@
+CPPFLAGS="$(printenv CPPFLAGS || true) @CPPFLAGS@"
+CXXFLAGS="$(printenv CXXFLAGS || true) @SOUFFLE_CXXFLAGS@"
+LDFLAGS="$(printenv LDFLAGS || true) @LDFLAGS@"
+LIBS="$(printenv LIBS || true) @LIBS@"
 
 # set by command flags
 WARNINGS=""
@@ -64,6 +65,9 @@ while getopts "hwvs" opt; do
   case "$opt" in
     h|\?) # Show usage and exit
       usage;
+    ;;
+    g|\?) # enable debug mode
+      CXXFLAGS = "$CXXFLAGS -g";
     ;;
     w) # enable warnings
       WARNINGS="1"

--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -46,7 +46,7 @@ set -e
 CXX="$(printenv CXX || true)"
 test -z "$CXX" && CXX=@CXX@
 CPPFLAGS="$(printenv CPPFLAGS || true) @CPPFLAGS@"
-CXXFLAGS="$(printenv CXXFLAGS || true) @SOUFFLE_CXXFLAGS@"
+CXXFLAGS="$(printenv CXXFLAGS || true) @SOUFFLE_CXXFLAGS@ -march=native"
 LDFLAGS="$(printenv LDFLAGS || true) @LDFLAGS@"
 LIBS="$(printenv LIBS || true) @LIBS@"
 

--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -18,7 +18,6 @@ Usage:
   souffle-compile [options] <FILE>.cpp
 Options:
   -h           show usage
-  -s           compile a program without OpenMP support
   -v           verbose output
   -w           enable warnings\n"
   exit 1;
@@ -72,9 +71,6 @@ while getopts "hwvs" opt; do
     v) # Verbose output
       set -x
     ;;
-    s) # compile without openmp
-      OMP_FLAG=""
-    ;;
   esac
 done
 
@@ -106,13 +102,13 @@ if test -f $dir/$exe
 then
   if [ "$WARNINGS" = 1 ]
   then
-     echo "$CXX $CXXFLAGS $CPPFLAGS -o$dir/$exe $1 $LIBS -I$HEADER_DIR $OMP_FLAG"
+     echo "$CXX $CXXFLAGS $CPPFLAGS -o$dir/$exe $1 $LIBS -I$HEADER_DIR"
      cat $dir/$exe.$$.ccerr 1>&2
   fi
   rm $dir/$exe.$$.ccerr
 else
   echo "compiler error: cannot compile source file $1" 1>&2
-  echo "$CXX $CXXFLAGS $CPPFLAGS -o$dir/$exe $1 $LIBS -I$HEADER_DIR $OMP_FLAG"
+  echo "$CXX $CXXFLAGS $CPPFLAGS -o$dir/$exe $1 $LIBS -I$HEADER_DIR"
   cat $dir/$exe.$$.ccerr 1>&2
   rm -f $dir/$exe.$$.ccerr
   exit 1


### PR DESCRIPTION
- Improve compilation speed further by wrapping stratum in lambdas
  - I think these should be extracted further in a future PR, perhaps as a collection of objects that can be parallelised
- Separate souffle-compile flags from Makefile flags
  - The main benefit for us is that the distributed version adds debug symbols to synthesised souffle, slowing compilation and execution.
 - Add debug flag to souffle-compile
- Enable passing compiler flags to the compile script
- Some other changes that did not improve compilation speed, but improve user reading speed for the synthesised code:
  - raw pointers to relations are now unique pointers
  - relation structs are declared before the main program class