### PR TITLE
Extended --verbose to note if an AST transformation changed the program.

### DIFF
--- a/src/AstTransformer.cpp
+++ b/src/AstTransformer.cpp
@@ -37,8 +37,9 @@ bool MetaTransformer::applySubtransformer(AstTranslationUnit& translationUnit, A
     auto end = std::chrono::high_resolution_clock::now();
 
     if (verbose && !dynamic_cast<MetaTransformer*>(transformer)) {
+        std::string changedString = changed ? "changed" : "unchanged";
         std::cout << transformer->getName() << " time: " << std::chrono::duration<double>(end - start).count()
-                  << "sec" << std::endl;
+                  << "sec [" << changedString << "]" << std::endl;
     }
 
     /* Abort evaluation of the program if errors were encountered */

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1617,7 +1617,7 @@ bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) 
 
                 unsigned int numAdded = 0;
                 while (numAdded < atoms.size()) {
-                    int nextIdx = getNextAtomSIPS(atoms, boundVariables);
+                    unsigned int nextIdx = getNextAtomSIPS(atoms, boundVariables);
 
                     if (nextIdx != numAdded) {
                         changed = true;


### PR DESCRIPTION
*Tiny* pull-request to add whether a transformation changed the AST or not in the verbose output. Will make some benchmarking/testing easier, without having to generate the debug report.

Also fixed a warning that comes up when compiling souffle.