### PR TITLE
Added macro flag

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -303,11 +303,11 @@ int main(int argc, char** argv) {
             std::string allMacros = "";
             for (const char& ch : Global::config().get("macro")) {
                 if (ch == ' ') {
-                   allMacros += " -D";
-                   allMacros += currentMacro;
-                   currentMacro = "";
+                    allMacros += " -D";
+                    allMacros += currentMacro;
+                    currentMacro = "";
                 } else {
-                   currentMacro += ch;
+                    currentMacro += ch;
                 }
             }
             allMacros += " -D" + currentMacro;
@@ -378,7 +378,7 @@ int main(int argc, char** argv) {
 
     cmd += " -W0 " + Global::config().get("include-dir");
     if (Global::config().has("macro")) {
-        cmd += " " + Global::config().get("macro"); 
+        cmd += " " + Global::config().get("macro");
     }
     cmd += " " + Global::config().get("");
     FILE* in = popen(cmd.c_str(), "r");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,6 +188,8 @@ int main(int argc, char** argv) {
                             {"magic-transform", 'm', "RELATIONS", "", false,
                                     "Enable magic set transformation changes on the given relations, use '*' "
                                     "for all."},
+                            {"macro", 'M', "MACROS", "", false,
+                                    "Set macro definitions for the pre-processor"},
                             {"disable-transformers", 'z', "TRANSFORMERS", "", false,
                                     "Disable the given AST transformers."},
                             {"dl-program", 'o', "FILE", "", false,
@@ -295,6 +297,23 @@ int main(int argc, char** argv) {
             Global::config().set("include-dir", allIncludes);
         }
 
+        /* collect all macro definitions for the pre-processor */
+        if (Global::config().has("macro")) {
+            std::string currentMacro = "";
+            std::string allMacros = "";
+            for (const char& ch : Global::config().get("macro")) {
+                if (ch == ' ') {
+                   allMacros += " -D";
+                   allMacros += currentMacro;
+                   currentMacro = "";
+                } else {
+                   currentMacro += ch;
+                }
+            }
+            allMacros += " -D" + currentMacro;
+            Global::config().set("macro", allMacros);
+        }
+
         /* turn on compilation of executables */
         if (Global::config().has("dl-program")) {
             Global::config().set("compile");
@@ -357,7 +376,11 @@ int main(int argc, char** argv) {
         throw std::runtime_error("failed to locate mcpp pre-processor");
     }
 
-    cmd += " -W0 " + Global::config().get("include-dir") + " " + Global::config().get("");
+    cmd += " -W0 " + Global::config().get("include-dir");
+    if (Global::config().has("macro")) {
+        cmd += " " + Global::config().get("macro"); 
+    }
+    cmd += " " + Global::config().get("");
     FILE* in = popen(cmd.c_str(), "r");
 
     /* Time taking for parsing */


### PR DESCRIPTION
Enables macro definitions via command lines that are passed on to mcpp. 

For example,
```
.decl A(x:number)
.output A

#ifdef A1
A(1).
#else
A(2).
#endif

#ifdef A1
A(3).
#else
A(4).
#endif
```
has conditionals that can be enabled via command line options as follows:

```
./souffle -M'A1 A2' test.dl -D-
```
