### PR TITLE
Added profile-guided reordering transformation.

### DIFF
--- a/src/AstProfileUse.cpp
+++ b/src/AstProfileUse.cpp
@@ -44,15 +44,15 @@ void AstProfileUse::print(std::ostream& os) const {}
 /**
  * Check whether relation size is defined in profile
  */
-bool AstProfileUse::hasRelationSize(const AstRelationIdentifier* rel) {
-    return programRun->getRelation(rel->getName()) != nullptr;
+bool AstProfileUse::hasRelationSize(const AstRelationIdentifier& rel) {
+    return programRun->getRelation(rel.getName()) != nullptr;
 }
 
 /**
  * Get relation size from profile
  */
-size_t AstProfileUse::getRelationSize(const AstRelationIdentifier* rel) {
-    if (profile::Relation* profRel = programRun->getRelation(rel->getName())) {
+size_t AstProfileUse::getRelationSize(const AstRelationIdentifier& rel) {
+    if (profile::Relation* profRel = programRun->getRelation(rel.getName())) {
         return profRel->getTotNum_tuples();
     } else {
         return 0;

--- a/src/AstProfileUse.cpp
+++ b/src/AstProfileUse.cpp
@@ -55,7 +55,7 @@ size_t AstProfileUse::getRelationSize(const AstRelationIdentifier& rel) {
     if (profile::Relation* profRel = programRun->getRelation(rel.getName())) {
         return profRel->getTotNum_tuples();
     } else {
-        return 0;
+        return INT_MAX;
     }
 }
 

--- a/src/AstProfileUse.h
+++ b/src/AstProfileUse.h
@@ -47,10 +47,10 @@ public:
     void print(std::ostream& os) const override;
 
     /** Check whether the relation size exists in profile */
-    bool hasRelationSize(const AstRelationIdentifier* rel);
+    bool hasRelationSize(const AstRelationIdentifier& rel);
 
     /** Return size of relation in the profile */
-    size_t getRelationSize(const AstRelationIdentifier* rel);
+    size_t getRelationSize(const AstRelationIdentifier& rel);
 };
 
 }  // end of namespace souffle

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1391,10 +1391,10 @@ int numBoundArguments(const AstAtom* atom, const std::set<std::string>& boundVar
         // Argument is bound iff all contained variables are bound
         bool isBound = true;
         visitDepthFirst(*arg, [&](const AstVariable& var) {
-                if (boundVariables.find(var.getName()) == boundVariables.end()) {
+            if (boundVariables.find(var.getName()) == boundVariables.end()) {
                 isBound = false;
-                }
-                });
+            }
+        });
         if (isBound) {
             count++;
         }
@@ -1617,9 +1617,9 @@ std::vector<unsigned int> applySIPS(
             }
         }
 
-        newOrder[numAdded] = nextIdx; // add to the ordering
-        atoms[nextIdx] = nullptr; // mark as done
-        numAdded++; // move on
+        newOrder[numAdded] = nextIdx;  // add to the ordering
+        atoms[nextIdx] = nullptr;      // mark as done
+        numAdded++;                    // move on
     }
 
     return newOrder;

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1510,6 +1510,33 @@ std::function<unsigned int(std::vector<AstAtom*>, const std::set<std::string>&)>
 
             return currMaxIdx;
         };
+    } else if (SIPSchosen == "least-free") {
+        // Order based on the least amount of non-bound arguments in the atom
+        getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
+            int currLeastFree = -1;
+            unsigned int currLeastIdx = 0;
+
+            for (unsigned int i = 0; i < atoms.size(); i++) {
+                if (atoms[i] == nullptr) {
+                    // Already processed, move on
+                    continue;
+                }
+
+                if (isProposition(atoms[i])) {
+                    return i;
+                }
+
+                int numBound = numBoundArguments(atoms[i], boundVariables);
+                // TODO (azreika): add assertion here?
+                int numFree = atoms[i]->getArity() - numBound;
+                if (currLeastFree == -1 || numFree < currLeastFree) {
+                    currLeastFree = numFree;
+                    currLeastIdx = i;
+                }
+            }
+
+            return currLeastIdx;
+        };
     } else if (SIPSchosen == "least-free-vars") {
         // Order based on the least amount of free variables in the atom
         getNextAtomSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1565,8 +1565,29 @@ bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) 
     bool changed = false;
     AstProgram& program = *translationUnit.getProgram();
 
-    // Works only if profile-use in Globals is set!!
-    // auto* profileUse = translationUnit.getAnalysis<AstProfileUse>();
+    if (Global::config().has("profile-use")) {
+        auto* profileUse = translationUnit.getAnalysis<AstProfileUse>();
+
+        auto getExpectedSize = [&](const AstAtom* atom) {
+            return profileUse->getRelationSize(atom->getName());
+        };
+
+        for (AstRelation* rel : program.getRelations()) {
+            for (AstClause* clause : rel->getClauses()) {
+                std::vector<AstAtom*> atoms = clause->getAtoms();
+                std::vector<std::pair<int, unsigned int>> atomSizes;
+                for (unsigned int i = 0; i < atoms.size(); i++) {
+                    atomSizes.push_back(std::pair<int,unsigned int>(getExpectedSize(atoms[i]), i));
+                }
+                std::sort(atomSizes.begin(), atomSizes.end());
+                std::vector<unsigned int> newOrder;
+                for (const auto& pair : atomSizes) {
+                    newOrder.push_back(pair.second);
+                }
+                clause->reorderAtoms(newOrder);
+            }
+        }
+    }
 
     // --- Reordering --- : Prepend Propositions
     auto prependPropositions = [&](AstClause* clause) {

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1701,39 +1701,38 @@ bool ReorderLiteralsTransformer::transform(AstTranslationUnit& translationUnit) 
             return count;
         };
 
-        auto profilerSIPS =
-                [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
-                    double currOptimalVal = -1;
-                    unsigned int currOptimalIdx = 0;
-                    bool set = false;
+        auto profilerSIPS = [&](std::vector<AstAtom*> atoms, const std::set<std::string>& boundVariables) {
+            double currOptimalVal = -1;
+            unsigned int currOptimalIdx = 0;
+            bool set = false;
 
-                    for (unsigned int i = 0; i < atoms.size(); i++) {
-                        if (atoms[i] == nullptr) {
-                            // Already processed, move on
-                            continue;
-                        }
-
-                        AstAtom* atom = atoms[i];
-
-                        if (isProposition(atom)) {
-                            return i;
-                        }
-
-                        int numBound = numBoundArguments(atoms[i], boundVariables);
-                        int numArgs = atoms[i]->getArity();
-                        int numFree = numArgs - numBound;
-
-                        double value = log(profileUse->getRelationSize(atom->getName()));
-                        value *= (numFree * 1.0) / numArgs;
-                        if (!set || value < currOptimalVal) {
-                            set = true;
-                            currOptimalVal = value;
-                            currOptimalIdx = i;
-                        }
-                    }
-
-                    return currOptimalIdx;
+            for (unsigned int i = 0; i < atoms.size(); i++) {
+                if (atoms[i] == nullptr) {
+                    // Already processed, move on
+                    continue;
                 }
+
+                AstAtom* atom = atoms[i];
+
+                if (isProposition(atom)) {
+                    return i;
+                }
+
+                int numBound = numBoundArguments(atoms[i], boundVariables);
+                int numArgs = atoms[i]->getArity();
+                int numFree = numArgs - numBound;
+
+                double value = log(profileUse->getRelationSize(atom->getName()));
+                value *= (numFree * 1.0) / numArgs;
+                if (!set || value < currOptimalVal) {
+                    set = true;
+                    currOptimalVal = value;
+                    currOptimalIdx = i;
+                }
+            }
+
+            return currOptimalIdx;
+        };
 
         // TODO: extract to function
         // TODO: extract this whole thing ot an external file

--- a/src/MinimiseProgramTransformer.cpp
+++ b/src/MinimiseProgramTransformer.cpp
@@ -248,6 +248,7 @@ bool areBijectivelyEquivalent(const AstClause* left, const AstClause* right) {
     auto isValidClause = [&](const AstClause* clause) {
         // check that all body literals are atoms
         // i.e. avoid clauses with constraints or negations
+        // TODO (azreika): extend to constraints and negations
         for (AstLiteral* lit : clause->getBodyLiterals()) {
             if (dynamic_cast<AstAtom*>(lit) == nullptr) {
                 return false;


### PR DESCRIPTION
### Added profile-guided reordering transformation
- Given a profile output file (after running `--profile="ProfilerStuff.out"` on a dl file), a heuristic can now be used to reorder literals based on profile information.
- To do this, use the `--profile-use` command,

```
souffle somedatalogcode.dl --profile-use="ProfilerStuff.out" 
```

- Right now uses a somewhat crude heuristic.

### Added `least-free` SIPS option
- Like `least-free-vars`, except prioritises based on minimising the number of free arguments in an atom (i.e. arguments with any free variables), rather than free variables.
- Use like `.pragma "SIPS" "least-free"`