### PR TITLE
Fix sizes in profile output

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -966,10 +966,8 @@ std::unique_ptr<RamStatement> AstTranslator::translateNonRecursiveRelation(const
                     LogStatement::tNonrecursiveRule(relationName, srcLocation, clauseText);
             const std::string logSizeStatement =
                     LogStatement::nNonrecursiveRule(relationName, srcLocation, clauseText);
-            rule = std::make_unique<RamSequence>(
-                    std::make_unique<RamLogTimer>(std::move(rule), logTimerStatement),
-                    std::make_unique<RamLogSize>(
-                            std::unique_ptr<RamRelation>(rrel->clone()), logSizeStatement));
+            rule = std::make_unique<RamSequence>(std::make_unique<RamLogTimer>(
+                    std::move(rule), logTimerStatement, std::unique_ptr<RamRelation>(rrel->clone())));
         }
 
         // add debug info
@@ -992,12 +990,13 @@ std::unique_ptr<RamStatement> AstTranslator::translateNonRecursiveRelation(const
         if (res) {
             const std::string logTimerStatement =
                     LogStatement::tNonrecursiveRelation(relationName, srcLocation);
-            res = std::make_unique<RamLogTimer>(std::move(res), logTimerStatement);
+            res = std::make_unique<RamLogTimer>(
+                    std::move(res), logTimerStatement, std::unique_ptr<RamRelation>(rrel->clone()));
+        } else {
+            // add table size printer
+            appendStmt(res, std::make_unique<RamLogSize>(
+                                    std::unique_ptr<RamRelation>(rrel->clone()), logSizeStatement));
         }
-
-        // add table size printer
-        appendStmt(res,
-                std::make_unique<RamLogSize>(std::unique_ptr<RamRelation>(rrel->clone()), logSizeStatement));
     }
 
     // done
@@ -1085,7 +1084,8 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
         /* measure update time for each relation */
         if (Global::config().has("profile")) {
             updateRelTable = std::make_unique<RamLogTimer>(std::move(updateRelTable),
-                    LogStatement::cRecursiveRelation(toString(rel->getName()), rel->getSrcLoc()));
+                    LogStatement::cRecursiveRelation(toString(rel->getName()), rel->getSrcLoc()),
+                    std::unique_ptr<RamRelation>(relNew[rel]->clone()));
         }
 
         /* drop temporary tables after recursion */
@@ -1176,10 +1176,8 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
                             LogStatement::tRecursiveRule(relationName, version, srcLocation, clauseText);
                     const std::string logSizeStatement =
                             LogStatement::nRecursiveRule(relationName, version, srcLocation, clauseText);
-                    rule = std::make_unique<RamSequence>(
-                            std::make_unique<RamLogTimer>(std::move(rule), logTimerStatement),
-                            std::make_unique<RamLogSize>(
-                                    std::unique_ptr<RamRelation>(relNew[rel]->clone()), logSizeStatement));
+                    rule = std::make_unique<RamSequence>(std::make_unique<RamLogTimer>(std::move(rule),
+                            logTimerStatement, std::unique_ptr<RamRelation>(relNew[rel]->clone())));
                 }
 
                 // add debug info
@@ -1208,10 +1206,8 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
             const SrcLocation& srcLocation = rel->getSrcLoc();
             const std::string logTimerStatement = LogStatement::tRecursiveRelation(relationName, srcLocation);
             const std::string logSizeStatement = LogStatement::nRecursiveRelation(relationName, srcLocation);
-            loopRelSeq = std::make_unique<RamLogTimer>(std::move(loopRelSeq), logTimerStatement);
-            appendStmt(loopRelSeq,
-                    std::make_unique<RamLogSize>(
-                            std::unique_ptr<RamRelation>(relNew[rel]->clone()), logSizeStatement));
+            loopRelSeq = std::make_unique<RamLogTimer>(std::move(loopRelSeq), logTimerStatement,
+                    std::unique_ptr<RamRelation>(relNew[rel]->clone()));
         }
 
         /* add rule computations of a relation to parallel statement */
@@ -1336,7 +1332,10 @@ std::unique_ptr<RamProgram> AstTranslator::translateProgram(const AstTranslation
         if (Global::config().has("profile")) {
             const std::string logTimerStatement = LogStatement::tRelationLoadTime(
                     getRelationName(relation->getName()), relation->getSrcLoc());
-            statement = std::make_unique<RamLogTimer>(std::move(statement), logTimerStatement);
+            statement = std::make_unique<RamLogTimer>(std::move(statement), logTimerStatement,
+                    std::unique_ptr<RamRelation>(
+                            getRamRelation(relation, &typeEnv, getRelationName(relation->getName()),
+                                    relation->getArity(), false, relation->isHashset())));
         }
         appendStmt(current, std::move(statement));
     };
@@ -1360,7 +1359,10 @@ std::unique_ptr<RamProgram> AstTranslator::translateProgram(const AstTranslation
         if (Global::config().has("profile")) {
             const std::string logTimerStatement = LogStatement::tRelationSaveTime(
                     getRelationName(relation->getName()), relation->getSrcLoc());
-            statement = std::make_unique<RamLogTimer>(std::move(statement), logTimerStatement);
+            statement = std::make_unique<RamLogTimer>(std::move(statement), logTimerStatement,
+                    std::unique_ptr<RamRelation>(
+                            getRamRelation(relation, &typeEnv, getRelationName(relation->getName()),
+                                    relation->getArity(), false, relation->isHashset())));
         }
         appendStmt(current, std::move(statement));
     };
@@ -1600,7 +1602,7 @@ std::unique_ptr<RamProgram> AstTranslator::translateProgram(const AstTranslation
 
     // add main timer if profiling
     if (res && Global::config().has("profile")) {
-        res = std::make_unique<RamLogTimer>(std::move(res), LogStatement::runtime());
+        res = std::make_unique<RamLogTimer>(std::move(res), LogStatement::runtime(), nullptr);
     }
 
     // done for main prog

--- a/src/EventProcessor.h
+++ b/src/EventProcessor.h
@@ -196,6 +196,7 @@ public:
         microseconds end = va_arg(args, microseconds);
         size_t startMaxRSS = va_arg(args, size_t);
         size_t endMaxRSS = va_arg(args, size_t);
+        size_t size = va_arg(args, size_t);
         db.addSizeEntry(
                 {"program", "relation", relation, "non-recursive-rule", rule, "maxRSS", "pre"}, startMaxRSS);
         db.addSizeEntry(
@@ -204,6 +205,7 @@ public:
                 {"program", "relation", relation, "non-recursive-rule", rule, "source-locator"}, srcLocator);
         db.addDurationEntry(
                 {"program", "relation", relation, "non-recursive-rule", rule, "runtime"}, start, end);
+        db.addSizeEntry({"program", "relation", relation, "non-recursive-rule", rule, "num-tuples"}, size);
     }
 } nonRecursiveRuleTimingProcessor;
 
@@ -244,6 +246,7 @@ public:
         microseconds end = va_arg(args, microseconds);
         size_t startMaxRSS = va_arg(args, size_t);
         size_t endMaxRSS = va_arg(args, size_t);
+        size_t size = va_arg(args, size_t);
         std::string iteration = std::to_string(va_arg(args, size_t));
         db.addSizeEntry({"program", "relation", relation, "iteration", iteration, "recursive-rule", rule,
                                 version, "maxRSS", "pre"},
@@ -257,6 +260,9 @@ public:
         db.addDurationEntry({"program", "relation", relation, "iteration", iteration, "recursive-rule", rule,
                                     version, "runtime"},
                 start, end);
+        db.addSizeEntry({"program", "relation", relation, "iteration", iteration, "recursive-rule", rule,
+                                version, "num-tuples"},
+                size);
     }
 } recursiveRuleTimingProcessor;
 
@@ -300,8 +306,10 @@ public:
         microseconds end = va_arg(args, microseconds);
         size_t startMaxRSS = va_arg(args, size_t);
         size_t endMaxRSS = va_arg(args, size_t);
+        size_t size = va_arg(args, size_t);
         db.addSizeEntry({"program", "relation", relation, "maxRSS", "pre"}, startMaxRSS);
         db.addSizeEntry({"program", "relation", relation, "maxRSS", "post"}, endMaxRSS);
+        db.addSizeEntry({"program", "relation", relation, "num-tuples"}, size);
         db.addTextEntry({"program", "relation", relation, "source-locator"}, srcLocator);
         db.addDurationEntry({"program", "relation", relation, "runtime"}, start, end);
     }
@@ -341,6 +349,7 @@ public:
         microseconds end = va_arg(args, microseconds);
         size_t startMaxRSS = va_arg(args, size_t);
         size_t endMaxRSS = va_arg(args, size_t);
+        size_t size = va_arg(args, size_t);
         std::string iteration = std::to_string(va_arg(args, size_t));
         db.addTextEntry({"program", "relation", relation, "source-locator"}, srcLocator);
         db.addDurationEntry({"program", "relation", relation, "iteration", iteration, "runtime"}, start, end);
@@ -348,6 +357,7 @@ public:
                 {"program", "relation", relation, "iteration", iteration, "maxRSS", "pre"}, startMaxRSS);
         db.addSizeEntry(
                 {"program", "relation", relation, "iteration", iteration, "maxRSS", "post"}, endMaxRSS);
+        db.addSizeEntry({"program", "relation", relation, "iteration", iteration, "num-tuples"}, size);
     }
 } recursiveRelationTimingProcessor;
 
@@ -386,6 +396,7 @@ public:
         microseconds end = va_arg(args, microseconds);
         size_t startMaxRSS = va_arg(args, size_t);
         size_t endMaxRSS = va_arg(args, size_t);
+        va_arg(args, size_t);
         std::string iteration = std::to_string(va_arg(args, size_t));
         db.addSizeEntry(
                 {"program", "relation", relation, "iteration", iteration, "maxRSS", "pre"}, startMaxRSS);

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -678,8 +678,15 @@ void Interpreter::evalStmt(const RamStatement& stmt) {
         }
 
         bool visitLogTimer(const RamLogTimer& timer) override {
-            Logger logger(timer.getMessage().c_str(), interpreter.getIterationNumber());
-            return visit(timer.getStatement());
+            if (timer.getRelation() == nullptr) {
+                Logger logger(timer.getMessage().c_str(), interpreter.getIterationNumber());
+                return visit(timer.getStatement());
+            } else {
+                const InterpreterRelation& rel = interpreter.getRelation(*timer.getRelation());
+                Logger logger(timer.getMessage().c_str(), interpreter.getIterationNumber(),
+                        std::bind(&InterpreterRelation::size, &rel));
+                return visit(timer.getStatement());
+            }
         }
 
         bool visitDebugInfo(const RamDebugInfo& dbg) override {
@@ -732,10 +739,10 @@ void Interpreter::evalStmt(const RamStatement& stmt) {
             return true;
         }
 
-        bool visitLogSize(const RamLogSize& print) override {
-            const InterpreterRelation& rel = interpreter.getRelation(print.getRelation());
+        bool visitLogSize(const RamLogSize& size) override {
+            const InterpreterRelation& rel = interpreter.getRelation(size.getRelation());
             ProfileEventSingleton::instance().makeQuantityEvent(
-                    print.getMessage(), rel.size(), interpreter.getIterationNumber());
+                    size.getMessage(), rel.size(), interpreter.getIterationNumber());
             return true;
         }
 

--- a/src/ProfileEvent.h
+++ b/src/ProfileEvent.h
@@ -81,11 +81,11 @@ public:
 
     /** create an event for recording start and end times */
     void makeTimingEvent(const std::string& txt, time_point start, time_point end, size_t startMaxRSS,
-            size_t endMaxRSS, size_t iteration) {
+            size_t endMaxRSS, size_t size, size_t iteration) {
         microseconds start_ms = std::chrono::duration_cast<microseconds>(start.time_since_epoch());
         microseconds end_ms = std::chrono::duration_cast<microseconds>(end.time_since_epoch());
         profile::EventProcessorSingleton::instance().process(
-                database, txt.c_str(), start_ms, end_ms, startMaxRSS, endMaxRSS, iteration);
+                database, txt.c_str(), start_ms, end_ms, startMaxRSS, endMaxRSS, size, iteration);
     }
 
     /** create quantity event */

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -761,9 +761,13 @@ protected:
     /** logging message */
     std::string message;
 
+    /** Relation */
+    std::unique_ptr<RamRelation> relation;
+
 public:
-    RamLogTimer(std::unique_ptr<RamStatement> stmt, std::string msg)
-            : RamStatement(RN_LogTimer), statement(std::move(stmt)), message(std::move(msg)) {
+    RamLogTimer(std::unique_ptr<RamStatement> stmt, std::string msg, std::unique_ptr<RamRelation> relation)
+            : RamStatement(RN_LogTimer), statement(std::move(stmt)), message(std::move(msg)),
+              relation(std::move(relation)) {
         assert(statement);
     }
 
@@ -776,6 +780,11 @@ public:
     const RamStatement& getStatement() const {
         assert(statement);
         return *statement;
+    }
+
+    /** get logged relation */
+    const std::unique_ptr<RamRelation>& getRelation() const {
+        return relation;
     }
 
     /** Pretty print */
@@ -795,7 +804,8 @@ public:
 
     /** Create clone */
     RamLogTimer* clone() const override {
-        RamLogTimer* res = new RamLogTimer(std::unique_ptr<RamStatement>(statement->clone()), message);
+        RamLogTimer* res = new RamLogTimer(std::unique_ptr<RamStatement>(statement->clone()), message,
+                std::unique_ptr<RamRelation>(relation->clone()));
         return res;
     }
 


### PR DESCRIPTION
Use size delta rather than final size. e.g.
```
A(1).
A(2).
```
Will now show an increase of 1 for both, rather than the existing 1,2.