### PR TITLE
Standardise notation in profiler

### DIFF
--- a/src/AstProfileUse.cpp
+++ b/src/AstProfileUse.cpp
@@ -52,8 +52,8 @@ bool AstProfileUse::hasRelationSize(const AstRelationIdentifier& rel) {
  * Get relation size from profile
  */
 size_t AstProfileUse::getRelationSize(const AstRelationIdentifier& rel) {
-    if (profile::Relation* profRel = programRun->getRelation(rel.getName())) {
-        return profRel->getTotNum_tuples();
+    if (const auto* profRel = programRun->getRelation(rel.getName())) {
+        return profRel->size();
     } else {
         return INT_MAX;
     }

--- a/src/profile/Cell.h
+++ b/src/profile/Cell.h
@@ -20,72 +20,76 @@ namespace profile {
 
 template <typename T>
 class Cell : public CellInterface {
+    const T value;
+
 public:
-    T val;
-    Cell(T value) : val(value){};
+    Cell(T value) : value(value){};
     ~Cell() override = default;
 };
 
 template <>
 class Cell<double> : public CellInterface {
+    const double value;
+
 public:
-    double val;
-    Cell(double value) : val(value){};
-    double getDoubVal() override {
-        return val;
+    Cell(double value) : value(value){};
+    double getDoubleVal() const override {
+        return value;
     }
-    long getLongVal() override {
+    long getLongVal() const override {
         std::cerr << "getting long on double cell\n";
         throw this;
     }
-    std::string getStringVal() override {
+    std::string getStringVal() const override {
         std::cerr << "getting string on double cell\n";
         throw this;
     }
-    std::string toString(int precision) override {
-        return Tools::formatTime(val);
+    std::string toString(int precision) const override {
+        return Tools::formatTime(value);
     }
 };
 
 template <>
 class Cell<std::string> : public CellInterface {
+    const std::string value;
+
 public:
-    std::string val;
-    Cell(std::string value) : val(std::move(value)){};
-    double getDoubVal() override {
+    Cell(std::string value) : value(std::move(value)){};
+    double getDoubleVal() const override {
         std::cerr << "getting double on string cell\n";
         throw this;
     }
-    long getLongVal() override {
+    long getLongVal() const override {
         std::cerr << "getting long on string cell\n";
         throw this;
     }
-    std::string getStringVal() override {
-        return val;
+    std::string getStringVal() const override {
+        return value;
     }
-    std::string toString(int precision) override {
-        return Tools::cleanString(val);
+    std::string toString(int precision) const override {
+        return Tools::cleanString(value);
     }
 };
 
 template <>
 class Cell<long> : public CellInterface {
+    const long value;
+
 public:
-    long val;
-    Cell(long value) : val(value){};
-    double getDoubVal() override {
+    Cell(long value) : value(value){};
+    double getDoubleVal() const override {
         std::cerr << "getting double on long cell\n";
         throw this;
     }
-    std::string getStringVal() override {
+    std::string getStringVal() const override {
         std::cerr << "getting string on long cell\n";
         throw this;
     }
-    long getLongVal() override {
-        return val;
+    long getLongVal() const override {
+        return value;
     }
-    std::string toString(int precision) override {
-        return Tools::formatNum(precision, val);
+    std::string toString(int precision) const override {
+        return Tools::formatNum(precision, value);
     };
 };
 
@@ -93,19 +97,19 @@ template <>
 class Cell<void> : public CellInterface, std::false_type {
 public:
     Cell() = default;
-    double getDoubVal() override {
+    double getDoubleVal() const override {
         std::cerr << "getting double on void cell";
         throw this;
     }
-    long getLongVal() override {
+    long getLongVal() const override {
         std::cerr << "getting long on void cell";
         throw this;
     }
-    std::string getStringVal() override {
+    std::string getStringVal() const override {
         std::cerr << "getting string on void cell\n";
         throw this;
     }
-    std::string toString(int precision) override {
+    std::string toString(int precision) const override {
         return "-";
     }
 };

--- a/src/profile/CellInterface.h
+++ b/src/profile/CellInterface.h
@@ -15,13 +15,13 @@ namespace profile {
 
 class CellInterface {
 public:
-    virtual std::string toString(int precision) = 0;
+    virtual std::string toString(int precision) const = 0;
 
-    virtual double getDoubVal() = 0;
+    virtual double getDoubleVal() const = 0;
 
-    virtual long getLongVal() = 0;
+    virtual long getLongVal() const = 0;
 
-    virtual std::string getStringVal() = 0;
+    virtual std::string getStringVal() const = 0;
 
     virtual ~CellInterface() = default;
 };

--- a/src/profile/DataComparator.h
+++ b/src/profile/DataComparator.h
@@ -28,22 +28,22 @@ class DataComparator {
 public:
     /** Sort by total time. */
     static bool TIME(const std::shared_ptr<Row>& a, const std::shared_ptr<Row>& b) {
-        return a->cells[0]->getDoubVal() > b->cells[0]->getDoubVal();
+        return a->cells[0]->getDoubleVal() > b->cells[0]->getDoubleVal();
     }
 
     /** Sort by non-recursive time. */
     static bool NR_T(const std::shared_ptr<Row>& a, const std::shared_ptr<Row>& b) {
-        return a->cells[1]->getDoubVal() > b->cells[1]->getDoubVal();
+        return a->cells[1]->getDoubleVal() > b->cells[1]->getDoubleVal();
     }
 
     /** Sort by recursive time. */
     static bool R_T(const std::shared_ptr<Row>& a, const std::shared_ptr<Row>& b) {
-        return a->cells[2]->getDoubVal() > b->cells[2]->getDoubVal();
+        return a->cells[2]->getDoubleVal() > b->cells[2]->getDoubleVal();
     }
 
     /** Sort by copy time. */
     static bool C_T(const std::shared_ptr<Row>& a, const std::shared_ptr<Row>& b) {
-        return a->cells[3]->getDoubVal() > b->cells[3]->getDoubVal();
+        return a->cells[3]->getDoubleVal() > b->cells[3]->getDoubleVal();
     }
 
     /** Sort by tuple count. */

--- a/src/profile/Iteration.h
+++ b/src/profile/Iteration.h
@@ -25,76 +25,76 @@ class Iteration {
 private:
     double starttime = 0;
     double endtime = 0;
-    long num_tuples = 0;
-    double copy_time = 0;
+    size_t numTuples = 0;
+    double copytime = 0;
     std::string locator = "";
 
-    std::unordered_map<std::string, std::shared_ptr<Rule>> rul_rec_map;
+    std::unordered_map<std::string, std::shared_ptr<Rule>> rules;
 
 public:
-    Iteration() : rul_rec_map() {}
+    Iteration() : rules() {}
 
     void addRule(const std::string& ruleKey, std::shared_ptr<Rule>& rule) {
-        rul_rec_map[ruleKey] = rule;
+        rules[ruleKey] = rule;
     }
 
-    inline const std::unordered_map<std::string, std::shared_ptr<Rule>>& getRul_rec() {
-        return this->rul_rec_map;
+    const std::unordered_map<std::string, std::shared_ptr<Rule>>& getRules() const {
+        return rules;
     }
 
-    std::string toString() {
+    std::string toString() const {
         std::ostringstream output;
 
-        output << getRuntime() << "," << num_tuples << "," << copy_time << ",";
+        output << getRuntime() << "," << numTuples << "," << copytime << ",";
         output << " recRule:";
-        for (auto& rul : rul_rec_map) {
+        for (auto& rul : rules) {
             output << rul.second->toString();
         }
         output << "\n";
         return output.str();
     }
 
-    inline double getRuntime() {
+    double getRuntime() const {
         return endtime - starttime;
     }
 
-    inline double getStarttime() {
+    double getStarttime() const {
         return starttime;
     }
 
-    inline double getEndtime() {
+    double getEndtime() const {
         return endtime;
     }
 
-    inline long getNum_tuples() {
-        return num_tuples;
+    size_t size() const {
+        return numTuples;
     }
 
-    inline void setNum_tuples(long num_tuples) {
-        this->num_tuples = num_tuples;
+    void setNumTuples(long numTuples) {
+        this->numTuples = numTuples;
     }
 
-    inline double getCopy_time() {
-        return copy_time;
+    double getCopytime() const {
+        return copytime;
     }
 
-    inline void setCopy_time(double copy_time) {
-        this->copy_time = copy_time;
+    void setCopytime(double copy_time) {
+        this->copytime = copy_time;
     }
 
-    inline void setStarttime(double time) {
+    void setStarttime(double time) {
         starttime = time;
     }
 
-    inline void setEndtime(double time) {
+    void setEndtime(double time) {
         endtime = time;
     }
 
-    inline std::string getLocator() {
+    const std::string& getLocator() const {
         return locator;
     }
 
-    inline void setLocator(std::string locator) {
+    void setLocator(std::string locator) {
         this->locator = locator;
     }
 };

--- a/src/profile/ProgramRun.h
+++ b/src/profile/ProgramRun.h
@@ -28,15 +28,12 @@ namespace profile {
  */
 class ProgramRun {
 private:
-    std::unordered_map<std::string, std::shared_ptr<Relation>> relation_map;
+    std::unordered_map<std::string, std::shared_ptr<Relation>> relationMap;
     std::chrono::microseconds startTime{0};
     std::chrono::microseconds endTime{0};
 
-    double tot_rec_tup = 0.0;
-    double tot_copy_time = 0.0;
-
 public:
-    ProgramRun() : relation_map() {}
+    ProgramRun() : relationMap() {}
 
     inline void setStarttime(std::chrono::microseconds time) {
         startTime = time;
@@ -46,29 +43,24 @@ public:
         endTime = time;
     }
 
-    inline void setRelation_map(std::unordered_map<std::string, std::shared_ptr<Relation>>& relation_map) {
-        this->relation_map = relation_map;
+    inline void setRelationMap(std::unordered_map<std::string, std::shared_ptr<Relation>>& relationMap) {
+        this->relationMap = relationMap;
     }
-
-    inline void update() {
-        tot_rec_tup = (double)getTotNumRecTuples();
-        tot_copy_time = getTotCopyTime();
-    };
 
     std::string toString() {
         std::ostringstream output;
         output << "ProgramRun:" << getRuntime() << "\nRelations:\n";
-        for (auto r = relation_map.begin(); r != relation_map.end(); ++r) {
+        for (auto r = relationMap.begin(); r != relationMap.end(); ++r) {
             output << r->second->toString() << "\n";
         }
         return output.str();
     }
 
-    inline std::unordered_map<std::string, std::shared_ptr<Relation>>& getRelation_map() {
-        return relation_map;
+    inline const std::unordered_map<std::string, std::shared_ptr<Relation>>& getRelationMap() const {
+        return relationMap;
     }
 
-    std::string getRuntime() {
+    std::string getRuntime() const {
         if (startTime == endTime) {
             return "--";
         }
@@ -83,64 +75,64 @@ public:
         return endTime;
     }
 
-    double getTotLoadtime() {
+    double getTotalLoadtime() const {
         double result = 0;
-        for (auto& item : relation_map) {
+        for (auto& item : relationMap) {
             result += item.second->getLoadtime();
         }
         return result;
     }
 
-    double getTotSavetime() {
+    double getTotalSavetime() const {
         double result = 0;
-        for (auto& item : relation_map) {
+        for (auto& item : relationMap) {
             result += item.second->getSavetime();
         }
         return result;
     }
 
-    long getTotNumTuples() {
+    long getTotalSize() const {
         long result = 0;
-        for (auto& item : relation_map) {
-            result += item.second->getTotNum_tuples();
+        for (auto& item : relationMap) {
+            result += item.second->size();
         }
         return result;
     }
 
-    long getTotNumRecTuples() {
+    long getTotalRecursiveSize() const {
         long result = 0;
-        for (auto& item : relation_map) {
-            result += item.second->getTotNumRec_tuples();
+        for (auto& item : relationMap) {
+            result += item.second->getTotalRecursiveRuleSize();
         }
         return result;
     }
 
-    double getTotCopyTime() {
+    double getTotalCopyTime() const {
         double result = 0;
-        for (auto& item : relation_map) {
+        for (auto& item : relationMap) {
             result += item.second->getCopyTime();
         }
         return result;
     }
 
-    double getTotTime() {
+    double getTotalTime() const {
         double result = 0;
-        for (auto& item : relation_map) {
+        for (auto& item : relationMap) {
             result += item.second->getRecTime();
         }
         return result;
     }
 
-    Relation* getRelation(std::string name) {
-        if (relation_map.find(name) != relation_map.end()) {
-            return &(*relation_map[name]);
+    const Relation* getRelation(const std::string& name) const {
+        if (relationMap.find(name) != relationMap.end()) {
+            return &(*relationMap.at(name));
         }
         return nullptr;
     }
 
-    std::set<std::shared_ptr<Relation>> getRelationsAtTime(double start, double end) {
+    std::set<std::shared_ptr<Relation>> getRelationsAtTime(double start, double end) const {
         std::set<std::shared_ptr<Relation>> result;
-        for (auto& cur : relation_map) {
+        for (auto& cur : relationMap) {
             if (cur.second->getStarttime() <= end && cur.second->getEndtime() >= start) {
                 result.insert(cur.second);
             }
@@ -148,15 +140,15 @@ public:
         return result;
     }
 
-    inline std::string formatTime(double runtime) {
+    inline std::string formatTime(double runtime) const {
         return Tools::formatTime(runtime);
     }
 
-    inline std::string formatNum(int precision, long number) {
+    inline std::string formatNum(int precision, long number) const {
         return Tools::formatNum(precision, number);
     }
 
-    inline std::vector<std::vector<std::string>> formatTable(Table table, int precision) {
+    inline std::vector<std::vector<std::string>> formatTable(Table& table, int precision) const {
         return Tools::formatTable(table, precision);
     }
 };

--- a/src/profile/Rule.h
+++ b/src/profile/Rule.h
@@ -48,7 +48,7 @@ protected:
     std::string name;
     double starttime = 0;
     double endtime = 0;
-    long num_tuples = 0;
+    long numTuples = 0;
     std::string identifier;
     std::string locator = "";
     std::set<Atom> atoms;
@@ -63,55 +63,54 @@ public:
     Rule(std::string name, int version, std::string id)
             : name(std::move(name)), identifier(std::move(id)), recursive(true), version(version) {}
 
-    inline std::string getId() {
+    std::string getId() const {
         return identifier;
     }
 
-    inline double getRuntime() {
+    double getRuntime() const {
         return endtime - starttime;
     }
 
-    inline double getStarttime() {
+    double getStarttime() const {
         return starttime;
     }
 
-    inline double getEndtime() {
+    double getEndtime() const {
         return endtime;
     }
 
-    inline long getNum_tuples() {
-        return num_tuples;
+    long size() {
+        return numTuples;
     }
 
-    inline void setStarttime(double time) {
+    void setStarttime(double time) {
         starttime = time;
     }
 
-    inline void setEndtime(double time) {
+    void setEndtime(double time) {
         endtime = time;
     }
 
-    inline void setNum_tuples(long num_tuples) {
-        this->num_tuples = num_tuples;
+    void setNumTuples(long numTuples) {
+        this->numTuples = numTuples;
     }
 
-    inline void addAtomFrequency(
-            const std::string& subruleName, std::string atom, size_t level, size_t frequency) {
+    void addAtomFrequency(const std::string& subruleName, std::string atom, size_t level, size_t frequency) {
         atoms.emplace(atom, subruleName, level, frequency);
     }
 
-    const std::set<Atom>& getAtoms() {
+    const std::set<Atom>& getAtoms() const {
         return atoms;
     }
-    inline std::string getName() {
+    std::string getName() const {
         return name;
     }
 
-    inline void setId(std::string id) {
+    void setId(std::string id) {
         identifier = id;
     }
 
-    inline std::string getLocator() {
+    std::string getLocator() const {
         return locator;
     }
 
@@ -119,30 +118,30 @@ public:
         this->locator = locator;
     }
 
-    inline bool isRecursive() {
+    bool isRecursive() const {
         return recursive;
     }
 
-    inline void setRecursive(bool recursive) {
+    void setRecursive(bool recursive) {
         this->recursive = recursive;
     }
 
-    inline int getVersion() {
+    int getVersion() const {
         return version;
     }
 
-    inline void setVersion(int version) {
+    void setVersion(int version) {
         this->version = version;
     }
 
-    std::string toString() {
+    std::string toString() const {
         std::ostringstream output;
         if (recursive) {
             output << "{" << name << "," << version << ":";
         } else {
             output << "{" << name << ":";
         }
-        output << "[" << getRuntime() << "," << num_tuples << "]}";
+        output << "[" << getRuntime() << "," << numTuples << "]}";
         return output.str();
     }
 };


### PR DESCRIPTION
Change profiler notation to meet Souffle standard.
No functional changes, other than a fix to maxRSS size calculation.