### PR TITLE
Move souffle-docker code to souffle main repo.

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/docker/.travis.yml
+++ b/docker/.travis.yml
@@ -1,0 +1,6 @@
+os: linux
+dist: trusty
+sudo: false
+language: generic
+services: docker
+script: make check

--- a/docker/LICENSE
+++ b/docker/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2018 The Souffle Developers. All Rights reserved
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software,
+associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the 
+Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified 
+Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+
+(a) the Software, and
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a “Larger
+Work” to which the Software is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and 
+distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the 
+Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+
+This license is subject to the following condition:
+The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,89 @@
+# souffle-docker
+
+[Docker](https://www.docker.com/) images for [Soufflé](https://github.com/souffle-lang/souffle).
+
+This is the development repository for the official Soufflé account on Dockerhub, found [here](https://hub.docker.com/r/souffle).
+
+## Installation
+
+If all you want to do is run Soufflé in a Docker container, then simply use any of the images in the official Soufflé account on Dockerhub.
+
+For example, if you wanted to run souffle for Ubuntu, specifically version xenial, you would do
+
+~~~
+$ docker run souffle/ubuntu:xenial
+~~~
+
+Which will pull the container from Dockerhub and run it.
+
+## Usage
+
+A more useful way to do things is
+
+~~~
+$ docker run -v${PWD}:/mnt -it souffle/ubuntu:xenial /bin/bash
+~~~
+
+Which will enter a bash shell in the container, with your current working directory mounted at `/mnt`.
+
+From here, it is as simple as running
+
+~~~
+$ souffle
+~~~
+
+To invoke Soufflé.
+
+## Development
+
+If you want to actually develop souffle-docker itself, then you'll need to learn some commands, and how to configure them.
+
+### Commands
+
+The commands are provided by a simple Makefile, and are explained as follows.
+
+~~~
+$ make
+~~~
+
+This will build one image per Dockerfile in this repository.
+
+For a Dockerfile at `./path/to/Dockerfile`, relative to the root of this repository, the tag of the corresponding image would be `souffle/path:to`.
+
+New Dockerfiles can be added by following this directory structure, and will be detected automatically.
+
+~~~
+$ make check
+~~~
+
+This will run the Soufflé testsuite for each of the Docker images.
+
+Specific test categories and command line flags to use may be configured as described below, and this functionality may be used in future for CI testing with Travis.
+
+~~~
+$ make deploy
+~~~
+
+This will deploy the Docker images to an account on Dockerhub, if you have authorisation for that account.
+
+### Configuration
+
+All configuration is done through environment variables.
+
+Defaults are defined at the top of the Makefile, and in each Dockerfile.
+
+These may be overriden within individual Dockerfiles for reasons specific to them.
+
+They are explained as follows:
+
+- `SOUFFLE_CATEGORY`: The test categories to be used in a call to `make check`.
+- `SOUFFLE_CONFIGURE_OPTIONS`: The arguments passed to `./configure` when building Soufflé in a call to `make`.
+- `SOUFFLE_CONFS`: The command line flags to be used for Soufflé in a call to `make check`.
+- `SOUFFLE_CC`: The value of the `CC` environment variable used in Dockerfiles.
+- `SOUFFLE_CXX`: The value of the `CXX` environment variable used in Dockerfiles.
+- `SOUFFLE_DOCKERFILES`: A list of paths to Dockerfile's in this repository, which determine all those that are considered in any `make` command.
+- `SOUFFLE_DOCKERHUB_USER`: The username of the Dockerhub account to use in a call to `make deploy`.
+- `SOUFFLE_GITHUB_USER`: The username of the Github repository from which Soufflé will be pulled in a call to `make`.
+- `SOUFFLE_GIT_BRANCH`: The git branch used when building the images in a call to `make`.
+- `SOUFFLE_GIT_REVISION`: The commit SHA of the git revision, or `HEAD` to use the latest commit, used in a call to `make`.
+- `SOUFFLE_MAKE_JOBS`: The number of jobs for each `make` command within a Dockerfile (i.e. with the `-j` option).

--- a/docker/centos/centos7-base/Dockerfile
+++ b/docker/centos/centos7-base/Dockerfile
@@ -1,0 +1,31 @@
+FROM centos:centos7
+
+WORKDIR /tmp
+
+RUN yum -y install epel-release
+
+RUN curl -O http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
+RUN rpm -Uvh nux-dextop-release*rpm
+
+RUN yum -y install \
+        automake \
+        autoconf \
+        bison \
+        doxygen \
+        flex \
+        git \
+        gcc-c++ \
+        graphviz \
+        java-1.8.0-openjdk-devel \
+        libtool \
+        libsqlite3x-devel \
+        make \
+        mcpp \
+        ncurses-devel \
+        zlib-devel
+
+RUN useradd --create-home --shell /bin/bash souffle
+
+USER souffle
+
+WORKDIR /home/souffle

--- a/docker/centos/centos7/Dockerfile
+++ b/docker/centos/centos7/Dockerfile
@@ -1,0 +1,33 @@
+FROM souffle/centos:centos7-base
+
+ARG SOUFFLE_CC="gcc"
+ARG SOUFFLE_CXX="g++"
+ARG SOUFFLE_CONFIGURE_OPTIONS=""
+ARG SOUFFLE_GITHUB_USER="souffle-lang"
+ARG SOUFFLE_GIT_BRANCH="master"
+ARG SOUFFLE_GIT_REVISION="HEAD"
+ARG SOUFFLE_MAKE_JOBS="2"
+
+ENV CC "${SOUFFLE_CC}"
+ENV CXX "${SOUFFLE_CXX}"
+
+RUN git clone https://github.com/${SOUFFLE_GITHUB_USER}/souffle /home/souffle/souffle
+
+WORKDIR /home/souffle/souffle
+
+RUN git pull
+RUN git checkout ${SOUFFLE_GIT_BRANCH}
+RUN git reset --hard ${SOUFFLE_GIT_REVISION}
+RUN git clean -xdf
+RUN ./bootstrap
+RUN ./configure ${SOUFFLE_CONFIGURE_OPTIONS}
+RUN make -j${SOUFFLE_MAKE_JOBS}
+RUN ./src/souffle
+
+USER root
+
+RUN make install -j${SOUFFLE_MAKE_JOBS}
+
+WORKDIR /
+
+RUN souffle -h

--- a/docker/oraclelinux/7.3-base/Dockerfile
+++ b/docker/oraclelinux/7.3-base/Dockerfile
@@ -1,0 +1,33 @@
+FROM oraclelinux:7.3
+
+WORKDIR /tmp
+
+RUN yum install -y \
+        autoconf \
+        automake \
+        bison \
+        clang \
+        doxygen \
+        flex \
+        gcc-c++ \
+        git \
+        graphviz \
+        kernel-devel \
+        ncurses-devel \
+        sqlite-devel \
+        libtool \
+        make \
+        mcpp \
+        pkg-config \
+        python \
+        sqlite \
+        zlib-devel
+
+RUN yum install -y http://dl.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/Packages/l/libmcpp-2.7.2-19.fc27.x86_64.rpm
+RUN yum install -y http://dl.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/Packages/m/mcpp-2.7.2-19.fc27.x86_64.rpm
+
+RUN useradd --create-home --shell /bin/bash souffle
+
+USER souffle
+
+WORKDIR /home/souffle

--- a/docker/oraclelinux/7.3/Dockerfile
+++ b/docker/oraclelinux/7.3/Dockerfile
@@ -1,0 +1,33 @@
+FROM souffle/oraclelinux:7.3-base
+
+ARG SOUFFLE_CC="gcc"
+ARG SOUFFLE_CXX="g++"
+ARG SOUFFLE_CONFIGURE_OPTIONS=""
+ARG SOUFFLE_GITHUB_USER="souffle-lang"
+ARG SOUFFLE_GIT_BRANCH="master"
+ARG SOUFFLE_GIT_REVISION="HEAD"
+ARG SOUFFLE_MAKE_JOBS="2"
+
+ENV CC "${SOUFFLE_CC}"
+ENV CXX "${SOUFFLE_CXX}"
+
+RUN git clone https://github.com/${SOUFFLE_GITHUB_USER}/souffle /home/souffle/souffle
+
+WORKDIR /home/souffle/souffle
+
+RUN git pull
+RUN git checkout ${SOUFFLE_GIT_BRANCH}
+RUN git reset --hard ${SOUFFLE_GIT_REVISION}
+RUN git clean -xdf
+RUN ./bootstrap
+RUN ./configure ${SOUFFLE_CONFIGURE_OPTIONS}
+RUN make -j${SOUFFLE_MAKE_JOBS}
+RUN ./src/souffle
+
+USER root
+
+RUN make install -j${SOUFFLE_MAKE_JOBS}
+
+WORKDIR /
+
+RUN souffle -h

--- a/docker/ubuntu/bionic-base/Dockerfile
+++ b/docker/ubuntu/bionic-base/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:bionic
+
+WORKDIR /tmp
+
+RUN apt-get update -y && \
+        apt-get upgrade -y && \
+        apt-get install -y \
+        curl \
+        software-properties-common
+
+RUN apt-add-repository ppa:ubuntu-toolchain-r/test
+
+RUN curl -fsSL http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main"
+
+RUN apt-get update -y && \
+        apt-get upgrade -y && \
+        apt-get install -y \
+        automake \
+        autoconf \
+        bison \
+        build-essential \
+        clang-4.0 \
+        doxygen \
+        flex \
+        g++-7 \
+        git \
+        graphviz \
+        libncurses5-dev \
+        libopenmpi-dev \
+        libsqlite3-dev \
+        libstdc++-7-dev \
+        libtool \
+        lsb-release \
+        mcpp \
+        openmpi-bin \
+        zlib1g-dev
+
+RUN useradd --create-home --shell /bin/bash souffle
+
+USER souffle
+
+WORKDIR /home/souffle

--- a/docker/ubuntu/bionic/Dockerfile
+++ b/docker/ubuntu/bionic/Dockerfile
@@ -1,0 +1,33 @@
+FROM souffle/ubuntu:bionic-base
+
+ARG SOUFFLE_CC="gcc"
+ARG SOUFFLE_CXX="g++"
+ARG SOUFFLE_CONFIGURE_OPTIONS=""
+ARG SOUFFLE_GITHUB_USER="souffle-lang"
+ARG SOUFFLE_GIT_BRANCH="master"
+ARG SOUFFLE_GIT_REVISION="HEAD"
+ARG SOUFFLE_MAKE_JOBS="2"
+
+ENV CC "${SOUFFLE_CC}"
+ENV CXX "${SOUFFLE_CXX}"
+
+RUN git clone https://github.com/${SOUFFLE_GITHUB_USER}/souffle /home/souffle/souffle
+
+WORKDIR /home/souffle/souffle
+
+RUN git pull
+RUN git checkout ${SOUFFLE_GIT_BRANCH}
+RUN git reset --hard ${SOUFFLE_GIT_REVISION}
+RUN git clean -xdf
+RUN ./bootstrap
+RUN ./configure ${SOUFFLE_CONFIGURE_OPTIONS}
+RUN make -j${SOUFFLE_MAKE_JOBS}
+RUN ./src/souffle
+
+USER root
+
+RUN make install -j${SOUFFLE_MAKE_JOBS}
+
+WORKDIR /
+
+RUN souffle -h

--- a/docker/ubuntu/xenial-base/Dockerfile
+++ b/docker/ubuntu/xenial-base/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:xenial
+
+WORKDIR /tmp
+
+RUN apt-get update -y
+RUN apt-get install -y \
+        autoconf \
+        automake \
+        bison \
+        build-essential \
+        clang \
+        clang-format-4.0 \
+        doxygen \
+        flex \
+        g++ \
+        git \
+        graphviz \
+        libsqlite3-dev \
+        libtool \
+        lsb-release \
+        libncurses5-dev \
+        make \
+        mcpp \
+        python \
+        sqlite \
+        zlib1g-dev
+
+RUN useradd --create-home --shell /bin/bash souffle
+
+USER souffle
+
+WORKDIR /home/souffle

--- a/docker/ubuntu/xenial/Dockerfile
+++ b/docker/ubuntu/xenial/Dockerfile
@@ -1,0 +1,33 @@
+FROM souffle/ubuntu:xenial-base
+
+ARG SOUFFLE_CC="gcc"
+ARG SOUFFLE_CXX="g++"
+ARG SOUFFLE_CONFIGURE_OPTIONS=""
+ARG SOUFFLE_GITHUB_USER="souffle-lang"
+ARG SOUFFLE_GIT_BRANCH="master"
+ARG SOUFFLE_GIT_REVISION="HEAD"
+ARG SOUFFLE_MAKE_JOBS="2"
+
+ENV CC "${SOUFFLE_CC}"
+ENV CXX "${SOUFFLE_CXX}"
+
+RUN git clone https://github.com/${SOUFFLE_GITHUB_USER}/souffle /home/souffle/souffle
+
+WORKDIR /home/souffle/souffle
+
+RUN git pull
+RUN git checkout ${SOUFFLE_GIT_BRANCH}
+RUN git reset --hard ${SOUFFLE_GIT_REVISION}
+RUN git clean -xdf
+RUN ./bootstrap
+RUN ./configure ${SOUFFLE_CONFIGURE_OPTIONS}
+RUN make -j${SOUFFLE_MAKE_JOBS}
+RUN ./src/souffle
+
+USER root
+
+RUN make install -j${SOUFFLE_MAKE_JOBS}
+
+WORKDIR /
+
+RUN souffle -h


### PR DESCRIPTION
- This is a fix for issue #589.
- Code was previously in repo souffle-lang/souffle-docker.
- Moved to new "docker" directory of souffle-lang/souffle.
- Old README.md file is retained for usage instructions.
- Docker images built in this directory can be deployed to official
souffle repo on Dockerhub.
- Images from official souffle repo on Dockerhub are used in MPI tests
by travis.