### PR TITLE
Reordered Transformation Pipeline

### DIFF
--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1232,7 +1232,7 @@ bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUni
     // All other relations are necessarily existential
     std::set<AstRelationIdentifier> existentialRelations;
     for (AstRelation* relation : program.getRelations()) {
-        if (!relation->getClauses().empty() &&
+        if (!relation->getClauses().empty() && relation->getArity() != 0 &&
                 irreducibleRelations.find(relation->getName()) == irreducibleRelations.end()) {
             existentialRelations.insert(relation->getName());
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -458,7 +458,7 @@ int main(int argc, char** argv) {
             std::make_unique<InlineRelationsTransformer>(), std::make_unique<ResolveAliasesTransformer>(),
             std::make_unique<RemoveRedundantRelationsTransformer>(),
             std::make_unique<RemoveRelationCopiesTransformer>(),
-            std::make_unique<FixpointTransformer>(std::make_unique<RemoveEmptyRelationsTransformer>()),
+            std::make_unique<RemoveEmptyRelationsTransformer>(),
             std::make_unique<ReplaceSingletonVariablesTransformer>(),
             std::make_unique<FixpointTransformer>(
                     std::make_unique<PipelineTransformer>(std::make_unique<ReduceExistentialsTransformer>(),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -453,7 +453,6 @@ int main(int argc, char** argv) {
             std::make_unique<ComponentInstantiationTransformer>(),
             std::make_unique<UniqueAggregationVariablesTransformer>(), std::make_unique<AstSemanticChecker>(),
             std::make_unique<RemoveBooleanConstraintsTransformer>(),
-
             std::make_unique<ResolveAliasesTransformer>(), std::make_unique<MinimiseProgramTransformer>(),
             std::make_unique<InlineRelationsTransformer>(), std::make_unique<ResolveAliasesTransformer>(),
             std::make_unique<RemoveRedundantRelationsTransformer>(),
@@ -468,7 +467,6 @@ int main(int argc, char** argv) {
             std::make_unique<MinimiseProgramTransformer>(),
             std::make_unique<RemoveRelationCopiesTransformer>(),
             std::make_unique<ReorderLiteralsTransformer>(),
-
             std::make_unique<MaterializeAggregationQueriesTransformer>(),
             std::make_unique<RemoveEmptyRelationsTransformer>(),
             std::make_unique<ReorderLiteralsTransformer>(), std::move(magicPipeline),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -453,15 +453,25 @@ int main(int argc, char** argv) {
             std::make_unique<ComponentInstantiationTransformer>(),
             std::make_unique<UniqueAggregationVariablesTransformer>(), std::make_unique<AstSemanticChecker>(),
             std::make_unique<RemoveBooleanConstraintsTransformer>(),
+
+            std::make_unique<ResolveAliasesTransformer>(), std::make_unique<MinimiseProgramTransformer>(),
+            std::make_unique<InlineRelationsTransformer>(), std::make_unique<ResolveAliasesTransformer>(),
+            std::make_unique<RemoveRedundantRelationsTransformer>(),
+            std::make_unique<RemoveRelationCopiesTransformer>(),
+            std::make_unique<FixpointTransformer>(std::make_unique<RemoveEmptyRelationsTransformer>()),
             std::make_unique<ReplaceSingletonVariablesTransformer>(),
-            std::make_unique<InlineRelationsTransformer>(), std::make_unique<ReduceExistentialsTransformer>(),
+            std::make_unique<FixpointTransformer>(
+                    std::make_unique<PipelineTransformer>(std::make_unique<ReduceExistentialsTransformer>(),
+                            std::make_unique<RemoveRedundantRelationsTransformer>())),
+            std::make_unique<RemoveRelationCopiesTransformer>(),
             std::make_unique<PartitionBodyLiteralsTransformer>(),
-            std::make_unique<ResolveAliasesTransformer>(),
-            std::make_unique<RemoveRelationCopiesTransformer>(), std::move(equivalencePipeline),
+            std::make_unique<MinimiseProgramTransformer>(),
+            std::make_unique<RemoveRelationCopiesTransformer>(),
+            std::make_unique<ReorderLiteralsTransformer>(),
+
             std::make_unique<MaterializeAggregationQueriesTransformer>(),
             std::make_unique<RemoveEmptyRelationsTransformer>(),
-            std::make_unique<ReorderLiteralsTransformer>(),
-            std::make_unique<RemoveRedundantRelationsTransformer>(), std::move(magicPipeline),
+            std::make_unique<ReorderLiteralsTransformer>(), std::move(magicPipeline),
             std::make_unique<AstExecutionPlanChecker>(), std::move(provenancePipeline));
 
     // Disable unwanted transformations


### PR DESCRIPTION
Reordered transformation pipeline based on their effects and interactions.

The `RemoveEmptyRelationsTransformer` transformation should technically have a fixpoint wrapped around it, but currently the `changed` result returns true more times than it should, leading to potential infinite loops, which is a separate issue.