### PR TITLE
Add configure cache to distclean target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,10 @@ include $(top_srcdir)/aminclude.am
 # add doxygen configuration to the distribution
 EXTRA_DIST = doxygen.cfg
 
+# clean up the autoconf cache
+distclean-local:
+	-rm -rf autom4te.cache
+
 # Debian packaging
 if DEBIAN_PACKAGE
 dpkg_dir = packaging


### PR DESCRIPTION
Clean up cached files from configure script. The most obvious sign will be that the souffle version number will change if you do `make distclean`.