### PR TITLE
Fixed parser issues for functors

### DIFF
--- a/src/AstArgument.h
+++ b/src/AstArgument.h
@@ -400,7 +400,7 @@ public:
 
     /** print user-defined functor */
     void print(std::ostream& os) const override {
-        os << '#' << name << "(" << join(args, ",", print_deref<std::unique_ptr<AstArgument>>()) << ")";
+        os << '@' << name << "(" << join(args, ",", print_deref<std::unique_ptr<AstArgument>>()) << ")";
     }
 
     /** Create clone */

--- a/src/Interpreter.h
+++ b/src/Interpreter.h
@@ -160,10 +160,7 @@ protected:
     void* loadDLL() {
         if (dll == nullptr) {
             // check environment variable
-            std::string fname = ::getenv("SOUFFLE_FUNCTOR_LIB");
-            if (fname == "") {
-                fname = SOUFFLE_DLL;
-            }
+            std::string fname = SOUFFLE_DLL;
             dll = dlopen(SOUFFLE_DLL, RTLD_LAZY);
             if (dll == nullptr) {
                 std::cerr << "Cannot find Souffle's DLL" << std::endl;

--- a/src/RamValue.h
+++ b/src/RamValue.h
@@ -148,7 +148,7 @@ public:
 
     /** Print */
     void print(std::ostream& os) const override {
-        os << "%" << name << "_" << type << "(";
+        os << "@" << name << "_" << type << "(";
         os << join(
                 arguments, ",", [](std::ostream& out, const std::unique_ptr<RamValue>& arg) { out << *arg; });
         os << ")";

--- a/src/SynthesiserRelation.h
+++ b/src/SynthesiserRelation.h
@@ -44,7 +44,7 @@ public:
     SynthesiserRelation(const RamRelation& rel, const IndexSet& indices, const bool isProvenance = false)
             : relation(rel), indices(indices), isProvenance(isProvenance) {}
 
-    ~SynthesiserRelation() = default;
+    virtual ~SynthesiserRelation() = default;
 
     /** Compute the final list of indices to be used */
     virtual void computeIndices() = 0;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -148,6 +148,7 @@
 %token DOT                       "."
 %token EQUALS                    "="
 %token STAR                      "*"
+%token AT                        "@"
 %token SLASH                     "/"
 %token CARET                     "^"
 %token PERCENT                   "%"
@@ -205,7 +206,6 @@
 %precedence BW_NOT L_NOT
 %precedence NEG
 %left CARET
-%left IDENT LPAREN
 
 %%
 %start program;
@@ -551,9 +551,9 @@ arg
         $$ = new AstCounter();
         $$->setSrcLoc(@$);
     }
-  | IDENT functor_list {
-        $$ = $2;
-        $2->setName($1);
+  | AT IDENT functor_list {
+        $$ = $3;
+        $3->setName($2);
         $$->setSrcLoc(@$);
     }
   | IDENT {

--- a/src/scanner.ll
+++ b/src/scanner.ll
@@ -131,6 +131,7 @@
 "."                                   { return yy::parser::make_DOT(yylloc); }
 "="                                   { return yy::parser::make_EQUALS(yylloc); }
 "*"                                   { return yy::parser::make_STAR(yylloc); }
+"@"                                   { return yy::parser::make_AT(yylloc); }
 "/"                                   { return yy::parser::make_SLASH(yylloc); }
 "^"                                   { return yy::parser::make_CARET(yylloc); }
 "%"                                   { return yy::parser::make_PERCENT(yylloc); }


### PR DESCRIPTION
There were issues with functors. The usage of functors requires to add a @ prior to user-defined functors in their use. For example,

```
.functor f(number, number):number

.decl A(x:number) output
A(@f(1,1)) :- true.

```

Without the prefix, extensive changes to the parser would have been required. Martin also recommended to have a symbol so that there is a differentiation between user-defined functors and internal functors. 