### PR TITLE
Add quotes to sqlite relation name

### DIFF
--- a/src/WriteStreamSQLite.h
+++ b/src/WriteStreamSQLite.h
@@ -176,7 +176,7 @@ private:
 
     void prepareInsertStatement() {
         std::stringstream insertSQL;
-        insertSQL << "INSERT INTO _" << relationName << " VALUES ";
+        insertSQL << "INSERT INTO '_" << relationName << "' VALUES ";
         insertSQL << "(@V0";
         for (unsigned int i = 1; i < arity; i++) {
             insertSQL << ",@V" << i;


### PR DESCRIPTION
Adding quotes to allow use of all characters in souffle's usual relation naming schemes.

Fixes #778 