### PR TITLE
Fix attempts to delete non-existent files

### DIFF
--- a/.travis/osx/install_withgcc.sh
+++ b/.travis/osx/install_withgcc.sh
@@ -6,7 +6,7 @@ set -e
 set -x
 
 # Install requirements of MAC OS X
-rm /usr/local/include/c++
+rm /usr/local/include/c++ || true
 brew update
 
 # Install gcc instead of gcc-x.x if a current version is preferred


### PR DESCRIPTION
The travis script deletes a file on osx that may not be present. This PR enables the script to keep running if the file is not present.