### PR TITLE
Fix relation naming in profile output

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -1155,8 +1155,8 @@ std::unique_ptr<RamProgram> AstTranslator::translateProgram(const AstTranslation
                         relation->getArity(), false, relation->isHashset())),
                 getInputIODirectives(relation, Global::config().get(inputDirectory), fileExtension));
         if (Global::config().has("profile")) {
-            const std::string logTimerStatement = LogStatement::tRelationLoadTime(
-                    getRelationName(relation->getName()), relation->getSrcLoc());
+            const std::string logTimerStatement =
+                    LogStatement::tRelationLoadTime(toString(relation->getName()), relation->getSrcLoc());
             statement = std::make_unique<RamLogTimer>(std::move(statement), logTimerStatement,
                     std::unique_ptr<RamRelation>(
                             translateRelation(relation, getRelationName(relation->getName()),

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -886,10 +886,6 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
         relDelta[rel] = translateRelation(rel, "delta_" + relName, rel->getArity(), true, rel->isHashset());
         relNew[rel] = translateRelation(rel, "new_" + relName, rel->getArity(), true, rel->isHashset());
 
-        modifiedIdMap[relName] = relName;
-        modifiedIdMap[relDelta[rel]->getName()] = relName;
-        modifiedIdMap[relNew[rel]->getName()] = relName;
-
         /* create update statements for fixpoint (even iteration) */
         appendStmt(updateRelTable,
                 std::make_unique<RamSequence>(

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -1180,8 +1180,8 @@ std::unique_ptr<RamProgram> AstTranslator::translateProgram(const AstTranslation
                         relation->getArity(), false, relation->isHashset())),
                 getOutputIODirectives(relation, Global::config().get(outputDirectory), fileExtension));
         if (Global::config().has("profile")) {
-            const std::string logTimerStatement = LogStatement::tRelationSaveTime(
-                    getRelationName(relation->getName()), relation->getSrcLoc());
+            const std::string logTimerStatement =
+                    LogStatement::tRelationSaveTime(toString(relation->getName()), relation->getSrcLoc());
             statement = std::make_unique<RamLogTimer>(std::move(statement), logTimerStatement,
                     std::unique_ptr<RamRelation>(
                             translateRelation(relation, getRelationName(relation->getName()),

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -593,15 +593,9 @@ std::unique_ptr<RamStatement> AstTranslator::translateClause(
             if (Global::config().has("profile")) {
                 std::stringstream ss;
                 ss << clause.getHead()->getName();
-                std::string relName = ss.str();
                 ss.str("");
-
-                if (modifiedIdMap.find(relName) != modifiedIdMap.end()) {
-                    relName = modifiedIdMap[relName];
-                }
-
                 ss << "@frequency-atom" << ';';
-                ss << relName << ';';
+                ss << originalClause.getHead()->getName() << ';';
                 ss << version << ';';
                 ss << stringify(toString(clause)) << ';';
                 ss << stringify(toString(*atom)) << ';';

--- a/src/AstTranslator.h
+++ b/src/AstTranslator.h
@@ -48,9 +48,6 @@ class TypeEnvironment;
  */
 class AstTranslator {
 private:
-    /** Map modified relation identifiers to original relation identifiers */
-    std::map<std::string, std::string> modifiedIdMap;
-
     /** AST program */
     const AstProgram* program;
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -61,12 +61,18 @@ unsigned Synthesiser::lookupFreqIdx(const std::string& txt) {
 
 /** Lookup frequency counter */
 size_t Synthesiser::lookupReadIdx(const std::string& txt) {
+    std::string modifiedTxt = txt;
+    for (auto& cur : modifiedTxt) {
+        if (cur == '-') {
+            cur = '.';
+        }
+    }
     static unsigned counter;
-    auto pos = neIdxMap.find(txt);
+    auto pos = neIdxMap.find(modifiedTxt);
     if (pos == neIdxMap.end()) {
-        return neIdxMap[txt] = counter++;
+        return neIdxMap[modifiedTxt] = counter++;
     } else {
-        return neIdxMap[txt];
+        return neIdxMap[modifiedTxt];
     }
 }
 

--- a/src/profile/Reader.h
+++ b/src/profile/Reader.h
@@ -326,14 +326,14 @@ public:
         for (const auto& relation : relationMap) {
             for (const auto& rule : relation.second->getRuleMap()) {
                 for (const auto& atom : rule.second->getAtoms()) {
-                    std::string relationName = atom.identifier.substr(0, atom.identifier.find('('));
+                    std::string relationName = extractRelationNameFromAtom(atom);
                     relationMap[relationName]->addReads(atom.frequency);
                 }
             }
             for (const auto& iteration : relation.second->getIterations()) {
                 for (const auto& rule : iteration->getRules()) {
                     for (const auto& atom : rule.second->getAtoms()) {
-                        std::string relationName = atom.identifier.substr(0, atom.identifier.find('('));
+                        std::string relationName = extractRelationNameFromAtom(atom);
                         if (relationName.substr(0, 6) == "@delta") {
                             relationName = relationName.substr(7);
                         }
@@ -354,7 +354,7 @@ public:
     }
 
     void addRelation(const DirectoryEntry& relation) {
-        const std::string& name = relation.getKey();
+        const std::string& name = cleanRelationName(relation.getKey());
 
         relationMap.emplace(name, std::make_shared<Relation>(name, createId()));
         auto& rel = *relationMap[name];
@@ -375,6 +375,20 @@ public:
 
     std::string createId() {
         return "R" + std::to_string(++rel_id);
+    }
+
+protected:
+    std::string cleanRelationName(const std::string& relationName) {
+        std::string cleanName = relationName;
+        for (auto& cur : cleanName) {
+            if (cur == '-') {
+                cur = '.';
+            }
+        }
+        return cleanName;
+    }
+    std::string extractRelationNameFromAtom(const Atom& atom) {
+        return cleanRelationName(atom.identifier.substr(0, atom.identifier.find('(')));
     }
 };
 


### PR DESCRIPTION
Currently we occasionally rename relations from a.b.c to a-b-c, but not always. This PR standardises the naming in the profiler.

I think this should be changed throughout Souffle, and the filtered name only used where needed - naming of Synthesised relations - but that's a change for another PR.