### PR TITLE
Keep track of the 'end points' of zero length input

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -68,6 +68,7 @@
            (Cur).filename     = YYRHSLOC(Rhs, N).filename;     \
        } else {                                                \
            (Cur).start    = YYRHSLOC(Rhs, 0).end;              \
+           (Cur).end      = YYRHSLOC(Rhs, 0).end;              \
            (Cur).filename = YYRHSLOC(Rhs, 0).filename;         \
        }                                                       \
     } while (0)


### PR DESCRIPTION
Currently any decl with no qualifiers has an end source location of 0:0. This PR is to set empty endpoints equal to the start point, which should then produce useful end source locations when included in other rules. e.g.,

```
.decl A(x:number)
.decl B(x:number) btree
```
Before, A -> [1:7-0:0], B->[2:7-2:24]
After, A -> [1:7-1:17], B->[2:7-2:24]