### PR TITLE
Refactor synthesiser casting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -288,7 +288,6 @@ AC_CONFIG_FILES([
   tests/Makefile
   tests/atlocal
 ])
-AC_CONFIG_LINKS([include/souffle/AstTypes.h:src/AstTypes.h])
 AC_CONFIG_LINKS([include/souffle/BTree.h:src/BTree.h])
 AC_CONFIG_LINKS([include/souffle/BinaryRelation.h:src/BinaryRelation.h])
 AC_CONFIG_LINKS([include/souffle/BlockList.h:src/BlockList.h])

--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "souffle/AstTypes.h"
 #include "souffle/CompiledIndexUtils.h"
 #include "souffle/CompiledOptions.h"
 #include "souffle/CompiledRecord.h"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,6 +81,7 @@ souffle_sources = \
               AstTranslator.cpp     AstTranslator.h     \
               AstType.h                                 \
               AstTypeAnalysis.cpp   AstTypeAnalysis.h   \
+              AstTypes.h                                \
               AstUtils.cpp          AstUtils.h          \
               AstVisitor.h                              \
               BinaryConstraintOps.h                     \
@@ -165,7 +166,6 @@ soufflepublicdir = $(includedir)/souffle
 
 soufflepublic_HEADERS = \
 						CompiledOptions.h       \
-                        AstTypes.h              \
                         BTree.h                 \
                         BinaryRelation.h        \
                         BlockList.h             \

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -889,8 +889,8 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             if (project.getValues().empty()) {
                 out << "Tuple<RamDomain," << arity << "> tuple({{}});\n";
             } else {
-                out << "Tuple<RamDomain," << arity << "> tuple({{(RamDomain)("
-                    << join(project.getValues(), "),(RamDomain)(", rec) << ")}});\n";
+                out << "Tuple<RamDomain," << arity << "> tuple({{" << join(project.getValues(), ",", rec)
+                    << "}});\n";
             }
 
             // check filter
@@ -1121,9 +1121,9 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                     visit(op.getValue(), out);
                     break;
                 case UnaryOp::STRLEN:
-                    out << "symTable.resolve((size_t)";
+                    out << "static_cast<RamDomain>(symTable.resolve(";
                     visit(op.getValue(), out);
-                    out << ").size()";
+                    out << ").size())";
                     break;
                 case UnaryOp::NEG:
                     out << "(-(";

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -889,8 +889,8 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             if (project.getValues().empty()) {
                 out << "Tuple<RamDomain," << arity << "> tuple({{}});\n";
             } else {
-                out << "Tuple<RamDomain," << arity << "> tuple({{" << join(project.getValues(), ",", rec)
-                    << "}});\n";
+                out << "Tuple<RamDomain," << arity << "> tuple({{static_cast<RamDomain>("
+                    << join(project.getValues(), "),static_cast<RamDomain>(", rec) << ")}});\n";
             }
 
             // check filter

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1195,9 +1195,11 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                     break;
                 }
                 case BinaryOp::EXP: {
-                    out << "(AstDomain)(std::pow((AstDomain)";
+                    // Cast as int64, then back to RamDomain of int32 to avoid wrapping to negative
+                    // when using int32 RamDomains
+                    out << "static_cast<int64_t>(std::pow(";
                     visit(op.getLHS(), out);
-                    out << ",(AstDomain)";
+                    out << ",";
                     visit(op.getRHS(), out);
                     out << "))";
                     break;
@@ -1251,19 +1253,19 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                     break;
                 }
                 case BinaryOp::MAX: {
-                    out << "(AstDomain)(std::max((AstDomain)";
+                    out << "std::max(";
                     visit(op.getLHS(), out);
-                    out << ",(AstDomain)";
+                    out << ",";
                     visit(op.getRHS(), out);
-                    out << "))";
+                    out << ")";
                     break;
                 }
                 case BinaryOp::MIN: {
-                    out << "(AstDomain)(std::min((AstDomain)";
+                    out << "std::min(";
                     visit(op.getLHS(), out);
-                    out << ",(AstDomain)";
+                    out << ",";
                     visit(op.getRHS(), out);
-                    out << "))";
+                    out << ")";
                     break;
                 }
 


### PR DESCRIPTION
Remove dependency of synthesised code on AstTypes.h
Remove unhelpful casts
Use clearer casting

Some casting is still needed as we want to handle `-(2^31)`, which goes from double to int64 to, eventually, int32.