### PR TITLE
Use pkgconfig for Linux as well

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -257,7 +257,7 @@ m4_define_default([PKG_CHECK_MODULES],
    [AC_MSG_ERROR(required pkg-config not installed)
     $4])
 case $host_os in
-  darwin* )
+  darwin* | linux*)
     PKG_PROG_PKG_CONFIG()
     PKG_CHECK_MODULES(FFI, [libffi])
   ;;


### PR DESCRIPTION
On Arch, the libffi package (https://www.archlinux.org/packages/core/x86_64/libffi/) installs headers in `/usr/lib/libffi-X.Y.Z/include/ffi.h`, which isn't visible to `AC_CHECK_HEADER(ffi.h, ...)`, causing `./configure` to fail with
```
checking for ffi_call in -lffi... yes
checking ffi.h usability... no
checking ffi.h presence... no
checking for ffi.h... no
configure: error: required headers ffi.h missing.
```
. 

This change unbreaks the build for me, but I don't know if there was a reason to only use pkg-config for `darwin*`.