### PR TITLE
Refactor translateRelation

### DIFF
--- a/src/AstTranslator.h
+++ b/src/AstTranslator.h
@@ -273,20 +273,27 @@ private:
     std::vector<IODirectives> getOutputIODirectives(const AstRelation* rel,
             std::string filePath = std::string(), const std::string& fileExt = std::string());
 
-    /** a utility to translate atoms to relations */
-    std::unique_ptr<RamRelationReference> translateRelation(const AstAtom* atom) {
-        std::string name = getRelationName(atom->getName());
-        bool isTemp = name.at(0) == '@';
-        if (isTemp) {
-            name = name.substr(1);
-        }
-        return translateRelation(
-                (program ? getAtomRelation(atom, program) : nullptr), name, atom->getArity(), isTemp);
-    }
+    /** create a reference to a RAM relation */
+    std::unique_ptr<RamRelationReference> createRelationReference(const std::string name, const size_t arity,
+            const std::vector<std::string> attributeNames,
+            const std::vector<std::string> attributeTypeQualifiers, const SymbolMask mask, const bool input,
+            const bool computed, const bool output, const bool btree, const bool brie, const bool eqrel);
 
-    /** translate a AST relation to a RAM relation */
+    /** create a reference to a RAM relation */
+    std::unique_ptr<RamRelationReference> createRelationReference(const std::string name, const size_t arity);
+
+    /** a utility to translate atoms to relations */
+    std::unique_ptr<RamRelationReference> translateRelation(const AstAtom* atom);
+
+    /** translate an AST relation to a RAM relation */
     std::unique_ptr<RamRelationReference> translateRelation(
-            const AstRelation* rel, std::string name, size_t arity, const bool istemp = false);
+            const AstRelation* rel, const std::string relationNamePrefix = "");
+
+    /** translate a temporary `delta` relation to a RAM relation for semi-naive evaluation */
+    std::unique_ptr<RamRelationReference> translateDeltaRelation(const AstRelation* rel);
+
+    /** translate a temporary `new` relation to a RAM relation for semi-naive evaluation */
+    std::unique_ptr<RamRelationReference> translateNewRelation(const AstRelation* rel);
 
     /** translate an AST argument to a RAM value */
     std::unique_ptr<RamValue> translateValue(const AstArgument* arg, const ValueIndex& index);

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -41,16 +41,16 @@ protected:
     const std::string name;
 
     /** Arity, i.e., number of attributes */
-    const unsigned arity = 0;
+    const size_t arity;
 
     /** Name of attributes */
-    std::vector<std::string> attributeNames;
+    const std::vector<std::string> attributeNames;
 
     /** Type of attributes */
-    std::vector<std::string> attributeTypeQualifiers;
+    const std::vector<std::string> attributeTypeQualifiers;
 
     /** TODO (#541): legacy, i.e., duplicated information */
-    SymbolMask mask;
+    const SymbolMask mask;
 
     /** Relation qualifiers */
     // TODO: Simplify interface
@@ -62,21 +62,14 @@ protected:
     const bool brie;   // brie data-structure
     const bool eqrel;  // equivalence relation
 
-    const bool istemp;  // Temporary relation for semi-naive evaluation
-
 public:
-    RamRelation(const std::string& name, unsigned arity, const bool istemp)
-            : RamRelation(
-                      name, arity, {}, {}, SymbolMask(0), false, false, false, false, false, false, istemp) {}
-
-    RamRelation(std::string name, unsigned arity, std::vector<std::string> attributeNames,
-            std::vector<std::string> attributeTypeQualifiers, SymbolMask mask, bool input, bool computed,
-            bool output, bool btree, bool brie, bool eqrel, bool istemp)
+    RamRelation(const std::string name, const size_t arity, const std::vector<std::string> attributeNames,
+            const std::vector<std::string> attributeTypeQualifiers, const SymbolMask mask, const bool input,
+            const bool computed, const bool output, const bool btree, const bool brie, const bool eqrel)
             : RamNode(RN_Relation), name(std::move(name)), arity(arity),
               attributeNames(std::move(attributeNames)),
               attributeTypeQualifiers(std::move(attributeTypeQualifiers)), mask(std::move(mask)),
-              input(input), output(output), computed(computed), btree(btree), brie(brie), eqrel(eqrel),
-              istemp(istemp) {
+              input(input), output(output), computed(computed), btree(btree), brie(brie), eqrel(eqrel) {
         assert(this->attributeNames.size() == arity || this->attributeNames.empty());
         assert(this->attributeTypeQualifiers.size() == arity || this->attributeTypeQualifiers.empty());
     }
@@ -141,9 +134,9 @@ public:
         return true;
     }
 
-    /** Is temporary relation */
+    /** Is temporary relation (for semi-naive evaluation) */
     const bool isTemp() const {
-        return istemp;
+        return name.at(0) == '@';
     }
 
     /* Get arity of relation */
@@ -179,7 +172,7 @@ public:
     /** Create clone */
     RamRelation* clone() const override {
         RamRelation* res = new RamRelation(name, arity, attributeNames, attributeTypeQualifiers, mask, input,
-                computed, output, btree, brie, eqrel, istemp);
+                computed, output, btree, brie, eqrel);
         return res;
     }
 

--- a/src/test/matching_test.cpp
+++ b/src/test/matching_test.cpp
@@ -29,7 +29,7 @@
 using namespace std;
 using namespace souffle;
 
-RamRelation r("test", 0, false);
+RamRelation r("test", 0, {}, {}, SymbolMask(0), false, false, false, false, false, false);
 RamRelationReference rel(&r);
 class TestAutoIndex : public IndexSet {
 public:


### PR DESCRIPTION
Refactoring work for the AST translator

Changes:
- Cut down the number of parameters to `translateRelation`
- Introduced `createRelation` to handle creating RamRelationReferences - RamRelations are created as a side effect if they don't already exist
- Removed `istemp` parameter to `RamRelation` - it's now a property that returns true if the relation name starts with "@delta_" or "@new_" (which is how the flag was originally initialised anyway)
- New methods `translateDeltaRelation` and `translateNewRelation` - rather than duplicating the relation name prefixes in the caller (I also tried with enums and a single method, but I think this way is a bit cleaner)