### PR TITLE
Fix string substring test

### DIFF
--- a/tests/semantic/string_substr/string_substr.dl
+++ b/tests/semantic/string_substr/string_substr.dl
@@ -11,7 +11,10 @@ B(substr(x,2,2)) :- A(x).
 
 .output B()
 
+.decl Nullary()
+Nullary().
+
 .decl C(x:symbol) 
-C(substr("12",22,12)) :- A(_).
+C(substr("12",22,12)) :- Nullary().
 
 .output C()


### PR DESCRIPTION
This test was causing issues for my #811

The error message in the `string_substr.err` file assumes that `A(_)` gets converted to an existence check (i.e. if statement where `substr()` is evaluated only once) rather than scan (i.e. for loop where `substr()` gets evaluated |A| times). That's what should happen, but both translations of the RAM are technically correct, and I think this test should not depend on the level of optimisations.