### PR TITLE
Export bison path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ aliases:
     stage: Testing
     os: osx
     osx_image: xcode8.3
-    install: "travis_retry .travis/osx/install_withgcc.sh"
+    install: ". .travis/osx/install_withgcc.sh"
     before_script: ".travis/init_test.sh"
     script: ".travis/run_test.sh"
     after_failure: ".travis/after_failure.sh"
@@ -69,7 +69,7 @@ aliases:
       directories: $HOME/Library/Caches/Homebrew
   - &osxclang
     <<: *osxgcc
-    install: "travis_retry .travis/osx/install.sh"
+    install: ". .travis/osx/install.sh"
     compiler: clang
     language: cpp
   - &osxpackage

--- a/.travis/osx/install.sh
+++ b/.travis/osx/install.sh
@@ -10,6 +10,8 @@ brew update
 brew install md5sha1sum bison libtool mcpp libffi
 brew link bison --force
 brew link libffi --force
+
+export PATH="/usr/local/opt/bison/bin:$PATH"
 export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig/
 
 rm /Users/travis/Library/Logs/DiagnosticReports/* || true

--- a/.travis/osx/install_withgcc.sh
+++ b/.travis/osx/install_withgcc.sh
@@ -13,6 +13,8 @@ brew update
 brew install md5sha1sum bison libtool gcc@7 mcpp libffi
 brew link bison --force
 brew link libffi --force
+
+export PATH="/usr/local/opt/bison/bin:$PATH"
 export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig/
 
 # Using 'g++' will call the xcode link to clang


### PR DESCRIPTION
Recent versions of brew and osx do not allow force linking. This PR adds bison to the path.