### PR TITLE
Specify language encoding to avoid mcpp bugs

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -368,7 +368,7 @@ int main(int argc, char** argv) {
         throw std::runtime_error("failed to locate mcpp pre-processor");
     }
 
-    cmd += " -W0 " + Global::config().get("include-dir");
+    cmd += " -e utf8 -W0 " + Global::config().get("include-dir");
     if (Global::config().has("macro")) {
         cmd += " " + Global::config().get("macro");
     }


### PR DESCRIPTION
mcpp expects environment variables for language encoding to be defined 'correctly', and can use uninitialised memory to generate unclear warnings, or segfaults. This PR specifies utf8 encoding as standard to avoid the errors, and aligns with souffle standard encoding.

Fixes #828 