### PR TITLE
Fix cropped messages in verbose logs

### DIFF
--- a/src/SignalHandler.h
+++ b/src/SignalHandler.h
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <cassert>
 #include <csignal>
+#include <cstring>
 #include <iostream>
 #include <mutex>
 #include <string>
@@ -90,15 +91,24 @@ public:
     void setMsg(const char* m) {
         if (logMessages && m != nullptr) {
             static std::mutex outputMutex;
-            std::string outputMessage(m);
-            for (size_t pos = 0; pos < outputMessage.size(); ++pos) {
-                char& c = outputMessage[pos];
-                if (c == '\n' || c == '\t') {
-                    c = ' ';
-                }
-            }
+            static bool sameLine = false;
             std::lock_guard<std::mutex> guard(outputMutex);
-            std::cout << "Starting work on " << outputMessage << std::endl;
+            if (msg != nullptr && strcmp(m, msg) == 0) {
+                std::cout << ".";
+                sameLine = true;
+            } else {
+                if (sameLine) {
+                    sameLine = false;
+                    std::cout << std::endl;
+                }
+                std::string outputMessage(m);
+                for (char& c : outputMessage) {
+                    if (c == '\n' || c == '\t') {
+                        c = ' ';
+                    }
+                }
+                std::cout << "Starting work on " << outputMessage << std::endl;
+            }
         }
         msg = m;
     }

--- a/src/SignalHandler.h
+++ b/src/SignalHandler.h
@@ -95,9 +95,6 @@ public:
                 char& c = outputMessage[pos];
                 if (c == '\n' || c == '\t') {
                     c = ' ';
-                } else if (c == '.') {
-                    outputMessage = outputMessage.substr(0, pos + 1);
-                    break;
                 }
             }
             std::lock_guard<std::mutex> guard(outputMutex);


### PR DESCRIPTION
Messages were being cut when a '.' was reached, which also matches a component.relation name. This PR shows the full message in the log.