### PR TITLE
Fixed union and record types in components.

### DIFF
--- a/src/AstType.h
+++ b/src/AstType.h
@@ -212,6 +212,11 @@ public:
         types.push_back(type);
     }
 
+    void setVariantType(size_t idx, const AstTypeIdentifier& type) {
+        assert(idx < types.size() && "union variant index out of bounds");
+        types[idx] = type;
+    }
+
     /** Prints a summary of this type to the given stream */
     void print(std::ostream& os) const override {
         os << ".type " << getName() << " = " << join(types, " | ");
@@ -268,6 +273,11 @@ public:
     /** Obtains the list of field constituting this record type */
     const std::vector<Field>& getFields() const {
         return fields;
+    }
+
+    void setFieldType(size_t idx, const AstTypeIdentifier& type) {
+        assert(idx < fields.size() && "record field index out of bounds");
+        fields[idx].type = type;
     }
 
     /** Prints a summary of this type to the given stream */


### PR DESCRIPTION
Fixes issue #810.

Previously, the following program:

```
.comp Component {
    .type N1
    .type N2
    .type Record = [n1: N1, n2: N2]
    .type Union = N1 | N2
    .decl blah(record: Record)
}
.init comp = Component
```

was incorrectly rewritten to:

```
.type comp.N1
.type comp.N2
.type Record = [n1: N1, n2: N2]
.type Union = N1 | N2
.decl comp.blah(record: comp.Record, union: comp.Union)
```

rather than:

```
.type comp.N1
.type comp.N2
.type Record = [n1: comp.N1, n2: comp.N2]
.type Union = comp.N1 | comp.N2
.decl comp.blah(record: comp.Record)
```

