### PR TITLE
Bugfix for issue 787

### DIFF
--- a/src/LambdaBTree.h
+++ b/src/LambdaBTree.h
@@ -310,7 +310,7 @@ public:
                 // split this node
                 auto old_root = this->root;
                 idx -= cur->rebalance_or_split(
-                        const_cast<typename parenttype::node**>(&this->root), this->root_lock, idx);
+                        const_cast<typename parenttype::node**>(&this->root), this->root_lock, idx, parents);
 
                 // release parent lock
                 for (auto it = parents.rbegin(); it != parents.rend(); ++it) {


### PR DESCRIPTION
A fix for issue #787 

The locking protocol for Btree had a flaw that could lead to a deadlock when utilizing a large number of cores and high-arity tuples. This modification removes this problem.