### PR TITLE
Remove deprecated errors from bison.

### DIFF
--- a/.travis/linux/install_centos_deps.sh
+++ b/.travis/linux/install_centos_deps.sh
@@ -33,6 +33,7 @@ travis_retry yum install -y devtoolset-7-gcc-c++
 
 # Set up the package builder
 travis_retry yum install -y -q rpm-build ruby-devel
+travis_retry gem install --no-ri --no-rdoc rake
 travis_retry gem install --no-ri --no-rdoc fpm
 
 fpm --version

--- a/.travis/linux/install_fedora_deps.sh
+++ b/.travis/linux/install_fedora_deps.sh
@@ -26,6 +26,7 @@ travis_retry yum install -y -q autoconf automake bison clang doxygen flex gcc gc
 
 # Set up the package builder
 travis_retry yum install -y -q rpm-build ruby-devel
+travis_retry gem install --no-ri --no-rdoc rake
 travis_retry gem install --no-ri --no-rdoc fpm
 
 fpm --version

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -220,7 +220,7 @@ CLEANFILES = $(BUILT_SOURCES)  parser.cc scanner.cc parser.hh stack.hh
 
 # run Bison
 $(builddir)/parser.hh: $(srcdir)/parser.yy
-	$(BISON) -Wall -Werror -v -d -o parser.cc $(srcdir)/parser.yy
+	$(BISON) -Wall -Werror -Wno-deprecated -v -d -o parser.cc $(srcdir)/parser.yy
 
 # and FLEX
 $(builddir)/scanner.cc: $(srcdir)/scanner.ll

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -220,7 +220,7 @@ CLEANFILES = $(BUILT_SOURCES)  parser.cc scanner.cc parser.hh stack.hh
 
 # run Bison
 $(builddir)/parser.hh: $(srcdir)/parser.yy
-	$(BISON) -Wall -Werror -Wno-deprecated -v -d -o parser.cc $(srcdir)/parser.yy
+	$(BISON) -Wall -Werror -Wno-error=deprecated -v -d -o parser.cc $(srcdir)/parser.yy
 
 # and FLEX
 $(builddir)/scanner.cc: $(srcdir)/scanner.ll

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -220,7 +220,7 @@ CLEANFILES = $(BUILT_SOURCES)  parser.cc scanner.cc parser.hh stack.hh
 
 # run Bison
 $(builddir)/parser.hh: $(srcdir)/parser.yy
-	$(BISON) -Wall -Werror -Wno-error=deprecated -v -d -o parser.cc $(srcdir)/parser.yy
+	$(BISON) -Wall -Werror -Wno-error=deprecated -Wno-error=other -v -d -o parser.cc $(srcdir)/parser.yy
 
 # and FLEX
 $(builddir)/scanner.cc: $(srcdir)/scanner.ll


### PR DESCRIPTION
Different platforms have different bison versions, giving spurious
errors since the deprecation warnings were set to stop compilation.

The rake gem, used by fpm, is not a default install, so this is added to the fpm jobs on travis.