### PR TITLE
Initialise class variables.

### DIFF
--- a/src/Trie.h
+++ b/src/Trie.h
@@ -348,9 +348,9 @@ public:
      * to speed up the execution of various operations (optional parameter).
      */
     struct op_context {
-        index_type lastIndex = 0;
-        Node* lastNode;
-        op_context() : lastNode(nullptr) {}
+        index_type lastIndex{0};
+        Node* lastNode{nullptr};
+        op_context() = default;
     };
 
 private:
@@ -2148,19 +2148,17 @@ public:
         using nested_ctxt = typename nested_trie_type::op_context;
 
         // for insert and contain
-        local_ctxt local;
-        RamDomain lastQuery;
-        nested_trie_type* lastNested;
-        nested_ctxt nestedCtxt;
+        local_ctxt local{};
+        RamDomain lastQuery{};
+        nested_trie_type* lastNested{nullptr};
+        nested_ctxt nestedCtxt{};
 
         // for boundaries
-        unsigned lastBoundaryLevels;
-        entry_type lastBoundaryRequest;
-        range<iterator> lastBoundaries;
+        unsigned lastBoundaryLevels{Dim + 1};
+        entry_type lastBoundaryRequest{};
+        range<iterator> lastBoundaries{iterator(), iterator()};
 
-        op_context()
-                : local(), lastNested(nullptr), lastBoundaryLevels(Dim + 1),
-                  lastBoundaries(iterator(), iterator()) {}
+        op_context() = default;
     };
 
     using base::contains;
@@ -2354,7 +2352,7 @@ public:
         base::hint_stats.get_boundaries.addMiss();
 
         // start with two end iterators
-        iterator begin, end;
+        iterator begin{}, end{};
 
         // adapt them level by level
         auto found = detail::fix_binding<levels, 0, Dim>()(store, begin, end, entry);


### PR DESCRIPTION
Tries and their iterators were not initialised in some cases (although never used uninitialised in current code). This PR avoids potential future misuse and silences compilation warnings.