### PR TITLE
Refactor RamValue level computations into a RamAnalysis

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -114,6 +114,8 @@ souffle_sources = \
               ProvenanceTransformer.cpp                 \
               RamAnalysis.h                             \
               RamConstValue.cpp RamConstValue.h         \
+              RamConditionLevel.cpp RamConditionLevel.h \
+              RamValueLevel.cpp RamValueLevel.h         \
               RamCondition.h                            \
               RamNode.h                                 \
               RamOperation.cpp      RamOperation.h      \

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -38,9 +38,6 @@ class RamCondition : public RamNode {
 public:
     RamCondition(RamNodeType type) : RamNode(type) {}
 
-    /** Get level */
-    virtual size_t getLevel() const = 0;
-
     /** Create clone */
     RamCondition* clone() const override = 0;
 };
@@ -78,11 +75,6 @@ public:
         lhs->print(os);
         os << " and ";
         rhs->print(os);
-    }
-
-    /** Get level */
-    size_t getLevel() const override {
-        return std::max(lhs->getLevel(), rhs->getLevel());
     }
 
     /** Obtains list of child nodes */
@@ -136,11 +128,6 @@ public:
         lhs->print(os);
         os << " " << toBinaryConstraintSymbol(op) << " ";
         rhs->print(os);
-    }
-
-    /** Get level */
-    size_t getLevel() const override {
-        return std::max(lhs->getLevel(), rhs->getLevel());
     }
 
     /** Get left-hand side */
@@ -231,17 +218,6 @@ public:
     /** Add argument */
     void addArg(std::unique_ptr<RamValue> v) {
         values.push_back(std::move(v));
-    }
-
-    /** Get level */
-    size_t getLevel() const override {
-        size_t level = 0;
-        for (const auto& cur : values) {
-            if (cur) {
-                level = std::max(level, cur->getLevel());
-            }
-        }
-        return level;
     }
 
     /** Print */
@@ -349,17 +325,6 @@ public:
         values.push_back(std::move(v));
     }
 
-    /** Get level */
-    size_t getLevel() const override {
-        size_t level = 0;
-        for (const auto& cur : values) {
-            if (cur) {
-                level = std::max(level, cur->getLevel());
-            }
-        }
-        return level;
-    }
-
     /** Print */
     void print(std::ostream& os) const override {
         os << "("
@@ -452,11 +417,6 @@ public:
     /** Get relation */
     const RamRelationReference& getRelation() const {
         return *relation;
-    }
-
-    /** Get level */
-    size_t getLevel() const override {
-        return 0;  // can be in the top level
     }
 
     /** Print */

--- a/src/RamConditionLevel.cpp
+++ b/src/RamConditionLevel.cpp
@@ -1,0 +1,70 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2019, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file RamConditionLevel.cpp
+ *
+ * Implementation of RAM Condition Level Analysis
+ *
+ ***********************************************************************/
+
+#include "RamConditionLevel.h"
+#include "RamValueLevel.h"
+#include "RamVisitor.h"
+
+namespace souffle {
+
+/** Get level of condition (which for-loop of a query) */
+size_t RamConditionLevelAnalysis::getLevel(const RamCondition* condition) const {
+    // visitor
+    class ConditionLevelVisitor : public RamVisitor<size_t> {
+        RamValueLevelAnalysis* rvla;
+
+    public:
+        // conjunction
+        size_t visitAnd(const RamAnd& conj) override {
+            return std::max(visit(conj.getLHS()), visit(conj.getRHS()));
+        }
+
+        // binary constraint
+        size_t visitBinaryRelation(const RamBinaryRelation& binRel) override {
+            return std::max(rvla->getLevel(binRel.getLHS()), rvla->getLevel(binRel.getRHS()));
+        }
+
+        // not exists check
+        size_t visitNotExists(const RamNotExists& notExists) override {
+            size_t level = 0;
+            for (const auto& cur : notExists.getValues()) {
+                if (cur) {
+                    level = std::max(level, rvla->getLevel(cur));
+                }
+            }
+            return level;
+        }
+
+        // not exists check for a provenance existence check
+        size_t visitProvenanceNotExists(const RamProvenanceNotExists& provNotExists) override {
+            size_t level = 0;
+            for (const auto& cur : provNotExists.getValues()) {
+                if (cur) {
+                    level = std::max(level, rvla->getLevel(cur));
+                }
+            }
+            return level;
+        }
+
+        // emptiness check
+        size_t visitEmpty(const RamEmpty& emptiness) override {
+            return 0;  // can be in the top level
+        }
+    };
+    return ConditionLevelVisitor().visit(condition);
+}
+
+}  // end of namespace souffle

--- a/src/RamConditionLevel.h
+++ b/src/RamConditionLevel.h
@@ -1,0 +1,39 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2019, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file RamConditionLevel.h
+ *
+ * Get level of condition (which for-loop of a query)
+ *
+ ***********************************************************************/
+
+#pragma once
+
+#include "RamAnalysis.h"
+#include "RamCondition.h"
+
+namespace souffle {
+
+/*
+ * Class for a level analysis
+ */
+class RamConditionLevelAnalysis : public RamAnalysis {
+public:
+    /** name of analysis */
+    static constexpr const char* name = "condition-level-analysis";
+
+    /** run level analysis for a RAM translation unit */
+    void run(const RamTranslationUnit& translationUnit) override {}
+
+    /** Get level */
+    size_t getLevel(const RamCondition* condition) const;
+};
+
+}  // end of namespace souffle

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -17,10 +17,13 @@
 #pragma once
 
 #include "RamCondition.h"
+#include "RamConditionLevel.h"
+#include "RamConstValue.h"
 #include "RamNode.h"
 #include "RamRelation.h"
 #include "RamTypes.h"
 #include "RamValue.h"
+#include "RamValueLevel.h"
 #include "Util.h"
 #include <cassert>
 #include <cstddef>
@@ -397,6 +400,10 @@ protected:
  * Aggregation
  */
 class RamAggregate : public RamSearch {
+    RamConstValueAnalysis* rcva;
+    RamConditionLevelAnalysis* rcla;
+    RamValueLevelAnalysis* rvla;
+
 public:
     /** Types of aggregation functions */
     enum Function { MAX, MIN, COUNT, SUM };
@@ -462,6 +469,9 @@ public:
     SearchColumns getRangeQueryColumns() const {
         return keys;
     }
+
+    /** Get indexable element */
+    std::unique_ptr<RamValue> getIndexElement(RamCondition* c, size_t& element, size_t level);
 
     /** Add condition */
     void addCondition(std::unique_ptr<RamCondition> newCondition);

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -16,9 +16,11 @@
 
 #pragma once
 
+#include "RamConditionLevel.h"
 #include "RamConstValue.h"
 #include "RamTransformer.h"
 #include "RamTranslationUnit.h"
+#include "RamValueLevel.h"
 
 namespace souffle {
 
@@ -29,6 +31,8 @@ class RamProgram;
  * can be evaluated.
  */
 class LevelConditionsTransformer : public RamTransformer {
+    RamConditionLevelAnalysis* rcla;
+
 private:
     bool transform(RamTranslationUnit& translationUnit) override {
         return levelConditions(*translationUnit.getProgram());
@@ -48,6 +52,7 @@ public:
 
 class CreateIndicesTransformer : public RamTransformer {
     RamConstValueAnalysis* rcva;
+    RamValueLevelAnalysis* rvla;
 
 private:
     bool transform(RamTranslationUnit& translationUnit) override {
@@ -73,6 +78,8 @@ public:
 
 class ConvertExistenceChecksTransformer : public RamTransformer {
     RamConstValueAnalysis* rcva;
+    RamConditionLevelAnalysis* rcla;
+    RamValueLevelAnalysis* rvla;
 
 private:
     bool transform(RamTranslationUnit& translationUnit) override {

--- a/src/RamValue.h
+++ b/src/RamValue.h
@@ -38,9 +38,6 @@ class RamValue : public RamNode {
 public:
     RamValue(RamNodeType type) : RamNode(type) {}
 
-    /** get level of value (which for-loop of a query) */
-    virtual size_t getLevel() const = 0;
-
     /** Create clone */
     RamValue* clone() const override = 0;
 };
@@ -100,18 +97,6 @@ public:
 
     size_t getArgCount() const {
         return arguments.size();
-    }
-
-    /** Get level */
-    // TODO (#541): move to an analysis
-    size_t getLevel() const override {
-        size_t level = 0;
-        for (const auto& arg : arguments) {
-            if (arg != nullptr) {
-                level = std::max(level, arg->getLevel());
-            }
-        }
-        return level;
     }
 
     /** Obtain list of child nodes */
@@ -196,18 +181,6 @@ public:
         return type;
     }
 
-    /** Get level */
-    // TODO (#541): move to an analysis
-    size_t getLevel() const override {
-        size_t level = 0;
-        for (const auto& arg : arguments) {
-            if (arg != nullptr) {
-                level = std::max(level, arg->getLevel());
-            }
-        }
-        return level;
-    }
-
     /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> res;
@@ -273,7 +246,7 @@ public:
     }
 
     /** Get level */
-    size_t getLevel() const override {
+    size_t getLevel() const {
         return level;
     }
 
@@ -332,12 +305,6 @@ public:
         os << "number(" << constant << ")";
     }
 
-    /** Get level */
-    // TODO (#541): move to analysis
-    size_t getLevel() const override {
-        return 0;
-    }
-
     /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return std::vector<const RamNode*>();  // no child nodes
@@ -374,12 +341,6 @@ public:
     /** Print */
     void print(std::ostream& os) const override {
         os << "autoinc()";
-    }
-
-    /** Get level */
-    // TODO (#541): move to analysis
-    size_t getLevel() const override {
-        return 0;
     }
 
     /** Obtain list of child nodes */
@@ -434,18 +395,6 @@ public:
                 out << "_";
             }
         }) << "]";
-    }
-
-    /** Get level */
-    // TODO (#541): move to analysis
-    size_t getLevel() const override {
-        size_t level = 0;
-        for (const auto& arg : arguments) {
-            if (arg) {
-                level = std::max(level, arg->getLevel());
-            }
-        }
-        return level;
     }
 
     /** Obtain list of child nodes */
@@ -512,12 +461,6 @@ public:
     /** Print */
     void print(std::ostream& os) const override {
         os << "argument(" << number << ")";
-    }
-
-    /** Get level */
-    // TODO (#541): move to an analysis
-    size_t getLevel() const override {
-        return 0;
     }
 
     /** Obtain list of child nodes */

--- a/src/RamValueLevel.cpp
+++ b/src/RamValueLevel.cpp
@@ -1,0 +1,83 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2019, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file RamValueLevel.cpp
+ *
+ * Implementation of RAM Value Level Analysis
+ *
+ ***********************************************************************/
+
+#include "RamValueLevel.h"
+#include "RamVisitor.h"
+
+namespace souffle {
+
+/** Get level of value (which for-loop of a query) */
+size_t RamValueLevelAnalysis::getLevel(const RamValue* value) const {
+    // visitor
+    class ValueLevelVisitor : public RamVisitor<size_t> {
+    public:
+        // number
+        size_t visitNumber(const RamNumber& num) override {
+            return 0;
+        }
+
+        // tuple element access
+        size_t visitElementAccess(const RamElementAccess& elem) override {
+            return elem.getLevel();
+        }
+
+        // auto increment
+        size_t visitAutoIncrement(const RamAutoIncrement& increment) override {
+            return 0;
+        }
+
+        // intrinsic functors
+        size_t visitIntrinsicOperator(const RamIntrinsicOperator& op) override {
+            size_t level = 0;
+            for (const auto& arg : op.getArguments()) {
+                if (arg != nullptr) {
+                    level = std::max(level, visit(arg));
+                }
+            }
+            return level;
+        }
+
+        // pack operator
+        size_t visitPack(const RamPack& pack) override {
+            size_t level = 0;
+            for (const auto& arg : pack.getArguments()) {
+                if (arg) {
+                    level = std::max(level, visit(arg));
+                }
+            }
+            return level;
+        }
+
+        // argument
+        size_t visitArgument(const RamArgument& arg) override {
+            return 0;
+        }
+
+        // user defined operator
+        size_t visitUserDefinedOperator(const RamUserDefinedOperator& op) override {
+            size_t level = 0;
+            for (const auto& arg : op.getArguments()) {
+                if (arg != nullptr) {
+                    level = std::max(level, visit(arg));
+                }
+            }
+            return level;
+        }
+    };
+    return ValueLevelVisitor().visit(value);
+}
+
+}  // end of namespace souffle

--- a/src/RamValueLevel.h
+++ b/src/RamValueLevel.h
@@ -1,0 +1,39 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2019, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file RamValueLevel.h
+ *
+ * Get level of value (which for-loop of a query)
+ *
+ ***********************************************************************/
+
+#pragma once
+
+#include "RamAnalysis.h"
+#include "RamValue.h"
+
+namespace souffle {
+
+/*
+ * Class for a level analysis
+ */
+class RamValueLevelAnalysis : public RamAnalysis {
+public:
+    /** name of analysis */
+    static constexpr const char* name = "value-level-analysis";
+
+    /** run level analysis for a RAM translation unit */
+    void run(const RamTranslationUnit& translationUnit) override {}
+
+    /** Get level */
+    size_t getLevel(const RamValue* value) const;
+};
+
+}  // end of namespace souffle


### PR DESCRIPTION
- Related to #541
- Follow on from #858

This is part of tidying up the RAM representation => level information for RamValues (which is primarily used to determine the earliest point in a loop nest that the value can be evaluated) is now computed with a RamAnalysis class.