### PR TITLE
Add a depth analysis for RAM operations

### DIFF
--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -28,6 +28,7 @@
 #include "ProfileEvent.h"
 #include "RamNode.h"
 #include "RamOperation.h"
+#include "RamOperationDepth.h"
 #include "RamValue.h"
 #include "RamVisitor.h"
 #include "ReadStream.h"
@@ -665,7 +666,7 @@ void Interpreter::evalOp(const RamOperation& op, const InterpreterContext& args)
     };
 
     // create and run interpreter for operations
-    InterpreterContext ctxt(op.getDepth());
+    InterpreterContext ctxt(translationUnit.getAnalysis<RamOperationDepthAnalysis>()->getDepth(&op));
     ctxt.setReturnValues(args.getReturnValues());
     ctxt.setReturnErrors(args.getReturnErrors());
     ctxt.setArguments(args.getArguments());

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -115,6 +115,7 @@ souffle_sources = \
               RamAnalysis.h                             \
               RamConstValue.cpp RamConstValue.h         \
               RamConditionLevel.cpp RamConditionLevel.h \
+              RamOperationDepth.cpp RamOperationDepth.h \
               RamValueLevel.cpp RamValueLevel.h         \
               RamCondition.h                            \
               RamNode.h                                 \

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -41,10 +41,6 @@ class RamOperation : public RamNode {
 public:
     RamOperation(RamNodeType type) : RamNode(type) {}
 
-    /** Get depth */
-    // TODO (#541): move to analysis
-    virtual size_t getDepth() const = 0;
-
     /** Print */
     virtual void print(std::ostream& os, int tabpos) const = 0;
 
@@ -77,11 +73,6 @@ class RamNestedOperation : public RamOperation {
 public:
     RamNestedOperation(RamNodeType type, std::unique_ptr<RamOperation> nested)
             : RamOperation(type), nestedOperation(std::move(nested)) {}
-
-    /** Get depth of query */
-    size_t getDepth() const override {
-        return 1 + nestedOperation->getDepth();
-    }
 
     /** Get nested operation */
     RamOperation& getOperation() const {
@@ -677,11 +668,6 @@ public:
         return toPtrVector(values);
     }
 
-    /** Get depth */
-    size_t getDepth() const override {
-        return 1;
-    }
-
     /** Print */
     void print(std::ostream& os, int tabpos) const override {
         const std::string tabs(tabpos, '\t');
@@ -762,10 +748,6 @@ public:
         }
 
         os << ")";
-    }
-
-    size_t getDepth() const override {
-        return 1;
     }
 
     void addValue(std::unique_ptr<RamValue> val) {

--- a/src/RamOperationDepth.cpp
+++ b/src/RamOperationDepth.cpp
@@ -1,0 +1,45 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2019, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file RamOperationDepth.cpp
+ *
+ * Implementation of RAM Operation Depth Analysis
+ *
+ ***********************************************************************/
+
+#include "RamOperationDepth.h"
+#include "RamVisitor.h"
+
+namespace souffle {
+
+/** Get depth of query */
+size_t RamOperationDepthAnalysis::getDepth(const RamOperation* op) const {
+    // visitor
+    class OperationDepthVisitor : public RamVisitor<size_t> {
+    public:
+        // nested operation
+        size_t visitNestedOperation(const RamNestedOperation& nestedOp) override {
+            return 1 + visit(nestedOp.getOperation());
+        }
+
+        // project
+        size_t visitProject(const RamProject& project) override {
+            return 1;
+        }
+
+        // return
+        size_t visitReturn(const RamReturn& ret) override {
+            return 1;
+        }
+    };
+    return OperationDepthVisitor().visit(op);
+}
+
+}  // end of namespace souffle

--- a/src/RamOperationDepth.h
+++ b/src/RamOperationDepth.h
@@ -1,0 +1,39 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2019, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file RamOperationDepth.h
+ *
+ * Get the depth (number of nested operations) of a RAM operation
+ *
+ ***********************************************************************/
+
+#pragma once
+
+#include "RamAnalysis.h"
+#include "RamOperation.h"
+
+namespace souffle {
+
+/*
+ * Class to compute the depth
+ */
+class RamOperationDepthAnalysis : public RamAnalysis {
+public:
+    /** name of analysis */
+    static constexpr const char* name = "operation-depth-analysis";
+
+    /** run depth analysis for a RAM translation unit */
+    void run(const RamTranslationUnit& translationUnit) override {}
+
+    /** get depth */
+    size_t getDepth(const RamOperation* op) const;
+};
+
+}  // end of namespace souffle


### PR DESCRIPTION
- Related to #541
- Follow on from #858

`getDepth()` for RamOperations has now been replaced by a RamOperationDepthAnalysis