### PR TITLE
Refactor RAM transforms #1 (Remove setOperation)

### DIFF
--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -80,11 +80,6 @@ public:
         return *nestedOperation;
     }
 
-    /** Set nested operation */
-    void setOperation(std::unique_ptr<RamOperation> nested) {
-        nestedOperation = std::move(nested);
-    }
-
     /** Print */
     void print(std::ostream& os, int tabpos) const override {
         nestedOperation->print(os, tabpos + 1);


### PR DESCRIPTION
The state of RamNodes should be purely static. The RAM transformers have been rewritten to not use `setOperation()` and it has been removed from the interface.