### PR TITLE
Make a RamNot condition for negated conditions

### DIFF
--- a/src/IndexSetAnalysis.cpp
+++ b/src/IndexSetAnalysis.cpp
@@ -290,12 +290,12 @@ void IndexSetAnalysis::run(const RamTranslationUnit& translationUnit) {
         } else if (const auto* agg = dynamic_cast<const RamAggregate*>(&node)) {
             IndexSet& indexes = getIndexes(agg->getRelation());
             indexes.addSearch(agg->getRangeQueryColumns());
-        } else if (const auto* ne = dynamic_cast<const RamNotExists*>(&node)) {
-            IndexSet& indexes = getIndexes(ne->getRelation());
-            indexes.addSearch(ne->getKey());
-        } else if (const RamProvenanceNotExists* ne = dynamic_cast<const RamProvenanceNotExists*>(&node)) {
-            IndexSet& indexes = getIndexes(ne->getRelation());
-            indexes.addSearch(ne->getKey());
+        } else if (const auto* exists = dynamic_cast<const RamExists*>(&node)) {
+            IndexSet& indexes = getIndexes(exists->getRelation());
+            indexes.addSearch(exists->getKey());
+        } else if (const auto* provExists = dynamic_cast<const RamProvenanceExists*>(&node)) {
+            IndexSet& indexes = getIndexes(provExists->getRelation());
+            indexes.addSearch(provExists->getKey());
         }
     });
 

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -45,7 +45,7 @@ public:
 /**
  * Conjunction
  */
-// TODO (#541): rename to RAMConjunction
+// TODO (#541): rename to RamConjunction
 class RamAnd : public RamCondition {
 protected:
     /** Left-hand side of conjunction */
@@ -77,7 +77,7 @@ public:
         rhs->print(os);
     }
 
-    /** Obtains list of child nodes */
+    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {lhs.get(), rhs.get()};
     }
@@ -101,6 +101,55 @@ protected:
         assert(nullptr != dynamic_cast<const RamAnd*>(&node));
         const auto& other = static_cast<const RamAnd&>(node);
         return getLHS() == other.getLHS() && getRHS() == other.getRHS();
+    }
+};
+
+/**
+ * Negation
+ */
+// TODO (#541): rename to RamNegation
+class RamNot : public RamCondition {
+protected:
+    /** Condition to be negated */
+    std::unique_ptr<RamCondition> operand;
+
+public:
+    RamNot(std::unique_ptr<RamCondition> o) : RamCondition(RN_Not), operand(std::move(o)) {}
+
+    /** Get operand of negation */
+    const RamCondition& getOperand() const {
+        assert(nullptr != operand);
+        return *operand;
+    }
+
+    /** Print */
+    void print(std::ostream& os) const override {
+        os << "not ";
+        operand->print(os);
+    }
+
+    /** Obtain list of child nodes */
+    std::vector<const RamNode*> getChildNodes() const override {
+        return {operand.get()};
+    }
+
+    /** Create clone */
+    RamNot* clone() const override {
+        RamNot* res = new RamNot(std::unique_ptr<RamCondition>(operand->clone()));
+        return res;
+    }
+
+    /** Apply */
+    void apply(const RamNodeMapper& map) override {
+        operand = map(std::move(operand));
+    }
+
+protected:
+    /** Check equality */
+    bool equal(const RamNode& node) const override {
+        assert(nullptr != dynamic_cast<const RamNot*>(&node));
+        const auto& other = static_cast<const RamNot&>(node);
+        return getOperand() == other.getOperand();
     }
 };
 
@@ -191,8 +240,9 @@ protected:
     }
 };
 
-/** Not existence check for a relation */
-class RamNotExists : public RamCondition {
+/** Existence check for a relation */
+// TODO (#541): rename to RamExistenceCheck
+class RamExists : public RamCondition {
 protected:
     /* Relation */
     std::unique_ptr<RamRelationReference> relation;
@@ -202,8 +252,8 @@ protected:
     std::vector<std::unique_ptr<RamValue>> values;
 
 public:
-    RamNotExists(std::unique_ptr<RamRelationReference> rel)
-            : RamCondition(RN_NotExists), relation(std::move(rel)) {}
+    RamExists(std::unique_ptr<RamRelationReference> rel)
+            : RamCondition(RN_Exists), relation(std::move(rel)) {}
 
     /** Get relation */
     const RamRelationReference& getRelation() const {
@@ -265,8 +315,8 @@ public:
     }
 
     /** Create clone */
-    RamNotExists* clone() const override {
-        RamNotExists* res = new RamNotExists(std::unique_ptr<RamRelationReference>(relation->clone()));
+    RamExists* clone() const override {
+        RamExists* res = new RamExists(std::unique_ptr<RamRelationReference>(relation->clone()));
         for (auto& cur : values) {
             RamValue* val = nullptr;
             if (cur != nullptr) {
@@ -290,14 +340,15 @@ public:
 protected:
     /** Check equality */
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamNotExists*>(&node));
-        const auto& other = static_cast<const RamNotExists&>(node);
+        assert(nullptr != dynamic_cast<const RamExists*>(&node));
+        const auto& other = static_cast<const RamExists&>(node);
         return getRelation() == other.getRelation() && equal_targets(values, other.values);
     }
 };
 
-/** Not existence check for a relation for provenance existence check */
-class RamProvenanceNotExists : public RamCondition {
+/** Existence check for a relation for provenance existence check */
+// TODO (#541): rename to RamProvenanceExistenceCheck
+class RamProvenanceExists : public RamCondition {
 protected:
     /* Relation */
     std::unique_ptr<RamRelationReference> relation;
@@ -307,8 +358,8 @@ protected:
     std::vector<std::unique_ptr<RamValue>> values;
 
 public:
-    RamProvenanceNotExists(std::unique_ptr<RamRelationReference> rel)
-            : RamCondition(RN_ProvenanceNotExists), relation(std::move(rel)) {}
+    RamProvenanceExists(std::unique_ptr<RamRelationReference> rel)
+            : RamCondition(RN_ProvenanceExists), relation(std::move(rel)) {}
 
     /** Get relation */
     const RamRelationReference& getRelation() const {
@@ -371,9 +422,9 @@ public:
     }
 
     /** Create clone */
-    RamProvenanceNotExists* clone() const override {
-        RamProvenanceNotExists* res =
-                new RamProvenanceNotExists(std::unique_ptr<RamRelationReference>(relation->clone()));
+    RamProvenanceExists* clone() const override {
+        RamProvenanceExists* res =
+                new RamProvenanceExists(std::unique_ptr<RamRelationReference>(relation->clone()));
         for (auto& cur : values) {
             RamValue* val = nullptr;
             if (cur != nullptr) {
@@ -397,8 +448,8 @@ public:
 protected:
     /** Check equality */
     bool equal(const RamNode& node) const override {
-        assert(dynamic_cast<const RamProvenanceNotExists*>(&node));
-        const auto& other = static_cast<const RamProvenanceNotExists&>(node);
+        assert(dynamic_cast<const RamProvenanceExists*>(&node));
+        const auto& other = static_cast<const RamProvenanceExists&>(node);
         return getRelation() == other.getRelation() && equal_targets(values, other.values);
     }
 };

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -114,7 +114,7 @@ protected:
     std::unique_ptr<RamCondition> operand;
 
 public:
-    RamNot(std::unique_ptr<RamCondition> o) : RamCondition(RN_Not), operand(std::move(o)) {}
+    RamNot(std::unique_ptr<RamCondition> operand) : RamCondition(RN_Not), operand(std::move(operand)) {}
 
     /** Get operand of negation */
     const RamCondition& getOperand() const {

--- a/src/RamConditionLevel.cpp
+++ b/src/RamConditionLevel.cpp
@@ -39,15 +39,20 @@ size_t RamConditionLevelAnalysis::getLevel(const RamCondition* condition) const 
             return std::max(visit(conj.getLHS()), visit(conj.getRHS()));
         }
 
+        // negation
+        size_t visitNot(const RamNot& neg) override {
+            return visit(neg.getOperand());
+        }
+
         // binary constraint
         size_t visitBinaryRelation(const RamBinaryRelation& binRel) override {
             return std::max(rvla->getLevel(binRel.getLHS()), rvla->getLevel(binRel.getRHS()));
         }
 
         // not exists check
-        size_t visitNotExists(const RamNotExists& notExists) override {
+        size_t visitExists(const RamExists& exists) override {
             size_t level = 0;
-            for (const auto& cur : notExists.getValues()) {
+            for (const auto& cur : exists.getValues()) {
                 if (cur) {
                     level = std::max(level, rvla->getLevel(cur));
                 }
@@ -56,9 +61,9 @@ size_t RamConditionLevelAnalysis::getLevel(const RamCondition* condition) const 
         }
 
         // not exists check for a provenance existence check
-        size_t visitProvenanceNotExists(const RamProvenanceNotExists& provNotExists) override {
+        size_t visitProvenanceExists(const RamProvenanceExists& provExists) override {
             size_t level = 0;
-            for (const auto& cur : provNotExists.getValues()) {
+            for (const auto& cur : provExists.getValues()) {
                 if (cur) {
                     level = std::max(level, rvla->getLevel(cur));
                 }

--- a/src/RamNode.h
+++ b/src/RamNode.h
@@ -42,10 +42,11 @@ enum RamNodeType {
     RN_Argument,
 
     // conditions
-    RN_NotExists,
-    RN_ProvenanceNotExists,
+    RN_Exists,
+    RN_ProvenanceExists,
     RN_Empty,
     RN_And,
+    RN_Not,
     RN_BinaryRelation,
 
     // operations

--- a/src/RamOperation.cpp
+++ b/src/RamOperation.cpp
@@ -156,15 +156,20 @@ size_t getLevel(const RamCondition* condition) {
             return std::max(visit(conj.getLHS()), visit(conj.getRHS()));
         }
 
+        // negation
+        size_t visitNot(const RamNot& neg) override {
+            return visit(neg.getOperand());
+        }
+
         // binary constraint
         size_t visitBinaryRelation(const RamBinaryRelation& binRel) override {
             return std::max(getLevel(binRel.getLHS()), getLevel(binRel.getRHS()));
         }
 
         // not exists check
-        size_t visitNotExists(const RamNotExists& notExists) override {
+        size_t visitExists(const RamExists& exists) override {
             size_t level = 0;
-            for (const auto& cur : notExists.getValues()) {
+            for (const auto& cur : exists.getValues()) {
                 if (cur != nullptr) {
                     level = std::max(level, getLevel(cur));
                 }
@@ -173,9 +178,9 @@ size_t getLevel(const RamCondition* condition) {
         }
 
         // not exists check for a provenance existence check
-        size_t visitProvenanceNotExists(const RamProvenanceNotExists& provNotExists) override {
+        size_t visitProvenanceExists(const RamProvenanceExists& provExists) override {
             size_t level = 0;
-            for (const auto& cur : provNotExists.getValues()) {
+            for (const auto& cur : provExists.getValues()) {
                 if (cur != nullptr) {
                     level = std::max(level, getLevel(cur));
                 }

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -412,9 +412,9 @@ bool ConvertExistenceChecksTransformer::convertExistenceChecks(RamProgram& progr
                     });
                 }
                 if (isExistCheck) {
-                    visitDepthFirst(scan->getOperation(), [&](const RamNotExists& notExists) {
+                    visitDepthFirst(scan->getOperation(), [&](const RamExists& exists) {
                         if (isExistCheck) {
-                            for (const RamValue* value : notExists.getValues()) {
+                            for (const RamValue* value : exists.getValues()) {
                                 if (value != nullptr && !context->rcva->isConstant(value) &&
                                         dependsOn(value, identifier)) {
                                     isExistCheck = false;

--- a/src/RamVisitor.h
+++ b/src/RamVisitor.h
@@ -89,9 +89,10 @@ struct RamVisitor : public ram_visitor_tag {
 
             // conditions
             FORWARD(Empty);
-            FORWARD(NotExists);
-            FORWARD(ProvenanceNotExists);
+            FORWARD(Exists);
+            FORWARD(ProvenanceExists);
             FORWARD(And);
+            FORWARD(Not);
             FORWARD(BinaryRelation);
 
             // operations
@@ -197,9 +198,10 @@ protected:
 
     // -- conditions --
     LINK(And, Condition)
+    LINK(Not, Condition)
     LINK(BinaryRelation, Condition)
-    LINK(NotExists, Condition)
-    LINK(ProvenanceNotExists, Condition)
+    LINK(Exists, Condition)
+    LINK(ProvenanceExists, Condition)
     LINK(Empty, Condition)
 
     LINK(Condition, Node)


### PR DESCRIPTION
Related to #541

This PR introduces a `RamNot` class for negating RAM conditions, i.e. instead of a `RamNotExists` condition we now create a `RamNot(RamExists)` object as nested conditions.

This sets up the groundwork for a future PR where `ConvertExistenceChecksTransformer` will convert existence check scans to RAM filters, without needing a new RAM operation or relying on a flag.