### PR TITLE
Remove input/output/computed/printsize from relations

### DIFF
--- a/src/AstRelation.h
+++ b/src/AstRelation.h
@@ -147,6 +147,25 @@ public:
         } else if (q & BTREE_RELATION) {
             representation = RelationRepresentation::BTREE;
         }
+
+        if (q & INPUT_RELATION) {
+            ioDirectives.push_back(std::make_unique<AstIODirective>());
+            ioDirectives.back()->setAsInput();
+            ioDirectives.back()->setName(getName());
+            ioDirectives.back()->setSrcLoc(getSrcLoc());
+        }
+        if (q & OUTPUT_RELATION) {
+            ioDirectives.push_back(std::make_unique<AstIODirective>());
+            ioDirectives.back()->setAsOutput();
+            ioDirectives.back()->setName(getName());
+            ioDirectives.back()->setSrcLoc(getSrcLoc());
+        }
+        if (q & PRINTSIZE_RELATION) {
+            ioDirectives.push_back(std::make_unique<AstIODirective>());
+            ioDirectives.back()->setAsPrintSize();
+            ioDirectives.back()->setName(getName());
+            ioDirectives.back()->setSrcLoc(getSrcLoc());
+        }
     }
 
     /** Get representation for this relation */
@@ -160,17 +179,32 @@ public:
 
     /** Check whether relation is an output relation */
     bool isOutput() const {
-        return (qualifier & OUTPUT_RELATION) != 0;
+        for (const auto& directive : ioDirectives) {
+            if (directive->isOutput()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** Check whether relation is an input relation */
     bool isInput() const {
-        return (qualifier & INPUT_RELATION) != 0;
+        for (const auto& directive : ioDirectives) {
+            if (directive->isInput()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** Check whether relation is an input relation */
     bool isPrintSize() const {
-        return (qualifier & PRINTSIZE_RELATION) != 0;
+        for (const auto& directive : ioDirectives) {
+            if (directive->isPrintSize()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** Check whether relation is an output relation */
@@ -329,14 +363,6 @@ public:
 
     void addIODirectives(std::unique_ptr<AstIODirective> directive) {
         assert(directive && "Undefined directive");
-        // Make sure the old style qualifiers still work.
-        if (directive->isInput()) {
-            qualifier |= INPUT_RELATION;
-        } else if (directive->isOutput()) {
-            qualifier |= OUTPUT_RELATION;
-        } else if (directive->isPrintSize()) {
-            qualifier |= PRINTSIZE_RELATION;
-        }
         ioDirectives.push_back(std::move(directive));
     }
 

--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -1023,22 +1023,15 @@ void AstSemanticChecker::checkInlining(
         ErrorReport& report, const AstProgram& program, const PrecedenceGraph& precedenceGraph) {
     // Find all inlined relations
     AstRelationSet inlinedRelations;
-    visitDepthFirst(program, [&](const AstRelation& relation) {
-        if (relation.isInline()) {
-            inlinedRelations.insert(&relation);
-
-            // Inlined relations cannot be computed or input relations
-            if (relation.isComputed()) {
-                report.addError("Computed relation " + toString(relation.getName()) + " cannot be inlined",
-                        relation.getSrcLoc());
-            }
-
-            if (relation.isInput()) {
-                report.addError("Input relation " + toString(relation.getName()) + " cannot be inlined",
-                        relation.getSrcLoc());
+    for (const auto& relation : program.getRelations()) {
+        if (relation->isInline()) {
+            inlinedRelations.insert(relation);
+            if (!relation->getIODirectives().empty()) {
+                report.addError("IO relation " + toString(relation->getName()) + " cannot be inlined",
+                        relation->getSrcLoc());
             }
         }
-    });
+    }
 
     // Check 1:
     // Let G' be the subgraph of the precedence graph G containing only those nodes

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -198,12 +198,12 @@ std::vector<IODirectives> AstTranslator::getOutputIODirectives(
 
 std::unique_ptr<RamRelationReference> AstTranslator::createRelationReference(const std::string name,
         const size_t arity, const std::vector<std::string> attributeNames,
-        const std::vector<std::string> attributeTypeQualifiers, const SymbolMask mask, const bool input,
-        const bool output, const RelationRepresentation representation) {
+        const std::vector<std::string> attributeTypeQualifiers, const SymbolMask mask,
+        const RelationRepresentation representation) {
     const RamRelation* ramRel = ramProg->getRelation(name);
     if (ramRel == nullptr) {
         ramProg->addRelation(std::make_unique<RamRelation>(
-                name, arity, attributeNames, attributeTypeQualifiers, mask, input, output, representation));
+                name, arity, attributeNames, attributeTypeQualifiers, mask, representation));
         ramRel = ramProg->getRelation(name);
         assert(ramRel != nullptr && "cannot find relation");
     }
@@ -212,7 +212,7 @@ std::unique_ptr<RamRelationReference> AstTranslator::createRelationReference(con
 
 std::unique_ptr<RamRelationReference> AstTranslator::createRelationReference(
         const std::string name, const size_t arity) {
-    return createRelationReference(name, arity, {}, {}, SymbolMask(arity), false, false, {});
+    return createRelationReference(name, arity, {}, {}, SymbolMask(arity), {});
 }
 
 std::unique_ptr<RamRelationReference> AstTranslator::translateRelation(const AstAtom* atom) {
@@ -236,8 +236,7 @@ std::unique_ptr<RamRelationReference> AstTranslator::translateRelation(
     }
 
     return createRelationReference(relationNamePrefix + getRelationName(rel->getName()), rel->getArity(),
-            attributeNames, attributeTypeQualifiers, getSymbolMask(*rel), rel->isInput(), rel->isOutput(),
-            rel->getRepresentation());
+            attributeNames, attributeTypeQualifiers, getSymbolMask(*rel), rel->getRepresentation());
 }
 
 std::unique_ptr<RamRelationReference> AstTranslator::translateDeltaRelation(const AstRelation* rel) {

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -199,11 +199,11 @@ std::vector<IODirectives> AstTranslator::getOutputIODirectives(
 std::unique_ptr<RamRelationReference> AstTranslator::createRelationReference(const std::string name,
         const size_t arity, const std::vector<std::string> attributeNames,
         const std::vector<std::string> attributeTypeQualifiers, const SymbolMask mask, const bool input,
-        const bool computed, const bool output, const RelationRepresentation structure) {
+        const bool output, const RelationRepresentation representation) {
     const RamRelation* ramRel = ramProg->getRelation(name);
     if (ramRel == nullptr) {
-        ramProg->addRelation(std::make_unique<RamRelation>(name, arity, attributeNames,
-                attributeTypeQualifiers, mask, input, computed, output, structure));
+        ramProg->addRelation(std::make_unique<RamRelation>(
+                name, arity, attributeNames, attributeTypeQualifiers, mask, input, output, representation));
         ramRel = ramProg->getRelation(name);
         assert(ramRel != nullptr && "cannot find relation");
     }
@@ -212,7 +212,7 @@ std::unique_ptr<RamRelationReference> AstTranslator::createRelationReference(con
 
 std::unique_ptr<RamRelationReference> AstTranslator::createRelationReference(
         const std::string name, const size_t arity) {
-    return createRelationReference(name, arity, {}, {}, SymbolMask(arity), false, false, false, {});
+    return createRelationReference(name, arity, {}, {}, SymbolMask(arity), false, false, {});
 }
 
 std::unique_ptr<RamRelationReference> AstTranslator::translateRelation(const AstAtom* atom) {
@@ -236,8 +236,8 @@ std::unique_ptr<RamRelationReference> AstTranslator::translateRelation(
     }
 
     return createRelationReference(relationNamePrefix + getRelationName(rel->getName()), rel->getArity(),
-            attributeNames, attributeTypeQualifiers, getSymbolMask(*rel), rel->isInput(), rel->isComputed(),
-            rel->isOutput(), rel->getRepresentation());
+            attributeNames, attributeTypeQualifiers, getSymbolMask(*rel), rel->isInput(), rel->isOutput(),
+            rel->getRepresentation());
 }
 
 std::unique_ptr<RamRelationReference> AstTranslator::translateDeltaRelation(const AstRelation* rel) {

--- a/src/AstTranslator.h
+++ b/src/AstTranslator.h
@@ -288,7 +288,7 @@ private:
     std::unique_ptr<RamRelationReference> createRelationReference(const std::string name, const size_t arity,
             const std::vector<std::string> attributeNames,
             const std::vector<std::string> attributeTypeQualifiers, const SymbolMask mask, const bool input,
-            const bool computed, const bool output, const RelationRepresentation structure);
+            const bool output, const RelationRepresentation structure);
 
     /** create a reference to a RAM relation */
     std::unique_ptr<RamRelationReference> createRelationReference(const std::string name, const size_t arity);

--- a/src/AstTranslator.h
+++ b/src/AstTranslator.h
@@ -287,8 +287,8 @@ private:
     /** create a reference to a RAM relation */
     std::unique_ptr<RamRelationReference> createRelationReference(const std::string name, const size_t arity,
             const std::vector<std::string> attributeNames,
-            const std::vector<std::string> attributeTypeQualifiers, const SymbolMask mask, const bool input,
-            const bool output, const RelationRepresentation structure);
+            const std::vector<std::string> attributeTypeQualifiers, const SymbolMask mask,
+            const RelationRepresentation structure);
 
     /** create a reference to a RAM relation */
     std::unique_ptr<RamRelationReference> createRelationReference(const std::string name, const size_t arity);

--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -67,7 +67,7 @@ inline souffle::SouffleProgram* getInstance(const char* p) {
 /**
  * Relation wrapper used internally in the generated Datalog program
  */
-template <uint32_t id, class RelType, class TupleType, size_t Arity, bool IsInputRel, bool IsOutputRel>
+template <uint32_t id, class RelType, class TupleType, size_t Arity>
 class RelationWrapper : public Relation {
 private:
     RelType& relation;
@@ -130,12 +130,6 @@ public:
             t[i] = arg[i];
         }
         return relation.contains(t);
-    }
-    bool isInput() const override {
-        return IsInputRel;
-    }
-    bool isOutput() const override {
-        return IsOutputRel;
     }
     std::size_t size() override {
         return relation.size();

--- a/src/MagicSet.cpp
+++ b/src/MagicSet.cpp
@@ -727,9 +727,10 @@ void Adornment::run(const AstTranslationUnit& translationUnit) {
         AstRelationIdentifier relName = rel->getName();
 
         // find computed relations for the topdown part
-        if (rel->isComputed()) {
+        if (rel->isOutput() || rel->isPrintSize()) {
             outputQueries.push_back(rel->getName());
-            adornmentRelations.push_back(rel->getName());  // add relation to adornment
+            // add relation to adornment
+            adornmentRelations.push_back(rel->getName());
         }
 
         // check whether edb or idb

--- a/src/PrecedenceGraph.cpp
+++ b/src/PrecedenceGraph.cpp
@@ -79,10 +79,9 @@ void RedundantRelations::run(const AstTranslationUnit& translationUnit) {
     std::set<const AstRelation*> notRedundant;
 
     const std::vector<AstRelation*>& relations = translationUnit.getProgram()->getRelations();
-
     /* Add all output relations to the work set */
     for (const AstRelation* r : relations) {
-        if (r->isComputed()) {
+        if (r->isOutput() || r->isPrintSize()) {
             work.insert(r);
         }
     }

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -55,20 +55,19 @@ protected:
 
     /** Relation qualifiers */
     // TODO: Simplify interface
-    const bool input;     // input relation
-    const bool output;    // output relation
-    const bool computed;  // either output or printed
+    const bool input;   // input relation
+    const bool output;  // output relation
 
     const RelationRepresentation representation;
 
 public:
     RamRelation(const std::string name, const size_t arity, const std::vector<std::string> attributeNames,
             const std::vector<std::string> attributeTypeQualifiers, const SymbolMask mask, const bool input,
-            const bool computed, const bool output, const RelationRepresentation representation)
+            const bool output, const RelationRepresentation representation)
             : RamNode(RN_Relation), name(std::move(name)), arity(arity),
               attributeNames(std::move(attributeNames)),
               attributeTypeQualifiers(std::move(attributeTypeQualifiers)), mask(std::move(mask)),
-              input(input), output(output), computed(computed), representation(representation) {
+              input(input), output(output), representation(representation) {
         assert(this->attributeNames.size() == arity || this->attributeNames.empty());
         assert(this->attributeTypeQualifiers.size() == arity || this->attributeTypeQualifiers.empty());
     }
@@ -101,11 +100,6 @@ public:
     /** Is input relation */
     const bool isInput() const {
         return input;
-    }
-
-    /** Is relation computed */
-    const bool isComputed() const {
-        return computed;
     }
 
     /** Is output relation */
@@ -163,8 +157,8 @@ public:
 
     /** Create clone */
     RamRelation* clone() const override {
-        RamRelation* res = new RamRelation(name, arity, attributeNames, attributeTypeQualifiers, mask, input,
-                computed, output, representation);
+        RamRelation* res = new RamRelation(
+                name, arity, attributeNames, attributeTypeQualifiers, mask, input, output, representation);
         return res;
     }
 
@@ -227,11 +221,6 @@ public:
     /** Is input relation */
     const bool isInput() const {
         return relation->isInput();
-    }
-
-    /** Is computed relation */
-    const bool isComputed() const {
-        return relation->isComputed();
     }
 
     /** Is output relation */

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -53,21 +53,16 @@ protected:
     /** TODO (#541): legacy, i.e., duplicated information */
     const SymbolMask mask;
 
-    /** Relation qualifiers */
-    // TODO: Simplify interface
-    const bool input;   // input relation
-    const bool output;  // output relation
-
     const RelationRepresentation representation;
 
 public:
     RamRelation(const std::string name, const size_t arity, const std::vector<std::string> attributeNames,
-            const std::vector<std::string> attributeTypeQualifiers, const SymbolMask mask, const bool input,
-            const bool output, const RelationRepresentation representation)
+            const std::vector<std::string> attributeTypeQualifiers, const SymbolMask mask,
+            const RelationRepresentation representation)
             : RamNode(RN_Relation), name(std::move(name)), arity(arity),
               attributeNames(std::move(attributeNames)),
               attributeTypeQualifiers(std::move(attributeTypeQualifiers)), mask(std::move(mask)),
-              input(input), output(output), representation(representation) {
+              representation(representation) {
         assert(this->attributeNames.size() == arity || this->attributeNames.empty());
         assert(this->attributeTypeQualifiers.size() == arity || this->attributeTypeQualifiers.empty());
     }
@@ -95,16 +90,6 @@ public:
     /** Get symbol mask */
     const SymbolMask& getSymbolMask() const {
         return mask;
-    }
-
-    /** Is input relation */
-    const bool isInput() const {
-        return input;
-    }
-
-    /** Is output relation */
-    const bool isOutput() const {
-        return output;
     }
 
     /** Is nullary relation */
@@ -157,8 +142,8 @@ public:
 
     /** Create clone */
     RamRelation* clone() const override {
-        RamRelation* res = new RamRelation(
-                name, arity, attributeNames, attributeTypeQualifiers, mask, input, output, representation);
+        RamRelation* res =
+                new RamRelation(name, arity, attributeNames, attributeTypeQualifiers, mask, representation);
         return res;
     }
 
@@ -172,7 +157,6 @@ protected:
         const auto& other = static_cast<const RamRelation&>(node);
         return name == other.name && arity == other.arity && attributeNames == other.attributeNames &&
                attributeTypeQualifiers == other.attributeTypeQualifiers && mask == other.mask &&
-               isInput() == other.isInput() && isOutput() == other.isOutput() &&
                representation == other.representation && isTemp() == other.isTemp();
     }
 };
@@ -216,16 +200,6 @@ public:
     /** Is temp relation */
     const bool isTemp() const {
         return relation->isTemp();
-    }
-
-    /** Is input relation */
-    const bool isInput() const {
-        return relation->isInput();
-    }
-
-    /** Is output relation */
-    const bool isOutput() const {
-        return relation->isOutput();
     }
 
     /** Get symbol mask */

--- a/src/SouffleInterface.h
+++ b/src/SouffleInterface.h
@@ -110,8 +110,6 @@ public:
     virtual std::size_t size() = 0;
 
     // properties
-    virtual bool isOutput() const = 0;
-    virtual bool isInput() const = 0;
     virtual std::string getName() const = 0;
     virtual const char* getAttrType(size_t) const = 0;
     virtual const char* getAttrName(size_t) const = 0;

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1675,14 +1675,14 @@ void Synthesiser::generateCode(
         os << "// -- Table: " << raw_name << "\n";
 
         os << "std::unique_ptr<" << type << "> " << name << " = std::make_unique<" << type << ">();\n";
-        if ((rel.isInput() || rel.isComputed() || Global::config().has("provenance")) && !rel.isTemp()) {
+        if ((rel.isInput() || rel.isOutput() || Global::config().has("provenance")) && !rel.isTemp()) {
             os << "souffle::RelationWrapper<";
             os << relCtr++ << ",";
             os << type << ",";
             os << "Tuple<RamDomain," << arity << ">,";
             os << arity << ",";
             os << (rel.isInput() ? "true" : "false") << ",";
-            os << (rel.isComputed() ? "true" : "false");
+            os << (rel.isOutput() ? "true" : "false");
             os << "> wrapper_" << name << ";\n";
 
             // construct types

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1655,6 +1655,14 @@ void Synthesiser::generateCode(
     std::string registerRel;  // registration of relations
     int relCtr = 0;
     std::string tempType;  // string to hold the type of the temporary relations
+    std::set<std::string> storeRelations;
+    std::set<std::string> loadRelations;
+    visitDepthFirst(*(prog.getMain()),
+            [&](const RamStore& store) { storeRelations.insert(store.getRelation().getName()); });
+    visitDepthFirst(*(prog.getMain()),
+            [&](const RamPrintSize& size) { storeRelations.insert(size.getRelation().getName()); });
+    visitDepthFirst(*(prog.getMain()),
+            [&](const RamLoad& load) { loadRelations.insert(load.getRelation().getName()); });
     visitDepthFirst(*(prog.getMain()), [&](const RamCreate& create) {
         // get some table details
         const auto& rel = create.getRelation();
@@ -1675,14 +1683,14 @@ void Synthesiser::generateCode(
         os << "// -- Table: " << raw_name << "\n";
 
         os << "std::unique_ptr<" << type << "> " << name << " = std::make_unique<" << type << ">();\n";
-        if ((rel.isInput() || rel.isOutput() || Global::config().has("provenance")) && !rel.isTemp()) {
+        if ((loadRelations.count(rel.getName()) > 0 || storeRelations.count(rel.getName()) > 0 ||
+                    Global::config().has("provenance")) &&
+                !rel.isTemp()) {
             os << "souffle::RelationWrapper<";
             os << relCtr++ << ",";
             os << type << ",";
             os << "Tuple<RamDomain," << arity << ">,";
-            os << arity << ",";
-            os << (rel.isInput() ? "true" : "false") << ",";
-            os << (rel.isOutput() ? "true" : "false");
+            os << arity;
             os << "> wrapper_" << name << ";\n";
 
             // construct types
@@ -1708,8 +1716,11 @@ void Synthesiser::generateCode(
             }
             initCons += "\nwrapper_" + name + "(" + "*" + name + ",symTable,\"" + raw_name + "\"," +
                         tupleType + "," + tupleName + ")";
-            registerRel += "addRelation(\"" + raw_name + "\",&wrapper_" + name + "," +
-                           std::to_string(rel.isInput()) + "," + std::to_string(rel.isOutput()) + ");\n";
+            registerRel += "addRelation(\"" + raw_name + "\",&wrapper_" + name + ",";
+            registerRel += (loadRelations.count(rel.getName()) > 0) ? "true" : "false";
+            registerRel += ",";
+            registerRel += (storeRelations.count(rel.getName()) > 0) ? "true" : "false";
+            registerRel += ");\n";
         }
     });
 

--- a/src/test/matching_test.cpp
+++ b/src/test/matching_test.cpp
@@ -29,7 +29,7 @@
 using namespace std;
 using namespace souffle;
 
-RamRelation r("test", 0, {}, {}, SymbolMask(0), false, false, false, {});
+RamRelation r("test", 0, {}, {}, SymbolMask(0), false, false, {});
 RamRelationReference rel(&r);
 class TestAutoIndex : public IndexSet {
 public:

--- a/src/test/matching_test.cpp
+++ b/src/test/matching_test.cpp
@@ -29,7 +29,7 @@
 using namespace std;
 using namespace souffle;
 
-RamRelation r("test", 0, {}, {}, SymbolMask(0), false, false, {});
+RamRelation r("test", 0, {}, {}, SymbolMask(0), {});
 RamRelationReference rel(&r);
 class TestAutoIndex : public IndexSet {
 public:

--- a/tests/semantic/inline_output/inline_output.err
+++ b/tests/semantic/inline_output/inline_output.err
@@ -1,4 +1,4 @@
-Error: Computed relation b cannot be inlined in file inline_output.dl at line 12
+Error: IO relation b cannot be inlined in file inline_output.dl at line 12
 .decl b(x:number, y:number) inline
 ------^----------------------------
 1 errors generated, evaluation aborted


### PR DESCRIPTION
Remove IO information from relations and use the AST/RAM instead.

AstIODirectives are children of AstRelations, similar to AstClauses, so some IO related methods remain there. IO related qualifiers are also still handled, but will be removed when the long deprecated qualifiers are.

A followup PR will split AstIODirective into AstLoad and AstStore to match RamLoad/RamStore which will simplify things further.