### PR TITLE
Make translationUnit a member variable of Synthesiser

### DIFF
--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1476,14 +1476,13 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
     CodeEmitter(*this).visit(stmt, out);
 }
 
-void Synthesiser::generateCode(
-        const RamTranslationUnit& unit, std::ostream& os, const std::string& id, bool& withSharedLibrary) {
+void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& withSharedLibrary) {
     // ---------------------------------------------------------------
     //                      Auto-Index Generation
     // ---------------------------------------------------------------
-    const SymbolTable& symTable = unit.getSymbolTable();
-    const RamProgram& prog = unit.getP();
-    auto* idxAnalysis = unit.getAnalysis<IndexSetAnalysis>();
+    const SymbolTable& symTable = translationUnit.getSymbolTable();
+    const RamProgram& prog = translationUnit.getP();
+    auto* idxAnalysis = translationUnit.getAnalysis<IndexSetAnalysis>();
 
     // ---------------------------------------------------------------
     //                      Code Generation

--- a/src/Synthesiser.h
+++ b/src/Synthesiser.h
@@ -36,6 +36,9 @@ class RamTranslationUnit;
  */
 class Synthesiser {
 private:
+    /** RAM translation unit */
+    RamTranslationUnit& translationUnit;
+
     /** RAM identifier to C++ identifier map */
     std::map<const std::string, const std::string> identifiers;
 
@@ -83,11 +86,10 @@ protected:
     size_t lookupReadIdx(const std::string& txt);
 
 public:
-    Synthesiser() = default;
+    Synthesiser(RamTranslationUnit& tUnit) : translationUnit(tUnit) {}
     virtual ~Synthesiser() = default;
 
     /** Generate code */
-    void generateCode(
-            const RamTranslationUnit& tu, std::ostream& os, const std::string& id, bool& withSharedLibrary);
+    void generateCode(std::ostream& os, const std::string& id, bool& withSharedLibrary);
 };
 }  // end of namespace souffle

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -550,7 +550,7 @@ int main(int argc, char** argv) {
         }
         compileCmd += " ";
 
-        std::unique_ptr<Synthesiser> synthesiser = std::make_unique<Synthesiser>();
+        std::unique_ptr<Synthesiser> synthesiser = std::make_unique<Synthesiser>(*ramTranslationUnit);
 
         try {
             // Find the base filename for code generation and execution
@@ -575,7 +575,7 @@ int main(int argc, char** argv) {
 
             bool withSharedLibrary;
             std::ofstream os(sourceFilename);
-            synthesiser->generateCode(*ramTranslationUnit, os, baseIdentifier, withSharedLibrary);
+            synthesiser->generateCode(os, baseIdentifier, withSharedLibrary);
             os.close();
 
             if (withSharedLibrary) {


### PR DESCRIPTION
Gives [Interpreter](https://github.com/brodyf/souffle/blob/a0cde9b4ebd96f08075c470b694639c76a2bed91/src/main.cpp#L515) and Synthesiser the same constructor interface.

This lets the [CodeEmitter](https://github.com/brodyf/souffle/blob/a0cde9b4ebd96f08075c470b694639c76a2bed91/src/Synthesiser.cpp#L189) use RAM analyses if ever required.