### PR TITLE
Rename RamBinaryRelation -> RamConstraint

### DIFF
--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -355,7 +355,7 @@ bool Interpreter::evalCond(const RamCondition& cond, const InterpreterContext& c
         }
 
         // -- comparison operators --
-        bool visitBinaryRelation(const RamBinaryRelation& relOp) override {
+        bool visitConstraint(const RamConstraint& relOp) override {
             RamDomain lhs = interpreter.evalVal(*relOp.getLHS(), ctxt);
             RamDomain rhs = interpreter.evalVal(*relOp.getRHS(), ctxt);
             switch (relOp.getOperator()) {

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -156,8 +156,7 @@ protected:
 /**
  * Binary constraint
  */
-// TODO (#541): rename to RamConstraint
-class RamBinaryRelation : public RamCondition {
+class RamConstraint : public RamCondition {
 private:
     /** Operator */
     BinaryConstraintOp op;
@@ -169,8 +168,8 @@ private:
     std::unique_ptr<RamValue> rhs;
 
 public:
-    RamBinaryRelation(BinaryConstraintOp op, std::unique_ptr<RamValue> l, std::unique_ptr<RamValue> r)
-            : RamCondition(RN_BinaryRelation), op(op), lhs(std::move(l)), rhs(std::move(r)) {}
+    RamConstraint(BinaryConstraintOp op, std::unique_ptr<RamValue> l, std::unique_ptr<RamValue> r)
+            : RamCondition(RN_Constraint), op(op), lhs(std::move(l)), rhs(std::move(r)) {}
 
     /** Print */
     void print(std::ostream& os) const override {
@@ -198,15 +197,6 @@ public:
         return std::move(rhs);
     }
 
-    /** Set left-hand side */
-    void setLHS(std::unique_ptr<RamValue> l) {
-        lhs.swap(l);
-    }
-    /** Set right-hand side */
-    void setRHS(std::unique_ptr<RamValue> r) {
-        rhs.swap(r);
-    }
-
     /** Get operator symbol */
     BinaryConstraintOp getOperator() const {
         return op;
@@ -218,8 +208,8 @@ public:
     }
 
     /** Create clone */
-    RamBinaryRelation* clone() const override {
-        RamBinaryRelation* res = new RamBinaryRelation(
+    RamConstraint* clone() const override {
+        RamConstraint* res = new RamConstraint(
                 op, std::unique_ptr<RamValue>(lhs->clone()), std::unique_ptr<RamValue>(rhs->clone()));
         return res;
     }
@@ -233,8 +223,8 @@ public:
 protected:
     /** Check equality */
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamBinaryRelation*>(&node));
-        const auto& other = static_cast<const RamBinaryRelation&>(node);
+        assert(nullptr != dynamic_cast<const RamConstraint*>(&node));
+        const auto& other = static_cast<const RamConstraint&>(node);
         return getOperator() == other.getOperator() && getLHS() == other.getLHS() &&
                getRHS() == other.getRHS();
     }

--- a/src/RamConditionLevel.cpp
+++ b/src/RamConditionLevel.cpp
@@ -45,7 +45,7 @@ size_t RamConditionLevelAnalysis::getLevel(const RamCondition* condition) const 
         }
 
         // binary constraint
-        size_t visitBinaryRelation(const RamBinaryRelation& binRel) override {
+        size_t visitConstraint(const RamConstraint& binRel) override {
             return std::max(rvla->getLevel(binRel.getLHS()), rvla->getLevel(binRel.getRHS()));
         }
 

--- a/src/RamNode.h
+++ b/src/RamNode.h
@@ -47,7 +47,7 @@ enum RamNodeType {
     RN_Empty,
     RN_And,
     RN_Not,
-    RN_BinaryRelation,
+    RN_Constraint,
 
     // operations
     RN_Project,

--- a/src/RamOperation.cpp
+++ b/src/RamOperation.cpp
@@ -162,7 +162,7 @@ size_t getLevel(const RamCondition* condition) {
         }
 
         // binary constraint
-        size_t visitBinaryRelation(const RamBinaryRelation& binRel) override {
+        size_t visitConstraint(const RamConstraint& binRel) override {
             return std::max(getLevel(binRel.getLHS()), getLevel(binRel.getRHS()));
         }
 
@@ -198,7 +198,7 @@ size_t getLevel(const RamCondition* condition) {
 
 /** get indexable element */
 std::unique_ptr<RamValue> RamAggregate::getIndexElement(RamCondition* c, size_t& element, size_t level) {
-    if (auto* binRelOp = dynamic_cast<RamBinaryRelation*>(c)) {
+    if (auto* binRelOp = dynamic_cast<RamConstraint*>(c)) {
         if (binRelOp->getOperator() == BinaryConstraintOp::EQ) {
             if (auto* lhs = dynamic_cast<RamElementAccess*>(binRelOp->getLHS())) {
                 RamValue* rhs = binRelOp->getRHS();
@@ -242,13 +242,13 @@ void RamAggregate::addCondition(std::unique_ptr<RamCondition> newCondition) {
                     }
                 };
 
-                addCondition(std::make_unique<RamBinaryRelation>(
+                addCondition(std::make_unique<RamConstraint>(
                         BinaryConstraintOp::EQ, std::move(field), std::move(value)));
             }
         } else {
             std::unique_ptr<RamValue> field(new RamElementAccess(getIdentifier(), element));
             std::unique_ptr<RamCondition> eq(
-                    new RamBinaryRelation(BinaryConstraintOp::EQ, std::move(field), std::move(value)));
+                    new RamConstraint(BinaryConstraintOp::EQ, std::move(field), std::move(value)));
             if (condition != nullptr) {
                 condition = std::make_unique<RamAnd>(std::move(condition), std::move(eq));
             } else {

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -167,7 +167,7 @@ bool LevelConditionsTransformer::levelConditions(RamProgram& program) {
 /** Get indexable element */
 std::unique_ptr<RamValue> CreateIndicesTransformer::getIndexElement(
         RamCondition* c, size_t& element, size_t identifier) {
-    if (auto* binRelOp = dynamic_cast<RamBinaryRelation*>(c)) {
+    if (auto* binRelOp = dynamic_cast<RamConstraint*>(c)) {
         if (binRelOp->getOperator() == BinaryConstraintOp::EQ) {
             if (auto* lhs = dynamic_cast<RamElementAccess*>(binRelOp->getLHS())) {
                 RamValue* rhs = binRelOp->getRHS();
@@ -340,7 +340,7 @@ bool ConvertExistenceChecksTransformer::convertExistenceChecks(RamProgram& progr
         }
 
         bool dependsOn(const RamCondition* condition, const size_t identifier) const {
-            if (const auto* binRel = dynamic_cast<const RamBinaryRelation*>(condition)) {
+            if (const auto* binRel = dynamic_cast<const RamConstraint*>(condition)) {
                 return dependsOn(binRel->getLHS(), identifier) || dependsOn(binRel->getRHS(), identifier);
             }
             return false;

--- a/src/RamVisitor.h
+++ b/src/RamVisitor.h
@@ -93,7 +93,7 @@ struct RamVisitor : public ram_visitor_tag {
             FORWARD(ProvenanceExists);
             FORWARD(And);
             FORWARD(Not);
-            FORWARD(BinaryRelation);
+            FORWARD(Constraint);
 
             // operations
             FORWARD(Filter);
@@ -199,7 +199,7 @@ protected:
     // -- conditions --
     LINK(And, Condition)
     LINK(Not, Condition)
-    LINK(BinaryRelation, Condition)
+    LINK(Constraint, Condition)
     LINK(Exists, Condition)
     LINK(ProvenanceExists, Condition)
     LINK(Empty, Condition)

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -956,7 +956,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitBinaryRelation(const RamBinaryRelation& rel, std::ostream& out) override {
+        void visitConstraint(const RamConstraint& rel, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             switch (rel.getOperator()) {
                 // comparison operators


### PR DESCRIPTION
Related to #541

This PR introduces no new functionality except addressing a TODO and note from @b-scholz.

This PR also removes the methods `setLHS()` and `setRHS()` since Ram nodes should be static and they weren't being used anywhere.