### PR TITLE
Remove filter relation and non-const methods from RamProject

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -532,11 +532,13 @@ void AstTranslator::ClauseTranslator::createValueIndex(const AstClause& clause) 
 std::unique_ptr<RamOperation> AstTranslator::ClauseTranslator::createOperation(const AstClause& clause) {
     const auto head = clause.getHead();
 
-    std::unique_ptr<RamProject> project = std::make_unique<RamProject>(translator.translateRelation(head));
-
+    std::vector<std::unique_ptr<RamValue>> values;
     for (AstArgument* arg : head->getArguments()) {
-        project->addArg(translator.translateValue(arg, valueIndex));
+        values.push_back(translator.translateValue(arg, valueIndex));
     }
+
+    std::unique_ptr<RamProject> project =
+            std::make_unique<RamProject>(translator.translateRelation(head), std::move(values));
 
     // check existence for original tuple if we have provenance
     // only if we don't compile

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -909,21 +909,9 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                     << join(project.getValues(), "),static_cast<RamDomain>(", rec) << ")}});\n";
             }
 
-            // check filter
-            if (project.hasFilter()) {
-                auto relFilter = synthesiser.getRelationName(project.getFilter());
-                auto ctxFilter = "READ_OP_CONTEXT(" + synthesiser.getOpContextName(project.getFilter()) + ")";
-                out << "if (!" << relFilter << ".contains(tuple," << ctxFilter << ")) {";
-            }
-
             // insert tuple
             out << relName << "->"
                 << "insert(tuple," << ctxName << ");\n";
-
-            // end filter
-            if (project.hasFilter()) {
-                out << "}";
-            }
 
             PRINT_END_COMMENT(out);
         }


### PR DESCRIPTION
The functionality for the `filter` attribute is not being used and should be expressed via a `RamFilter` if it was.