### PR TITLE
Move getRangeQueryColumns() into a RAM analysis

### DIFF
--- a/src/IndexSetAnalysis.cpp
+++ b/src/IndexSetAnalysis.cpp
@@ -17,6 +17,7 @@
 #include "IndexSetAnalysis.h"
 #include "Global.h"
 #include "RamCondition.h"
+#include "RamIndexScanKeys.h"
 #include "RamNode.h"
 #include "RamOperation.h"
 #include "RamTranslationUnit.h"
@@ -286,7 +287,8 @@ void IndexSetAnalysis::run(const RamTranslationUnit& translationUnit) {
     visitDepthFirst(translationUnit.getP(), [&](const RamNode& node) {
         if (const auto* indexScan = dynamic_cast<const RamIndexScan*>(&node)) {
             IndexSet& indexes = getIndexes(indexScan->getRelation());
-            indexes.addSearch(indexScan->getRangeQueryColumns());
+            indexes.addSearch(
+                    translationUnit.getAnalysis<RamIndexScanKeysAnalysis>()->getRangeQueryColumns(indexScan));
         } else if (const auto* agg = dynamic_cast<const RamAggregate*>(&node)) {
             IndexSet& indexes = getIndexes(agg->getRelation());
             indexes.addSearch(agg->getRangeQueryColumns());

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -26,6 +26,7 @@
 #include "Logger.h"
 #include "ParallelUtils.h"
 #include "ProfileEvent.h"
+#include "RamIndexScanKeys.h"
 #include "RamNode.h"
 #include "RamOperation.h"
 #include "RamOperationDepth.h"
@@ -435,9 +436,12 @@ void Interpreter::evalOp(const RamOperation& op, const InterpreterContext& args)
     class OperationEvaluator : public RamVisitor<void> {
         Interpreter& interpreter;
         InterpreterContext& ctxt;
+        RamIndexScanKeysAnalysis* keysAnalysis;
 
     public:
-        OperationEvaluator(Interpreter& interp, InterpreterContext& ctxt) : interpreter(interp), ctxt(ctxt) {}
+        OperationEvaluator(Interpreter& interp, InterpreterContext& ctxt)
+                : interpreter(interp), ctxt(ctxt),
+                  keysAnalysis(interp.getTranslationUnit().getAnalysis<RamIndexScanKeysAnalysis>()) {}
 
         // -- Operations -----------------------------
 
@@ -484,7 +488,7 @@ void Interpreter::evalOp(const RamOperation& op, const InterpreterContext& args)
             }
 
             // obtain index
-            auto idx = rel.getIndex(scan.getRangeQueryColumns(), nullptr);
+            auto idx = rel.getIndex(keysAnalysis->getRangeQueryColumns(&scan), nullptr);
 
             // get iterator range
             auto range = idx->lowerUpperBound(low, hig);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -116,6 +116,7 @@ souffle_sources = \
               ProvenanceTransformer.cpp                 \
               RamAnalysis.h                             \
               RamConstValue.cpp RamConstValue.h         \
+              RamIndexScanKeys.cpp  RamIndexScanKeys.h  \
               RamConditionLevel.cpp RamConditionLevel.h \
               RamOperationDepth.cpp RamOperationDepth.h \
               RamValueLevel.cpp RamValueLevel.h         \

--- a/src/RamIndexScanKeys.cpp
+++ b/src/RamIndexScanKeys.cpp
@@ -1,0 +1,34 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2019, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file RamIndexScanKeys.cpp
+ *
+ * Implementation of RamIndexScan Keys Analysis
+ *
+ ***********************************************************************/
+
+#include "RamIndexScanKeys.h"
+#include "RamVisitor.h"
+
+namespace souffle {
+
+/** Get indexable columns of index scan */
+SearchColumns RamIndexScanKeysAnalysis::getRangeQueryColumns(const RamIndexScan* scan) const {
+    SearchColumns keys = 0;
+    std::vector<RamValue*> rangePattern = scan->getRangePattern();
+    for (std::size_t i = 0; i < rangePattern.size(); i++) {
+        if (rangePattern[i] != nullptr) {
+            keys |= (1 << i);
+        }
+    }
+    return keys;
+}
+
+}  // end of namespace souffle

--- a/src/RamIndexScanKeys.h
+++ b/src/RamIndexScanKeys.h
@@ -1,0 +1,39 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2019, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file RamIndexScanKeys.h
+ *
+ * Get the indexable columns for a range query
+ *
+ ***********************************************************************/
+
+#pragma once
+
+#include "RamAnalysis.h"
+#include "RamOperation.h"
+
+namespace souffle {
+
+/*
+ * Class to compute the search columns of an index scan
+ */
+class RamIndexScanKeysAnalysis : public RamAnalysis {
+public:
+    /** Name of analysis */
+    static constexpr const char* name = "index-scan-keys-analysis";
+
+    /** Run keys analysis for a RAM translation unit */
+    void run(const RamTranslationUnit& translationUnit) override {}
+
+    /** Get indexable columns of index scan */
+    SearchColumns getRangeQueryColumns(const RamIndexScan* scan) const;
+};
+
+}  // end of namespace souffle

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -208,26 +208,18 @@ protected:
     /** Values of index per column of table (if indexable) */
     std::vector<std::unique_ptr<RamValue>> queryPattern;
 
-    /** Indexable columns for a range query */
-    SearchColumns keys = 0;
-
 public:
     RamIndexScan(std::unique_ptr<RamRelationReference> r, size_t ident,
-            std::vector<std::unique_ptr<RamValue>> queryPattern, SearchColumns keys,
-            std::unique_ptr<RamOperation> nested, std::string profileText = "")
+            std::vector<std::unique_ptr<RamValue>> queryPattern, std::unique_ptr<RamOperation> nested,
+            std::string profileText = "")
             : RamRelationSearch(RN_IndexScan, std::move(r), ident, std::move(nested), std::move(profileText)),
-              queryPattern(std::move(queryPattern)), keys(keys) {
+              queryPattern(std::move(queryPattern)) {
         assert(getRangePattern().size() == getRelation().getArity());
     }
 
     /** Get range pattern */
     std::vector<RamValue*> getRangePattern() const {
         return toPtrVector(queryPattern);
-    }
-
-    /** Get indexable columns of scan */
-    const SearchColumns& getRangeQueryColumns() const {
-        return keys;
     }
 
     /** Print */
@@ -271,7 +263,7 @@ public:
             }
         }
         RamIndexScan* res = new RamIndexScan(std::unique_ptr<RamRelationReference>(getRelation().clone()),
-                getIdentifier(), std::move(resQueryPattern), keys,
+                getIdentifier(), std::move(resQueryPattern),
                 std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
         return res;
     }
@@ -291,8 +283,7 @@ protected:
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamIndexScan*>(&node));
         const auto& other = static_cast<const RamIndexScan&>(node);
-        return RamRelationSearch::equal(other) && equal_targets(queryPattern, other.queryPattern) &&
-               keys == other.keys;
+        return RamRelationSearch::equal(other) && equal_targets(queryPattern, other.queryPattern);
     }
 };
 
@@ -582,7 +573,7 @@ protected:
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamFilter*>(&node));
         const auto& other = static_cast<const RamFilter&>(node);
-        return getCondition() == other.getCondition() && RamNestedOperation::equal(node);
+        return RamNestedOperation::equal(node) && getCondition() == other.getCondition();
     }
 };
 

--- a/src/Synthesiser.h
+++ b/src/Synthesiser.h
@@ -89,6 +89,11 @@ public:
     Synthesiser(RamTranslationUnit& tUnit) : translationUnit(tUnit) {}
     virtual ~Synthesiser() = default;
 
+    /** Get translation unit */
+    RamTranslationUnit& getTranslationUnit() {
+        return translationUnit;
+    }
+
     /** Generate code */
     void generateCode(std::ostream& os, const std::string& id, bool& withSharedLibrary);
 };


### PR DESCRIPTION
Related to #541

The `keys` attribute is removed from `RamIndexScan` and now computed dynamically by a new RAM analysis.