### PR TITLE
Refactor printsize to be a subtype of store

### DIFF
--- a/src/AstIO.h
+++ b/src/AstIO.h
@@ -205,14 +205,16 @@ public:
 
 /**
  * @class AstPrintSize
- * @brief Intermediate representation of a store operation.
+ * @brief Intermediate representation of a summary store operation.
  */
-class AstPrintSize : public AstIO {
+class AstPrintSize : public AstStore {
 public:
-    AstPrintSize(const AstIO& io) : AstIO(io) {
-        setSrcLoc(io.getSrcLoc());
+    AstPrintSize(const AstIO& io) : AstStore(io) {
+        addKVP("IO", "stdoutprintsize");
     }
-    AstPrintSize() = default;
+    AstPrintSize() {
+        addKVP("IO", "stdoutprintsize");
+    }
     ~AstPrintSize() override = default;
 
     /** Output to a given output stream */
@@ -232,6 +234,7 @@ public:
     AstPrintSize* clone() const override {
         auto res = new AstPrintSize();
         res->names = names;
+        res->kvps = kvps;
         res->setSrcLoc(getSrcLoc());
         return res;
     }

--- a/src/AstRelation.h
+++ b/src/AstRelation.h
@@ -136,9 +136,9 @@ public:
             stores.back()->setSrcLoc(getSrcLoc());
         }
         if (q & PRINTSIZE_RELATION) {
-            printSize = std::make_unique<AstPrintSize>();
-            printSize->setName(getName());
-            printSize->setSrcLoc(getSrcLoc());
+            stores.emplace_back(new AstPrintSize());
+            stores.back()->setName(getName());
+            stores.back()->setSrcLoc(getSrcLoc());
         }
     }
 
@@ -227,9 +227,6 @@ public:
         for (const auto& cur : loads) {
             res->loads.emplace_back(cur->clone());
         }
-        if (printSize != nullptr) {
-            res->printSize = std::unique_ptr<AstPrintSize>(printSize->clone());
-        }
         res->qualifier = qualifier;
         return res;
     }
@@ -247,9 +244,6 @@ public:
         }
         for (auto& cur : loads) {
             cur = map(std::move(cur));
-        }
-        if (printSize != nullptr) {
-            printSize = map(std::move(printSize));
         }
     }
 
@@ -303,9 +297,6 @@ public:
         for (const auto& cur : loads) {
             res.push_back(cur.get());
         }
-        if (printSize != nullptr) {
-            res.push_back(printSize.get());
-        }
         return res;
     }
 
@@ -319,23 +310,11 @@ public:
         loads.push_back(std::move(directive));
     }
 
-    void setPrintSize(std::unique_ptr<AstPrintSize> directive) {
-        assert(directive && "Undefined directive");
-        printSize = std::move(directive);
-    }
-
     std::vector<AstStore*> getStores() const {
         return toPtrVector(stores);
     }
     std::vector<AstLoad*> getLoads() const {
         return toPtrVector(loads);
-    }
-    std::vector<AstPrintSize*> getPrintSizes() const {
-        std::vector<AstPrintSize*> printSizes;
-        if (printSize != nullptr) {
-            printSizes.push_back(printSize.get());
-        }
-        return printSizes;
     }
 
 protected:
@@ -357,7 +336,6 @@ protected:
     /** IO directives associated with this relation. */
     std::vector<std::unique_ptr<AstStore>> stores;
     std::vector<std::unique_ptr<AstLoad>> loads;
-    std::unique_ptr<AstPrintSize> printSize;
 
     /** Datastructure to use for this relation */
     RelationRepresentation representation{RelationRepresentation::DEFAULT};

--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -602,7 +602,7 @@ void AstSemanticChecker::checkRelationDeclaration(ErrorReport& report, const Typ
                                     toString(attr->getTypeName()),
                             attr->getSrcLoc());
                 }
-                if (ioTypes.isOutput(&relation)) {
+                if (ioTypes.isOutput(&relation) && !ioTypes.isPrintSize(&relation)) {
                     report.addWarning(
                             "Record types in output relations are not printed verbatim: attribute " +
                                     attr->getAttributeName() + " has record type " +
@@ -791,9 +791,6 @@ void AstSemanticChecker::checkIODirectives(ErrorReport& report, const AstProgram
         }
     };
     for (const auto& directive : program.getLoads()) {
-        checkIODirective(directive.get());
-    }
-    for (const auto& directive : program.getPrintSizes()) {
         checkIODirective(directive.get());
     }
     for (const auto& directive : program.getStores()) {

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -379,7 +379,7 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelations(AstTranslationUnit& t
             }
         });
 
-        if (!usedInAggregate && !ioTypes->isOutput(rel) && !ioTypes->isPrintSize(rel)) {
+        if (!usedInAggregate && !ioTypes->isOutput(rel)) {
             program.removeRelation(rel->getName());
             changed = true;
         }

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -1220,12 +1220,6 @@ void AstTranslator::translateProgram(const AstTranslationUnit& translationUnit) 
         appendStmt(current, std::move(statement));
     };
 
-    // a function to print the size of relations
-    const auto& makeRamPrintSize = [&](std::unique_ptr<RamStatement>& current, const AstRelation* relation) {
-        appendStmt(current, std::make_unique<RamPrintSize>(
-                                    std::unique_ptr<RamRelationReference>(translateRelation(relation))));
-    };
-
     // a function to store relations
     const auto& makeRamStore = [&](std::unique_ptr<RamStatement>& current, const AstRelation* relation,
                                        const std::string& outputDirectory, const std::string& fileExtension) {
@@ -1345,15 +1339,6 @@ void AstTranslator::translateProgram(const AstTranslationUnit& translationUnit) 
                                          *((const AstRelation*)*allInterns.begin()), recursiveClauses)
                                : translateRecursiveRelation(allInterns, recursiveClauses);
         appendStmt(current, std::move(bodyStatement));
-
-        auto* ioTypes = translationUnit.getAnalysis<IOType>();
-
-        // print the size of all printsize relations in the current SCC
-        for (const auto& relation : allInterns) {
-            if (ioTypes->isPrintSize(relation)) {
-                makeRamPrintSize(current, relation);
-            }
-        }
 #ifdef USE_MPI
         // note that the order of sends is first by relation then second destination
         if (Global::config().get("engine") == "mpi") {

--- a/src/AstVisitor.h
+++ b/src/AstVisitor.h
@@ -105,7 +105,6 @@ struct AstVisitor : public ast_visitor_tag {
         FORWARD(Clause);
         FORWARD(Relation);
         FORWARD(Load);
-        FORWARD(PrintSize);
         FORWARD(Store);
         FORWARD(Program);
         FORWARD(Pragma);
@@ -172,7 +171,6 @@ protected:
     LINK(Attribute, Node);
     LINK(Clause, Node);
     LINK(Load, Node);
-    LINK(PrintSize, Node);
     LINK(Store, Node);
     LINK(Relation, Node);
     LINK(Pragma, Node);

--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -131,7 +131,7 @@ public:
         }
         return relation.contains(t);
     }
-    std::size_t size() override {
+    std::size_t size() const override {
         return relation.size();
     }
     std::string getName() const override {

--- a/src/ComponentModel.cpp
+++ b/src/ComponentModel.cpp
@@ -570,18 +570,6 @@ bool ComponentInstantiationTransformer::transform(AstTranslationUnit& translatio
     program.loads.clear();
     program.loads.swap(unboundLoads);
 
-    for (auto& cur : program.printSizes) {
-        auto pos = program.relations.find(cur->getName());
-        if (pos != program.relations.end()) {
-            pos->second->setPrintSize(std::move(cur));
-        } else {
-            unboundPrintSizes.push_back(std::move(cur));
-        }
-    }
-    // remember the remaining orphan directives
-    program.printSizes.clear();
-    program.printSizes.swap(unboundPrintSizes);
-
     for (auto& cur : program.stores) {
         auto pos = program.relations.find(cur->getName());
         if (pos != program.relations.end()) {

--- a/src/IOSystem.h
+++ b/src/IOSystem.h
@@ -78,6 +78,7 @@ private:
         registerReadStreamFactory(std::make_shared<ReadCinCSVFactory>());
         registerWriteStreamFactory(std::make_shared<WriteFileCSVFactory>());
         registerWriteStreamFactory(std::make_shared<WriteCoutCSVFactory>());
+        registerWriteStreamFactory(std::make_shared<WriteCoutPrintSizeFactory>());
 #ifdef USE_SQLITE
         registerReadStreamFactory(std::make_shared<ReadSQLiteFactory>());
         registerWriteStreamFactory(std::make_shared<WriteSQLiteFactory>());

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -784,14 +784,6 @@ void Interpreter::evalStmt(const RamStatement& stmt) {
             return true;
         }
 
-        bool visitPrintSize(const RamPrintSize& print) override {
-            auto lease = getOutputLock().acquire();
-            (void)lease;
-            const InterpreterRelation& rel = interpreter.getRelation(print.getRelation());
-            std::cout << print.getMessage() << rel.size() << "\n";
-            return true;
-        }
-
         bool visitLogSize(const RamLogSize& size) override {
             const InterpreterRelation& rel = interpreter.getRelation(size.getRelation());
             ProfileEventSingleton::instance().makeQuantityEvent(

--- a/src/InterpreterInterface.h
+++ b/src/InterpreterInterface.h
@@ -100,7 +100,7 @@ public:
     }
 
     /** Get number of tuples in relation */
-    std::size_t size() override {
+    std::size_t size() const override {
         return relation.size();
     }
 

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -26,13 +26,6 @@
 #include <utility>
 
 namespace souffle {
-/**
- * Obtains a reference to the lock synchronizing output operations.
- */
-inline Lock& getOutputLock() {
-    static Lock outputLock;
-    return outputLock;
-}
 
 /**
  * The class utilized to times for the souffle profiling tool. This class

--- a/src/MagicSet.cpp
+++ b/src/MagicSet.cpp
@@ -730,7 +730,7 @@ void Adornment::run(const AstTranslationUnit& translationUnit) {
         AstRelationIdentifier relName = rel->getName();
 
         // find computed relations for the topdown part
-        if (ioTypes->isOutput(rel) || ioTypes->isPrintSize(rel)) {
+        if (ioTypes->isOutput(rel)) {
             outputQueries.push_back(rel->getName());
             // add relation to adornment
             adornmentRelations.push_back(rel->getName());
@@ -1409,15 +1409,6 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
                 }
             });
             outputDirectives[relationName] = std::move(clonedDirectives);
-        } else if (ioTypes->isPrintSize(relation)) {
-            addAsPrintSize.insert(relationName);
-            std::vector<std::unique_ptr<AstPrintSize>> clonedDirectives;
-            visitDepthFirst(*program, [&](const AstPrintSize current) {
-                if (current.getName() == relationName) {
-                    clonedDirectives.emplace_back(current.clone());
-                }
-            });
-            printSizeDirectives[relationName] = std::move(clonedDirectives);
         }
 
         // do not delete negated atoms, ignored atoms, or atoms added by aggregate relations
@@ -1499,11 +1490,6 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
     for (auto& iopair : outputDirectives) {
         for (auto& iodir : iopair.second) {
             program->getRelation(iopair.first)->addStore(std::move(iodir));
-        }
-    }
-    for (auto& iopair : printSizeDirectives) {
-        for (auto& iodir : iopair.second) {
-            program->getRelation(iopair.first)->setPrintSize(std::move(iodir));
         }
     }
 

--- a/src/ParallelUtils.h
+++ b/src/ParallelUtils.h
@@ -496,8 +496,6 @@ public:
     }
 };
 
-}  // end of namespace souffle
-
 #else
 
 namespace souffle {
@@ -601,6 +599,14 @@ public:
     }
 };
 
-}  // end of namespace souffle
-
 #endif
+
+/**
+ * Obtains a reference to the lock synchronizing output operations.
+ */
+inline Lock& getOutputLock() {
+    static Lock outputLock;
+    return outputLock;
+}
+
+}  // end of namespace souffle

--- a/src/ParserDriver.h
+++ b/src/ParserDriver.h
@@ -30,7 +30,6 @@ class AstComponentInit;
 class AstFunctorDeclaration;
 class AstLoad;
 class AstPragma;
-class AstPrintsize;
 class AstRelation;
 class AstStore;
 class AstTranslationUnit;
@@ -59,7 +58,6 @@ public:
     void addFunctorDeclaration(std::unique_ptr<AstFunctorDeclaration> f);
     void addStore(std::unique_ptr<AstStore> d);
     void addLoad(std::unique_ptr<AstLoad> d);
-    void addPrintSize(std::unique_ptr<AstPrintSize> d);
     void addType(std::unique_ptr<AstType> type);
     void addClause(std::unique_ptr<AstClause> c);
     void addComponent(std::unique_ptr<AstComponent> c);

--- a/src/PrecedenceGraph.cpp
+++ b/src/PrecedenceGraph.cpp
@@ -83,7 +83,7 @@ void RedundantRelations::run(const AstTranslationUnit& translationUnit) {
     const std::vector<AstRelation*>& relations = translationUnit.getProgram()->getRelations();
     /* Add all output relations to the work set */
     for (const AstRelation* r : relations) {
-        if (ioType->isOutput(r) || ioType->isPrintSize(r)) {
+        if (ioType->isOutput(r)) {
             work.insert(r);
         }
     }

--- a/src/RamNode.h
+++ b/src/RamNode.h
@@ -65,7 +65,6 @@ enum RamNodeType {
     RN_Insert,
     RN_Clear,
     RN_Drop,
-    RN_PrintSize,
     RN_LogSize,
     RN_Return,
 

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -991,48 +991,6 @@ protected:
     }
 };
 
-/**
- * Print relation size and a print message
- *
- * Print relation size for the printsize qualifier for relations.
- */
-class RamPrintSize : public RamRelationStatement {
-protected:
-    /** print message */
-    std::string message;
-
-public:
-    RamPrintSize(std::unique_ptr<RamRelationReference> rel)
-            : RamRelationStatement(RN_PrintSize, std::move(rel)), message(relation->getName() + "\t") {}
-
-    /** Get message */
-    const std::string& getMessage() const {
-        return message;
-    }
-
-    /** Pretty print */
-    void print(std::ostream& os, int tabpos) const override {
-        os << std::string(tabpos, '\t');
-        os << "PRINTSIZE " << getRelation().getName() << " TEXT ";
-        os << "\"" << stringify(message) << "\"";
-    }
-
-    /** Create clone */
-    RamPrintSize* clone() const override {
-        RamPrintSize* res = new RamPrintSize(std::unique_ptr<RamRelationReference>(relation->clone()));
-        return res;
-    }
-
-protected:
-    /** Check equality */
-    bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamPrintSize*>(&node));
-        const auto& other = static_cast<const RamPrintSize&>(node);
-        RamRelationStatement::equal(other);
-        return message == other.message;
-    }
-};
-
 #ifdef USE_MPI
 
 class RamRecv : public RamRelationStatement {

--- a/src/RamVisitor.h
+++ b/src/RamVisitor.h
@@ -112,7 +112,6 @@ struct RamVisitor : public ram_visitor_tag {
             FORWARD(Insert);
             FORWARD(Clear);
             FORWARD(Drop);
-            FORWARD(PrintSize);
             FORWARD(LogSize);
 
             FORWARD(Merge);
@@ -164,7 +163,6 @@ protected:
     LINK(Insert, Statement);
     LINK(Clear, RelationStatement);
     LINK(Drop, RelationStatement);
-    LINK(PrintSize, RelationStatement);
     LINK(LogSize, RelationStatement);
 
     LINK(RelationStatement, Statement);

--- a/src/SouffleInterface.h
+++ b/src/SouffleInterface.h
@@ -107,7 +107,7 @@ public:
     virtual iterator end() const = 0;
 
     // number of tuples in relation
-    virtual std::size_t size() = 0;
+    virtual std::size_t size() const = 0;
 
     // properties
     virtual std::string getName() const = 0;

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -439,19 +439,6 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitPrintSize(const RamPrintSize& print, std::ostream& out) override {
-            PRINT_BEGIN_COMMENT(out);
-            out << "if (performIO) {\n";
-            out << "{ auto lease = getOutputLock().acquire(); \n";
-            out << "(void)lease;\n";
-            out << "std::cout << R\"(" << print.getMessage() << ")\" <<  ";
-            out << synthesiser.getRelationName(print.getRelation()) << "->"
-                << "size() << std::endl;\n";
-            out << "}";
-            out << "}\n";
-            PRINT_END_COMMENT(out);
-        }
-
         void visitLogSize(const RamLogSize& size, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "ProfileEventSingleton::instance().makeQuantityEvent( R\"(";
@@ -1643,8 +1630,6 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
     visitDepthFirst(*(prog.getMain()),
             [&](const RamStore& store) { storeRelations.insert(store.getRelation().getName()); });
     visitDepthFirst(*(prog.getMain()),
-            [&](const RamPrintSize& size) { storeRelations.insert(size.getRelation().getName()); });
-    visitDepthFirst(*(prog.getMain()),
             [&](const RamLoad& load) { loadRelations.insert(load.getRelation().getName()); });
     visitDepthFirst(*(prog.getMain()), [&](const RamCreate& create) {
         // get some table details
@@ -1894,13 +1879,6 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
 
                 os << "} catch (std::exception& e) {std::cerr << e.what();exit(1);}\n";
             }
-        } else if (auto print = dynamic_cast<const RamPrintSize*>(&node)) {
-            os << "{ auto lease = getOutputLock().acquire(); \n";
-            os << "(void)lease;\n";
-            os << "std::cout << R\"(" << print->getMessage() << ")\" <<  ";
-            os << getRelationName(print->getRelation()) << "->"
-               << "size() << std::endl;\n";
-            os << "}";
         }
     });
     os << "}\n";  // end of printAll() method

--- a/src/WriteStreamCSV.h
+++ b/src/WriteStreamCSV.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "IODirectives.h"
+#include "ParallelUtils.h"
 #include "SymbolMask.h"
 #include "SymbolTable.h"
 #include "WriteStream.h"
@@ -22,6 +23,7 @@
 #include "gzfstream.h"
 #endif
 
+#include <cassert>
 #include <fstream>
 #include <memory>
 #include <ostream>
@@ -160,6 +162,31 @@ protected:
     const std::string delimiter;
 };
 
+class WriteCoutPrintSize : public WriteStream {
+public:
+    WriteCoutPrintSize(const IODirectives& ioDirectives)
+            : WriteStream({}, {}, false, true), lease(souffle::getOutputLock().acquire()) {
+        std::cout << ioDirectives.getRelationName() << "\t";
+    }
+
+    ~WriteCoutPrintSize() override = default;
+
+protected:
+    void writeNullary() override {
+        assert(false && "attempting to iterate over a print size operation");
+    }
+
+    void writeNextTuple(const RamDomain* /* tuple */) override {
+        assert(false && "attempting to iterate over a print size operation");
+    }
+
+    void writeSize(std::size_t size) {
+        std::cout << size << "\n";
+    }
+
+    Lock::Lease lease;
+};
+
 class WriteFileCSVFactory : public WriteStreamFactory {
 public:
     std::unique_ptr<WriteStream> getWriter(const SymbolMask& symbolMask, const SymbolTable& symbolTable,
@@ -189,6 +216,20 @@ public:
         return name;
     }
     ~WriteCoutCSVFactory() override = default;
+};
+
+class WriteCoutPrintSizeFactory : public WriteStreamFactory {
+public:
+    std::unique_ptr<WriteStream> getWriter(const SymbolMask& /* symbolMask */,
+            const SymbolTable& /* symbolTable */, const IODirectives& ioDirectives,
+            const bool /* provenance */) override {
+        return std::make_unique<WriteCoutPrintSize>(ioDirectives);
+    }
+    const std::string& getName() const override {
+        static const std::string name = "stdoutprintsize";
+        return name;
+    }
+    ~WriteCoutPrintSizeFactory() override = default;
 };
 
 } /* namespace souffle */

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -192,7 +192,6 @@
 %type <AstIO *>                          key_value_pairs non_empty_key_value_pairs iodirective_body
 %type <std::vector<AstIO *>>             iodirective_list
 %type <std::vector<AstLoad *>>           load_head
-%type <std::vector<AstPrintSize *>>      printsize_head
 %type <std::vector<AstStore *>>          store_head
 %printer { yyoutput << $$; } <*>;
 
@@ -228,9 +227,6 @@ unit
     }
   | unit load_head {
         for(const auto& cur : $2) driver.addLoad(std::unique_ptr<AstLoad>(cur));
-    }
-  | unit printsize_head {
-        for(const auto& cur : $2) driver.addPrintSize(std::unique_ptr<AstPrintSize>(cur));
     }
   | unit store_head {
         for(const auto& cur : $2) driver.addStore(std::unique_ptr<AstStore>(cur));
@@ -502,16 +498,16 @@ load_head
           $$.push_back(new AstLoad(*cur));
       }
     }
-printsize_head
-  : PRINTSIZE_DECL iodirective_list {
-      for (auto* cur : $2) {
-          $$.push_back(new AstPrintSize(*cur));
-      }
-    }
 store_head
   : OUTPUT_DECL iodirective_list {
       for (auto* cur : $2) {
           $$.push_back(new AstStore(*cur));
+      }
+    }
+  | PRINTSIZE_DECL iodirective_list {
+      for (auto* cur : $2) {
+          auto tmp = new AstPrintSize(*cur);
+          $$.push_back(tmp);
       }
     }
 
@@ -1067,10 +1063,6 @@ component_body
   | component_body load_head {
         $$ = $1;
         for(const auto& cur : $2) $$->addLoad(std::unique_ptr<AstLoad>(cur));
-    }
-  | component_body printsize_head {
-        $$ = $1;
-        for(const auto& cur : $2) $$->addPrintSize(std::unique_ptr<AstPrintSize>(cur));
     }
   | component_body store_head {
         $$ = $1;

--- a/src/souffle2lb.cpp
+++ b/src/souffle2lb.cpp
@@ -167,7 +167,7 @@ private:
             });
             iout << "\n";
         }
-        if (ioTypes->isOutput(&rel) || ioTypes->isPrintSize(&rel)) {
+        if (ioTypes->isOutput(&rel)) {
             int i = 0;
             eout << "fromPredicate," << rel.getName() << ",";
             eout << join(rel.getAttributes(), ",", [&](std::ostream& os, AstAttribute* cur) {


### PR DESCRIPTION
With this PR, souffle treats printsize operations as a subtype of store operations.

As a side effect, it's now also possible to do
```
.output A(IO=stdoutprintsize)
```