### PR TITLE
Memory leak fixes

### DIFF
--- a/src/InterpreterInterface.h
+++ b/src/InterpreterInterface.h
@@ -180,12 +180,6 @@ private:
     /** Attribute Names */
     std::vector<std::string> attrNames;
 
-    /** Input relation flag */
-    bool relInput;
-
-    /** Output relation flag */
-    bool relOutput;
-
     /** Unique id for wrapper */
     // TODO (#541): replace unique id by dynamic type checking for C++
     uint32_t id;

--- a/src/WriteStreamCSV.h
+++ b/src/WriteStreamCSV.h
@@ -180,7 +180,7 @@ protected:
         assert(false && "attempting to iterate over a print size operation");
     }
 
-    void writeSize(std::size_t size) {
+    void writeSize(std::size_t size) override {
         std::cout << size << "\n";
     }
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -496,31 +496,33 @@ load_head
   : INPUT_DECL iodirective_list {
       for (auto* cur : $2) {
           $$.push_back(new AstLoad(*cur));
+          delete cur;
       }
     }
 store_head
   : OUTPUT_DECL iodirective_list {
       for (auto* cur : $2) {
           $$.push_back(new AstStore(*cur));
+          delete cur;
       }
     }
   | PRINTSIZE_DECL iodirective_list {
       for (auto* cur : $2) {
-          auto tmp = new AstPrintSize(*cur);
-          $$.push_back(tmp);
+          $$.push_back(new AstPrintSize(*cur));
+          delete cur;
       }
     }
 
 iodirective_list
   : iodirective_body {
-      $$.emplace_back($1);
+      $$.push_back($1);
     }
   | IDENT COMMA iodirective_list {
       $$.swap($3);
       auto tmp = $$.back()->clone();
       tmp->setName($1);
       tmp->setSrcLoc(@1);
-      $$.emplace_back(tmp);
+      $$.push_back(tmp);
     }
 
 iodirective_body

--- a/tests/interface/repeat_analysis/driver.cpp
+++ b/tests/interface/repeat_analysis/driver.cpp
@@ -90,4 +90,6 @@ int main(int argc, char** argv){
     prog->run();
     std::cout<<"source2sink - run 3"<<std::endl;
     printSource2sink(prog);
+
+    delete prog;
 }

--- a/tests/interface/repeat_analysis/driver.cpp
+++ b/tests/interface/repeat_analysis/driver.cpp
@@ -1,6 +1,6 @@
 /*
  * Souffle - A Datalog Compiler
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved
+ * Copyright (c) 2019 The Souffle Developers. All Rights reserved
  * Licensed under the Universal Permissive License v 1.0 as shown at:
  * - https://opensource.org/licenses/UPL
  * - <souffle root>/licenses/SOUFFLE-UPL.txt


### PR DESCRIPTION
* Fix for memory leaks in parsing, RAM transforms, and interface tests.
* Remove unused variables
* Add missing notation
* Fix license.