### PR TITLE
Fix compile warnings

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -518,8 +518,7 @@ void AstTranslator::ClauseTranslator::createValueIndex(const AstClause& clause) 
         const AstAtom& atom = static_cast<const AstAtom&>(*cur.getBodyLiterals()[0]);
         for (size_t pos = 0; pos < atom.getArguments().size(); ++pos) {
             if (const auto* var = dynamic_cast<const AstVariable*>(atom.getArgument(pos))) {
-                valueIndex.addVarReference(
-                        *var, aggLoc, (int)pos, std::move(translator.translateRelation(&atom)));
+                valueIndex.addVarReference(*var, aggLoc, (int)pos, translator.translateRelation(&atom));
             }
         };
 
@@ -686,11 +685,10 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
             for (size_t pos = 0; pos < atom->argSize(); ++pos) {
                 if (auto* agg = dynamic_cast<AstAggregator*>(atom->getArgument(pos))) {
                     auto loc = valueIndex.getAggregatorLocation(*agg);
-                    op = std::make_unique<RamFilter>(
-                            std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
-                                    std::make_unique<RamElementAccess>(
-                                            curLevel, pos, std::move(translator.translateRelation(atom))),
-                                    makeRamElementAccess(loc)),
+                    op = std::make_unique<RamFilter>(std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
+                                                             std::make_unique<RamElementAccess>(curLevel, pos,
+                                                                     translator.translateRelation(atom)),
+                                                             makeRamElementAccess(loc)),
                             std::move(op));
                 }
             }
@@ -735,8 +733,7 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
         for (size_t pos = 0; pos < atom->argSize(); ++pos) {
             if (auto* c = dynamic_cast<AstConstant*>(atom->getArgument(pos))) {
                 aggregate->addCondition(std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
-                        std::make_unique<RamElementAccess>(
-                                level, pos, std::move(translator.translateRelation(atom))),
+                        std::make_unique<RamElementAccess>(level, pos, translator.translateRelation(atom)),
                         std::make_unique<RamNumber>(c->getIndex())));
             } else if (const auto* var = dynamic_cast<const AstVariable*>(atom->getArgument(pos))) {
                 // all other appearances
@@ -745,7 +742,7 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
                         aggregate->addCondition(std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
                                 makeRamElementAccess(loc),
                                 std::make_unique<RamElementAccess>(
-                                        level, pos, std::move(translator.translateRelation(atom)))));
+                                        level, pos, translator.translateRelation(atom))));
                         break;
                     }
                 }
@@ -767,11 +764,10 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
             // add constraints
             for (size_t pos = 0; pos < atom->argSize(); ++pos) {
                 if (auto* c = dynamic_cast<AstConstant*>(atom->getArgument(pos))) {
-                    op = std::make_unique<RamFilter>(
-                            std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
-                                    std::make_unique<RamElementAccess>(
-                                            level, pos, std::move(translator.translateRelation(atom))),
-                                    std::make_unique<RamNumber>(c->getIndex())),
+                    op = std::make_unique<RamFilter>(std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
+                                                             std::make_unique<RamElementAccess>(level, pos,
+                                                                     translator.translateRelation(atom)),
+                                                             std::make_unique<RamNumber>(c->getIndex())),
                             std::move(op));
                 }
             }

--- a/src/test/binary_relation_test.cpp
+++ b/src/test/binary_relation_test.cpp
@@ -382,7 +382,7 @@ TEST(EqRelTest, IterRange) {
     br.insert(8, 10);
 
     // this should return an iterator covering (3, 0), (3, 1), ..., (3, 6), it's a (3, *) iterator
-    auto rangeIt = br.getBoundaries<1>({3, 18293018});
+    auto rangeIt = br.getBoundaries<1>({{3, 18293018}});
 
     std::vector<size_t> posteriorsCovered;
     for (auto tup : rangeIt) {
@@ -391,7 +391,7 @@ TEST(EqRelTest, IterRange) {
     EXPECT_EQ(posteriorsCovered.size(), 7);
 
     // this should be of everything, so doesn't matter the args
-    rangeIt = br.getBoundaries<0>({332, 888});
+    rangeIt = br.getBoundaries<0>({{332, 888}});
     posteriorsCovered.clear();
     for (auto tup : rangeIt) {
         posteriorsCovered.push_back(tup[1]);
@@ -399,7 +399,7 @@ TEST(EqRelTest, IterRange) {
     EXPECT_EQ(posteriorsCovered.size(), (7 * 7) + (3 * 3));
 
     // and now iterate over two levels (exactly one pretty much)
-    rangeIt = br.getBoundaries<2>({2, 3});
+    rangeIt = br.getBoundaries<2>({{2, 3}});
     posteriorsCovered.clear();
     for (auto tup : rangeIt) {
         posteriorsCovered.push_back(tup[1]);
@@ -408,14 +408,14 @@ TEST(EqRelTest, IterRange) {
     EXPECT_EQ(posteriorsCovered.front(), 3);
 
     // and now the same, but for levels 1 and two, stuff that doesn't exist
-    rangeIt = br.getBoundaries<1>({99, 99});
+    rangeIt = br.getBoundaries<1>({{99, 99}});
     posteriorsCovered.clear();
     for (auto tup : rangeIt) {
         posteriorsCovered.push_back(tup[1]);
     }
     EXPECT_EQ(posteriorsCovered.size(), 0);
 
-    rangeIt = br.getBoundaries<2>({8, 1});
+    rangeIt = br.getBoundaries<2>({{8, 1}});
     posteriorsCovered.clear();
     for (auto tup : rangeIt) {
         posteriorsCovered.push_back(tup[1]);
@@ -426,7 +426,7 @@ TEST(EqRelTest, IterRange) {
     br.clear();
     // repeat the same, but notice that we expect the size to be 0 always
     {
-        auto rangeIt = br.getBoundaries<1>({3, 18293018});
+        auto rangeIt = br.getBoundaries<1>({{3, 18293018}});
 
         std::vector<size_t> posteriorsCovered;
         for (auto tup : rangeIt) {
@@ -435,7 +435,7 @@ TEST(EqRelTest, IterRange) {
         EXPECT_EQ(posteriorsCovered.size(), 0);
 
         // this should be of everything, so doesn't matter the args
-        rangeIt = br.getBoundaries<0>({332, 888});
+        rangeIt = br.getBoundaries<0>({{332, 888}});
         posteriorsCovered.clear();
         for (auto tup : rangeIt) {
             posteriorsCovered.push_back(tup[1]);
@@ -443,7 +443,7 @@ TEST(EqRelTest, IterRange) {
         EXPECT_EQ(posteriorsCovered.size(), 0);
 
         // and now iterate over two levels (exactly one pretty much)
-        rangeIt = br.getBoundaries<2>({2, 3});
+        rangeIt = br.getBoundaries<2>({{2, 3}});
         posteriorsCovered.clear();
         for (auto tup : rangeIt) {
             posteriorsCovered.push_back(tup[1]);
@@ -451,14 +451,14 @@ TEST(EqRelTest, IterRange) {
         EXPECT_EQ(posteriorsCovered.size(), 0);
 
         // and now the same, but for levels 1 and two, stuff that doesn't exist
-        rangeIt = br.getBoundaries<1>({99, 99});
+        rangeIt = br.getBoundaries<1>({{99, 99}});
         posteriorsCovered.clear();
         for (auto tup : rangeIt) {
             posteriorsCovered.push_back(tup[1]);
         }
         EXPECT_EQ(posteriorsCovered.size(), 0);
 
-        rangeIt = br.getBoundaries<2>({8, 1});
+        rangeIt = br.getBoundaries<2>({{8, 1}});
         posteriorsCovered.clear();
         for (auto tup : rangeIt) {
             posteriorsCovered.push_back(tup[1]);


### PR DESCRIPTION
Fix some compile warnings about unnecessary moves blocking copy elision, and potentially ambiguous initialisations.