### PR TITLE
Free memory on parser error

### DIFF
--- a/src/AstParserUtils.cpp
+++ b/src/AstParserUtils.cpp
@@ -206,11 +206,11 @@ void RuleBody::insert(std::vector<clause>& cnf, clause&& cls) {
     std::vector<clause> res;
     for (auto& cur : cnf) {
         if (!isSubsetOf(cls, cur)) {
-            res.emplace_back(std::move(cur));
+            res.push_back(std::move(cur));
         }
     }
     res.swap(cnf);
-    cnf.emplace_back(std::move(cls));
+    cnf.push_back(std::move(cls));
 }
 
 }  // end of namespace souffle

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -229,19 +229,19 @@ unit
         driver.addFunctorDeclaration(std::unique_ptr<AstFunctorDeclaration>($2));
     }
   | unit relation_decl {
-        for(auto* cur : $2) {
+        for (auto* cur : $2) {
             driver.addRelation(std::unique_ptr<AstRelation>(cur));
         }
         $2.clear();
     }
   | unit load_head {
-        for(auto* cur : $2) {
+        for (auto* cur : $2) {
             driver.addLoad(std::unique_ptr<AstLoad>(cur));
         }
         $2.clear();
     }
   | unit store_head {
-        for(auto* cur : $2) {
+        for (auto* cur : $2) {
             driver.addStore(std::unique_ptr<AstStore>(cur));
         }
         $2.clear();
@@ -250,7 +250,7 @@ unit
         driver.addClause(std::unique_ptr<AstClause>($2));
     }
   | unit rule {
-        for(auto* cur : $2) {
+        for (auto* cur : $2) {
             driver.addClause(std::unique_ptr<AstClause>(cur));
         }
         $2.clear();
@@ -720,7 +720,7 @@ arg
             std::cerr << "ERROR: currently not supporting non-conjunctive aggregation clauses!";
             exit(1);
         }
-        for(const auto& cur : bodies[0]->getBodyLiterals()) {
+        for (const auto& cur : bodies[0]->getBodyLiterals()) {
             res->addBodyLiteral(std::unique_ptr<AstLiteral>(cur->clone()));
         }
         delete bodies[0];
@@ -742,7 +742,7 @@ arg
             std::cerr << "ERROR: currently not supporting non-conjunctive aggregation clauses!";
             exit(1);
         }
-        for(const auto& cur : bodies[0]->getBodyLiterals()) {
+        for (const auto& cur : bodies[0]->getBodyLiterals()) {
 	    res->addBodyLiteral(std::unique_ptr<AstLiteral>(cur->clone()));
         }
         delete bodies[0];
@@ -764,7 +764,7 @@ arg
             std::cerr << "ERROR: currently not supporting non-conjunctive aggregation clauses!";
             exit(1);
         }
-        for(const auto& cur : bodies[0]->getBodyLiterals()) {
+        for (const auto& cur : bodies[0]->getBodyLiterals()) {
             res->addBodyLiteral(std::unique_ptr<AstLiteral>(cur->clone()));
         }
         delete bodies[0];
@@ -786,7 +786,7 @@ arg
             std::cerr << "ERROR: currently not supporting non-conjunctive aggregation clauses!";
             exit(1);
         }
-        for(const auto& cur : bodies[0]->getBodyLiterals()) {
+        for (const auto& cur : bodies[0]->getBodyLiterals()) {
             res->addBodyLiteral(std::unique_ptr<AstLiteral>(cur->clone()));
         }
         delete bodies[0];
@@ -1015,7 +1015,7 @@ rule_def
                 $$.push_back(cur);
             }
         }
-        for(auto* head : $1) {
+        for (auto* head : $1) {
             delete head;
         }
         $1.clear();
@@ -1032,11 +1032,11 @@ rule
     }
   | rule STRICT {
         std::swap($$, $1);
-        for(auto* cur : $$) cur->setFixedExecutionPlan();
+        for (auto* cur : $$) cur->setFixedExecutionPlan();
     }
   | rule exec_plan {
         std::swap($$, $1);
-        for(auto* cur : $$) cur->setExecutionPlan(std::unique_ptr<AstExecutionPlan>($2->clone()));
+        for (auto* cur : $$) cur->setExecutionPlan(std::unique_ptr<AstExecutionPlan>($2->clone()));
         delete $2;
     }
 
@@ -1089,21 +1089,21 @@ component_body
     }
   | component_body relation_decl {
         $$ = $1;
-        for(auto* cur : $2) {
+        for (auto* cur : $2) {
             $$->addRelation(std::unique_ptr<AstRelation>(cur));
         }
         $2.clear();
     }
   | component_body load_head {
         $$ = $1;
-        for(auto* cur : $2) {
+        for (auto* cur : $2) {
             $$->addLoad(std::unique_ptr<AstLoad>(cur));
         }
         $2.clear();
     }
   | component_body store_head {
         $$ = $1;
-        for(auto* cur : $2) {
+        for (auto* cur : $2) {
             $$->addStore(std::unique_ptr<AstStore>(cur));
         }
         $2.clear();
@@ -1114,7 +1114,7 @@ component_body
     }
   | component_body rule {
         $$ = $1;
-        for(auto* cur : $2) {
+        for (auto* cur : $2) {
             $$->addClause(std::unique_ptr<AstClause>(cur));
         }
         $2.clear();


### PR DESCRIPTION
Currently, finding memory leaks in souffle is difficult as the parser leaks memory on any error (immediately followed by program exit). Finding memory issues is thus a manual process with much customisation needed. With this PR, souffle can be configured with --enable-sanitise-memory and all tests run successfully. New memory leaks can thus be easily found.

This is not a complete set of destructors, just enough to cover expected/tested parsing errors. Using unique_ptr instead of raw pointers would be much better, and more general, but is not possible unless bison 3.2 or newer is used.