### PR TITLE
Add public header BinaryConstraintOps.h needed by ExplainProvenanceSLD.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -181,6 +181,7 @@ soufflepublicdir = $(includedir)/souffle
 
 soufflepublic_HEADERS = \
 						CompiledOptions.h       \
+						BinaryConstraintOps.h   \
                         Brie.h                  \
                         BTree.h                 \
                         CompiledIndexUtils.h    \


### PR DESCRIPTION
This pull request installs missing header BinaryConstraintOps.h with the rest of the public headers when running "make install". This is needed when compiling with provenance enabled.