### PR TITLE
Fix541

### DIFF
--- a/src/AstNode.h
+++ b/src/AstNode.h
@@ -143,7 +143,7 @@ public:
  * Creates a node mapper based on a corresponding lambda expression.
  */
 template <typename Lambda>
-detail::LambdaNodeMapper<Lambda> makeLambdaMapper(const Lambda& lambda) {
+detail::LambdaNodeMapper<Lambda> makeLambdaAstMapper(const Lambda& lambda) {
     return detail::LambdaNodeMapper<Lambda>(lambda);
 }
 

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -256,8 +256,8 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
             if (agg.getOperator() == AstAggregator::count) {
                 int count = 0;
                 for (const auto& cur : aggClause->getBodyLiterals()) {
-                    cur->apply(
-                            makeLambdaAstMapper([&](std::unique_ptr<AstNode> node) -> std::unique_ptr<AstNode> {
+                    cur->apply(makeLambdaAstMapper(
+                            [&](std::unique_ptr<AstNode> node) -> std::unique_ptr<AstNode> {
                                 // check whether it is a unnamed variable
                                 auto* var = dynamic_cast<AstUnnamedVariable*>(node.get());
                                 if (!var) {

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -257,7 +257,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
                 int count = 0;
                 for (const auto& cur : aggClause->getBodyLiterals()) {
                     cur->apply(
-                            makeLambdaMapper([&](std::unique_ptr<AstNode> node) -> std::unique_ptr<AstNode> {
+                            makeLambdaAstMapper([&](std::unique_ptr<AstNode> node) -> std::unique_ptr<AstNode> {
                                 // check whether it is a unnamed variable
                                 auto* var = dynamic_cast<AstUnnamedVariable*>(node.get());
                                 if (!var) {

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -464,7 +464,7 @@ void AstTranslator::ClauseTranslator::indexValues(const AstNode* curNode,
 
         // check for variable references
         if (auto var = dynamic_cast<const AstVariable*>(arg)) {
-            if (pos < relation->getArity()) {
+            if (pos < relation->get()->getArity()) {
                 valueIndex.addVarReference(
                         *var, arg_level[cur], pos, std::unique_ptr<RamRelationReference>(relation->clone()));
             } else {
@@ -1033,8 +1033,8 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
 
                 // modify the processed rule to use relDelta and write to relNew
                 std::unique_ptr<AstClause> r1(cl->clone());
-                r1->getHead()->setName(relNew[rel]->getName());
-                r1->getAtoms()[j]->setName(relDelta[atomRelation]->getName());
+                r1->getHead()->setName(relNew[rel]->get()->getName());
+                r1->getAtoms()[j]->setName(relDelta[atomRelation]->get()->getName());
                 if (Global::config().has("provenance")) {
                     r1->addToBody(std::make_unique<AstProvenanceNegation>(
                             std::unique_ptr<AstAtom>(cl->getHead()->clone())));
@@ -1051,7 +1051,7 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
                 for (size_t k = j + 1; k < atoms.size(); k++) {
                     if (isInSameSCC(getAtomRelation(atoms[k], program))) {
                         AstAtom* cur = r1->getAtoms()[k]->clone();
-                        cur->setName(relDelta[getAtomRelation(atoms[k], program)]->getName());
+                        cur->setName(relDelta[getAtomRelation(atoms[k], program)]->get()->getName());
                         r1->addToBody(std::make_unique<AstNegation>(std::unique_ptr<AstAtom>(cur)));
                     }
                 }

--- a/src/IndexSetAnalysis.cpp
+++ b/src/IndexSetAnalysis.cpp
@@ -314,7 +314,7 @@ void IndexSetAnalysis::print(std::ostream& os) const {
     for (auto& cur : data) {
         const std::string& relName = cur.first;
         const IndexSet& indexes = cur.second;
-        const RamRelationReference& rel = indexes.getRelation();
+        const RamRelation& rel = indexes.getRelation();
 
         /* Print searches */
         os << "Relation " << relName << "\n";

--- a/src/IndexSetAnalysis.h
+++ b/src/IndexSetAnalysis.h
@@ -162,11 +162,11 @@ public:
     }
 
 protected:
-    SearchSet searches;                    // set of search patterns on table
-    OrderCollection orders;                // collection of lexicographical orders
-    ChainOrderMap chainToOrder;            // maps order index to set of searches covered by chain
-    MaxMatching matching;                  // matching problem for finding minimal number of orders
-    const RamRelation& relation;           // relation
+    SearchSet searches;           // set of search patterns on table
+    OrderCollection orders;       // collection of lexicographical orders
+    ChainOrderMap chainToOrder;   // maps order index to set of searches covered by chain
+    MaxMatching matching;         // matching problem for finding minimal number of orders
+    const RamRelation& relation;  // relation
 
     /** count the number of bits in key */
     static size_t card(SearchColumns cols) {

--- a/src/IndexSetAnalysis.h
+++ b/src/IndexSetAnalysis.h
@@ -104,7 +104,7 @@ public:
     using ChainOrderMap = std::vector<Chain>;
     using SearchSet = std::set<SearchColumns>;
 
-    IndexSet(const RamRelationReference& rel) : relation(rel) {}
+    IndexSet(const RamRelation& rel) : relation(rel) {}
 
     /** Add new key to an Index Set */
     inline void addSearch(SearchColumns cols) {
@@ -113,7 +113,7 @@ public:
         }
     }
     /** Get relation */
-    const RamRelationReference& getRelation() const {
+    const RamRelation& getRelation() const {
         return relation;
     }
 
@@ -166,7 +166,7 @@ protected:
     OrderCollection orders;                // collection of lexicographical orders
     ChainOrderMap chainToOrder;            // maps order index to set of searches covered by chain
     MaxMatching matching;                  // matching problem for finding minimal number of orders
-    const RamRelationReference& relation;  // relation
+    const RamRelation& relation;           // relation
 
     /** count the number of bits in key */
     static size_t card(SearchColumns cols) {
@@ -250,7 +250,7 @@ public:
     void print(std::ostream& os) const override;
 
     /** get indexes */
-    IndexSet& getIndexes(const RamRelationReference& rel) {
+    IndexSet& getIndexes(const RamRelation& rel) {
         auto pos = data.find(rel.getName());
         if (pos != data.end()) {
             return pos->second;

--- a/src/Interpreter.h
+++ b/src/Interpreter.h
@@ -115,11 +115,6 @@ protected:
         iteration = 0;
     }
 
-    /** Create relation */
-    void createRelation(const RamRelationReference& id) {
-         createRelation(*id.get());  
-    } 
-
     void createRelation(const RamRelation& id) {
         InterpreterRelation* res = nullptr;
         assert(environment.find(id.getName()) == environment.end());
@@ -140,10 +135,6 @@ protected:
     }
 
     /** Get relation */
-    inline InterpreterRelation& getRelation(const RamRelationReference& id) {
-        return getRelation(*id.get());
-    }
-
     inline InterpreterRelation& getRelation(const RamRelation& id) {
         return getRelation(id.getName());
     }
@@ -161,11 +152,11 @@ protected:
     }
 
     /** Swap relation */
-    void swapRelation(const RamRelationReference& ramRel1, const RamRelationReference& ramRel2) {
+    void swapRelation(const RamRelation& ramRel1, const RamRelation& ramRel2) {
         InterpreterRelation* rel1 = &getRelation(ramRel1);
         InterpreterRelation* rel2 = &getRelation(ramRel2);
-        environment[ramRel1.get()->getName()] = rel2;
-        environment[ramRel2.get()->getName()] = rel1;
+        environment[ramRel1.getName()] = rel2;
+        environment[ramRel2.getName()] = rel1;
     }
 
     /** Load dll */

--- a/src/Interpreter.h
+++ b/src/Interpreter.h
@@ -117,6 +117,10 @@ protected:
 
     /** Create relation */
     void createRelation(const RamRelationReference& id) {
+         createRelation(*id.get());  
+    } 
+
+    void createRelation(const RamRelation& id) {
         InterpreterRelation* res = nullptr;
         assert(environment.find(id.getName()) == environment.end());
         if (id.getRepresentation() == RelationRepresentation::EQREL) {
@@ -137,6 +141,10 @@ protected:
 
     /** Get relation */
     inline InterpreterRelation& getRelation(const RamRelationReference& id) {
+        return getRelation(*id.get());
+    }
+
+    inline InterpreterRelation& getRelation(const RamRelation& id) {
         return getRelation(id.getName());
     }
 
@@ -146,7 +154,7 @@ protected:
     }
 
     /** Drop relation */
-    void dropRelation(const RamRelationReference& id) {
+    void dropRelation(const RamRelation& id) {
         InterpreterRelation& rel = getRelation(id);
         environment.erase(id.getName());
         delete &rel;
@@ -156,8 +164,8 @@ protected:
     void swapRelation(const RamRelationReference& ramRel1, const RamRelationReference& ramRel2) {
         InterpreterRelation* rel1 = &getRelation(ramRel1);
         InterpreterRelation* rel2 = &getRelation(ramRel2);
-        environment[ramRel1.getName()] = rel2;
-        environment[ramRel2.getName()] = rel1;
+        environment[ramRel1.get()->getName()] = rel2;
+        environment[ramRel2.get()->getName()] = rel1;
     }
 
     /** Load dll */

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -231,19 +231,19 @@ protected:
 class RamAbstractExistenceCheck : public RamCondition {
 protected:
     /* Relation */
-    std::unique_ptr<RamRelationReference> relation;
+    std::unique_ptr<RamRelationReference> relationRef;
 
     /** Pattern -- nullptr if undefined */
     std::vector<std::unique_ptr<RamValue>> values;
 
 public:
-    RamAbstractExistenceCheck(RamNodeType type, std::unique_ptr<RamRelationReference> rel,
+    RamAbstractExistenceCheck(RamNodeType type, std::unique_ptr<RamRelationReference> relRef,
             std::vector<std::unique_ptr<RamValue>> vals)
-            : RamCondition(type), relation(std::move(rel)), values(std::move(vals)) {}
+            : RamCondition(type), relationRef(std::move(relRef)), values(std::move(vals)) {}
 
     /** Get relation */
-    const RamRelationReference& getRelation() const {
-        return *relation;
+    const RamRelation& getRelation() const {
+        return *relationRef->get();
     }
 
     /** Get arguments */
@@ -253,7 +253,7 @@ public:
 
     /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
-        std::vector<const RamNode*> res = {relation.get()};
+        std::vector<const RamNode*> res = {relationRef.get()};
         for (const auto& cur : values) {
             res.push_back(cur.get());
         }
@@ -262,7 +262,7 @@ public:
 
     /** Apply */
     void apply(const RamNodeMapper& map) override {
-        relation = map(std::move(relation));
+        relationRef = map(std::move(relationRef));
         for (auto& val : values) {
             if (val != nullptr) {
                 val = map(std::move(val));
@@ -284,8 +284,8 @@ protected:
  */
 class RamExistenceCheck : public RamAbstractExistenceCheck {
 public:
-    RamExistenceCheck(std::unique_ptr<RamRelationReference> rel, std::vector<std::unique_ptr<RamValue>> vals)
-            : RamAbstractExistenceCheck(RN_ExistenceCheck, std::move(rel), std::move(vals)) {}
+    RamExistenceCheck(std::unique_ptr<RamRelationReference> relRef, std::vector<std::unique_ptr<RamValue>> vals)
+            : RamAbstractExistenceCheck(RN_ExistenceCheck, std::move(relRef), std::move(vals)) {}
 
     /** Print */
     void print(std::ostream& os) const override {
@@ -298,7 +298,7 @@ public:
                               out << *value;
                           }
                       })
-           << ") ∈ " << relation->getName();
+           << ") ∈ " << relationRef->get()->getName();
     }
 
     /** Create clone */
@@ -312,7 +312,7 @@ public:
             newValues.emplace_back(val);
         }
         RamExistenceCheck* res = new RamExistenceCheck(
-                std::unique_ptr<RamRelationReference>(relation->clone()), std::move(newValues));
+                std::unique_ptr<RamRelationReference>(relationRef->clone()), std::move(newValues));
         return res;
     }
 
@@ -330,8 +330,8 @@ protected:
 class RamProvenanceExistenceCheck : public RamAbstractExistenceCheck {
 public:
     RamProvenanceExistenceCheck(
-            std::unique_ptr<RamRelationReference> rel, std::vector<std::unique_ptr<RamValue>> vals)
-            : RamAbstractExistenceCheck(RN_ProvenanceExistenceCheck, std::move(rel), std::move(vals)) {}
+            std::unique_ptr<RamRelationReference> relRef, std::vector<std::unique_ptr<RamValue>> vals)
+            : RamAbstractExistenceCheck(RN_ProvenanceExistenceCheck, std::move(relRef), std::move(vals)) {}
 
     /** Print */
     void print(std::ostream& os) const override {
@@ -344,7 +344,7 @@ public:
                               out << *value;
                           }
                       })
-           << ") prov∈ " << relation->getName();
+           << ") prov∈ " << relationRef->get()->getName();
     }
 
     /** Create clone */
@@ -358,7 +358,7 @@ public:
             newValues.emplace_back(val);
         }
         RamProvenanceExistenceCheck* res = new RamProvenanceExistenceCheck(
-                std::unique_ptr<RamRelationReference>(relation->clone()), std::move(newValues));
+                std::unique_ptr<RamRelationReference>(relationRef->clone()), std::move(newValues));
         return res;
     }
 
@@ -375,37 +375,37 @@ protected:
  */
 class RamEmptinessCheck : public RamCondition {
     /** Relation */
-    std::unique_ptr<RamRelationReference> relation;
+    std::unique_ptr<RamRelationReference> relationRef;
 
 public:
-    RamEmptinessCheck(std::unique_ptr<RamRelationReference> rel)
-            : RamCondition(RN_EmptinessCheck), relation(std::move(rel)) {}
+    RamEmptinessCheck(std::unique_ptr<RamRelationReference> relRef)
+            : RamCondition(RN_EmptinessCheck), relationRef(std::move(relRef)) {}
 
     /** Get relation */
-    const RamRelationReference& getRelation() const {
-        return *relation;
+    const RamRelation& getRelation() const {
+        return *relationRef->get();
     }
 
     /** Print */
     void print(std::ostream& os) const override {
-        os << "(" << relation->getName() << " = ∅)";
+        os << "(" << relationRef->get()->getName() << " = ∅)";
     }
 
     /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
-        return std::vector<const RamNode*>() = {relation.get()};
+        return std::vector<const RamNode*>() = {relationRef.get()};
     }
 
     /** Create clone */
     RamEmptinessCheck* clone() const override {
         RamEmptinessCheck* res =
-                new RamEmptinessCheck(std::unique_ptr<RamRelationReference>(relation->clone()));
+                new RamEmptinessCheck(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
 
     /** Apply */
     void apply(const RamNodeMapper& map) override {
-        relation = map(std::move(relation));
+        relationRef = map(std::move(relationRef));
     }
 
 protected:

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -284,7 +284,8 @@ protected:
  */
 class RamExistenceCheck : public RamAbstractExistenceCheck {
 public:
-    RamExistenceCheck(std::unique_ptr<RamRelationReference> relRef, std::vector<std::unique_ptr<RamValue>> vals)
+    RamExistenceCheck(
+            std::unique_ptr<RamRelationReference> relRef, std::vector<std::unique_ptr<RamValue>> vals)
             : RamAbstractExistenceCheck(RN_ExistenceCheck, std::move(relRef), std::move(vals)) {}
 
     /** Print */

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -299,7 +299,7 @@ public:
                               out << *value;
                           }
                       })
-           << ") ∈ " << relationRef->get()->getName();
+           << ") ∈ " << getRelation().getName();
     }
 
     /** Create clone */
@@ -345,7 +345,7 @@ public:
                               out << *value;
                           }
                       })
-           << ") prov∈ " << relationRef->get()->getName();
+           << ") prov∈ " << getRelation().getName();
     }
 
     /** Create clone */
@@ -389,7 +389,7 @@ public:
 
     /** Print */
     void print(std::ostream& os) const override {
-        os << "(" << relationRef->get()->getName() << " = ∅)";
+        os << "(" << getRelation().getName() << " = ∅)";
     }
 
     /** Obtain list of child nodes */

--- a/src/RamNode.h
+++ b/src/RamNode.h
@@ -192,7 +192,7 @@ public:
  * Creates a node mapper based on a corresponding lambda expression.
  */
 template <typename Lambda>
-detail::LambdaRamNodeMapper<Lambda> makeLambdaMapper(const Lambda& lambda) {
+detail::LambdaRamNodeMapper<Lambda> makeLambdaRamMapper(const Lambda& lambda) {
     return detail::LambdaRamNodeMapper<Lambda>(lambda);
 }
 

--- a/src/RamOperation.cpp
+++ b/src/RamOperation.cpp
@@ -227,7 +227,7 @@ void RamAggregate::addCondition(std::unique_ptr<RamCondition> newCondition) {
     // use condition to narrow scan if possible
     size_t element = 0;
     if (std::unique_ptr<RamValue> value = getIndexElement(newCondition.get(), element, getIdentifier())) {
-        if (element > 0 || relation->getName().find("__agg") == std::string::npos) {
+        if (element > 0 || relationRef->get()->getName().find("__agg") == std::string::npos) {
             keys |= (1 << element);
             if (pattern[element] == nullptr) {
                 pattern[element] = std::move(value);

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -146,7 +146,8 @@ protected:
 public:
     RamRelationSearch(RamNodeType type, std::unique_ptr<RamRelationReference> relRef, size_t ident,
             std::unique_ptr<RamOperation> nested, std::string profileText = "")
-            : RamSearch(type, ident, std::move(nested), std::move(profileText)), relationRef(std::move(relRef)) {}
+            : RamSearch(type, ident, std::move(nested), std::move(profileText)),
+              relationRef(std::move(relRef)) {}
 
     /** Get search relation */
     const RamRelation& getRelation() const {
@@ -221,7 +222,7 @@ public:
 
     /** Print */
     void print(std::ostream& os, int tabpos) const override {
-        const RamRelation &rel = getRelation();
+        const RamRelation& rel = getRelation();
         os << times('\t', tabpos);
         os << "SEARCH " << rel.getName() << " AS t" << getIdentifier() << " ON INDEX ";
         bool first = true;

--- a/src/RamProgram.h
+++ b/src/RamProgram.h
@@ -118,11 +118,11 @@ public:
 
     /** Create clone */
     RamProgram* clone() const override {
-        typedef std::map<const RamRelation *, const RamRelation *> RefMapType;
-        RefMapType refMap; 
+        typedef std::map<const RamRelation*, const RamRelation*> RefMapType;
+        RefMapType refMap;
         RamProgram* res = new RamProgram(std::unique_ptr<RamStatement>(main->clone()));
         for (auto& cur : relations) {
-            RamRelation *newRel = cur.second->clone(); 
+            RamRelation* newRel = cur.second->clone();
             refMap[cur.second.get()] = newRel;
             res->addRelation(std::unique_ptr<RamRelation>(newRel));
         }
@@ -131,18 +131,20 @@ public:
         }
         // Rewrite relation references
         class RamRefRewriter : public RamNodeMapper {
-            RefMapType &refMap;
+            RefMapType& refMap;
+
         public:
-            RamRefRewriter(RefMapType &rm) : refMap(rm) { }
+            RamRefRewriter(RefMapType& rm) : refMap(rm) {}
             std::unique_ptr<RamNode> operator()(std::unique_ptr<RamNode> node) const override {
-               if (const RamRelationReference* relRef = dynamic_cast<RamRelationReference*>(node.get())) {
-                  const RamRelation *rel = refMap[relRef->get()]; 
-                  assert(rel != nullptr && "dangling RAM relation reference");
-                  return std::unique_ptr<RamRelationReference>(new RamRelationReference(rel));
-               } else return node;
+                if (const RamRelationReference* relRef = dynamic_cast<RamRelationReference*>(node.get())) {
+                    const RamRelation* rel = refMap[relRef->get()];
+                    assert(rel != nullptr && "dangling RAM relation reference");
+                    return std::unique_ptr<RamRelationReference>(new RamRelationReference(rel));
+                } else
+                    return node;
             }
         } refRewriter(refMap);
-        res->apply(refRewriter); 
+        res->apply(refRewriter);
         return res;
     }
 

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -179,62 +179,13 @@ public:
 
     /** Get reference */ 
     const RamRelation* get() const {
+        assert(relation != nullptr && "null relation"); 
         return relation;
     } 
 
-    /** Get name */
-    const std::string& getName() const {
-        return relation->getName();
-    }
-
-    /** Get relation */
-    const RamRelation* getRelation() const {
-        return relation;
-    }
-
-    /** Get arity */
-    unsigned getArity() const {
-        return relation->getArity();
-    }
-
-    /** Is nullary relation */
-    const bool isNullary() const {
-        return relation->isNullary();
-    }
-
-    /** Relation representation type */
-    const RelationRepresentation getRepresentation() const {
-        return relation->getRepresentation();
-    }
-
-    /** Is temp relation */
-    const bool isTemp() const {
-        return relation->isTemp();
-    }
-
-    /** Get symbol mask */
-    const SymbolMask& getSymbolMask() const {
-        return relation->getSymbolMask();
-    }
-
-    /** Get argument */
-    const std::string getArg(uint32_t i) const {
-        return relation->getArg(i);
-    }
-
-    /** Get argument qualifier */
-    const std::string getArgTypeQualifier(uint32_t i) const {
-        return relation->getArgTypeQualifier(i);
-    }
-
-    /** Comparator */
-    bool operator<(const RamRelationReference& other) const {
-        return relation->operator<(*other.getRelation());
-    }
-
     /* Print */
     void print(std::ostream& out) const override {
-        out << getName();
+        out << relation->getName();
     }
 
     /** Obtain list of child nodes */

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -173,7 +173,14 @@ protected:
     const RamRelation* relation;
 
 public:
-    RamRelationReference(const RamRelation* relation) : RamNode(RN_RelationReference), relation(relation) {}
+    RamRelationReference(const RamRelation* relation) : RamNode(RN_RelationReference), relation(relation) {
+        assert(relation != nullptr && "null relation"); 
+    }
+
+    /** Get reference */ 
+    const RamRelation* get() const {
+        return relation;
+    } 
 
     /** Get name */
     const std::string& getName() const {

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -53,6 +53,7 @@ protected:
     /** TODO (#541): legacy, i.e., duplicated information */
     const SymbolMask mask;
 
+    /** Data-structure representation */
     const RelationRepresentation representation;
 
 public:
@@ -83,6 +84,7 @@ public:
         return "c" + std::to_string(i);
     }
 
+    /** Get Argument Type */
     const std::string getArgTypeQualifier(uint32_t i) const {
         return (i < attributeTypeQualifiers.size()) ? attributeTypeQualifiers[i] : "";
     }
@@ -100,11 +102,6 @@ public:
     /** Relation representation type */
     const RelationRepresentation getRepresentation() const {
         return representation;
-    }
-
-    // Flag to check whether the data-structure
-    const bool isCoverable() const {
-        return true;
     }
 
     /** Is temporary relation (for semi-naive evaluation) */

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -84,7 +84,7 @@ public:
         return "c" + std::to_string(i);
     }
 
-    /** Get Argument Type */
+    /** Get Argument Type Qualifier */
     const std::string getArgTypeQualifier(uint32_t i) const {
         return (i < attributeTypeQualifiers.size()) ? attributeTypeQualifiers[i] : "";
     }

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -174,14 +174,14 @@ protected:
 
 public:
     RamRelationReference(const RamRelation* relation) : RamNode(RN_RelationReference), relation(relation) {
-        assert(relation != nullptr && "null relation"); 
+        assert(relation != nullptr && "null relation");
     }
 
-    /** Get reference */ 
+    /** Get reference */
     const RamRelation* get() const {
-        assert(relation != nullptr && "null relation"); 
+        assert(relation != nullptr && "null relation");
         return relation;
-    } 
+    }
 
     /* Print */
     void print(std::ostream& out) const override {

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -786,7 +786,11 @@ public:
 
     /** get logged relation */
     const RamRelation* getRelation() const {
-        return relationRef->get();
+	if (relationRef != nullptr) {
+           return relationRef->get();
+	} else {
+           return nullptr;
+	}
     }
 
     /** Pretty print */

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -97,7 +97,7 @@ public:
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
-        const RamRelation& rel = *relationRef->get();
+        const RamRelation& rel = getRelation();
         os << std::string(tabpos, '\t');
         os << "CREATE " << rel.getName() << " " << rel.getRepresentation();
     };
@@ -123,7 +123,7 @@ public:
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
-        const RamRelation& rel = *relationRef->get();
+        const RamRelation& rel = getRelation();
         os << std::string(tabpos, '\t');
         os << "LOAD DATA FOR " << rel.getName() << " FROM {";
         os << join(ioDirectives, "], [",
@@ -155,7 +155,7 @@ public:
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
-        const RamRelation& rel = *relationRef->get();
+        const RamRelation& rel = getRelation();
         os << std::string(tabpos, '\t');
         os << "STORE DATA FOR " << rel.getName() << " TO {";
         os << join(ioDirectives, "], [",
@@ -184,7 +184,7 @@ public:
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
-        const RamRelation& rel = *relationRef->get();
+        const RamRelation& rel = getRelation();
         os << std::string(tabpos, '\t');
         os << "CLEAR ";
         os << rel.getName();
@@ -207,7 +207,7 @@ public:
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
-        const RamRelation& rel = *relationRef->get();
+        const RamRelation& rel = getRelation();
         os << std::string(tabpos, '\t');
         os << std::string(tabpos, '\t');
         os << "DROP " << rel.getName();
@@ -304,12 +304,6 @@ public:
         }
     }
 
-    /** Pretty print */
-    void print(std::ostream& os, int tabpos) const override {
-        os << std::string(tabpos, '\t');
-        os << "SWAP (" << first->get()->getName() << ", " << second->get()->getName() << ")";
-    };
-
     /** Get first relation */
     const RamRelation& getFirstRelation() const {
         return *first->get();
@@ -319,6 +313,12 @@ public:
     const RamRelation& getSecondRelation() const {
         return *second->get();
     }
+
+    /** Pretty print */
+    void print(std::ostream& os, int tabpos) const override {
+        os << std::string(tabpos, '\t');
+        os << "SWAP (" << getFirstRelation().getName() << ", " << getSecondRelation().getName() << ")";
+    };
 
     /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
@@ -369,7 +369,7 @@ public:
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
         os << "INSERT (" << join(values, ",", print_deref<std::unique_ptr<RamValue>>()) << ") INTO "
-           << relationRef->get()->getName();
+           << getRelation().getName();
     };
 
     /** Obtain list of child nodes */
@@ -972,7 +972,7 @@ public:
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
-        os << "LOGSIZE " << relationRef->get()->getName();
+        os << "LOGSIZE " << getRelation().getName();
         os << " TEXT "
            << "\"" << stringify(message) << "\"";
     }

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -786,11 +786,11 @@ public:
 
     /** get logged relation */
     const RamRelation* getRelation() const {
-	if (relationRef != nullptr) {
-           return relationRef->get();
-	} else {
-           return nullptr;
-	}
+        if (relationRef != nullptr) {
+            return relationRef->get();
+        } else {
+            return nullptr;
+        }
     }
 
     /** Pretty print */

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -57,26 +57,25 @@ public:
 class RamRelationStatement : public RamStatement {
 protected:
     /** Relation */
-    std::unique_ptr<RamRelationReference> relation;
+    std::unique_ptr<RamRelationReference> relationRef;
 
 public:
-    RamRelationStatement(RamNodeType type, std::unique_ptr<RamRelationReference> r)
-            : RamStatement(type), relation(std::move(r)) {}
+    RamRelationStatement(RamNodeType type, std::unique_ptr<RamRelationReference> relRef)
+            : RamStatement(type), relationRef(std::move(relRef)) {}
 
     /** Get RAM relation */
-    const RamRelationReference& getRelation() const {
-        assert(relation);
-        return *relation;
+    const RamRelation& getRelation() const {
+        return *relationRef->get();
     }
 
     /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
-        return std::vector<const RamNode*>() = {relation.get()};  // no child nodes
+        return std::vector<const RamNode*>() = {relationRef.get()};  // no child nodes
     }
 
     /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
-        relation = map(std::move(relation));
+        relationRef = map(std::move(relationRef));
     }
 
 protected:
@@ -93,24 +92,18 @@ protected:
  */
 class RamCreate : public RamRelationStatement {
 public:
-    RamCreate(std::unique_ptr<RamRelationReference> rel) : RamRelationStatement(RN_Create, std::move(rel)) {}
+    RamCreate(std::unique_ptr<RamRelationReference> relRef) : RamRelationStatement(RN_Create, std::move(relRef)) {}
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
+        const RamRelation &rel = *relationRef->get(); 
         os << std::string(tabpos, '\t');
-        os << "CREATE " << getRelation().getName() << "(";
-        os << getRelation().getArg(0);
-        for (size_t i = 1; i < getRelation().getArity(); i++) {
-            os << ",";
-            os << getRelation().getArg(i);
-        }
-        os << ")";
-        os << " " << getRelation().getRepresentation();
+        os << "CREATE " << rel.getName() << " " << rel.getRepresentation();
     };
 
     /** Create clone */
     RamCreate* clone() const override {
-        RamCreate* res = new RamCreate(std::unique_ptr<RamRelationReference>(relation->clone()));
+        RamCreate* res = new RamCreate(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
 };
@@ -120,8 +113,8 @@ public:
  */
 class RamLoad : public RamRelationStatement {
 public:
-    RamLoad(std::unique_ptr<RamRelationReference> rel, std::vector<IODirectives> ioDirectives)
-            : RamRelationStatement(RN_Load, std::move(rel)), ioDirectives(std::move(ioDirectives)) {}
+    RamLoad(std::unique_ptr<RamRelationReference> relRef, std::vector<IODirectives> ioDirectives)
+            : RamRelationStatement(RN_Load, std::move(relRef)), ioDirectives(std::move(ioDirectives)) {}
 
     const std::vector<IODirectives>& getIODirectives() const {
         return ioDirectives;
@@ -129,8 +122,9 @@ public:
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
+        const RamRelation &rel = *relationRef->get(); 
         os << std::string(tabpos, '\t');
-        os << "LOAD DATA FOR " << getRelation().getName() << " FROM {";
+        os << "LOAD DATA FOR " << rel.getName() << " FROM {";
         os << join(ioDirectives, "], [",
                 [](std::ostream& out, const IODirectives& directives) { out << directives; });
         os << ioDirectives << "}";
@@ -138,7 +132,7 @@ public:
 
     /** Create clone */
     RamLoad* clone() const override {
-        RamLoad* res = new RamLoad(std::unique_ptr<RamRelationReference>(relation->clone()), ioDirectives);
+        RamLoad* res = new RamLoad(std::unique_ptr<RamRelationReference>(relationRef->clone()), ioDirectives);
         return res;
     }
 
@@ -151,8 +145,8 @@ private:
  */
 class RamStore : public RamRelationStatement {
 public:
-    RamStore(std::unique_ptr<RamRelationReference> rel, std::vector<IODirectives> ioDirectives)
-            : RamRelationStatement(RN_Store, std::move(rel)), ioDirectives(std::move(ioDirectives)) {}
+    RamStore(std::unique_ptr<RamRelationReference> relRef, std::vector<IODirectives> ioDirectives)
+            : RamRelationStatement(RN_Store, std::move(relRef)), ioDirectives(std::move(ioDirectives)) {}
 
     const std::vector<IODirectives>& getIODirectives() const {
         return ioDirectives;
@@ -160,8 +154,9 @@ public:
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
+        const RamRelation &rel = *relationRef->get(); 
         os << std::string(tabpos, '\t');
-        os << "STORE DATA FOR " << getRelation().getName() << " TO {";
+        os << "STORE DATA FOR " << rel.getName() << " TO {";
         os << join(ioDirectives, "], [",
                 [](std::ostream& out, const IODirectives& directives) { out << directives; });
         os << "}";
@@ -169,7 +164,7 @@ public:
 
     /** Create clone */
     RamStore* clone() const override {
-        RamStore* res = new RamStore(std::unique_ptr<RamRelationReference>(relation->clone()), ioDirectives);
+        RamStore* res = new RamStore(std::unique_ptr<RamRelationReference>(relationRef->clone()), ioDirectives);
         return res;
     }
 
@@ -182,18 +177,19 @@ private:
  */
 class RamClear : public RamRelationStatement {
 public:
-    RamClear(std::unique_ptr<RamRelationReference> rel) : RamRelationStatement(RN_Clear, std::move(rel)) {}
+    RamClear(std::unique_ptr<RamRelationReference> relRef) : RamRelationStatement(RN_Clear, std::move(relRef)) {}
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
+        const RamRelation &rel = *relationRef->get(); 
         os << std::string(tabpos, '\t');
         os << "CLEAR ";
-        os << getRelation().getName();
+        os << rel.getName();
     }
 
     /** Create clone */
     RamClear* clone() const override {
-        RamClear* res = new RamClear(std::unique_ptr<RamRelationReference>(relation->clone()));
+        RamClear* res = new RamClear(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
 };
@@ -203,16 +199,18 @@ public:
  */
 class RamDrop : public RamRelationStatement {
 public:
-    RamDrop(std::unique_ptr<RamRelationReference> rel) : RamRelationStatement(RN_Drop, std::move(rel)) {}
+    RamDrop(std::unique_ptr<RamRelationReference> relRef) : RamRelationStatement(RN_Drop, std::move(relRef)) {}
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
+        const RamRelation &rel = *relationRef->get(); 
         os << std::string(tabpos, '\t');
-        os << "DROP " << getRelation().getName();
+        os << std::string(tabpos, '\t');
+        os << "DROP " << rel.getName();
     }
     /** Create clone */
     RamDrop* clone() const override {
-        RamDrop* res = new RamDrop(std::unique_ptr<RamRelationReference>(relation->clone()));
+        RamDrop* res = new RamDrop(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
 };
@@ -223,12 +221,14 @@ public:
  */
 class RamMerge : public RamStatement {
 protected:
-    std::unique_ptr<RamRelationReference> target;
-    std::unique_ptr<RamRelationReference> source;
+    std::unique_ptr<RamRelationReference> targetRef;
+    std::unique_ptr<RamRelationReference> sourceRef;
 
 public:
-    RamMerge(std::unique_ptr<RamRelationReference> t, std::unique_ptr<RamRelationReference> s)
-            : RamStatement(RN_Merge), target(std::move(t)), source(std::move(s)) {
+    RamMerge(std::unique_ptr<RamRelationReference> tRef, std::unique_ptr<RamRelationReference> sRef)
+            : RamStatement(RN_Merge), targetRef(std::move(tRef)), sourceRef(std::move(sRef)) {
+        const RamRelation *source = sourceRef->get(); 
+        const RamRelation *target = targetRef->get(); 
         assert(source->getArity() == target->getArity() && "mismatching relations");
         for (size_t i = 0; i < source->getArity(); i++) {
             assert(source->getArgTypeQualifier(i) == target->getArgTypeQualifier(i) && "mismatching type");
@@ -236,37 +236,37 @@ public:
     }
 
     /** Get source relation */
-    const RamRelationReference& getSourceRelation() const {
-        return *source;
+    const RamRelation& getSourceRelation() const {
+        return *sourceRef->get();
     }
 
     /** Get target relation */
-    const RamRelationReference& getTargetRelation() const {
-        return *target;
+    const RamRelation& getTargetRelation() const {
+        return *targetRef->get();
     }
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
-        os << "MERGE " << target->getName() << " WITH " << source->getName();
+        os << "MERGE " << getTargetRelation().getName() << " WITH " << getSourceRelation().getName();
     }
 
     /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
-        return std::vector<const RamNode*>({source.get(), target.get()});
+        return std::vector<const RamNode*>({sourceRef.get(), targetRef.get()});
     }
 
     /** Create clone */
     RamMerge* clone() const override {
-        RamMerge* res = new RamMerge(std::unique_ptr<RamRelationReference>(target->clone()),
-                std::unique_ptr<RamRelationReference>(source->clone()));
+        RamMerge* res = new RamMerge(std::unique_ptr<RamRelationReference>(targetRef->clone()),
+                std::unique_ptr<RamRelationReference>(sourceRef->clone()));
         return res;
     }
 
     /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
-        source = map(std::move(source));
-        target = map(std::move(target));
+        sourceRef = map(std::move(sourceRef));
+        targetRef = map(std::move(targetRef));
     }
 
 protected:
@@ -293,16 +293,16 @@ protected:
 public:
     RamSwap(std::unique_ptr<RamRelationReference> f, std::unique_ptr<RamRelationReference> s)
             : RamStatement(RN_Swap), first(std::move(f)), second(std::move(s)) {
-        assert(first->getArity() == second->getArity() && "mismatching relations");
-        for (size_t i = 0; i < first->getArity(); i++) {
-            assert(first->getArgTypeQualifier(i) == second->getArgTypeQualifier(i) && "mismatching type");
+        assert(first->get()->getArity() == second->get()->getArity() && "mismatching relations");
+        for (size_t i = 0; i < first->get()->getArity(); i++) {
+            assert(first->get()->getArgTypeQualifier(i) == second->get()->getArgTypeQualifier(i) && "mismatching type");
         }
     }
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
-        os << "SWAP (" << first->getName() << ", " << second->getName() << ")";
+        os << "SWAP (" << first->get()->getName() << ", " << second->get()->getName() << ")";
     };
 
     /** Get first relation */
@@ -352,8 +352,8 @@ protected:
     std::vector<std::unique_ptr<RamValue>> values;
 
 public:
-    RamFact(std::unique_ptr<RamRelationReference> rel, std::vector<std::unique_ptr<RamValue>>&& v)
-            : RamRelationStatement(RN_Fact, std::move(rel)), values(std::move(v)) {}
+    RamFact(std::unique_ptr<RamRelationReference> relRef, std::vector<std::unique_ptr<RamValue>>&& v)
+            : RamRelationStatement(RN_Fact, std::move(relRef)), values(std::move(v)) {}
 
     /** Get arguments of fact */
     std::vector<RamValue*> getValues() const {
@@ -364,7 +364,7 @@ public:
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
         os << "INSERT (" << join(values, ",", print_deref<std::unique_ptr<RamValue>>()) << ") INTO "
-           << getRelation().getName();
+           << relationRef->get()->getName();
     };
 
     /** Obtain list of child nodes */
@@ -378,7 +378,7 @@ public:
 
     /** Create clone */
     RamFact* clone() const override {
-        RamFact* res = new RamFact(std::unique_ptr<RamRelationReference>(relation->clone()), {});
+        RamFact* res = new RamFact(std::unique_ptr<RamRelationReference>(relationRef->clone()), {});
         for (auto& cur : values) {
             res->values.emplace_back(cur->clone());
         }
@@ -758,13 +758,13 @@ protected:
     std::string message;
 
     /** Relation */
-    std::unique_ptr<RamRelationReference> relation;
+    std::unique_ptr<RamRelationReference> relationRef;
 
 public:
     RamLogTimer(std::unique_ptr<RamStatement> stmt, std::string msg,
-            std::unique_ptr<RamRelationReference> relation)
+            std::unique_ptr<RamRelationReference> relationRef)
             : RamStatement(RN_LogTimer), statement(std::move(stmt)), message(std::move(msg)),
-              relation(std::move(relation)) {
+              relationRef(std::move(relationRef)) {
         assert(statement);
     }
 
@@ -781,7 +781,7 @@ public:
 
     /** get logged relation */
     const std::unique_ptr<RamRelationReference>& getRelation() const {
-        return relation;
+        return relationRef;
     }
 
     /** Pretty print */
@@ -802,7 +802,7 @@ public:
     /** Create clone */
     RamLogTimer* clone() const override {
         RamLogTimer* res = new RamLogTimer(std::unique_ptr<RamStatement>(statement->clone()), message,
-                std::unique_ptr<RamRelationReference>(relation->clone()));
+                std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
 
@@ -952,8 +952,8 @@ protected:
     std::string message;
 
 public:
-    RamLogSize(std::unique_ptr<RamRelationReference> relation, std::string message)
-            : RamRelationStatement(RN_LogSize, std::move(relation)), message(std::move(message)) {}
+    RamLogSize(std::unique_ptr<RamRelationReference> relRef, std::string message)
+            : RamRelationStatement(RN_LogSize, std::move(relRef)), message(std::move(message)) {}
 
     /** Get logging message */
     const std::string& getMessage() const {
@@ -963,14 +963,14 @@ public:
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
-        os << "LOGSIZE " << getRelation().getName();
+        os << "LOGSIZE " << relationRef->get()->getName();
         os << " TEXT "
            << "\"" << stringify(message) << "\"";
     }
 
     /** Create clone */
     RamLogSize* clone() const override {
-        RamLogSize* res = new RamLogSize(std::unique_ptr<RamRelationReference>(relation->clone()), message);
+        RamLogSize* res = new RamLogSize(std::unique_ptr<RamRelationReference>(relationRef->clone()), message);
         return res;
     }
 
@@ -1006,7 +1006,7 @@ public:
 
     /** Create clone */
     RamRecv* clone() const override {
-        RamRecv* res = new RamRecv(std::unique_ptr<RamRelationReference>(relation->clone()), sourceStratum);
+        RamRecv* res = new RamRecv(std::unique_ptr<RamRelationReference>(relationRef->clone()), sourceStratum);
         return res;
     }
 
@@ -1049,7 +1049,7 @@ public:
     /** Create clone */
     RamSend* clone() const override {
         RamSend* res =
-                new RamSend(std::unique_ptr<RamRelationReference>(relation->clone()), destinationStrata);
+                new RamSend(std::unique_ptr<RamRelationReference>(relationRef->clone()), destinationStrata);
         return res;
     }
 

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -306,13 +306,13 @@ public:
     };
 
     /** Get first relation */
-    const RamRelationReference& getFirstRelation() const {
-        return *first;
+    const RamRelation& getFirstRelation() const {
+        return *first->get();
     }
 
     /** Get second relation */
-    const RamRelationReference& getSecondRelation() const {
-        return *second;
+    const RamRelation& getSecondRelation() const {
+        return *second->get();
     }
 
     /** Obtain list of child nodes */
@@ -762,9 +762,9 @@ protected:
 
 public:
     RamLogTimer(std::unique_ptr<RamStatement> stmt, std::string msg,
-            std::unique_ptr<RamRelationReference> relationRef)
+            std::unique_ptr<RamRelationReference> relRef)
             : RamStatement(RN_LogTimer), statement(std::move(stmt)), message(std::move(msg)),
-              relationRef(std::move(relationRef)) {
+              relationRef(std::move(relRef)) {
         assert(statement);
     }
 
@@ -780,8 +780,8 @@ public:
     }
 
     /** get logged relation */
-    const std::unique_ptr<RamRelationReference>& getRelation() const {
-        return relationRef;
+    const RamRelation *getRelation() const {
+        return relationRef->get();
     }
 
     /** Pretty print */

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -92,11 +92,12 @@ protected:
  */
 class RamCreate : public RamRelationStatement {
 public:
-    RamCreate(std::unique_ptr<RamRelationReference> relRef) : RamRelationStatement(RN_Create, std::move(relRef)) {}
+    RamCreate(std::unique_ptr<RamRelationReference> relRef)
+            : RamRelationStatement(RN_Create, std::move(relRef)) {}
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
-        const RamRelation &rel = *relationRef->get(); 
+        const RamRelation& rel = *relationRef->get();
         os << std::string(tabpos, '\t');
         os << "CREATE " << rel.getName() << " " << rel.getRepresentation();
     };
@@ -122,7 +123,7 @@ public:
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
-        const RamRelation &rel = *relationRef->get(); 
+        const RamRelation& rel = *relationRef->get();
         os << std::string(tabpos, '\t');
         os << "LOAD DATA FOR " << rel.getName() << " FROM {";
         os << join(ioDirectives, "], [",
@@ -154,7 +155,7 @@ public:
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
-        const RamRelation &rel = *relationRef->get(); 
+        const RamRelation& rel = *relationRef->get();
         os << std::string(tabpos, '\t');
         os << "STORE DATA FOR " << rel.getName() << " TO {";
         os << join(ioDirectives, "], [",
@@ -164,7 +165,8 @@ public:
 
     /** Create clone */
     RamStore* clone() const override {
-        RamStore* res = new RamStore(std::unique_ptr<RamRelationReference>(relationRef->clone()), ioDirectives);
+        RamStore* res =
+                new RamStore(std::unique_ptr<RamRelationReference>(relationRef->clone()), ioDirectives);
         return res;
     }
 
@@ -177,11 +179,12 @@ private:
  */
 class RamClear : public RamRelationStatement {
 public:
-    RamClear(std::unique_ptr<RamRelationReference> relRef) : RamRelationStatement(RN_Clear, std::move(relRef)) {}
+    RamClear(std::unique_ptr<RamRelationReference> relRef)
+            : RamRelationStatement(RN_Clear, std::move(relRef)) {}
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
-        const RamRelation &rel = *relationRef->get(); 
+        const RamRelation& rel = *relationRef->get();
         os << std::string(tabpos, '\t');
         os << "CLEAR ";
         os << rel.getName();
@@ -199,11 +202,12 @@ public:
  */
 class RamDrop : public RamRelationStatement {
 public:
-    RamDrop(std::unique_ptr<RamRelationReference> relRef) : RamRelationStatement(RN_Drop, std::move(relRef)) {}
+    RamDrop(std::unique_ptr<RamRelationReference> relRef)
+            : RamRelationStatement(RN_Drop, std::move(relRef)) {}
 
     /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
-        const RamRelation &rel = *relationRef->get(); 
+        const RamRelation& rel = *relationRef->get();
         os << std::string(tabpos, '\t');
         os << std::string(tabpos, '\t');
         os << "DROP " << rel.getName();
@@ -227,8 +231,8 @@ protected:
 public:
     RamMerge(std::unique_ptr<RamRelationReference> tRef, std::unique_ptr<RamRelationReference> sRef)
             : RamStatement(RN_Merge), targetRef(std::move(tRef)), sourceRef(std::move(sRef)) {
-        const RamRelation *source = sourceRef->get(); 
-        const RamRelation *target = targetRef->get(); 
+        const RamRelation* source = sourceRef->get();
+        const RamRelation* target = targetRef->get();
         assert(source->getArity() == target->getArity() && "mismatching relations");
         for (size_t i = 0; i < source->getArity(); i++) {
             assert(source->getArgTypeQualifier(i) == target->getArgTypeQualifier(i) && "mismatching type");
@@ -295,7 +299,8 @@ public:
             : RamStatement(RN_Swap), first(std::move(f)), second(std::move(s)) {
         assert(first->get()->getArity() == second->get()->getArity() && "mismatching relations");
         for (size_t i = 0; i < first->get()->getArity(); i++) {
-            assert(first->get()->getArgTypeQualifier(i) == second->get()->getArgTypeQualifier(i) && "mismatching type");
+            assert(first->get()->getArgTypeQualifier(i) == second->get()->getArgTypeQualifier(i) &&
+                    "mismatching type");
         }
     }
 
@@ -761,8 +766,8 @@ protected:
     std::unique_ptr<RamRelationReference> relationRef;
 
 public:
-    RamLogTimer(std::unique_ptr<RamStatement> stmt, std::string msg,
-            std::unique_ptr<RamRelationReference> relRef)
+    RamLogTimer(
+            std::unique_ptr<RamStatement> stmt, std::string msg, std::unique_ptr<RamRelationReference> relRef)
             : RamStatement(RN_LogTimer), statement(std::move(stmt)), message(std::move(msg)),
               relationRef(std::move(relRef)) {
         assert(statement);
@@ -780,7 +785,7 @@ public:
     }
 
     /** get logged relation */
-    const RamRelation *getRelation() const {
+    const RamRelation* getRelation() const {
         return relationRef->get();
     }
 
@@ -970,7 +975,8 @@ public:
 
     /** Create clone */
     RamLogSize* clone() const override {
-        RamLogSize* res = new RamLogSize(std::unique_ptr<RamRelationReference>(relationRef->clone()), message);
+        RamLogSize* res =
+                new RamLogSize(std::unique_ptr<RamRelationReference>(relationRef->clone()), message);
         return res;
     }
 
@@ -1006,7 +1012,8 @@ public:
 
     /** Create clone */
     RamRecv* clone() const override {
-        RamRecv* res = new RamRecv(std::unique_ptr<RamRelationReference>(relationRef->clone()), sourceStratum);
+        RamRecv* res =
+                new RamRecv(std::unique_ptr<RamRelationReference>(relationRef->clone()), sourceStratum);
         return res;
     }
 

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -238,8 +238,8 @@ std::unique_ptr<RamOperation> CreateIndicesTransformer::rewriteScan(const RamSca
 
         if (indexable) {
             // replace scan by index scan
-            return std::make_unique<RamIndexScan>(std::make_unique<RamRelationReference>(&rel),
-                    identifier, std::move(queryPattern),
+            return std::make_unique<RamIndexScan>(std::make_unique<RamRelationReference>(&rel), identifier,
+                    std::move(queryPattern),
                     condition == nullptr
                             ? std::unique_ptr<RamOperation>(filter->getOperation().clone())
                             : std::make_unique<RamFilter>(std::move(condition),

--- a/src/RamValue.h
+++ b/src/RamValue.h
@@ -237,6 +237,7 @@ private:
     const size_t element;
 
     /** Relation */
+    /** TODO: 541 avoid null-pointers */
     std::unique_ptr<RamRelationReference> relationRef;
 
 public:

--- a/src/RamValue.h
+++ b/src/RamValue.h
@@ -237,18 +237,18 @@ private:
     const size_t element;
 
     /** Relation */
-    std::unique_ptr<RamRelationReference> relation;
+    std::unique_ptr<RamRelationReference> relationRef;
 
 public:
-    RamElementAccess(size_t ident, size_t elem, std::unique_ptr<RamRelationReference> rel = nullptr)
-            : RamValue(RN_ElementAccess), identifier(ident), element(elem), relation(std::move(rel)) {}
+    RamElementAccess(size_t ident, size_t elem, std::unique_ptr<RamRelationReference> relRef = nullptr)
+            : RamValue(RN_ElementAccess), identifier(ident), element(elem), relationRef(std::move(relRef)) {}
 
     /** Print */
     void print(std::ostream& os) const override {
-        if (nullptr == relation) {
+        if (nullptr == relationRef) {
             os << "env(t" << identifier << ", i" << element << ")";
         } else {
-            os << "t" << identifier << "." << relation->getArg(element);
+            os << "t" << identifier << "." << relationRef->get()->getArg(element);
         }
     }
 
@@ -264,14 +264,14 @@ public:
 
     /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
-        return std::vector<const RamNode*>({relation.get()});
+        return std::vector<const RamNode*>({relationRef.get()});
     }
 
     /** Create clone */
     RamElementAccess* clone() const override {
-        if (relation != nullptr) {
+        if (relationRef != nullptr) {
             return new RamElementAccess(
-                    identifier, element, std::unique_ptr<RamRelationReference>(relation->clone()));
+                    identifier, element, std::unique_ptr<RamRelationReference>(relationRef->clone()));
         } else {
             return new RamElementAccess(identifier, element);
         }
@@ -279,8 +279,8 @@ public:
 
     /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
-        if (relation != nullptr) {
-            relation = map(std::move(relation));
+        if (relationRef != nullptr) {
+            relationRef = map(std::move(relationRef));
         }
     }
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -169,8 +169,8 @@ std::string Synthesiser::toIndex(SearchColumns key) {
 }
 
 /** Get referenced relations */
-std::set<const RamRelation *> Synthesiser::getReferencedRelations(const RamOperation& op) {
-    std::set<const RamRelation *> res;
+std::set<const RamRelation*> Synthesiser::getReferencedRelations(const RamOperation& op) {
+    std::set<const RamRelation*> res;
     visitDepthFirst(op, [&](const RamNode& node) {
         if (auto scan = dynamic_cast<const RamRelationSearch*>(&node)) {
             res.insert(&scan->getRelation());
@@ -384,8 +384,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             }
 
             // create operation contexts for this operation
-            for (const RamRelation *rel :
-                    synthesiser.getReferencedRelations(insert.getOperation())) {
+            for (const RamRelation* rel : synthesiser.getReferencedRelations(insert.getOperation())) {
                 // TODO (#467): this causes bugs for subprogram compilation for record types if artificial
                 // dependencies are introduces in the precedence graph
                 out << "CREATE_OP_CONTEXT(" << synthesiser.getOpContextName(*rel);

--- a/src/Synthesiser.h
+++ b/src/Synthesiser.h
@@ -74,7 +74,7 @@ protected:
     std::string toIndex(SearchColumns key);
 
     /** Get referenced relations */
-    std::set<const RamRelation *> getReferencedRelations(const RamOperation& op);
+    std::set<const RamRelation*> getReferencedRelations(const RamOperation& op);
 
     /** Generate code */
     void emitCode(std::ostream& out, const RamStatement& stmt);

--- a/src/Synthesiser.h
+++ b/src/Synthesiser.h
@@ -27,9 +27,9 @@
 namespace souffle {
 
 class RamOperation;
-class RamRelationReference;
 class RamTranslationUnit;
 class SynthesiserRelation;
+class RamRelation;
 
 /**
  * A RAM synthesiser: synthesises a C++ program from a RAM program.
@@ -59,13 +59,13 @@ protected:
     bool areIndexesDisabled();
 
     /** Get relation name */
-    const std::string getRelationName(const RamRelationReference& rel);
+    const std::string getRelationName(const RamRelation& rel);
 
     /** Get relation name */
     const std::string getRelationName(const std::string& relName);
 
     /** Get context name */
-    const std::string getOpContextName(const RamRelationReference& rel);
+    const std::string getOpContextName(const RamRelation& rel);
 
     /** Get relation struct definition */
     void generateRelationTypeStruct(std::ostream& out, std::unique_ptr<SynthesiserRelation> relationType);
@@ -74,7 +74,7 @@ protected:
     std::string toIndex(SearchColumns key);
 
     /** Get referenced relations */
-    std::set<RamRelationReference> getReferencedRelations(const RamOperation& op);
+    std::set<const RamRelation *> getReferencedRelations(const RamOperation& op);
 
     /** Generate code */
     void emitCode(std::ostream& out, const RamStatement& stmt);

--- a/src/SynthesiserRelation.cpp
+++ b/src/SynthesiserRelation.cpp
@@ -18,7 +18,7 @@
 namespace souffle {
 
 std::unique_ptr<SynthesiserRelation> SynthesiserRelation::getSynthesiserRelation(
-        const RamRelationReference& ramRel, const IndexSet& indexSet, bool isProvenance) {
+        const RamRelation& ramRel, const IndexSet& indexSet, bool isProvenance) {
     SynthesiserRelation* rel;
 
     // Handle the qualifier in souffle code

--- a/src/SynthesiserRelation.h
+++ b/src/SynthesiserRelation.h
@@ -20,8 +20,7 @@ namespace souffle {
 
 class SynthesiserRelation {
 public:
-    SynthesiserRelation(
-            const RamRelation& rel, const IndexSet& indices, const bool isProvenance = false)
+    SynthesiserRelation(const RamRelation& rel, const IndexSet& indices, const bool isProvenance = false)
             : relation(rel), indices(indices), isProvenance(isProvenance) {}
 
     virtual ~SynthesiserRelation() = default;
@@ -88,8 +87,7 @@ protected:
 
 class SynthesiserNullaryRelation : public SynthesiserRelation {
 public:
-    SynthesiserNullaryRelation(
-            const RamRelation& ramRel, const IndexSet& indexSet, bool isProvenance)
+    SynthesiserNullaryRelation(const RamRelation& ramRel, const IndexSet& indexSet, bool isProvenance)
             : SynthesiserRelation(ramRel, indexSet, isProvenance) {}
 
     void computeIndices() override;
@@ -109,8 +107,7 @@ public:
 
 class SynthesiserIndirectRelation : public SynthesiserRelation {
 public:
-    SynthesiserIndirectRelation(
-            const RamRelation& ramRel, const IndexSet& indexSet, bool isProvenance)
+    SynthesiserIndirectRelation(const RamRelation& ramRel, const IndexSet& indexSet, bool isProvenance)
             : SynthesiserRelation(ramRel, indexSet, isProvenance) {}
 
     void computeIndices() override;

--- a/src/SynthesiserRelation.h
+++ b/src/SynthesiserRelation.h
@@ -21,7 +21,7 @@ namespace souffle {
 class SynthesiserRelation {
 public:
     SynthesiserRelation(
-            const RamRelationReference& rel, const IndexSet& indices, const bool isProvenance = false)
+            const RamRelation& rel, const IndexSet& indices, const bool isProvenance = false)
             : relation(rel), indices(indices), isProvenance(isProvenance) {}
 
     virtual ~SynthesiserRelation() = default;
@@ -52,7 +52,7 @@ public:
     }
 
     /** Get stored RamRelation */
-    const RamRelationReference& getRamRelation() const {
+    const RamRelation& getRamRelation() const {
         return relation;
     }
 
@@ -64,11 +64,11 @@ public:
 
     /** Factory method to generate a SynthesiserRelation */
     static std::unique_ptr<SynthesiserRelation> getSynthesiserRelation(
-            const RamRelationReference& ramRel, const IndexSet& indexSet, bool isProvenance);
+            const RamRelation& ramRel, const IndexSet& indexSet, bool isProvenance);
 
 protected:
     /** Ram relation referred to by this */
-    const RamRelationReference& relation;
+    const RamRelation& relation;
 
     /** Indices used for this relation */
     const IndexSet& indices;
@@ -89,7 +89,7 @@ protected:
 class SynthesiserNullaryRelation : public SynthesiserRelation {
 public:
     SynthesiserNullaryRelation(
-            const RamRelationReference& ramRel, const IndexSet& indexSet, bool isProvenance)
+            const RamRelation& ramRel, const IndexSet& indexSet, bool isProvenance)
             : SynthesiserRelation(ramRel, indexSet, isProvenance) {}
 
     void computeIndices() override;
@@ -99,7 +99,7 @@ public:
 
 class SynthesiserDirectRelation : public SynthesiserRelation {
 public:
-    SynthesiserDirectRelation(const RamRelationReference& ramRel, const IndexSet& indexSet, bool isProvenance)
+    SynthesiserDirectRelation(const RamRelation& ramRel, const IndexSet& indexSet, bool isProvenance)
             : SynthesiserRelation(ramRel, indexSet, isProvenance) {}
 
     void computeIndices() override;
@@ -110,7 +110,7 @@ public:
 class SynthesiserIndirectRelation : public SynthesiserRelation {
 public:
     SynthesiserIndirectRelation(
-            const RamRelationReference& ramRel, const IndexSet& indexSet, bool isProvenance)
+            const RamRelation& ramRel, const IndexSet& indexSet, bool isProvenance)
             : SynthesiserRelation(ramRel, indexSet, isProvenance) {}
 
     void computeIndices() override;
@@ -120,7 +120,7 @@ public:
 
 class SynthesiserBrieRelation : public SynthesiserRelation {
 public:
-    SynthesiserBrieRelation(const RamRelationReference& ramRel, const IndexSet& indexSet, bool isProvenance)
+    SynthesiserBrieRelation(const RamRelation& ramRel, const IndexSet& indexSet, bool isProvenance)
             : SynthesiserRelation(ramRel, indexSet, isProvenance) {}
 
     void computeIndices() override;
@@ -130,7 +130,7 @@ public:
 
 class SynthesiserEqrelRelation : public SynthesiserRelation {
 public:
-    SynthesiserEqrelRelation(const RamRelationReference& ramRel, const IndexSet& indexSet, bool isProvenance)
+    SynthesiserEqrelRelation(const RamRelation& ramRel, const IndexSet& indexSet, bool isProvenance)
             : SynthesiserRelation(ramRel, indexSet, isProvenance) {}
 
     void computeIndices() override;

--- a/src/test/matching_test.cpp
+++ b/src/test/matching_test.cpp
@@ -29,8 +29,7 @@
 using namespace std;
 using namespace souffle;
 
-RamRelation r("test", 0, {}, {}, SymbolMask(0), {});
-RamRelationReference rel(&r);
+RamRelation rel("test", 0, {}, {}, SymbolMask(0), {});
 class TestAutoIndex : public IndexSet {
 public:
     TestAutoIndex() : IndexSet(rel) {}


### PR DESCRIPTION
- Convert RamRelationReference to a proper proxy pattern
- Change references in cloned program to new relations (cf. clone() of RamProgram)
