### PR TITLE
Update supported Ubuntu releases

### DIFF
--- a/.travis/bintray_json.sh
+++ b/.travis/bintray_json.sh
@@ -42,7 +42,7 @@ then
   FILES="[{\"includePattern\": \"./(.*\.tar.gz)\", \"uploadPattern\": \"\$1\"}],"
 
 else
-  DIST=xenial,yakkety,zesty,artful,bionic
+  DIST=xenial,bionic,cosmic,disco
 
   FILES="[{\"includePattern\": \"deploy/(.*\.deb)\", \"uploadPattern\": \"pool/main/s/souffle/\$1\",
     \"matrixParams\": {


### PR DESCRIPTION
Supported releases are LTS releases, latest release, and beta release.

The same code should run on everything since xenial, but if a user wants to use an unsupported release they're responsible for managing any package/repo weirdness, should it occur.