### PR TITLE
Avoid deprecated bison directive

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -16,7 +16,7 @@
 %skeleton "lalr1.cc"
 %require "3.0.2"
 %defines
-%define parser_class_name {parser}
+%define api.parser.class {parser}
 %define api.token.constructor
 %define api.value.type variant
 %define parse.assert


### PR DESCRIPTION
This reflects a deprecation in `bison`, see [[1]](http://lists.gnu.org/archive/html/info-gnu/2019-01/msg00016.html).

This was breaking builds for nixpkgs, see [[2]](https://hydra.nixos.org/build/91526961/nixlog/2)