### PR TITLE
Stop adding test library to packages

### DIFF
--- a/tests/interface/functors/Makefile.am
+++ b/tests/interface/functors/Makefile.am
@@ -4,6 +4,6 @@
 # - https://opensource.org/licenses/UPL
 # - <souffle root>/licenses/SOUFFLE-UPL.txt
 
-lib_LTLIBRARIES = libfunctors.la
+noinst_LTLIBRARIES = libfunctors.la
 libfunctors_la_SOURCES = functors.cpp
 libfunctors_la_LDFLAGS = -version-info 0:0:0 


### PR DESCRIPTION
Currently we're adding the functor test library to the system libraries when we install souffle. This PR stops that behaviour