### PR TITLE
Remove need to use addValue for RamReturnValue

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -603,7 +603,7 @@ std::unique_ptr<RamOperation> AstTranslator::ProvenanceClauseTranslator::createO
         }
     }
 
-    return std::make_unique<RamReturn>(std::move(values));
+    return std::make_unique<RamReturnValue>(std::move(values));
 }
 
 std::unique_ptr<RamCondition> AstTranslator::ClauseTranslator::createCondition(
@@ -1286,16 +1286,16 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
 
             // make the nested operation to return the atom number if it exists
             std::vector<std::unique_ptr<RamExpression>> returnValue;
-            // auto returnValue = std::make_unique<RamReturn>(std::vector<std::unique_ptr<RamExpression>>());
+            // auto returnValue = std::make_unique<RamReturnValue>(std::vector<std::unique_ptr<RamExpression>>());
             returnValue.push_back(std::make_unique<RamNumber>(litNumber));
 
             // create a search
             auto search = std::make_unique<RamIndexScan>(std::move(relRef), litNumber, std::move(query),
-                    std::make_unique<RamReturn>(std::move(returnValue)));
+                    std::make_unique<RamReturnValue>(std::move(returnValue)));
 
             // now, return the values of the atoms, with a separator
             std::vector<std::unique_ptr<RamExpression>> returnAtom;
-            // auto returnAtom = std::make_unique<RamReturn>(std::vector<std::unique_ptr<RamExpression>>());
+            // auto returnAtom = std::make_unique<RamReturnValue>(std::vector<std::unique_ptr<RamExpression>>());
             // separator between atom number and atom
             returnAtom.push_back(nullptr);
             // the actual atom
@@ -1306,7 +1306,7 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
             // chain the atom number and atom value together
             auto atomSequence = std::make_unique<RamSequence>();
             atomSequence->add(std::make_unique<RamQuery>(std::move(search)));
-            atomSequence->add(std::make_unique<RamQuery>(std::make_unique<RamReturn>(std::move(returnAtom))));
+            atomSequence->add(std::make_unique<RamQuery>(std::make_unique<RamReturnValue>(std::move(returnAtom))));
 
             // append search to the sequence
             searchSequence->add(std::move(atomSequence));
@@ -1320,16 +1320,16 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
 
             // create a return value
             std::vector<std::unique_ptr<RamExpression>> returnValue;
-            // auto returnValue = std::make_unique<RamReturn>(std::vector<std::unique_ptr<RamExpression>>());
+            // auto returnValue = std::make_unique<RamReturnValue>(std::vector<std::unique_ptr<RamExpression>>());
             returnValue.push_back(std::make_unique<RamNumber>(litNumber));
 
             // create a filter
             auto filter = std::make_unique<RamFilter>(
-                    std::move(condition), std::make_unique<RamReturn>(std::move(returnValue)));
+                    std::move(condition), std::make_unique<RamReturnValue>(std::move(returnValue)));
 
             // now, return the values of the literal, with a separator
             std::vector<std::unique_ptr<RamExpression>> returnLit;
-            // auto returnLit = std::make_unique<RamReturn>(std::vector<std::unique_ptr<RamExpression>>());
+            // auto returnLit = std::make_unique<RamReturnValue>(std::vector<std::unique_ptr<RamExpression>>());
             // separator between atom number and atom
             returnLit.push_back(nullptr);
             // add return values for binary constraints and negations
@@ -1346,7 +1346,7 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
             // chain the atom number and atom value together
             auto litSequence = std::make_unique<RamSequence>();
             litSequence->add(std::make_unique<RamQuery>(std::move(filter)));
-            litSequence->add(std::make_unique<RamQuery>(std::make_unique<RamReturn>(std::move(returnLit))));
+            litSequence->add(std::make_unique<RamQuery>(std::make_unique<RamReturnValue>(std::move(returnLit))));
 
             // append search to the sequence
             searchSequence->add(std::move(litSequence));

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -1286,7 +1286,6 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
 
             // make the nested operation to return the atom number if it exists
             std::vector<std::unique_ptr<RamExpression>> returnValue;
-            // auto returnValue = std::make_unique<RamReturnValue>(std::vector<std::unique_ptr<RamExpression>>());
             returnValue.push_back(std::make_unique<RamNumber>(litNumber));
 
             // create a search
@@ -1294,9 +1293,8 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
                     std::make_unique<RamReturnValue>(std::move(returnValue)));
 
             // now, return the values of the atoms, with a separator
+            // between atom number and atom
             std::vector<std::unique_ptr<RamExpression>> returnAtom;
-            // auto returnAtom = std::make_unique<RamReturnValue>(std::vector<std::unique_ptr<RamExpression>>());
-            // separator between atom number and atom
             returnAtom.push_back(nullptr);
             // the actual atom
             for (size_t i = 0; i < atom->getArity() - 2; i++) {
@@ -1306,7 +1304,8 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
             // chain the atom number and atom value together
             auto atomSequence = std::make_unique<RamSequence>();
             atomSequence->add(std::make_unique<RamQuery>(std::move(search)));
-            atomSequence->add(std::make_unique<RamQuery>(std::make_unique<RamReturnValue>(std::move(returnAtom))));
+            atomSequence->add(
+                    std::make_unique<RamQuery>(std::make_unique<RamReturnValue>(std::move(returnAtom))));
 
             // append search to the sequence
             searchSequence->add(std::move(atomSequence));
@@ -1320,7 +1319,6 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
 
             // create a return value
             std::vector<std::unique_ptr<RamExpression>> returnValue;
-            // auto returnValue = std::make_unique<RamReturnValue>(std::vector<std::unique_ptr<RamExpression>>());
             returnValue.push_back(std::make_unique<RamNumber>(litNumber));
 
             // create a filter
@@ -1328,9 +1326,8 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
                     std::move(condition), std::make_unique<RamReturnValue>(std::move(returnValue)));
 
             // now, return the values of the literal, with a separator
+            // between atom number and atom
             std::vector<std::unique_ptr<RamExpression>> returnLit;
-            // auto returnLit = std::make_unique<RamReturnValue>(std::vector<std::unique_ptr<RamExpression>>());
-            // separator between atom number and atom
             returnLit.push_back(nullptr);
             // add return values for binary constraints and negations
             if (auto binaryConstraint = dynamic_cast<AstBinaryConstraint*>(con)) {
@@ -1346,7 +1343,8 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
             // chain the atom number and atom value together
             auto litSequence = std::make_unique<RamSequence>();
             litSequence->add(std::make_unique<RamQuery>(std::move(filter)));
-            litSequence->add(std::make_unique<RamQuery>(std::make_unique<RamReturnValue>(std::move(returnLit))));
+            litSequence->add(
+                    std::make_unique<RamQuery>(std::make_unique<RamReturnValue>(std::move(returnLit))));
 
             // append search to the sequence
             searchSequence->add(std::move(litSequence));

--- a/src/AstTranslator.h
+++ b/src/AstTranslator.h
@@ -367,15 +367,6 @@ private:
         ProvenanceClauseTranslator(AstTranslator& translator) : ClauseTranslator(translator) {}
     };
 
-    class ProvenanceNegationClauseTranslator : public ClauseTranslator {
-    protected:
-        std::unique_ptr<RamOperation> createOperation(const AstClause& clause) override;
-        std::unique_ptr<RamCondition> createCondition(const AstClause& originalClause) override;
-
-    public:
-        ProvenanceNegationClauseTranslator(AstTranslator& translator) : ClauseTranslator(translator) {}
-    };
-
     /**
      * translate RAM code for the non-recursive clauses of the given relation.
      *

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -722,7 +722,7 @@ void Interpreter::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterConte
                 ip += 3;
                 break;
             }
-            case LVM_Return: {
+            case LVM_ReturnValue: {
                 RamDomain size = code[ip + 1];
                 std::string types = symbolTable.resolve(code[ip + 2]);
                 for (auto i = 0; i < size; ++i) {

--- a/src/LVMCode.cpp
+++ b/src/LVMCode.cpp
@@ -274,8 +274,8 @@ void LVMCode::print() const {
                 printf("\tTarget: %s\t\n", symbolTable.resolve(code[ip + 2]).c_str());
                 ip += 3;
                 break;
-            case LVM_Return: {
-                printf("%ld\tLVM_Return\tArity:%dTypes:%s\t\n", ip, code[ip + 1],
+            case LVM_ReturnValue: {
+                printf("%ld\tLVM_ReturnValue\tArity:%dTypes:%s\t\n", ip, code[ip + 1],
                         symbolTable.resolve(code[ip + 2]).c_str());
                 ip += 3;
                 break;

--- a/src/LVMCode.h
+++ b/src/LVMCode.h
@@ -89,7 +89,7 @@ enum LVM_Type {
     LVM_Aggregate,
     LVM_Filter,
     LVM_Project,
-    LVM_Return,
+    LVM_ReturnValue,
     LVM_Search,
 
     // LVM Stmts

--- a/src/LVMGenerator.h
+++ b/src/LVMGenerator.h
@@ -515,7 +515,7 @@ protected:
         code->push_back(arity);
         code->push_back(symbolTable.lookup(relationName));
     }
-    void visitReturn(const RamReturn& ret, size_t exitAddress) override {
+    void visitReturnValue(const RamReturnValue& ret, size_t exitAddress) override {
         // The value must be pushed in correct order
         std::string types;
         auto expressions = ret.getValues();
@@ -528,7 +528,7 @@ protected:
                 visit(expressions[i], exitAddress);
             }
         }
-        code->push_back(LVM_Return);
+        code->push_back(LVM_ReturnValue);
         code->push_back(ret.getValues().size());
         code->push_back(symbolTable.lookup(types));
     }

--- a/src/RamNode.h
+++ b/src/RamNode.h
@@ -66,7 +66,7 @@ enum RamNodeType {
     RN_Clear,
     RN_Drop,
     RN_LogSize,
-    RN_Return,
+    RN_ReturnValue,
 
     RN_Merge,
     RN_Swap,

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -610,11 +610,6 @@ public:
         return toPtrVector(expressions);
     }
 
-    /** Add expression */
-    void addValue(std::unique_ptr<RamExpression> expr) {
-        expressions.push_back(std::move(expr));
-    }
-
     /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> res;

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -584,10 +584,10 @@ protected:
 };
 
 /** A statement for returning from a ram subroutine */
-class RamReturn : public RamOperation {
+class RamReturnValue : public RamOperation {
 public:
-    RamReturn(std::vector<std::unique_ptr<RamExpression>> vals)
-            : RamOperation(RN_Return), expressions(std::move(vals)) {}
+    RamReturnValue(std::vector<std::unique_ptr<RamExpression>> vals)
+            : RamOperation(RN_ReturnValue), expressions(std::move(vals)) {}
 
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
@@ -621,7 +621,7 @@ public:
         return res;
     }
 
-    RamReturn* clone() const override {
+    RamReturnValue* clone() const override {
         std::vector<std::unique_ptr<RamExpression>> newValues;
         for (auto& cur : expressions) {
             if (cur != nullptr) {
@@ -630,7 +630,7 @@ public:
                 newValues.push_back(nullptr);
             }
         }
-        return new RamReturn(std::move(newValues));
+        return new RamReturnValue(std::move(newValues));
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -645,8 +645,8 @@ protected:
     std::vector<std::unique_ptr<RamExpression>> expressions;
 
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamReturn*>(&node));
-        const auto& other = static_cast<const RamReturn&>(node);
+        assert(nullptr != dynamic_cast<const RamReturnValue*>(&node));
+        const auto& other = static_cast<const RamReturnValue&>(node);
         return equal_targets(expressions, other.expressions);
     }
 };

--- a/src/RamOperationDepth.cpp
+++ b/src/RamOperationDepth.cpp
@@ -36,7 +36,7 @@ size_t RamOperationDepthAnalysis::getDepth(const RamOperation* op) const {
         }
 
         // return
-        size_t visitReturn(const RamReturn& ret) override {
+        size_t visitReturnValue(const RamReturnValue& ret) override {
             return 1;
         }
     };

--- a/src/RamVisitor.h
+++ b/src/RamVisitor.h
@@ -98,7 +98,7 @@ struct RamVisitor : public ram_visitor_tag {
             // Operations
             FORWARD(Filter);
             FORWARD(Project);
-            FORWARD(Return);
+            FORWARD(ReturnValue);
             FORWARD(UnpackRecord);
             FORWARD(Scan);
             FORWARD(IndexScan);
@@ -182,7 +182,7 @@ protected:
 
     // -- operations --
     LINK(Project, Operation);
-    LINK(Return, Operation);
+    LINK(ReturnValue, Operation);
     LINK(UnpackRecord, Search);
     LINK(Scan, RelationSearch);
     LINK(IndexScan, RelationSearch);

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1362,7 +1362,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 
         // -- subroutine return --
 
-        void visitReturn(const RamReturn& ret, std::ostream& out) override {
+        void visitReturnValue(const RamReturnValue& ret, std::ostream& out) override {
             out << "std::lock_guard<std::mutex> guard(lock);\n";
             for (auto val : ret.getValues()) {
                 if (val == nullptr) {


### PR DESCRIPTION
This removes the need for addValue in the Ram, thus reducing the amount of side effects. Also renames RamReturn to RamReturnValue, so as to no longer suggest that RamReturn should stop execution (which it doesn't)