### PR TITLE
Refactoring of ConvertExistenceCheckTransformer

### DIFF
--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -439,8 +439,8 @@ public:
     }
 
     void print(std::ostream& os, int tabpos) const override {
-        os << times(" ", tabpos) << "UNPACK t" << refLevel << "." << refPos << " INTO t"
-           << getIdentifier() << std::endl;
+        os << times(" ", tabpos) << "UNPACK t" << refLevel << "." << refPos << " INTO t" << getIdentifier()
+           << std::endl;
         RamSearch::print(os, tabpos + 1);
     }
 

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -439,7 +439,7 @@ public:
     }
 
     void print(std::ostream& os, int tabpos) const override {
-        os << times(" ", tabpos) << "UNPACK env(t" << refLevel << ", i" << refPos << ") INTO t"
+        os << times(" ", tabpos) << "UNPACK t" << refLevel << "." << refPos << " INTO t"
            << getIdentifier() << std::endl;
         RamSearch::print(os, tabpos + 1);
     }

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -82,7 +82,7 @@ bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
 
     // hoist conditions to the most outer scope if they
     // don't depend on RamSearches
-    visitDepthFirst(program, [&](RamQuery& query) {
+    visitDepthFirst(program, [&](const RamQuery& query) {
         std::unique_ptr<RamCondition> newCondition;
         std::function<std::unique_ptr<RamNode>(std::unique_ptr<RamNode>)> filterRewriter =
                 [&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {
@@ -100,7 +100,7 @@ bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
             node->apply(makeLambdaRamMapper(filterRewriter));
             return node;
         };
-        query.apply(makeLambdaRamMapper(filterRewriter));
+        const_cast<RamQuery*>(&query)->apply(makeLambdaRamMapper(filterRewriter));
         if (newCondition != nullptr) {
             // insert new filter operation at outer-most level of the query
             changed = true;
@@ -109,7 +109,7 @@ bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
     });
 
     // hoist conditions for each RamSearch operation
-    visitDepthFirst(program, [&](RamSearch& search) {
+    visitDepthFirst(program, [&](const RamSearch& search) {
         std::unique_ptr<RamCondition> newCondition;
         std::function<std::unique_ptr<RamNode>(std::unique_ptr<RamNode>)> filterRewriter =
                 [&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {
@@ -127,7 +127,7 @@ bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
             node->apply(makeLambdaRamMapper(filterRewriter));
             return node;
         };
-        search.apply(makeLambdaRamMapper(filterRewriter));
+        const_cast<RamSearch*>(&search)->apply(makeLambdaRamMapper(filterRewriter));
         if (newCondition != nullptr) {
             // insert new filter operation after the search operation
             changed = true;
@@ -242,7 +242,7 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteScan(const RamScan* s
 
 bool MakeIndexTransformer::makeIndex(RamProgram& program) {
     bool changed = false;
-    visitDepthFirst(program, [&](RamQuery& query) {
+    visitDepthFirst(program, [&](const RamQuery& query) {
         std::function<std::unique_ptr<RamNode>(std::unique_ptr<RamNode>)> scanRewriter =
                 [&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {
             if (const RamScan* scan = dynamic_cast<RamScan*>(node.get())) {
@@ -259,7 +259,7 @@ bool MakeIndexTransformer::makeIndex(RamProgram& program) {
             node->apply(makeLambdaRamMapper(scanRewriter));
             return node;
         };
-        query.apply(makeLambdaRamMapper(scanRewriter));
+        const_cast<RamQuery*>(&query)->apply(makeLambdaRamMapper(scanRewriter));
     });
     return changed;
 }
@@ -302,7 +302,7 @@ std::unique_ptr<RamOperation> IfConversionTransformer::rewriteIndexScan(const Ra
 
 bool IfConversionTransformer::convertIndexScans(RamProgram& program) {
     bool changed = false;
-    visitDepthFirst(program, [&](RamQuery& query) {
+    visitDepthFirst(program, [&](const RamQuery& query) {
         std::function<std::unique_ptr<RamNode>(std::unique_ptr<RamNode>)> scanRewriter =
                 [&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {
             if (const RamIndexScan* scan = dynamic_cast<RamIndexScan*>(node.get())) {
@@ -314,7 +314,7 @@ bool IfConversionTransformer::convertIndexScans(RamProgram& program) {
             node->apply(makeLambdaRamMapper(scanRewriter));
             return node;
         };
-        query.apply(makeLambdaRamMapper(scanRewriter));
+        const_cast<RamQuery*>(&query)->apply(makeLambdaRamMapper(scanRewriter));
     });
     return changed;
 }

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -282,7 +282,7 @@ std::unique_ptr<RamOperation> ConvertExistenceChecksTransformer::rewriteIndexSca
 
     // check for record unpack operations
     visitDepthFirst(*indexScan, [&](const RamUnpackRecord& unpack) {
-        if(indexScan->getIdentifier() == unpack.getIdentifier()) {
+        if(indexScan->getIdentifier() == unpack.getReferenceLevel()) {
             tupleNotUsed = false;
         }
     });

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -270,8 +270,7 @@ bool MakeIndexTransformer::makeIndex(RamProgram& program) {
 
 /** rewrite IndexScan to a filter/existence check if the IndexScan's tuple
  * is not used in a consecutive RAM operation */
-std::unique_ptr<RamOperation> ConvertExistenceChecksTransformer::rewriteIndexScan(
-        const RamIndexScan* indexScan) {
+std::unique_ptr<RamOperation> IfConversionTransformer::rewriteIndexScan(const RamIndexScan* indexScan) {
     // check whether tuple is used in subsequent operations
     bool tupleNotUsed = true;
     visitDepthFirst(*indexScan, [&](const RamElementAccess& access) {
@@ -307,7 +306,7 @@ std::unique_ptr<RamOperation> ConvertExistenceChecksTransformer::rewriteIndexSca
 }
 
 /** Search for queries and rewrite their IndexScan operations if possible */
-bool ConvertExistenceChecksTransformer::convertExistenceChecks(RamProgram& program) {
+bool IfConversionTransformer::convertExistenceChecks(RamProgram& program) {
     bool changed = false;
     visitDepthFirst(program, [&](const RamQuery& query) {
         std::function<std::unique_ptr<RamNode>(std::unique_ptr<RamNode>)> scanRewriter =

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -268,165 +268,53 @@ bool MakeIndexTransformer::makeIndex(RamProgram& program) {
     return changed;
 }
 
+/** rewrite IndexScan to a filter/existence check if the tuple is not used in a consecutive RAM operation */
+std::unique_ptr<RamOperation> ConvertExistenceChecksTransformer::rewriteIndexScan(const RamIndexScan* indexScan) {
+    // check the existence of a use for the index-scan's tuple
+    bool notUsed = true;
+    visitDepthFirst(*indexScan, [&](const RamElementAccess& access) {
+        if(indexScan->getIdentifier() == access.getIdentifier()) {
+            notUsed = false;
+        }
+    });
+
+    // if not used transform the IndexScan operation to an existence check
+    if (notUsed) { 
+            std::vector<std::unique_ptr<RamExpression>> newValues;
+            for (auto& cur : indexScan->getRangePattern()) {
+               RamExpression* val = nullptr;
+               if (cur != nullptr) {
+                   val = cur->clone();
+               }
+               newValues.emplace_back(val);
+            }
+            return std::make_unique<RamFilter>( 
+                    std::make_unique<RamExistenceCheck>(
+                       std::make_unique<RamRelationReference>(&indexScan->getRelation()),
+                       std::move(newValues)), 
+                    std::unique_ptr<RamOperation>(indexScan->getOperation().clone()),
+                    indexScan->getProfileText());
+    }
+    return nullptr;
+}
+
 bool ConvertExistenceChecksTransformer::convertExistenceChecks(RamProgram& program) {
-    // TODO: Change these to LambdaRamNodeMapper lambdas
-    // Node-mapper that searches for and updates RAM scans nested in RAM inserts
-
-    class RamScanCapturer : public RamNodeMapper {
-        mutable bool modified = false;
-        ConvertExistenceChecksTransformer* context;
-
-    public:
-        RamScanCapturer(ConvertExistenceChecksTransformer* c) : context(c) {}
-
-        bool getModified() const {
-            return modified;
-        }
-
-        bool dependsOn(const RamExpression* value, const int identifier) const {
-            std::vector<const RamExpression*> queue = {value};
-            while (!queue.empty()) {
-                const RamExpression* val = queue.back();
-                queue.pop_back();
-                if (const auto* elemAccess = dynamic_cast<const RamElementAccess*>(val)) {
-                    if (context->rvla->getLevel(elemAccess) == identifier) {
-                        return true;
-                    }
-                } else if (const auto* intrinsicOp = dynamic_cast<const RamIntrinsicOperator*>(val)) {
-                    for (const RamExpression* arg : intrinsicOp->getArguments()) {
-                        queue.push_back(arg);
-                    }
-                } else if (const auto* userDefinedOp = dynamic_cast<const RamUserDefinedOperator*>(val)) {
-                    for (const RamExpression* arg : userDefinedOp->getArguments()) {
-                        queue.push_back(arg);
-                    }
+    bool changed = false;
+    visitDepthFirst(program, [&](const RamQuery& query) {
+        std::function<std::unique_ptr<RamNode>(std::unique_ptr<RamNode>)> scanRewriter =
+                [&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {
+            if (const RamIndexScan* scan = dynamic_cast<RamIndexScan*>(node.get())) {
+                if (std::unique_ptr<RamOperation> op = rewriteIndexScan(scan)) {
+                    changed = true;
+                    node = std::move(op);
                 }
             }
-            return false;
-        }
-
-        bool dependsOn(const RamCondition* condition, const int identifier) const {
-            if (const auto* binRel = dynamic_cast<const RamConstraint*>(condition)) {
-                return dependsOn(binRel->getLHS(), identifier) || dependsOn(binRel->getRHS(), identifier);
-            }
-            return false;
-        }
-
-        std::unique_ptr<RamNode> operator()(std::unique_ptr<RamNode> node) const override {
-            if (auto* scan = dynamic_cast<RamRelationSearch*>(node.get())) {
-                const int identifier = scan->getIdentifier();
-                bool isExistCheck = true;
-                visitDepthFirst(scan->getOperation(), [&](const RamProject& project) {
-                    if (isExistCheck) {
-                        std::vector<const RamExpression*> values;
-                        // TODO: function to extend vectors
-                        const std::vector<RamExpression*> initialVals = project.getValues();
-                        values.insert(values.end(), initialVals.begin(), initialVals.end());
-
-                        while (!values.empty()) {
-                            const RamExpression* value = values.back();
-                            values.pop_back();
-
-                            if (const auto* pack = dynamic_cast<const RamPackRecord*>(value)) {
-                                const std::vector<RamExpression*> args = pack->getArguments();
-                                values.insert(values.end(), args.begin(), args.end());
-                            } else if (const auto* intrinsicOp =
-                                               dynamic_cast<const RamIntrinsicOperator*>(value)) {
-                                for (auto* arg : intrinsicOp->getArguments()) {
-                                    values.push_back(arg);
-                                }
-                            } else if (value != nullptr && !context->rcva->isConstant(value) &&
-                                       context->rvla->getLevel(value) == identifier) {
-                                isExistCheck = false;
-                                break;
-                            }
-                        }
-                    }
-                });
-                if (isExistCheck) {
-                    visitDepthFirst(scan->getOperation(), [&](const RamUnpackRecord& lookup) {
-                        if (isExistCheck) {
-                            if (lookup.getReferenceLevel() == identifier) {
-                                isExistCheck = false;
-                            }
-                        }
-                    });
-                }
-                if (isExistCheck) {
-                    visitDepthFirst(scan->getOperation(), [&](const RamExpression& expression) {
-                        if (isExistCheck) {
-                            if (dependsOn(&expression, identifier)) {
-                                isExistCheck = false;
-                            }
-                        }
-                    });
-                }
-                if (isExistCheck) {
-                    // create constraint
-                    std::unique_ptr<RamCondition> constraint;
-
-                    if (nullptr != dynamic_cast<RamScan*>(scan)) {
-                        constraint = std::make_unique<RamNegation>(std::make_unique<RamEmptinessCheck>(
-                                std::make_unique<RamRelationReference>(&scan->getRelation())));
-                    } else if (auto* indexScan = dynamic_cast<RamIndexScan*>(scan)) {
-                        std::vector<std::unique_ptr<RamExpression>> values;
-                        for (RamExpression* value : indexScan->getRangePattern()) {
-                            if (value != nullptr) {
-                                values.emplace_back(value->clone());
-                            } else {
-                                values.push_back(nullptr);
-                            }
-                        }
-                        constraint = std::make_unique<RamExistenceCheck>(
-                                std::make_unique<RamRelationReference>(&scan->getRelation()),
-                                std::move(values));
-                    }
-
-                    node = std::make_unique<RamFilter>(std::move(constraint),
-                            std::unique_ptr<RamOperation>(scan->getOperation().clone()),
-                            scan->getProfileText());
-                    modified = true;
-                }
-            }
-            node->apply(*this);
+            node->apply(makeLambdaRamMapper(scanRewriter));
             return node;
-        }
-    };
-
-    // Node-mapper that searches for and updates RAM inserts
-    class RamQueryCapturer : public RamNodeMapper {
-        mutable bool modified;
-        ConvertExistenceChecksTransformer* context;
-
-    public:
-        RamQueryCapturer(ConvertExistenceChecksTransformer* c) : modified(false), context(c) {}
-
-        bool getModified() const {
-            return modified;
-        }
-
-        std::unique_ptr<RamNode> operator()(std::unique_ptr<RamNode> node) const override {
-            // get all RAM inserts
-            if (auto* insert = dynamic_cast<RamQuery*>(node.get())) {
-                RamScanCapturer scanUpdate(context);
-                insert->apply(scanUpdate);
-
-                if (scanUpdate.getModified()) {
-                    modified = true;
-                }
-            } else {
-                // no need to search for nested RAM inserts
-                node->apply(*this);
-            }
-            return node;
-        }
-    };
-
-    // level all RAM inserts
-    RamQueryCapturer insertUpdate(this);
-    program.getMain()->apply(insertUpdate);
-
-    return insertUpdate.getModified();
+        };
+        ((RamNode*)&query)->apply(makeLambdaRamMapper(scanRewriter));
+    });
+    return changed;
 }
 
 }  // end of namespace souffle

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -134,22 +134,12 @@ public:
     std::string getName() const override {
         return "ConvertExistenceChecksTransformer";
     }
-
-    /**
-     * @param program the program to be processed
-     * @return whether the program was modified
-     */
+    std::unique_ptr<RamOperation> rewriteIndexScan(const RamIndexScan* indexScan);
     bool convertExistenceChecks(RamProgram& program);
 
 protected:
-    RamConstValueAnalysis* rcva{nullptr};
-    RamConditionLevelAnalysis* rcla{nullptr};
-    RamExpressionLevelAnalysis* rvla{nullptr};
 
     bool transform(RamTranslationUnit& translationUnit) override {
-        rcva = translationUnit.getAnalysis<RamConstValueAnalysis>();
-        rcla = translationUnit.getAnalysis<RamConditionLevelAnalysis>();
-        rvla = translationUnit.getAnalysis<RamExpressionLevelAnalysis>();
         return convertExistenceChecks(*translationUnit.getProgram());
     }
 };

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -129,6 +129,25 @@ protected:
     }
 };
 
+/**
+ * Convert IndexScan operations to Filter/Existence Checks
+ * if the IndexScan's tuple is not further used in subsequent
+ * operations.
+ *
+ *  QUERY
+ *   ...
+ *    SEARCH t1 IN A INDEX t1.x=10 AND t1.y = 20
+ *      ... // no occurrence of t1
+ *
+ * will be rewritten to
+ *
+ *  QUERY
+ *   ...
+ *    IF (10,20) NOT IN A
+ *      ...
+ *
+ */
+
 class ConvertExistenceChecksTransformer : public RamTransformer {
 public:
     std::string getName() const override {

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -154,11 +154,11 @@ public:
         return "IfConversionTransformer";
     }
     std::unique_ptr<RamOperation> rewriteIndexScan(const RamIndexScan* indexScan);
-    bool convertExistenceChecks(RamProgram& program);
+    bool convertIndexScans(RamProgram& program);
 
 protected:
     bool transform(RamTranslationUnit& translationUnit) override {
-        return convertExistenceChecks(*translationUnit.getProgram());
+        return convertIndexScans(*translationUnit.getProgram());
     }
 };
 

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -148,10 +148,10 @@ protected:
  *
  */
 
-class ConvertExistenceChecksTransformer : public RamTransformer {
+class IfConversionTransformer : public RamTransformer {
 public:
     std::string getName() const override {
-        return "ConvertExistenceChecksTransformer";
+        return "IfConversionTransformer";
     }
     std::unique_ptr<RamOperation> rewriteIndexScan(const RamIndexScan* indexScan);
     bool convertExistenceChecks(RamProgram& program);

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -29,10 +29,13 @@ namespace souffle {
 class RamProgram;
 
 /**
- * Hoists the conditions to the earliest point in the loop nest where they
- * can be evaluated.
+ * @class HoistConditionsTransformer
+ * @brief Hosts conditions in a loop-nest to the most-outer/semantically-correct loop
  *
- * hoistConditions assumes that filter operations are stored verbose,
+ * Hoists the conditions to the earliest point in the loop nest where their
+ * evaluation is still semantically correct.
+ *
+ * The transformations assumes that filter operations are stored verbose,
  * i.e. a conjunction is expressed by two consecutive filter operations.
  * For example ..
  *
@@ -56,6 +59,9 @@ class RamProgram;
  * conjunction, another transformer is required that splits the
  * filter operations. However, at the moment this is not necessary
  * because the translator delivers already the right RAM format.
+ *
+ * TODO: break-up conditions while transforming so that this requirement
+ * is removed.
  */
 class HoistConditionsTransformer : public RamTransformer {
 public:
@@ -63,7 +69,17 @@ public:
         return "HoistConditionsTransformer";
     }
 
-    /** hoist all conditions in a RAM program to the outermost scope */
+    /**
+     * @brief Hoist filter operations.
+     * @param Program that is transformed
+     * @return Flag showing whether the program has been changed by the transformation
+     *
+     * There are two types of conditions in
+     * filter operations. The first type depends on tuples of
+     * RamSearch operations. The second type are independent of
+     * tuple access. Both types of conditions will be hoisted to
+     * the most out-scope such that the program is still valid.
+     */
     bool hoistConditions(RamProgram& program);
 
 protected:
@@ -76,11 +92,12 @@ protected:
 };
 
 /**
- * Make indexable operations to indexed operations.
+ * @class MakeIndexTransformer
+ * @brief Make indexable operations to indexed operations.
  *
- * makeIndex() assumes that the RAM has been levelled before, and
- * that the conditions that could be used for an index are located
- * immediately after the scan or aggregrate operation
+ * The transformer assumes that the RAM has been levelled before.
+ * The conditions that could be used for an index must be located
+ * immediately after the scan or aggregrate operation.
  *
  *  QUERY
  *   ...
@@ -103,20 +120,50 @@ public:
         return "MakeIndexTransformer";
     }
 
-    /** Get expression of an equivalence relation of the format t1.x = <expr> or <expr> = t1.x */
+    /**
+     * @brief Get expression of RAM element access
+     *
+     * @param Equivalence constraints of the format t1.x = <expression> or <expression> = t1.x
+     * @param Element that was accessed, e.g., for t1.x this would be the index of attribute x.
+     * @param Tuple identifier
+     *
+     * The method retrieves expression the expression of an equivalence constraint of the
+     * format t1.x = <expr> or <expr> = t1.x
+     */
     std::unique_ptr<RamExpression> getExpression(RamCondition* c, size_t& element, int level);
 
-    /** Construct patterns for an indexable operation and the remaining condition that cannot be indexed */
+    /**
+     * @brief Construct query patterns for an indexable operation
+     * @param Query pattern that is to be constructed
+     * @param Flag to indicate whether operation is indexable
+     * @param A list of conditions that will be transformed to query patterns
+     * @param Tuple identifier of the indexable operation
+     * @result Remaining conditions that could not be transformed to an index
+     */
     std::unique_ptr<RamCondition> constructPattern(std::vector<std::unique_ptr<RamExpression>>& queryPattern,
             bool& indexable, std::vector<std::unique_ptr<RamCondition>> conditionList, int identifier);
 
-    /** Rewrite a scan operation to an indexed scan operation */
+    /**
+     * @brief Rewrite a scan operation to an indexed scan operation
+     * @param Scan operation that is potentially rewritten to an IndexScan
+     * @result The result is null if the scan could not be rewritten to an IndexScan;
+     *         otherwise the new IndexScan operation is returned.
+     */
     std::unique_ptr<RamOperation> rewriteScan(const RamScan* scan);
 
-    /** Rewrite an aggregate operation to an indexed aggregate operation */
+    /**
+     * @brief Rewrite an aggregate operation to an indexed aggregate operation
+     * @param Aggregate operation that is potentially rewritten to an indexed version
+     * @result The result is null if the aggregate could not be rewritten to an indexed version;
+     *         otherwise the new indexed version of the aggregate is returned.
+     */
     std::unique_ptr<RamOperation> rewriteAggregate(const RamAggregate* agg);
 
-    /** Make indexable RAM operation indexed */
+    /**
+     * @brief Make indexable RAM operation indexed
+     * @param RAM program that is transformed
+     * @result Flag that indicates whether the input program has changed
+     */
     bool makeIndex(RamProgram& program);
 
 protected:
@@ -130,9 +177,14 @@ protected:
 };
 
 /**
- * Convert IndexScan operations to Filter/Existence Checks
- * if the IndexScan's tuple is not further used in subsequent
- * operations.
+ * @class IfConversionTransformer
+ * @brief Convert IndexScan operations to Filter/Existence Checks
+
+ * If there exists IndexScan operations in the RAM, and their tuples
+ * are not further used in subsequent operations, the IndexScan operations
+ * will be rewritten to Filter/Existence Checks.
+ *
+ * For example,
  *
  *  QUERY
  *   ...
@@ -147,13 +199,29 @@ protected:
  *      ...
  *
  */
-
 class IfConversionTransformer : public RamTransformer {
 public:
     std::string getName() const override {
         return "IfConversionTransformer";
     }
+
+    /**
+     * @brief Rewrite IndexScan operations
+     * @param An index operation
+     * @result The old operation if the if-conversion fails; otherwise the filter/existence check
+     *
+     * Rewrites IndexScan operations to a filter/existence check if the IndexScan's tuple
+     * is not used in a consecutive RAM operation
+     */
     std::unique_ptr<RamOperation> rewriteIndexScan(const RamIndexScan* indexScan);
+
+    /**
+     * @brief Apply if-conversion to the whole program
+     * @param RAM program
+     * @result A flag indicating whether the RAM program has been changed.
+     *
+     * Search for queries and rewrite their IndexScan operations if possible.
+     */
     bool convertIndexScans(RamProgram& program);
 
 protected:

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -138,7 +138,6 @@ public:
     bool convertExistenceChecks(RamProgram& program);
 
 protected:
-
     bool transform(RamTranslationUnit& translationUnit) override {
         return convertExistenceChecks(*translationUnit.getProgram());
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -483,7 +483,7 @@ int main(int argc, char** argv) {
     std::vector<std::unique_ptr<RamTransformer>> ramTransforms;
     ramTransforms.push_back(std::make_unique<HoistConditionsTransformer>());
     ramTransforms.push_back(std::make_unique<MakeIndexTransformer>());
-    ramTransforms.push_back(std::make_unique<ConvertExistenceChecksTransformer>());
+    ramTransforms.push_back(std::make_unique<IfConversionTransformer>());
 
     for (const auto& transform : ramTransforms) {
         /* If the ram transform changed the program, show this */


### PR DESCRIPTION
The classes of ConvertExistenceCheckTransfomer were removed and replaced by succinct visit/lambda constructs. 
This is related to issue #961.