### PR TITLE
Refactoring of visitQuery in Synthesiser. 

### DIFF
--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -436,22 +436,23 @@ inline std::vector<std::unique_ptr<RamCondition>> toConjList(const RamCondition*
 }
 
 /**
- * @brief Convert terms of a conjunction to a list
- * @param A RAM condition
+ * @brief Convert list of conditions to a conjunction
  * @param A list of RAM conditions
+ * @param A RAM condition
  *
- * Convert a condition of the format C1 /\ C2 /\ ... /\ Cn
- * to a list {C1, C2, ..., Cn}.
+ * Convert a list {C1, C2, ..., Cn} to a condition of
+ * the format C1 /\ C2 /\ ... /\ Cn.
  */
-inline std::unique_ptr<RamCondition> toCondition(const std::vector<const RamCondition *> &list) {
+inline std::unique_ptr<RamCondition> toCondition(const std::vector<const RamCondition*>& list) {
     std::unique_ptr<RamCondition> result;
-    for(const RamCondition *cur: list) { 
-       if(result == nullptr) { 
-          result = std::unique_ptr<RamCondition>(cur->clone());
-       } else { 
-          result = std::make_unique<RamConjunction>(std::move(result), std::unique_ptr<RamCondition>(cur->clone()));
-       } 
-    } 
+    for (const RamCondition* cur : list) {
+        if (result == nullptr) {
+            result = std::unique_ptr<RamCondition>(cur->clone());
+        } else {
+            result = std::make_unique<RamConjunction>(
+                    std::move(result), std::unique_ptr<RamCondition>(cur->clone()));
+        }
+    }
     return result;
 }
 

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -413,4 +413,46 @@ protected:
     }
 };
 
+/**
+ * @brief Convert terms of a conjunction to a list
+ * @param A RAM condition
+ * @param A list of RAM conditions
+ *
+ * Convert a condition of the format C1 /\ C2 /\ ... /\ Cn
+ * to a list {C1, C2, ..., Cn}.
+ */
+inline std::vector<std::unique_ptr<RamCondition>> toConjList(const RamCondition* condition) {
+    std::vector<std::unique_ptr<RamCondition>> conditions;
+    while (condition != nullptr) {
+        if (const auto* ramConj = dynamic_cast<const RamConjunction*>(condition)) {
+            conditions.emplace_back(ramConj->getRHS().clone());
+            condition = &ramConj->getLHS();
+        } else {
+            conditions.emplace_back(condition->clone());
+            break;
+        }
+    }
+    return conditions;
+}
+
+/**
+ * @brief Convert terms of a conjunction to a list
+ * @param A RAM condition
+ * @param A list of RAM conditions
+ *
+ * Convert a condition of the format C1 /\ C2 /\ ... /\ Cn
+ * to a list {C1, C2, ..., Cn}.
+ */
+inline std::unique_ptr<RamCondition> toCondition(const std::vector<const RamCondition *> &list) {
+    std::unique_ptr<RamCondition> result;
+    for(const RamCondition *cur: list) { 
+       if(result == nullptr) { 
+          result = std::unique_ptr<RamCondition>(cur->clone());
+       } else { 
+          result = std::make_unique<RamConjunction>(std::move(result), std::unique_ptr<RamCondition>(cur->clone()));
+       } 
+    } 
+    return result;
+}
+
 }  // end of namespace souffle

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -292,31 +292,32 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
         void visitQuery(const RamQuery& query, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
 
-            // check whether the outer-most filter operation
-            // can be pushed out of the parallel context
+            // split terms of conditions of outer filter operation
+            // into terms that require a context and terms that
+            // do not require a context
             const RamOperation* next = &query.getOperation();
             std::vector<std::unique_ptr<RamCondition>> requireCtx;
             std::vector<std::unique_ptr<RamCondition>> freeOfCtx;
             if (const RamFilter* filter = dynamic_cast<const RamFilter*>(&query.getOperation())) {
                 next = &filter->getOperation();
                 // Check terms of outer filter operation whether they can be pushed before
-                // the context-generation for speed imrovements 
+                // the context-generation for speed imrovements
                 auto conditions = toConjList(&filter->getCondition());
-                for(auto const &cur : conditions) {
+                for (auto const& cur : conditions) {
                     bool needContext = false;
                     visitDepthFirst(*cur, [&](const RamExistenceCheck& exists) { needContext = true; });
-                    if(needContext) { 
-                       requireCtx.push_back(std::unique_ptr<RamCondition>(cur->clone()));
+                    if (needContext) {
+                        requireCtx.push_back(std::unique_ptr<RamCondition>(cur->clone()));
                     } else {
-                       freeOfCtx.push_back(std::unique_ptr<RamCondition>(cur->clone()));
+                        freeOfCtx.push_back(std::unique_ptr<RamCondition>(cur->clone()));
                     }
-                } 
+                }
                 // discharge conditions that do not require a context
-                if(freeOfCtx.size() > 0) {
-                out << "if(";
-                visit(*toCondition(toConstPtrVector(freeOfCtx)), out);
-                out << ") {\n";
-                } 
+                if (freeOfCtx.size() > 0) {
+                    out << "if(";
+                    visit(*toCondition(toConstPtrVector(freeOfCtx)), out);
+                    out << ") {\n";
+                }
             }
 
             // outline each search operation to improve compilation time
@@ -333,62 +334,67 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             // check whether loop nest can be parallelized
             bool parallel = false;
 
+            // check whether outer-most loop is an scan operation
+            const RamScan* outerScan = nullptr;
             visitDepthFirst(*next, [&](const RamScan& scan) {
-                if (!parallel) {
-                    parallel = scan.getIdentifier() == 0 && !scan.getRelation().isNullary();
-                    if (parallel) {
-                        const auto& rel = scan.getRelation();
-                        const auto& relName = synthesiser.getRelationName(rel);
-                        // partition outermost relation
-                        out << "auto part = " << relName << "->partition();\n";
-
-                        // build a parallel block around this loop nest
-                        out << "PARALLEL_START;\n";
-                    }
+                if (scan.getIdentifier() == 0 && !scan.getRelation().isNullary()) {
+                    outerScan = &scan;
                 }
             });
+            if (outerScan != nullptr) {
+                parallel = true;
+                const auto& rel = outerScan->getRelation();
+                const auto& relName = synthesiser.getRelationName(rel);
+                // partition outermost relation
+                out << "auto part = " << relName << "->partition();\n";
 
-            if (!parallel)
-                visitDepthFirst(*next, [&](const RamIndexScan& scan) {
-                    if (!parallel) {
-                        parallel = scan.getIdentifier() == 0;
-                        if (parallel) {
-                            const auto& rel = scan.getRelation();
-                            const auto& relName = synthesiser.getRelationName(rel);
+                // build a parallel block around this loop nest
+                out << "PARALLEL_START;\n";
+            }
 
-                            // check list of keys
-                            auto arity = rel.getArity();
-                            const auto& rangePattern = scan.getRangePattern();
+            // check whether outer-most loop is an IndexScan
+            const RamIndexScan* outerIndexScan = nullptr;
+            visitDepthFirst(*next, [&](const RamIndexScan& indexScan) {
+                if (indexScan.getIdentifier() == 0) {
+                    outerIndexScan = &indexScan;
+                }
+            });
+            if (outerIndexScan != nullptr) {
+                parallel = true;
+                const auto& rel = outerIndexScan->getRelation();
+                const auto& relName = synthesiser.getRelationName(rel);
 
-                            // a lambda for printing boundary key values
-                            auto printKeyTuple = [&]() {
-                                for (size_t i = 0; i < arity; i++) {
-                                    if (rangePattern[i] != nullptr) {
-                                        visit(rangePattern[i], out);
-                                    } else {
-                                        out << "0";
-                                    }
-                                    if (i + 1 < arity) {
-                                        out << ",";
-                                    }
-                                }
-                            };
+                // check list of keys
+                auto arity = rel.getArity();
+                const auto& rangePattern = outerIndexScan->getRangePattern();
 
-                            // get index to be queried
-                            auto keys = keysAnalysis->getRangeQueryColumns(&scan);
-
-                            out << "const Tuple<RamDomain," << arity << "> key({{";
-                            printKeyTuple();
-                            out << "}});\n";
-                            out << "auto range = " << relName << "->"
-                                << "equalRange_" << keys << "(key);\n";
-                            out << "auto part = range.partition();\n";
-
-                            // build a parallel block around this loop nest
-                            out << "PARALLEL_START;\n";
+                // a lambda for printing boundary key values
+                auto printKeyTuple = [&]() {
+                    for (size_t i = 0; i < arity; i++) {
+                        if (rangePattern[i] != nullptr) {
+                            visit(rangePattern[i], out);
+                        } else {
+                            out << "0";
+                        }
+                        if (i + 1 < arity) {
+                            out << ",";
                         }
                     }
-                });
+                };
+
+                // get index to be queried
+                auto keys = keysAnalysis->getRangeQueryColumns(outerIndexScan);
+
+                out << "const Tuple<RamDomain," << arity << "> key({{";
+                printKeyTuple();
+                out << "}});\n";
+                out << "auto range = " << relName << "->"
+                    << "equalRange_" << keys << "(key);\n";
+                out << "auto part = range.partition();\n";
+
+                // build a parallel block around this loop nest
+                out << "PARALLEL_START;\n";
+            }
 
             // create operation contexts for this operation
             for (const RamRelation* rel : synthesiser.getReferencedRelations(query.getOperation())) {
@@ -399,15 +405,15 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 out << "->createContext());\n";
             }
 
-            // discharge conditions that require a context 
-            if (requireCtx.size() > 0 ) {
+            // discharge conditions that require a context
+            if (requireCtx.size() > 0) {
                 out << "if(";
                 visit(*toCondition(toConstPtrVector(requireCtx)), out);
                 out << ") {\n";
                 visit(*next, out);
                 out << "}\n";
             } else {
-               visit(*next, out);
+                visit(*next, out);
             }
 
             if (parallel) {
@@ -422,7 +428,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 #else
             out << "();";  // call lambda
 #endif
-            if(freeOfCtx.size() > 0) {
+            if (freeOfCtx.size() > 0) {
                 out << "}\n";
             }
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -162,6 +162,18 @@ std::vector<T*> toPtrVector(const std::vector<std::unique_ptr<T>>& v) {
  * A utility function enabling the creation of a vector of pointers.
  */
 template <typename T>
+std::vector<const T*> toConstPtrVector(const std::vector<std::unique_ptr<T>>& v) {
+    std::vector<const T*> res;
+    for (auto& e : v) {
+        res.push_back(e.get());
+    }
+    return res;
+}
+
+/**
+ * A utility function enabling the creation of a vector of pointers.
+ */
+template <typename T>
 std::vector<T*> toPtrVector(const std::vector<std::shared_ptr<T>>& v) {
     std::vector<T*> res;
     for (auto& e : v) {


### PR DESCRIPTION
The outermost filter operation is converted to a list of terms. This list is split into terms that either needs a context or don't need a context and two separate if-statements (before and after the context generation) are issued for them. Note that a condition such as an existence check requires a context. 

The previous version rejected all terms (which was slow) or the list did not contain any terms that required a context.

This is an issue related to #961.