### PR TITLE
Refactored helper functions for RAM

### DIFF
--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <sstream>
 #include <string>
+#include <stack>
 
 #include <cstdlib>
 
@@ -421,18 +422,23 @@ protected:
  * Convert a condition of the format C1 /\ C2 /\ ... /\ Cn
  * to a list {C1, C2, ..., Cn}.
  */
-inline std::vector<std::unique_ptr<RamCondition>> toConjList(const RamCondition* condition) {
-    std::vector<std::unique_ptr<RamCondition>> conditions;
-    while (condition != nullptr) {
-        if (const auto* ramConj = dynamic_cast<const RamConjunction*>(condition)) {
-            conditions.emplace_back(ramConj->getRHS().clone());
-            condition = &ramConj->getLHS();
-        } else {
-            conditions.emplace_back(condition->clone());
-            break;
-        }
-    }
-    return conditions;
+inline std::vector<std::unique_ptr<RamCondition>> toConjunctionList(const RamCondition* condition) {
+    std::vector<std::unique_ptr<RamCondition>> list;
+    std::stack<const RamCondition *> stack; 
+    if (condition != nullptr) { 
+       stack.push(condition); 
+       while (stack.size() > 0) {
+	   condition = stack.top();
+	   stack.pop();
+           if (const auto* ramConj = dynamic_cast<const RamConjunction*>(condition)) {
+               stack.push(&ramConj->getLHS());
+               stack.push(&ramConj->getRHS());
+           } else {
+               list.emplace_back(condition->clone());
+           }
+       }
+    } 
+    return list;
 }
 
 /**

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -25,8 +25,8 @@
 
 #include <algorithm>
 #include <sstream>
-#include <string>
 #include <stack>
+#include <string>
 
 #include <cstdlib>
 
@@ -424,20 +424,20 @@ protected:
  */
 inline std::vector<std::unique_ptr<RamCondition>> toConjunctionList(const RamCondition* condition) {
     std::vector<std::unique_ptr<RamCondition>> list;
-    std::stack<const RamCondition *> stack; 
-    if (condition != nullptr) { 
-       stack.push(condition); 
-       while (stack.size() > 0) {
-	   condition = stack.top();
-	   stack.pop();
-           if (const auto* ramConj = dynamic_cast<const RamConjunction*>(condition)) {
-               stack.push(&ramConj->getLHS());
-               stack.push(&ramConj->getRHS());
-           } else {
-               list.emplace_back(condition->clone());
-           }
-       }
-    } 
+    std::stack<const RamCondition*> stack;
+    if (condition != nullptr) {
+        stack.push(condition);
+        while (stack.size() > 0) {
+            condition = stack.top();
+            stack.pop();
+            if (const auto* ramConj = dynamic_cast<const RamConjunction*>(condition)) {
+                stack.push(&ramConj->getLHS());
+                stack.push(&ramConj->getRHS());
+            } else {
+                list.emplace_back(condition->clone());
+            }
+        }
+    }
     return list;
 }
 

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -427,7 +427,7 @@ inline std::vector<std::unique_ptr<RamCondition>> toConjunctionList(const RamCon
     std::stack<const RamCondition*> stack;
     if (condition != nullptr) {
         stack.push(condition);
-        while (stack.size() > 0) {
+        while (!stack.empty()) {
             condition = stack.top();
             stack.pop();
             if (const auto* ramConj = dynamic_cast<const RamConjunction*>(condition)) {

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -200,8 +200,8 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteScan(const RamScan* s
         const int identifier = scan->getIdentifier();
         std::vector<std::unique_ptr<RamExpression>> queryPattern(rel.getArity());
         bool indexable = false;
-        std::unique_ptr<RamCondition> condition =
-                constructPattern(queryPattern, indexable, toConjunctionList(&filter->getCondition()), identifier);
+        std::unique_ptr<RamCondition> condition = constructPattern(
+                queryPattern, indexable, toConjunctionList(&filter->getCondition()), identifier);
         if (indexable) {
             return std::make_unique<RamIndexScan>(std::make_unique<RamRelationReference>(&rel), identifier,
                     std::move(queryPattern),

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -180,7 +180,7 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteAggregate(const RamAg
         std::vector<std::unique_ptr<RamExpression>> queryPattern(rel.getArity());
         bool indexable = false;
         std::unique_ptr<RamCondition> condition =
-                constructPattern(queryPattern, indexable, toConjList(agg->getCondition()), identifier);
+                constructPattern(queryPattern, indexable, toConjunctionList(agg->getCondition()), identifier);
         if (indexable) {
             std::unique_ptr<RamExpression> expr;
             if (agg->getExpression() != nullptr) {
@@ -201,7 +201,7 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteScan(const RamScan* s
         std::vector<std::unique_ptr<RamExpression>> queryPattern(rel.getArity());
         bool indexable = false;
         std::unique_ptr<RamCondition> condition =
-                constructPattern(queryPattern, indexable, toConjList(&filter->getCondition()), identifier);
+                constructPattern(queryPattern, indexable, toConjunctionList(&filter->getCondition()), identifier);
         if (indexable) {
             return std::make_unique<RamIndexScan>(std::make_unique<RamRelationReference>(&rel), identifier,
                     std::move(queryPattern),

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -302,7 +302,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 next = &filter->getOperation();
                 // Check terms of outer filter operation whether they can be pushed before
                 // the context-generation for speed imrovements
-                auto conditions = toConjList(&filter->getCondition());
+                auto conditions = toConjunctionList(&filter->getCondition());
                 for (auto const& cur : conditions) {
                     bool needContext = false;
                     visitDepthFirst(*cur, [&](const RamExistenceCheck& exists) { needContext = true; });


### PR DESCRIPTION
The current implementation for converting conjunctions to list of terms was only partially implemented. This new version is for the general case. This is an issue related to #961.