### PR TITLE
Separate class Aggregate into Aggregate and IndexAggregate

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -707,19 +707,19 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
         const AstAggregator* cur = *it;
 
         // translate aggregation function
-        RamAggregate::Function fun = RamAggregate::MIN;
+        AggregateFunction fun = souffle::MIN;
         switch (cur->getOperator()) {
             case AstAggregator::min:
-                fun = RamAggregate::MIN;
+                fun = souffle::MIN;
                 break;
             case AstAggregator::max:
-                fun = RamAggregate::MAX;
+                fun = souffle::MAX;
                 break;
             case AstAggregator::count:
-                fun = RamAggregate::COUNT;
+                fun = souffle::COUNT;
                 break;
             case AstAggregator::sum:
-                fun = RamAggregate::SUM;
+                fun = souffle::SUM;
                 break;
         }
 
@@ -766,10 +766,9 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
         }
 
         // add Ram-Aggregation layer
-        std::vector<std::unique_ptr<RamExpression>> pattern(atom->getArity());
         std::unique_ptr<RamAggregate> aggregate =
                 std::make_unique<RamAggregate>(std::move(op), fun, translator.translateRelation(atom),
-                        std::move(value), std::move(aggCondition), std::move(pattern), level);
+                        std::move(value), std::move(aggCondition), level);
         op = std::move(aggregate);
     }
 

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -766,9 +766,8 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
         }
 
         // add Ram-Aggregation layer
-        std::unique_ptr<RamAggregate> aggregate =
-                std::make_unique<RamAggregate>(std::move(op), fun, translator.translateRelation(atom),
-                        std::move(value), std::move(aggCondition), level);
+        std::unique_ptr<RamAggregate> aggregate = std::make_unique<RamAggregate>(std::move(op), fun,
+                translator.translateRelation(atom), std::move(value), std::move(aggCondition), level);
         op = std::move(aggregate);
     }
 

--- a/src/LVM.cpp
+++ b/src/LVM.cpp
@@ -972,13 +972,23 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
                 ip += 1;
                 break;
             };
+            case LVM_IndexAggregate: {
+                ip += 1;
+                break;
+            };
             case LVM_Aggregate_COUNT: {
-                RamDomain idx = code[ip + 1];
-                auto iters = indexScanIteratorPool[idx];
                 RamDomain res = 0;
-                for (auto i = iters.first; i != iters.second; ++i) res++;
-                stack.push(res);
-                ip += 2;
+                RamDomain idx = code[ip + 2];
+                if (code[ip + 1] == LVM_ITER_TypeScan) {
+                    auto& iters = scanIteratorPool[idx];
+                    for (auto i = iters.first; i != iters.second; ++i) res++;
+                    stack.push(res);
+                } else {
+                    auto& iters = indexScanIteratorPool[idx];
+                    for (auto i = iters.first; i != iters.second; ++i) res++;
+                    stack.push(res);
+                }
+                ip += 3;
                 break;
             };
             case LVM_Aggregate_Return: {

--- a/src/LVM.cpp
+++ b/src/LVM.cpp
@@ -981,11 +981,15 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
                 RamDomain idx = code[ip + 2];
                 if (code[ip + 1] == LVM_ITER_TypeScan) {
                     auto& iters = scanIteratorPool[idx];
-                    for (auto i = iters.first; i != iters.second; ++i) res++;
+                    for (auto i = iters.first; i != iters.second; ++i) {
+                        res++;
+                    }
                     stack.push(res);
                 } else {
                     auto& iters = indexScanIteratorPool[idx];
-                    for (auto i = iters.first; i != iters.second; ++i) res++;
+                    for (auto i = iters.first; i != iters.second; ++i) {
+                        res++;
+                    }
                     stack.push(res);
                 }
                 ip += 3;

--- a/src/LVMCode.cpp
+++ b/src/LVMCode.cpp
@@ -418,6 +418,10 @@ void LVMCode::print() const {
                 printf("%ld\tLVM_Aggregate\t%d\n", ip, code[ip + 1]);
                 ip += 1;
                 break;
+            case LVM_IndexAggregate:
+                printf("%ld\tLVM_IndexAggregate\t%d\n", ip, code[ip + 1]);
+                ip += 1;
+                break;
             case LVM_Aggregate_COUNT: {
                 printf("%ld\tLVM_Aggregate_COUNT\t IndexScanIterID:%d\n", ip, code[ip + 1]);
                 ip += 2;

--- a/src/LVMCode.h
+++ b/src/LVMCode.h
@@ -87,6 +87,7 @@ enum LVM_Type {
     LVM_IndexScan,
     LVM_UnpackRecord,
     LVM_Aggregate,
+    LVM_IndexAggregate,
     LVM_Filter,
     LVM_Project,
     LVM_ReturnValue,

--- a/src/LVMGenerator.h
+++ b/src/LVMGenerator.h
@@ -391,6 +391,11 @@ protected:
     }
 
     void visitAggregate(const RamAggregate& aggregate, size_t exitAddress) override {
+        // TODO:
+        abort();
+    }
+
+    void visitIndexAggregate(const RamIndexAggregate& aggregate, size_t exitAddress) override {
         // TODO (xiaowen): The aggregate operation is now written in a less efficient way
         // e.g. The max & min now support arbitrary number of arguments, we should make use of it
         // count operation can be further simpfied
@@ -415,24 +420,24 @@ protected:
         code->push_back(symbolTable.lookup(aggregate.getRelation().getName()));
         code->push_back(symbolTable.lookup(types));
 
-        if (aggregate.getFunction() == RamAggregate::COUNT && aggregate.getCondition() == nullptr) {
+        if (aggregate.getFunction() == souffle::COUNT && aggregate.getCondition() == nullptr) {
             code->push_back(LVM_Aggregate_COUNT);
             code->push_back(counterLabel);
         } else {
             switch (aggregate.getFunction()) {  // Init value
-                case RamAggregate::MIN:
+                case souffle::MIN:
                     code->push_back(LVM_Number);
                     code->push_back(MAX_RAM_DOMAIN);
                     break;
-                case RamAggregate::MAX:
+                case souffle::MAX:
                     code->push_back(LVM_Number);
                     code->push_back(MIN_RAM_DOMAIN);
                     break;
-                case RamAggregate::COUNT:
+                case souffle::COUNT:
                     code->push_back(LVM_Number);
                     code->push_back(0);
                     break;
-                case RamAggregate::SUM:
+                case souffle::SUM:
                     code->push_back(LVM_Number);
                     code->push_back(0);
                     break;
@@ -460,25 +465,25 @@ protected:
                 code->push_back(lookupAddress(endOfLoop));
             }
 
-            if (aggregate.getFunction() != RamAggregate::COUNT) {
+            if (aggregate.getFunction() != souffle::COUNT) {
                 visit(aggregate.getExpression(), exitAddress);
             }
 
             switch (aggregate.getFunction()) {
-                case RamAggregate::MIN:
+                case souffle::MIN:
                     code->push_back(LVM_OP_MIN);
                     code->push_back(2);  // TODO quick fix, can be improved later
                     break;
-                case RamAggregate::MAX:
+                case souffle::MAX:
                     code->push_back(LVM_OP_MAX);
                     code->push_back(2);  // TODO quick fix, can be improved later
                     break;
-                case RamAggregate::COUNT:
+                case souffle::COUNT:
                     code->push_back(LVM_Number);
                     code->push_back(1);
                     code->push_back(LVM_OP_ADD);
                     break;
-                case RamAggregate::SUM:
+                case souffle::SUM:
                     code->push_back(LVM_OP_ADD);
                     break;
             }
@@ -496,7 +501,7 @@ protected:
         code->push_back(LVM_Aggregate_Return);
         code->push_back(aggregate.getIdentifier());
 
-        if (aggregate.getFunction() == RamAggregate::MIN || aggregate.getFunction() == RamAggregate::MAX) {
+        if (aggregate.getFunction() == souffle::MIN || aggregate.getFunction() == souffle::MAX) {
             // check whether there exists a min/max first before next loop
 
             // Retrieve the result we just saved.
@@ -504,7 +509,7 @@ protected:
             code->push_back(aggregate.getIdentifier());
             code->push_back(0);
             code->push_back(LVM_Number);
-            code->push_back(aggregate.getFunction() == RamAggregate::MIN ? MAX_RAM_DOMAIN : MIN_RAM_DOMAIN);
+            code->push_back(aggregate.getFunction() == souffle::MIN ? MAX_RAM_DOMAIN : MIN_RAM_DOMAIN);
             code->push_back(LVM_OP_EQ);
             code->push_back(LVM_Jmpnz);  // If init == result, does not visit nested search
             code->push_back(lookupAddress(L2));

--- a/src/LVMGenerator.h
+++ b/src/LVMGenerator.h
@@ -391,8 +391,113 @@ protected:
     }
 
     void visitAggregate(const RamAggregate& aggregate, size_t exitAddress) override {
-        // TODO:
-        abort();
+        code->push_back(LVM_Aggregate);
+
+        size_t counterLabel = getNewScanIterator();
+        size_t L1 = getNewAddressLabel();
+        size_t L2 = getNewAddressLabel();
+
+        code->push_back(LVM_ITER_TypeScan);
+        code->push_back(counterLabel);
+        code->push_back(symbolTable.lookup(aggregate.getRelation().getName()));
+
+        if (aggregate.getFunction() == souffle::COUNT && aggregate.getCondition() == nullptr) {
+            code->push_back(LVM_Aggregate_COUNT);
+            code->push_back(LVM_ITER_TypeScan);
+            code->push_back(counterLabel);
+        } else {
+            switch (aggregate.getFunction()) {  // Init value
+                case souffle::MIN:
+                    code->push_back(LVM_Number);
+                    code->push_back(MAX_RAM_DOMAIN);
+                    break;
+                case souffle::MAX:
+                    code->push_back(LVM_Number);
+                    code->push_back(MIN_RAM_DOMAIN);
+                    break;
+                case souffle::COUNT:
+                    code->push_back(LVM_Number);
+                    code->push_back(0);
+                    break;
+                case souffle::SUM:
+                    code->push_back(LVM_Number);
+                    code->push_back(0);
+                    break;
+            }
+
+            size_t address_L0 = code->size();
+
+            // Start the aggregate for loop
+            code->push_back(LVM_ITER_NotAtEnd);
+            code->push_back(counterLabel);
+            code->push_back(LVM_ITER_TypeScan);
+            code->push_back(LVM_Jmpez);
+            code->push_back(lookupAddress(L1));
+
+            code->push_back(LVM_ITER_Select);
+            code->push_back(counterLabel);
+            code->push_back(LVM_ITER_TypeScan);
+            code->push_back(aggregate.getIdentifier());
+
+            // Produce condition inside the loop
+            size_t endOfLoop = getNewAddressLabel();
+            if (aggregate.getCondition() != nullptr) {
+                visit(aggregate.getCondition(), exitAddress);
+                code->push_back(LVM_Jmpez);  // Continue; if condition is not met
+                code->push_back(lookupAddress(endOfLoop));
+            }
+
+            if (aggregate.getFunction() != souffle::COUNT) {
+                visit(aggregate.getExpression(), exitAddress);
+            }
+
+            switch (aggregate.getFunction()) {
+                case souffle::MIN:
+                    code->push_back(LVM_OP_MIN);
+                    code->push_back(2);  // TODO quick fix, can be improved later
+                    break;
+                case souffle::MAX:
+                    code->push_back(LVM_OP_MAX);
+                    code->push_back(2);  // TODO quick fix, can be improved later
+                    break;
+                case souffle::COUNT:
+                    code->push_back(LVM_Number);
+                    code->push_back(1);
+                    code->push_back(LVM_OP_ADD);
+                    break;
+                case souffle::SUM:
+                    code->push_back(LVM_OP_ADD);
+                    break;
+            }
+            setAddress(endOfLoop, code->size());
+            code->push_back(LVM_ITER_Inc);
+            code->push_back(counterLabel);
+            code->push_back(LVM_ITER_TypeScan);
+            code->push_back(LVM_Goto);
+            code->push_back(address_L0);
+        }
+
+        setAddress(L1, code->size());
+
+        // write result into environment tuple
+        code->push_back(LVM_Aggregate_Return);
+        code->push_back(aggregate.getIdentifier());
+
+        if (aggregate.getFunction() == souffle::MIN || aggregate.getFunction() == souffle::MAX) {
+            // check whether there exists a min/max first before next loop
+
+            // Retrieve the result we just saved.
+            code->push_back(LVM_ElementAccess);
+            code->push_back(aggregate.getIdentifier());
+            code->push_back(0);
+            code->push_back(LVM_Number);
+            code->push_back(aggregate.getFunction() == souffle::MIN ? MAX_RAM_DOMAIN : MIN_RAM_DOMAIN);
+            code->push_back(LVM_OP_EQ);
+            code->push_back(LVM_Jmpnz);  // If init == result, does not visit nested search
+            code->push_back(lookupAddress(L2));
+        }
+        visitSearch(aggregate, exitAddress);
+        setAddress(L2, code->size());
     }
 
     void visitIndexAggregate(const RamIndexAggregate& aggregate, size_t exitAddress) override {
@@ -402,7 +507,7 @@ protected:
         //
         // This should be reviewed later.
 
-        code->push_back(LVM_Aggregate);
+        code->push_back(LVM_IndexAggregate);
         auto patterns = aggregate.getRangePattern();
         std::string types;
         auto arity = aggregate.getRelation().getArity();
@@ -422,6 +527,7 @@ protected:
 
         if (aggregate.getFunction() == souffle::COUNT && aggregate.getCondition() == nullptr) {
             code->push_back(LVM_Aggregate_COUNT);
+            code->push_back(LVM_ITER_TypeIndexScan);
             code->push_back(counterLabel);
         } else {
             switch (aggregate.getFunction()) {  // Init value

--- a/src/RAMI.cpp
+++ b/src/RAMI.cpp
@@ -603,8 +603,7 @@ void RAMI::evalOp(const RamOperation& op, const InterpreterContext& args) {
             ctxt[aggregate.getIdentifier()] = tuple;
 
             // run nested part - using base class visitor
-            if (aggregate.getFunction() == souffle::MAX ||
-                    aggregate.getFunction() == souffle::MIN) {
+            if (aggregate.getFunction() == souffle::MAX || aggregate.getFunction() == souffle::MIN) {
                 if (res == (aggregate.getFunction() == souffle::MAX ? MIN_RAM_DOMAIN : MAX_RAM_DOMAIN)) {
                     return;
                 }
@@ -701,8 +700,7 @@ void RAMI::evalOp(const RamOperation& op, const InterpreterContext& args) {
             ctxt[aggregate.getIdentifier()] = tuple;
 
             // run nested part - using base class visitor
-            if (aggregate.getFunction() == souffle::MAX ||
-                    aggregate.getFunction() == souffle::MIN) {
+            if (aggregate.getFunction() == souffle::MAX || aggregate.getFunction() == souffle::MIN) {
                 if (res == (aggregate.getFunction() == souffle::MAX ? MIN_RAM_DOMAIN : MAX_RAM_DOMAIN)) {
                     return;
                 }

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -378,8 +378,8 @@ public:
         for (auto const& e : queryPattern) {
             pattern.push_back(std::unique_ptr<RamExpression>((e != nullptr) ? e->clone() : nullptr));
         }
-        RamIndexAggregate* res = new RamIndexAggregate(std::unique_ptr<RamOperation>(getOperation().clone()), function,
-                std::unique_ptr<RamRelationReference>(relationRef->clone()),
+        RamIndexAggregate* res = new RamIndexAggregate(std::unique_ptr<RamOperation>(getOperation().clone()),
+                function, std::unique_ptr<RamRelationReference>(relationRef->clone()),
                 expression == nullptr ? nullptr : std::unique_ptr<RamExpression>(expression->clone()),
                 condition == nullptr ? nullptr : std::unique_ptr<RamCondition>(condition->clone()),
                 std::move(pattern), getIdentifier());
@@ -418,18 +418,16 @@ protected:
     }
 };
 
-
 /**
  * Aggregation
  */
 class RamAggregate : public RamRelationSearch {
 public:
-
     RamAggregate(std::unique_ptr<RamOperation> nested, AggregateFunction fun,
             std::unique_ptr<RamRelationReference> relRef, std::unique_ptr<RamExpression> expression,
             std::unique_ptr<RamCondition> condition, int ident)
-            : RamRelationSearch(std::move(relRef), ident, std::move(nested)),
-              function(fun), expression(std::move(expression)), condition(std::move(condition)) {}
+            : RamRelationSearch(std::move(relRef), ident, std::move(nested)), function(fun),
+              expression(std::move(expression)), condition(std::move(condition)) {}
 
     /** Get condition */
     const RamCondition* getCondition() const {

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -288,15 +288,15 @@ public:
     }
 };
 
-/**
- * Aggregation
- */
-class RamAggregate : public RamIndexRelationSearch {
-public:
-    /** Types of aggregation functions */
-    enum Function { MAX, MIN, COUNT, SUM };
+/** Types of aggregation functions */
+enum AggregateFunction { MAX, MIN, COUNT, SUM };
 
-    RamAggregate(std::unique_ptr<RamOperation> nested, Function fun,
+/**
+ * Index Aggregation
+ */
+class RamIndexAggregate : public RamIndexRelationSearch {
+public:
+    RamIndexAggregate(std::unique_ptr<RamOperation> nested, AggregateFunction fun,
             std::unique_ptr<RamRelationReference> relRef, std::unique_ptr<RamExpression> expression,
             std::unique_ptr<RamCondition> condition, std::vector<std::unique_ptr<RamExpression>> queryPattern,
             int ident)
@@ -309,7 +309,7 @@ public:
     }
 
     /** Get aggregation function */
-    Function getFunction() const {
+    AggregateFunction getFunction() const {
         return function;
     }
 
@@ -339,7 +339,7 @@ public:
         if (function != COUNT) {
             os << *expression << " ";
         }
-        os << " FOR ALL t" << getIdentifier() << " ∈ " << getRelation().getName();
+        os << " SEARCH t" << getIdentifier() << " ∈ " << getRelation().getName();
         bool first = true;
         os << " INDEX ";
         for (unsigned int i = 0; i < rel.getArity(); ++i) {
@@ -373,12 +373,12 @@ public:
         return res;
     }
 
-    RamAggregate* clone() const override {
+    RamIndexAggregate* clone() const override {
         std::vector<std::unique_ptr<RamExpression>> pattern;
         for (auto const& e : queryPattern) {
             pattern.push_back(std::unique_ptr<RamExpression>((e != nullptr) ? e->clone() : nullptr));
         }
-        RamAggregate* res = new RamAggregate(std::unique_ptr<RamOperation>(getOperation().clone()), function,
+        RamIndexAggregate* res = new RamIndexAggregate(std::unique_ptr<RamOperation>(getOperation().clone()), function,
                 std::unique_ptr<RamRelationReference>(relationRef->clone()),
                 expression == nullptr ? nullptr : std::unique_ptr<RamExpression>(expression->clone()),
                 condition == nullptr ? nullptr : std::unique_ptr<RamCondition>(condition->clone()),
@@ -398,7 +398,115 @@ public:
 
 protected:
     /** Aggregation function */
-    Function function;
+    AggregateFunction function;
+
+    /** Aggregation expression */
+    std::unique_ptr<RamExpression> expression;
+
+    /** Aggregation tuple condition */
+    std::unique_ptr<RamCondition> condition;
+
+    bool equal(const RamNode& node) const override {
+        assert(nullptr != dynamic_cast<const RamIndexAggregate*>(&node));
+        const auto& other = static_cast<const RamIndexAggregate&>(node);
+        if (getCondition() != nullptr && other.getCondition() != nullptr &&
+                *getCondition() != *other.getCondition()) {
+            return false;
+        }
+        return RamIndexRelationSearch::equal(other) && getCondition() == other.getCondition() &&
+               getFunction() == other.getFunction() && getExpression() == other.getExpression();
+    }
+};
+
+
+/**
+ * Aggregation
+ */
+class RamAggregate : public RamRelationSearch {
+public:
+
+    RamAggregate(std::unique_ptr<RamOperation> nested, AggregateFunction fun,
+            std::unique_ptr<RamRelationReference> relRef, std::unique_ptr<RamExpression> expression,
+            std::unique_ptr<RamCondition> condition, int ident)
+            : RamRelationSearch(std::move(relRef), ident, std::move(nested)),
+              function(fun), expression(std::move(expression)), condition(std::move(condition)) {}
+
+    /** Get condition */
+    const RamCondition* getCondition() const {
+        return condition.get();
+    }
+
+    /** Get aggregation function */
+    AggregateFunction getFunction() const {
+        return function;
+    }
+
+    /** Get target expression */
+    const RamExpression* getExpression() const {
+        return expression.get();
+    }
+
+    void print(std::ostream& os, int tabpos) const override {
+        os << times(" ", tabpos);
+        os << "t" << getIdentifier() << ".0=";
+        switch (function) {
+            case MIN:
+                os << "MIN ";
+                break;
+            case MAX:
+                os << "MAX ";
+                break;
+            case COUNT:
+                os << "COUNT ";
+                break;
+            case SUM:
+                os << "SUM ";
+                break;
+        }
+        if (function != COUNT) {
+            os << *expression << " ";
+        }
+        os << " FOR ALL t" << getIdentifier() << " ∈ " << getRelation().getName();
+        if (condition != nullptr) {
+            os << " WHERE " << *getCondition();
+        }
+        os << std::endl;
+        RamRelationSearch::print(os, tabpos + 1);
+    }
+
+    std::vector<const RamNode*> getChildNodes() const override {
+        auto res = RamRelationSearch::getChildNodes();
+        if (expression != nullptr) {
+            res.push_back(expression.get());
+        }
+        if (condition != nullptr) {
+            res.push_back(condition.get());
+        }
+        return res;
+    }
+
+    RamAggregate* clone() const override {
+        RamAggregate* res = new RamAggregate(std::unique_ptr<RamOperation>(getOperation().clone()), function,
+                std::unique_ptr<RamRelationReference>(relationRef->clone()),
+                expression == nullptr ? nullptr : std::unique_ptr<RamExpression>(expression->clone()),
+                condition == nullptr ? nullptr : std::unique_ptr<RamCondition>(condition->clone()),
+                getIdentifier());
+        return res;
+    }
+
+    void apply(const RamNodeMapper& map) override {
+        RamRelationSearch::apply(map);
+        if (condition != nullptr) {
+            condition = map(std::move(condition));
+        }
+        if (expression != nullptr) {
+            expression = map(std::move(expression));
+        }
+    }
+
+protected:
+    /** Aggregation function */
+    AggregateFunction function;
 
     /** Aggregation expression */
     std::unique_ptr<RamExpression> expression;
@@ -413,7 +521,7 @@ protected:
                 *getCondition() != *other.getCondition()) {
             return false;
         }
-        return RamIndexRelationSearch::equal(other) && getCondition() == other.getCondition() &&
+        return RamRelationSearch::equal(other) && getCondition() == other.getCondition() &&
                getFunction() == other.getFunction() && getExpression() == other.getExpression();
     }
 };

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -186,9 +186,10 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteAggregate(const RamAg
             if (agg->getExpression() != nullptr) {
                 expr = std::unique_ptr<RamExpression>(agg->getExpression()->clone());
             }
-            return std::make_unique<RamIndexAggregate>(std::unique_ptr<RamOperation>(agg->getOperation().clone()),
-                    agg->getFunction(), std::make_unique<RamRelationReference>(&rel), std::move(expr),
-                    std::move(condition), std::move(queryPattern), agg->getIdentifier());
+            return std::make_unique<RamIndexAggregate>(
+                    std::unique_ptr<RamOperation>(agg->getOperation().clone()), agg->getFunction(),
+                    std::make_unique<RamRelationReference>(&rel), std::move(expr), std::move(condition),
+                    std::move(queryPattern), agg->getIdentifier());
         }
     }
     return nullptr;

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -186,7 +186,7 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteAggregate(const RamAg
             if (agg->getExpression() != nullptr) {
                 expr = std::unique_ptr<RamExpression>(agg->getExpression()->clone());
             }
-            return std::make_unique<RamAggregate>(std::unique_ptr<RamOperation>(agg->getOperation().clone()),
+            return std::make_unique<RamIndexAggregate>(std::unique_ptr<RamOperation>(agg->getOperation().clone()),
                     agg->getFunction(), std::make_unique<RamRelationReference>(&rel), std::move(expr),
                     std::move(condition), std::move(queryPattern), agg->getIdentifier());
         }

--- a/src/RamVisitor.h
+++ b/src/RamVisitor.h
@@ -101,6 +101,7 @@ struct RamVisitor : public ram_visitor_tag {
         FORWARD(Scan);
         FORWARD(IndexScan);
         FORWARD(Aggregate);
+        FORWARD(IndexAggregate);
 
         // Statements
         FORWARD(Create);
@@ -184,7 +185,8 @@ protected:
     LINK(Scan, RelationSearch);
     LINK(IndexScan, RelationSearch);
     LINK(RelationSearch, Search);
-    LINK(Aggregate, Search);
+    LINK(Aggregate, RelationSearch);
+    LINK(IndexAggregate, RelationSearch);
     LINK(Search, NestedOperation);
     LINK(Filter, NestedOperation);
     LINK(NestedOperation, Operation);

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -753,7 +753,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitAggregate(const RamAggregate& aggregate, std::ostream& out) override {
+        void visitIndexAggregate(const RamIndexAggregate& aggregate, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             // get some properties
             const auto& rel = aggregate.getRelation();
@@ -772,7 +772,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             auto keys = keysAnalysis->getRangeQueryColumns(&aggregate);
 
             // special case: counting number elements over an unrestricted predicate
-            if (aggregate.getFunction() == RamAggregate::COUNT && keys == 0 &&
+            if (aggregate.getFunction() == souffle::COUNT && keys == 0 &&
                     aggregate.getCondition() == nullptr) {
                 // shortcut: use relation size
                 out << "env" << identifier << "[0] = " << relName << "->"
@@ -785,16 +785,16 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             // init result
             std::string init;
             switch (aggregate.getFunction()) {
-                case RamAggregate::MIN:
+                case souffle::MIN:
                     init = "MAX_RAM_DOMAIN";
                     break;
-                case RamAggregate::MAX:
+                case souffle::MAX:
                     init = "MIN_RAM_DOMAIN";
                     break;
-                case RamAggregate::COUNT:
+                case souffle::COUNT:
                     init = "0";
                     break;
-                case RamAggregate::SUM:
+                case souffle::SUM:
                     init = "0";
                     break;
                 default:
@@ -842,10 +842,10 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             }
 
             // create aggregation code
-            if (aggregate.getFunction() == RamAggregate::COUNT) {
+            if (aggregate.getFunction() == souffle::COUNT) {
                 // count is easy
                 out << "++res" << identifier << "\n;";
-            } else if (aggregate.getFunction() == RamAggregate::SUM) {
+            } else if (aggregate.getFunction() == souffle::SUM) {
                 out << "res" << identifier << " += ";
                 visit(*aggregate.getExpression(), out);
                 out << ";\n";
@@ -853,15 +853,15 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 // pick function
                 std::string fun = "min";
                 switch (aggregate.getFunction()) {
-                    case RamAggregate::MIN:
+                    case souffle::MIN:
                         fun = "std::min";
                         break;
-                    case RamAggregate::MAX:
+                    case souffle::MAX:
                         fun = "std::max";
                         break;
-                    case RamAggregate::COUNT:
+                    case souffle::COUNT:
                         assert(false);
-                    case RamAggregate::SUM:
+                    case souffle::SUM:
                         assert(false);
                 }
 
@@ -880,8 +880,118 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             // write result into environment tuple
             out << "env" << identifier << "[0] = res" << identifier << ";\n";
 
-            if (aggregate.getFunction() == RamAggregate::MIN ||
-                    aggregate.getFunction() == RamAggregate::MAX) {
+            if (aggregate.getFunction() == souffle::MIN ||
+                    aggregate.getFunction() == souffle::MAX) {
+                // check whether there exists a min/max first before next loop
+                out << "if(res" << identifier << " != " << init << "){\n";
+                visitSearch(aggregate, out);
+                out << "}\n";
+            } else {
+                visitSearch(aggregate, out);
+            }
+
+            PRINT_END_COMMENT(out);
+        }
+
+        void visitAggregate(const RamAggregate& aggregate, std::ostream& out) override {
+            PRINT_BEGIN_COMMENT(out);
+            // get some properties
+            const auto& rel = aggregate.getRelation();
+            auto arity = rel.getArity();
+            auto relName = synthesiser.getRelationName(rel);
+            auto ctxName = "READ_OP_CONTEXT(" + synthesiser.getOpContextName(rel) + ")";
+            auto identifier = aggregate.getIdentifier();
+
+            // aggregate tuple storing the result of aggregate
+            std::string tuple_type = "ram::Tuple<RamDomain," + toString(arity) + ">";
+
+            // declare environment variable
+            out << "ram::Tuple<RamDomain,1> env" << identifier << ";\n";
+
+            // special case: counting number elements over an unrestricted predicate
+            if (aggregate.getFunction() == souffle::COUNT  &&
+                    aggregate.getCondition() == nullptr) {
+                // shortcut: use relation size
+                out << "env" << identifier << "[0] = " << relName << "->"
+                    << "size();\n";
+                visitSearch(aggregate, out);
+                PRINT_END_COMMENT(out);
+                return;
+            }
+
+            // init result
+            std::string init;
+            switch (aggregate.getFunction()) {
+                case souffle::MIN:
+                    init = "MAX_RAM_DOMAIN";
+                    break;
+                case souffle::MAX:
+                    init = "MIN_RAM_DOMAIN";
+                    break;
+                case souffle::COUNT:
+                    init = "0";
+                    break;
+                case souffle::SUM:
+                    init = "0";
+                    break;
+                default:
+                    abort();
+            }
+            out << "RamDomain res" << identifier << " = " << init << ";\n";
+
+            // check whether there is an index to use
+            out << "for(const auto& env" << identifier << " : "
+                << "*" << relName << ") {\n";
+
+            // produce condition inside the loop
+            auto condition = aggregate.getCondition();
+            if (condition != nullptr) {
+                out << "if( ";
+                visit(condition, out);
+                out << ") {\n";
+            }
+
+            // create aggregation code
+            if (aggregate.getFunction() == souffle::COUNT) {
+                // count is easy
+                out << "++res" << identifier << "\n;";
+            } else if (aggregate.getFunction() == souffle::SUM) {
+                out << "res" << identifier << " += ";
+                visit(*aggregate.getExpression(), out);
+                out << ";\n";
+            } else {
+                // pick function
+                std::string fun = "min";
+                switch (aggregate.getFunction()) {
+                    case souffle::MIN:
+                        fun = "std::min";
+                        break;
+                    case souffle::MAX:
+                        fun = "std::max";
+                        break;
+                    case souffle::COUNT:
+                        assert(false);
+                    case souffle::SUM:
+                        assert(false);
+                }
+
+                out << "res" << identifier << " = " << fun << "(res" << identifier << ",";
+                visit(*aggregate.getExpression(), out);
+                out << ");\n";
+            }
+
+            if (condition != nullptr) {
+                out << "}\n";
+            }
+
+            // end aggregator loop
+            out << "}\n";
+
+            // write result into environment tuple
+            out << "env" << identifier << "[0] = res" << identifier << ";\n";
+
+            if (aggregate.getFunction() == souffle::MIN ||
+                    aggregate.getFunction() == souffle::MAX) {
                 // check whether there exists a min/max first before next loop
                 out << "if(res" << identifier << " != " << init << "){\n";
                 visitSearch(aggregate, out);

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -841,33 +841,28 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 out << ") {\n";
             }
 
-            // create aggregation code
-            if (aggregate.getFunction() == souffle::COUNT) {
-                // count is easy
-                out << "++res" << identifier << "\n;";
-            } else if (aggregate.getFunction() == souffle::SUM) {
-                out << "res" << identifier << " += ";
-                visit(*aggregate.getExpression(), out);
-                out << ";\n";
-            } else {
-                // pick function
-                std::string fun = "min";
-                switch (aggregate.getFunction()) {
-                    case souffle::MIN:
-                        fun = "std::min";
-                        break;
-                    case souffle::MAX:
-                        fun = "std::max";
-                        break;
-                    case souffle::COUNT:
-                        assert(false);
-                    case souffle::SUM:
-                        assert(false);
-                }
-
-                out << "res" << identifier << " = " << fun << "(res" << identifier << ",";
-                visit(*aggregate.getExpression(), out);
-                out << ");\n";
+            switch (aggregate.getFunction()) {
+                case souffle::MIN:
+                    out << "res" << identifier << " = std::min (res" << identifier << ",";
+                    visit(*aggregate.getExpression(), out);
+                    out << ");\n";
+                    break;
+                case souffle::MAX:
+                    out << "res" << identifier << " = std::max (res" << identifier << ",";
+                    visit(*aggregate.getExpression(), out);
+                    out << ");\n";
+                    break;
+                case souffle::COUNT:
+                    // count is easy
+                    out << "++res" << identifier << "\n;";
+                    break;
+                case souffle::SUM:
+                    out << "res" << identifier << " += ";
+                    visit(*aggregate.getExpression(), out);
+                    out << ";\n";
+                    break;
+                default:
+                    abort();
             }
 
             if (condition != nullptr) {
@@ -896,13 +891,9 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             PRINT_BEGIN_COMMENT(out);
             // get some properties
             const auto& rel = aggregate.getRelation();
-            auto arity = rel.getArity();
             auto relName = synthesiser.getRelationName(rel);
             auto ctxName = "READ_OP_CONTEXT(" + synthesiser.getOpContextName(rel) + ")";
             auto identifier = aggregate.getIdentifier();
-
-            // aggregate tuple storing the result of aggregate
-            std::string tuple_type = "ram::Tuple<RamDomain," + toString(arity) + ">";
 
             // declare environment variable
             out << "ram::Tuple<RamDomain,1> env" << identifier << ";\n";
@@ -949,33 +940,28 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 out << ") {\n";
             }
 
-            // create aggregation code
-            if (aggregate.getFunction() == souffle::COUNT) {
-                // count is easy
-                out << "++res" << identifier << "\n;";
-            } else if (aggregate.getFunction() == souffle::SUM) {
-                out << "res" << identifier << " += ";
-                visit(*aggregate.getExpression(), out);
-                out << ";\n";
-            } else {
-                // pick function
-                std::string fun = "min";
-                switch (aggregate.getFunction()) {
-                    case souffle::MIN:
-                        fun = "std::min";
-                        break;
-                    case souffle::MAX:
-                        fun = "std::max";
-                        break;
-                    case souffle::COUNT:
-                        assert(false);
-                    case souffle::SUM:
-                        assert(false);
-                }
-
-                out << "res" << identifier << " = " << fun << "(res" << identifier << ",";
-                visit(*aggregate.getExpression(), out);
-                out << ");\n";
+            // pick function
+            switch (aggregate.getFunction()) {
+                case souffle::MIN:
+                    out << "res" << identifier << " = std::min(res" << identifier << ",";
+                    visit(*aggregate.getExpression(), out);
+                    out << ");\n";
+                    break;
+                case souffle::MAX:
+                    out << "res" << identifier << " = std::max(res" << identifier << ",";
+                    visit(*aggregate.getExpression(), out);
+                    out << ");\n";
+                    break;
+                case souffle::COUNT:
+                    out << "++res" << identifier << "\n;";
+                    break;
+                case souffle::SUM:
+                    out << "res" << identifier << " += ";
+                    visit(*aggregate.getExpression(), out);
+                    out << ";\n";
+                    break;
+                default:
+                    abort();
             }
 
             if (condition != nullptr) {

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -880,8 +880,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             // write result into environment tuple
             out << "env" << identifier << "[0] = res" << identifier << ";\n";
 
-            if (aggregate.getFunction() == souffle::MIN ||
-                    aggregate.getFunction() == souffle::MAX) {
+            if (aggregate.getFunction() == souffle::MIN || aggregate.getFunction() == souffle::MAX) {
                 // check whether there exists a min/max first before next loop
                 out << "if(res" << identifier << " != " << init << "){\n";
                 visitSearch(aggregate, out);
@@ -909,8 +908,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             out << "ram::Tuple<RamDomain,1> env" << identifier << ";\n";
 
             // special case: counting number elements over an unrestricted predicate
-            if (aggregate.getFunction() == souffle::COUNT  &&
-                    aggregate.getCondition() == nullptr) {
+            if (aggregate.getFunction() == souffle::COUNT && aggregate.getCondition() == nullptr) {
                 // shortcut: use relation size
                 out << "env" << identifier << "[0] = " << relName << "->"
                     << "size();\n";
@@ -990,8 +988,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             // write result into environment tuple
             out << "env" << identifier << "[0] = res" << identifier << ";\n";
 
-            if (aggregate.getFunction() == souffle::MIN ||
-                    aggregate.getFunction() == souffle::MAX) {
+            if (aggregate.getFunction() == souffle::MIN || aggregate.getFunction() == souffle::MAX) {
                 // check whether there exists a min/max first before next loop
                 out << "if(res" << identifier << " != " << init << "){\n";
                 visitSearch(aggregate, out);


### PR DESCRIPTION
This is an issue related to #961. At the moment RamAggregate describes the indexed and the unindexed version. This pull request introduces two separate classes for aggregates that describes the unindexed and indexed using two classes.