### PR TITLE
Expand Filter RAM Transformer

### DIFF
--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -34,14 +34,12 @@ bool ExpandFilterTransformer::expandFilters(RamProgram& program) {
     // flag to determine whether the RAM program has changed
     bool changed = false;
 
-    std::vector<std::unique_ptr<RamCondition>> conditionList;
-
     visitDepthFirst(program, [&](const RamQuery& query) {
         std::function<std::unique_ptr<RamNode>(std::unique_ptr<RamNode>)> filterRewriter =
                 [&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {
             if (const RamFilter* filter = dynamic_cast<RamFilter*>(node.get())) {
                 const RamCondition* condition = &filter->getCondition();
-                conditionList = toConjunctionList(condition);
+                std::vector<std::unique_ptr<RamCondition>> conditionList = toConjunctionList(condition);
                 if (conditionList.size() > 1) {
                     changed = true;
                     std::vector<std::unique_ptr<RamFilter>> filters;

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -30,6 +30,42 @@
 
 namespace souffle {
 
+bool FilterExpansionTransformer::expandFilters(RamProgram& program) {
+    // flag to determine whether the RAM program has changed
+    bool changed = false;
+
+    std::vector<std::unique_ptr<RamCondition>> conditionList;
+
+    visitDepthFirst(program, [&](const RamQuery& query) {
+        std::function<std::unique_ptr<RamNode>(std::unique_ptr<RamNode>)> filterRewriter =
+                [&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {
+            if (const RamFilter* filter = dynamic_cast<RamFilter*>(node.get())) {
+                const RamCondition* condition = &filter->getCondition();
+                conditionList = toConjunctionList(condition);
+                if (conditionList.size() > 1) {
+                    changed = true;
+                    std::vector<std::unique_ptr<RamFilter>> filters;
+                    for (auto iter = conditionList.end(); iter != conditionList.begin(); --iter) {
+                        auto& cond = *iter;
+                        if (filters.empty()) {
+                            filters.emplace_back(std::make_unique<RamFilter>(std::move(cond),
+                                    std::unique_ptr<RamOperation>(filter->getOperation().clone())));
+                        } else {
+                            filters.emplace_back(
+                                    std::make_unique<RamFilter>(std::move(cond), std::move(filters.back())));
+                        }
+                    }
+                    node = std::move(filters.back());
+                }
+            }
+            node->apply(makeLambdaRamMapper(filterRewriter));
+            return node;
+        };
+        const_cast<RamQuery*>(&query)->apply(makeLambdaRamMapper(filterRewriter));
+    });
+    return changed;
+}
+
 bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
     // flag to determine whether the RAM program has changed
     bool changed = false;

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -43,7 +43,7 @@ bool ExpandFilterTransformer::expandFilters(RamProgram& program) {
                 if (conditionList.size() > 1) {
                     changed = true;
                     std::vector<std::unique_ptr<RamFilter>> filters;
-                    for (auto iter = conditionList.rbegin(); iter != conditionList.rend(); iter++) {
+                    for (auto iter = conditionList.rbegin(); iter != conditionList.rend(); ++iter) {
                         auto& cond = *iter;
                         auto tempCond = cond->clone();
                         if (filters.empty()) {

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -30,7 +30,7 @@
 
 namespace souffle {
 
-bool FilterExpansionTransformer::expandFilters(RamProgram& program) {
+bool ExpandFilterTransformer::expandFilters(RamProgram& program) {
     // flag to determine whether the RAM program has changed
     bool changed = false;
 

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -45,14 +45,17 @@ bool ExpandFilterTransformer::expandFilters(RamProgram& program) {
                 if (conditionList.size() > 1) {
                     changed = true;
                     std::vector<std::unique_ptr<RamFilter>> filters;
-                    for (auto iter = conditionList.end(); iter != conditionList.begin(); --iter) {
+                    for (auto iter = conditionList.rbegin(); iter != conditionList.rend(); iter++) {
                         auto& cond = *iter;
+                        auto tempCond = cond->clone();
                         if (filters.empty()) {
-                            filters.emplace_back(std::make_unique<RamFilter>(std::move(cond),
+                            filters.emplace_back(std::make_unique<RamFilter>(
+                                    std::unique_ptr<RamCondition>(std::move(tempCond)),
                                     std::unique_ptr<RamOperation>(filter->getOperation().clone())));
                         } else {
-                            filters.emplace_back(
-                                    std::make_unique<RamFilter>(std::move(cond), std::move(filters.back())));
+                            filters.emplace_back(std::make_unique<RamFilter>(
+                                    std::unique_ptr<RamCondition>(std::move(tempCond)),
+                                    std::move(filters.back())));
                         }
                     }
                     node = std::move(filters.back());

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -29,7 +29,7 @@ namespace souffle {
 class RamProgram;
 
 /**
- * @class FilterExpansionTransformer
+ * @class ExpandFilterTransformer
  * @brief Transforms RamConjunctions into consecutive filter operations.
  *
  * For example ..
@@ -48,10 +48,10 @@ class RamProgram;
  *      ...
  *
  */
-class FilterExpansionTransformer : public RamTransformer {
+class ExpandFilterTransformer : public RamTransformer {
 public:
     std::string getName() const override {
-        return "FilterExpansionTransformer";
+        return "ExpandFilterTransformer";
     }
 
     /**

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -29,6 +29,45 @@ namespace souffle {
 class RamProgram;
 
 /**
+ * @class FilterExpansionTransformer
+ * @brief Transforms RamConjunctions into consecutive filter operations.
+ *
+ * For example ..
+ *
+ *  QUERY
+ *   ...
+ *    IF C1 /\ C2 then
+ *     ...
+ *
+ * will be rewritten to
+ *
+ *  QUERY
+ *   ...
+ *    IF C1
+ *     IF C2
+ *      ...
+ *
+ */
+class FilterExpansionTransformer : public RamTransformer {
+public:
+    std::string getName() const override {
+        return "FilterExpansionTransformer";
+    }
+
+    /**
+     * @brief Expand filter operations
+     * @param Program that is transformed
+     * @return Flag showing whether the program has been changed by the transformation
+     */
+    bool expandFilters(RamProgram& program);
+
+protected:
+    bool transform(RamTranslationUnit& translationUnit) override {
+        return expandFilters(*translationUnit.getProgram());
+    }
+};
+
+/**
  * @class HoistConditionsTransformer
  * @brief Hosts conditions in a loop-nest to the most-outer/semantically-correct loop
  *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -484,7 +484,7 @@ int main(int argc, char** argv) {
             AstTranslator().translateUnit(*astTranslationUnit);
 
     std::vector<std::unique_ptr<RamTransformer>> ramTransforms;
-    ramTransforms.push_back(std::make_unique<FilterExpansionTransformer>());
+    ramTransforms.push_back(std::make_unique<ExpandFilterTransformer>());
     ramTransforms.push_back(std::make_unique<HoistConditionsTransformer>());
     ramTransforms.push_back(std::make_unique<MakeIndexTransformer>());
     ramTransforms.push_back(std::make_unique<IfConversionTransformer>());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -484,6 +484,7 @@ int main(int argc, char** argv) {
             AstTranslator().translateUnit(*astTranslationUnit);
 
     std::vector<std::unique_ptr<RamTransformer>> ramTransforms;
+    ramTransforms.push_back(std::make_unique<FilterExpansionTransformer>());
     ramTransforms.push_back(std::make_unique<HoistConditionsTransformer>());
     ramTransforms.push_back(std::make_unique<MakeIndexTransformer>());
     ramTransforms.push_back(std::make_unique<IfConversionTransformer>());


### PR DESCRIPTION
Transforms RamConjunctions into consecutive filter operations.
```
 For example ..

  QUERY
   ...
    IF C1 /\ C2 then
     ...

 will be rewritten to

  QUERY
   ...
    IF C1
     IF C2
      ...
```
