### PR TITLE
RAM Level Analysis refactoring

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -122,7 +122,7 @@ souffle_sources = \
               RamProvenanceExistenceCheckAnalysis.cpp RamProvenanceExistenceCheckAnalysis.h \
               RamIndexKeys.cpp  RamIndexKeys.h          \
 			  RAMI.cpp RAMI.h 							\
-              RamLevel.cpp RamLevel.h                   \
+              RamLevelAnalysis.cpp RamLevelAnalysis.h   \
               RamCondition.h                            \
               RamNode.h                                 \
               RamOperation.h                            \

--- a/src/RamLevel.cpp
+++ b/src/RamLevel.cpp
@@ -120,7 +120,7 @@ int RamLevelAnalysis::getLevel(const RamNode* node) const {
         }
 
         // default rule
-        int visitNode(const RamNode& node) {
+        int visitNode(const RamNode& node) override {
             assert(false && "RamNode not implemented!");
             return -1;
         }

--- a/src/RamLevelAnalysis.cpp
+++ b/src/RamLevelAnalysis.cpp
@@ -8,13 +8,13 @@
 
 /************************************************************************
  *
- * @file RamLevel.cpp
+ * @file RamLevelAnalysis.cpp
  *
  * Implementation of RAM Level Analysis
  *
  ***********************************************************************/
 
-#include "RamLevel.h"
+#include "RamLevelAnalysis.h"
 #include "RamVisitor.h"
 #include <algorithm>
 

--- a/src/RamLevelAnalysis.h
+++ b/src/RamLevelAnalysis.h
@@ -8,7 +8,7 @@
 
 /************************************************************************
  *
- * @file RamLevel.h
+ * @file RamLevelAnalysis.h
  *
  * Get level of an expression/condition. The level of a condition/expression
  * determines the outer-most scope in a loop-next of a query,  for which the

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "RamLevel.h"
+#include "RamLevelAnalysis.h"
 #include "RamTransformer.h"
 #include "RamTranslationUnit.h"
 #include <memory>
@@ -32,18 +32,22 @@ class RamProgram;
  *
  * For example ..
  *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *  QUERY
  *   ...
  *    IF C1 /\ C2 then
  *     ...
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * will be rewritten to
  *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *  QUERY
  *   ...
  *    IF C1
  *     IF C2
  *      ...
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  */
 class ExpandFilterTransformer : public RamTransformer {
@@ -76,18 +80,22 @@ protected:
  * i.e. a conjunction is expressed by two consecutive filter operations.
  * For example ..
  *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *  QUERY
  *   ...
  *    IF C1 /\ C2 then
  *     ...
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * should be rewritten / or produced by the translator as
  *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *  QUERY
  *   ...
  *    IF C1
  *     IF C2
  *      ...
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * otherwise the levelling becomes imprecise, i.e., for both conditions
  * the most outer-level is sought rather than considered separately.
@@ -136,19 +144,23 @@ protected:
  * The conditions that could be used for an index must be located
  * immediately after the scan or aggregrate operation.
  *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *  QUERY
  *   ...
  *   FOR t1 in A
  *    IF t1.x = 10 /\ t1.y = 20 /\ C
  *     ...
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * will be rewritten to
  *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *  QUERY
  *   ...
  *    SEARCH t1 in A INDEX t1.x=10 and t1.y = 20
  *     IF C
  *      ...
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
 
 class MakeIndexTransformer : public RamTransformer {
@@ -221,17 +233,21 @@ protected:
  *
  * For example,
  *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *  QUERY
  *   ...
  *    SEARCH t1 IN A INDEX t1.x=10 AND t1.y = 20
  *      ... // no occurrence of t1
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * will be rewritten to
  *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *  QUERY
  *   ...
  *    IF (10,20) NOT IN A
  *      ...
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  */
 class IfConversionTransformer : public RamTransformer {
@@ -278,19 +294,23 @@ protected:
  *
  * For example,
  *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *  QUERY
  *   ...
  *    SEARCH t1 IN A INDEX t1.x=10 AND t1.y = 20
  *    	IF (t1.x, t1.y) NOT IN A
  *          ... // no occurrence of t1
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * will be rewritten to
  *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *  QUERY
  *   ...
  *    INDEXCHOICE AS t1 ON INDEX t1.x=10 AND t1.y = 20
  *    WHERE (t1.x, t1.y) NOT IN A
  *      ...
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  */
 class ChoiceConversionTransformer : public RamTransformer {


### PR DESCRIPTION
This is related to fix #961.

* The ```visitNode``` method has no override qualifier.
* The level analysis files have been renamed to RamLevelAnalysis to be consistent. 
* Code blocks are in doxygen/markdown format

