### PR TITLE
Tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 #disabled checks clash with wanted code
-Checks:          '-*,cppcoreguidelines-no-malloc,-cppcoreguidelines-pro-type-member-init,modernize-deprecated-headers,-modernize-loop-convert,modernize-make-unique,modernize-pass-by-value,modernize-raw-string-literal,modernize-use-auto,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-nullptr,modernize-use-override,modernize-use-using'
+Checks:          '-*,bugprone-suspicious-semicolon,bugprone-unused-raii,cppcoreguidelines-slicing,cppcoreguidelines-no-malloc,cppcoreguidelines-pro-type-member-init,modernize-deprecated-headers,modernize-loop-convert,modernize-make-unique,modernize-pass-by-value,modernize-raw-string-literal,modernize-use-auto,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-nullptr,modernize-use-override,modernize-use-using'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*\.h$'
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 #disabled checks clash with wanted code
-Checks:          '-*,cppcoreguidelines-no-malloc,-cppcoreguidelines-pro-type-member-init,modernize-deprecated-headers,-modernize-loop-convert,-modernize-make-unique,modernize-pass-by-value,modernize-raw-string-literal,modernize-use-auto,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-nullptr,modernize-use-override,modernize-use-using'
+Checks:          '-*,cppcoreguidelines-no-malloc,-cppcoreguidelines-pro-type-member-init,modernize-deprecated-headers,-modernize-loop-convert,modernize-make-unique,modernize-pass-by-value,modernize-raw-string-literal,modernize-use-auto,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-nullptr,modernize-use-override,modernize-use-using'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*\.h$'
 AnalyzeTemporaryDtors: false

--- a/src/AstArgument.h
+++ b/src/AstArgument.h
@@ -535,8 +535,8 @@ protected:
  */
 class AstTypeCast : public AstArgument {
 public:
-    AstTypeCast(std::unique_ptr<AstArgument> value, const AstTypeIdentifier& type)
-            : value(std::move(value)), type(type) {}
+    AstTypeCast(std::unique_ptr<AstArgument> value, AstTypeIdentifier type)
+            : value(std::move(value)), type(std::move(type)) {}
 
     void print(std::ostream& os) const override {
         os << "as(" << *value << "," << type << ")";

--- a/src/AstArgument.h
+++ b/src/AstArgument.h
@@ -77,7 +77,7 @@ public:
 
     /** Creates a clone of this AST sub-structure */
     AstVariable* clone() const override {
-        AstVariable* res = new AstVariable(name);
+        auto* res = new AstVariable(name);
         res->setSrcLoc(getSrcLoc());
         return res;
     }

--- a/src/AstAttribute.h
+++ b/src/AstAttribute.h
@@ -60,7 +60,7 @@ public:
 
     /** Creates a clone of this AST sub-structure */
     AstAttribute* clone() const override {
-        AstAttribute* res = new AstAttribute(name, typeName);
+        auto* res = new AstAttribute(name, typeName);
         res->setSrcLoc(getSrcLoc());
         return res;
     }

--- a/src/AstComponent.h
+++ b/src/AstComponent.h
@@ -76,7 +76,7 @@ public:
     }
 
     AstComponentType* clone() const override {
-        AstComponentType* res = new AstComponentType(name, typeParams);
+        auto* res = new AstComponentType(name, typeParams);
         res->setSrcLoc(getSrcLoc());
         return res;
     }

--- a/src/AstLiteral.h
+++ b/src/AstLiteral.h
@@ -196,7 +196,7 @@ public:
 
     /** Creates a clone of this AST sub-structure */
     AstNegation* clone() const override {
-        AstNegation* res = new AstNegation(std::unique_ptr<AstAtom>(atom->clone()));
+        auto* res = new AstNegation(std::unique_ptr<AstAtom>(atom->clone()));
         res->setSrcLoc(getSrcLoc());
         return res;
     }
@@ -253,7 +253,7 @@ public:
 
     /** Creates a clone if this AST sub-structure */
     AstProvenanceNegation* clone() const override {
-        AstProvenanceNegation* res = new AstProvenanceNegation(std::unique_ptr<AstAtom>(atom->clone()));
+        auto* res = new AstProvenanceNegation(std::unique_ptr<AstAtom>(atom->clone()));
         res->setSrcLoc(getSrcLoc());
         return res;
     }
@@ -404,8 +404,8 @@ public:
 
     /** Creates a clone of this AST sub-structure */
     AstBinaryConstraint* clone() const override {
-        AstBinaryConstraint* res = new AstBinaryConstraint(operation,
-                std::unique_ptr<AstArgument>(lhs->clone()), std::unique_ptr<AstArgument>(rhs->clone()));
+        auto* res = new AstBinaryConstraint(operation, std::unique_ptr<AstArgument>(lhs->clone()),
+                std::unique_ptr<AstArgument>(rhs->clone()));
         res->setSrcLoc(getSrcLoc());
         return res;
     }

--- a/src/AstParserUtils.cpp
+++ b/src/AstParserUtils.cpp
@@ -121,8 +121,7 @@ RuleBody RuleBody::atom(AstAtom* atom) {
     RuleBody body;
     body.dnf.push_back(clause());
     auto& clause = body.dnf.back();
-    clause.push_back(literal());
-    clause.back() = literal{false, std::unique_ptr<AstAtom>(atom)};
+    clause.emplace_back(false, std::unique_ptr<AstAtom>(atom));
     return body;
 }
 
@@ -130,8 +129,7 @@ RuleBody RuleBody::constraint(AstConstraint* constraint) {
     RuleBody body;
     body.dnf.push_back(clause());
     auto& clause = body.dnf.back();
-    clause.push_back(literal());
-    clause.back() = literal{false, std::unique_ptr<AstLiteral>(constraint)};
+    clause.emplace_back(false, std::unique_ptr<AstLiteral>(constraint));
     return body;
 }
 

--- a/src/AstParserUtils.h
+++ b/src/AstParserUtils.h
@@ -53,6 +53,7 @@ public:
 private:
     // a struct to represent literals
     struct literal {
+        literal(bool negated, std::unique_ptr<AstLiteral> atom) : negated(negated), atom(std::move(atom)) {}
         // whether this literal is negated or not
         bool negated;
 
@@ -60,7 +61,7 @@ private:
         std::unique_ptr<AstLiteral> atom;
 
         literal clone() const {
-            return literal({negated, std::unique_ptr<AstLiteral>(atom->clone())});
+            return literal(negated, std::unique_ptr<AstLiteral>(atom->clone()));
         }
     };
 

--- a/src/AstRelationIdentifier.h
+++ b/src/AstRelationIdentifier.h
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace souffle {
@@ -39,7 +40,7 @@ public:
 
     AstRelationIdentifier(const char* name) : AstRelationIdentifier(std::string(name)) {}
 
-    AstRelationIdentifier(std::vector<std::string> names) : names(names) {}
+    AstRelationIdentifier(std::vector<std::string> names) : names(std::move(names)) {}
 
     AstRelationIdentifier(const AstRelationIdentifier&) = default;
     AstRelationIdentifier(AstRelationIdentifier&&) = default;

--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -949,7 +949,7 @@ void AstSemanticChecker::checkWitnessProblem(ErrorReport& report, const AstProgr
         visitDepthFirst(*clause.getHead(), [&](const AstVariable& var) {
             headVariables->addArgument(std::unique_ptr<AstVariable>(var.clone()));
         });
-        AstNegation* headNegation = new AstNegation(std::move(headVariables));
+        auto* headNegation = new AstNegation(std::move(headVariables));
         bodyLiterals.push_back(headNegation);
 
         // Perform the check

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -84,7 +84,7 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(AstTranslationUnit& t
     // collect aliases
     alias_map isDirectAliasOf;
 
-    IOType* ioType = translationUnit.getAnalysis<IOType>();
+    auto* ioType = translationUnit.getAnalysis<IOType>();
 
     AstProgram& program = *translationUnit.getProgram();
 
@@ -804,7 +804,7 @@ bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUni
     // Keep track of all relations that cannot be transformed
     std::set<AstRelationIdentifier> minimalIrreducibleRelations;
 
-    IOType* ioType = translationUnit.getAnalysis<IOType>();
+    auto* ioType = translationUnit.getAnalysis<IOType>();
 
     for (AstRelation* relation : program.getRelations()) {
         // No I/O relations can be transformed

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -239,7 +239,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
                 relName = "__agg_rel_" + toString(counter++);
             }
 
-            AstAtom* head = new AstAtom();
+            auto* head = new AstAtom();
             head->setName(relName);
             std::vector<bool> symbolArguments;
             for (const auto& cur : vars) {

--- a/src/AstTranslator.h
+++ b/src/AstTranslator.h
@@ -73,8 +73,8 @@ private:
      * Concrete attribute
      */
     struct Location {
-        int identifier;
-        int element;
+        int identifier{};
+        int element{};
         std::unique_ptr<RamRelationReference> relation{nullptr};
 
         Location() = default;

--- a/src/EventProcessor.h
+++ b/src/EventProcessor.h
@@ -165,10 +165,10 @@ private:
             }
         }
         std::vector<std::string> result = split(str, ";");
-        for (size_t i = 0; i < result.size(); i++) {
-            for (size_t j = 0; j < result[i].size(); j++) {
-                if (result[i][j] == '\b') {
-                    result[i][j] = ';';
+        for (auto& i : result) {
+            for (char& j : i) {
+                if (j == '\b') {
+                    j = ';';
                 }
             }
         }

--- a/src/Explain.h
+++ b/src/Explain.h
@@ -56,7 +56,7 @@ public:
     int depthLimit = 4;
 
 private:
-    ExplainConfig() {}
+    ExplainConfig() = default;
 };
 
 class Explain {
@@ -64,7 +64,7 @@ public:
     ExplainProvenance& prov;
 
     Explain(ExplainProvenance& prov) : prov(prov) {}
-    ~Explain() {}
+    ~Explain() = default;
 
     /* Process a command, a return value of true indicates to continue, returning false indicates to break (if
      * the command is q/exit) */

--- a/src/ExplainProvenanceImpl.h
+++ b/src/ExplainProvenanceImpl.h
@@ -444,9 +444,9 @@ public:
     std::vector<std::string> getRules(std::string relName) override {
         std::vector<std::string> relRules;
         // go through all rules
-        for (auto it = rules.begin(); it != rules.end(); it++) {
-            if (it->first.first == relName) {
-                relRules.push_back(it->second);
+        for (auto& rule : rules) {
+            if (rule.first.first == relName) {
+                relRules.push_back(rule.second);
             }
         }
 

--- a/src/ExplainTree.h
+++ b/src/ExplainTree.h
@@ -18,12 +18,12 @@
 
 #include "Util.h"
 #include <cassert>
+#include <cstring>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
-#include <string.h>
 
 namespace souffle {
 

--- a/src/InlineRelationsTransformer.cpp
+++ b/src/InlineRelationsTransformer.cpp
@@ -335,7 +335,7 @@ std::pair<NullableVector<AstLiteral*>, std::vector<AstBinaryConstraint*>> inline
  */
 AstLiteral* negateLiteral(AstLiteral* lit) {
     if (auto* atom = dynamic_cast<AstAtom*>(lit)) {
-        AstNegation* neg = new AstNegation(std::unique_ptr<AstAtom>(atom->clone()));
+        auto* neg = new AstNegation(std::unique_ptr<AstAtom>(atom->clone()));
         return neg;
     } else if (auto* neg = dynamic_cast<AstNegation*>(lit)) {
         AstAtom* atom = neg->getAtom()->clone();

--- a/src/InterpreterInterface.h
+++ b/src/InterpreterInterface.h
@@ -201,7 +201,7 @@ public:
                 std::string n = rel.getArg(i);
                 attrNames.push_back(n);
             }
-            InterpreterRelInterface* interface = new InterpreterRelInterface(
+            auto* interface = new InterpreterRelInterface(
                     interpreterRel, symTable, rel.getName(), types, attrNames, id);
             interfaces.push_back(interface);
             bool input;

--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -32,7 +32,7 @@ namespace souffle {
  */
 class InterpreterRelation {
 public:
-    InterpreterRelation(size_t relArity) : arity(relArity), num_tuples(0), totalIndex(nullptr) {}
+    InterpreterRelation(size_t relArity) : arity(relArity), totalIndex(nullptr) {}
 
     InterpreterRelation(const InterpreterRelation& other) = delete;
 
@@ -303,7 +303,7 @@ private:
     static const int BLOCK_SIZE = 1024;
 
     /** Number of tuples in relation */
-    size_t num_tuples;
+    size_t num_tuples = 0;
 
     std::deque<std::unique_ptr<RamDomain[]>> blockList;
 
@@ -320,7 +320,7 @@ private:
     std::vector<std::string> attributeTypeQualifiers;
 
     /** Stratum level information */
-    size_t level;
+    size_t level = 0;
 };
 
 /**

--- a/src/LVM.cpp
+++ b/src/LVM.cpp
@@ -464,7 +464,7 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
 
                 // load DLL (if not done yet)
                 void* handle = this->loadDLL();
-                void (*fn)() = (void (*)())dlsym(handle, name.c_str());
+                auto fn = reinterpret_cast<void (*)()>(dlsym(handle, name.c_str()));
                 if (fn == nullptr) {
                     std::cerr << "Cannot find user-defined operator " << name << " in " << SOUFFLE_DLL
                               << std::endl;

--- a/src/LVM.h
+++ b/src/LVM.h
@@ -61,7 +61,7 @@ public:
     }
 
     /** Execute the main program */
-    virtual void executeMain();
+    void executeMain() override;
 
     /** Clean the cache of main Program */
     void resetMainProgram() {
@@ -75,7 +75,7 @@ public:
 
     /** Execute the subroutine */
     void executeSubroutine(const std::string& name, const std::vector<RamDomain>& arguments,
-            std::vector<RamDomain>& returnValues, std::vector<bool>& returnErrors) {
+            std::vector<RamDomain>& returnValues, std::vector<bool>& returnErrors) override {
         InterpreterContext ctxt;
         ctxt.setReturnValues(returnValues);
         ctxt.setReturnErrors(returnErrors);

--- a/src/LVMCode.h
+++ b/src/LVMCode.h
@@ -188,7 +188,7 @@ public:
     /** Print out the code stream */
     virtual void print() const;
 
-    virtual ~LVMCode() {}
+    virtual ~LVMCode() = default;
 
 private:
     /** Store reference to IODirectives */

--- a/src/LVMCode.h
+++ b/src/LVMCode.h
@@ -167,7 +167,7 @@ public:
 
     /** Return code stream */
     std::vector<RamDomain> getCode() const {
-        return *this;
+        return std::vector<RamDomain>(begin(), end());
     }
 
     /** Return IODirectives pool */

--- a/src/LVMGenerator.h
+++ b/src/LVMGenerator.h
@@ -199,8 +199,8 @@ protected:
 
     void visitPackRecord(const RamPackRecord& pack, size_t exitAddress) override {
         auto values = pack.getArguments();
-        for (size_t i = 0; i < values.size(); ++i) {
-            visit(values[i], exitAddress);
+        for (auto& value : values) {
+            visit(value, exitAddress);
         }
         code->push_back(LVM_PackRecord);
         code->push_back(values.size());
@@ -778,9 +778,9 @@ protected:
         size_t arity = project.getRelation().getArity();
         std::string relationName = project.getRelation().getName();
         auto values = project.getValues();
-        for (size_t i = 0; i < values.size(); ++i) {
-            assert(values[i]);
-            visit(values[i], exitAddress);
+        for (auto& value : values) {
+            assert(value);
+            visit(value, exitAddress);
         }
         code->push_back(LVM_Project);
         code->push_back(arity);

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -41,7 +41,7 @@ public:
 
     Logger(std::string label, size_t iteration, std::function<size_t()> size)
             : label(std::move(label)), start(now()), iteration(iteration), size(size), preSize(size()) {
-        struct rusage ru;
+        struct rusage ru {};
         getrusage(RUSAGE_SELF, &ru);
         startMaxRSS = ru.ru_maxrss;
         // Assume that if we are logging the progress of an event then we care about usage during that time.
@@ -49,7 +49,7 @@ public:
     }
 
     ~Logger() {
-        struct rusage ru;
+        struct rusage ru {};
         getrusage(RUSAGE_SELF, &ru);
         size_t endMaxRSS = ru.ru_maxrss;
         ProfileEventSingleton::instance().makeTimingEvent(

--- a/src/MagicSet.cpp
+++ b/src/MagicSet.cpp
@@ -957,8 +957,8 @@ void separateDBs(AstProgram* program) {
             newIdbClause->setSrcLoc(nextSrcLoc(relation->getSrcLoc()));
 
             // oldname(arg1...argn) :- newname(arg1...argn)
-            AstAtom* headAtom = new AstAtom(relName);
-            AstAtom* bodyAtom = new AstAtom(newEdbName);
+            auto* headAtom = new AstAtom(relName);
+            auto* bodyAtom = new AstAtom(newEdbName);
 
             size_t numargs = relation->getArity();
             for (size_t j = 0; j < numargs; j++) {
@@ -1258,7 +1258,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
                         magicClause->setSrcLoc(nextSrcLoc(atom->getSrcLoc()));
 
                         // create the head of the magic rule
-                        AstAtom* magicHead = new AstAtom(newAtomName);
+                        auto* magicHead = new AstAtom(newAtomName);
 
                         // copy over (bound) arguments from the original atom
                         int argCount = 0;
@@ -1276,7 +1276,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
                         // create the first body argument (mag(origClauseHead^adornment))
                         AstRelationIdentifier magPredName =
                                 createMagicIdentifier(newClause->getHead()->getName(), querynum);
-                        AstAtom* addedMagicPred = new AstAtom(magPredName);
+                        auto* addedMagicPred = new AstAtom(magPredName);
 
                         // create the relation if it does not exist
                         if (program->getRelation(magPredName) == nullptr) {
@@ -1365,7 +1365,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
             // create the first argument of this new clause
             const AstAtom* newClauseHead = newClause->getHead()->getAtom();
             AstRelationIdentifier newMag = createMagicIdentifier(newClauseHead->getName(), querynum);
-            AstAtom* newMagAtom = new AstAtom(newMag);
+            auto* newMagAtom = new AstAtom(newMag);
 
             // copy over the bound arguments from the head
             std::vector<AstArgument*> args = newClauseHead->getArguments();
@@ -1466,8 +1466,8 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
         // rules need to be the same
         // easy fix:
         //    oldname(arg1...argn) :- newname(arg1...argn)
-        AstAtom* headatom = new AstAtom(oldName);
-        AstAtom* bodyatom = new AstAtom(newRelationName);
+        auto* headatom = new AstAtom(oldName);
+        auto* bodyatom = new AstAtom(newRelationName);
 
         for (size_t j = 0; j < adornedRelation->getArity(); j++) {
             std::stringstream argName;

--- a/src/MinimiseProgramTransformer.cpp
+++ b/src/MinimiseProgramTransformer.cpp
@@ -165,8 +165,8 @@ bool isValidPermutation(
 
     // deduce the body atom permutation from the full clause permutation
     std::vector<unsigned int> bodyPermutation(permutation.begin() + 1, permutation.end());
-    for (size_t i = 0; i < bodyPermutation.size(); i++) {
-        bodyPermutation[i] -= 1;
+    for (unsigned int& i : bodyPermutation) {
+        i -= 1;
     }
 
     // currently, <permutation[i] == j> indicates that atom i should map to position j
@@ -290,8 +290,8 @@ bool areBijectivelyEquivalent(const AstClause* left, const AstClause* right) {
     // atoms in the clause, including the head atom
     size_t size = left->getBodyLiterals().size() + 1;
     auto permutationMatrix = std::vector<std::vector<unsigned int>>(size);
-    for (size_t i = 0; i < permutationMatrix.size(); i++) {
-        permutationMatrix[i] = std::vector<unsigned int>(size);
+    for (auto& i : permutationMatrix) {
+        i = std::vector<unsigned int>(size);
     }
 
     // create permutation matrix

--- a/src/Mpi.h
+++ b/src/Mpi.h
@@ -32,7 +32,7 @@ namespace mpi {
 
 /* typedefs */
 namespace {
-typedef std::unique_ptr<MPI_Status> Status;
+using Status = std::unique_ptr<MPI_Status>;
 }
 
 /* datatype */

--- a/src/ParallelUtils.h
+++ b/src/ParallelUtils.h
@@ -205,7 +205,7 @@ class Waiter {
     int i = 0;
 
 public:
-    Waiter() {}
+    Waiter() = default;
 
     /**
      * Conducts a wait operation.
@@ -225,10 +225,10 @@ public:
 
 /* compare: http://en.cppreference.com/w/cpp/atomic/atomic_flag */
 class SpinLock {
-    std::atomic<int> lck;
+    std::atomic<int> lck{0};
 
 public:
-    SpinLock() : lck(0) {}
+    SpinLock() = default;
 
     void lock() {
         detail::Waiter wait;
@@ -264,10 +264,10 @@ class ReadWriteLock {
      *      +-------------------------+--------------------+--------------------+
      */
 
-    std::atomic<int> lck;
+    std::atomic<int> lck{0};
 
 public:
-    ReadWriteLock() : lck(0) {}
+    ReadWriteLock() = default;
 
     void start_read() {
         // add reader
@@ -342,7 +342,7 @@ class OptimisticReadWriteLock {
      *      - even version numbers are stable versions, not being updated
      *      - odd version numbers are temporary versions, currently being updated
      */
-    std::atomic<int> version;
+    std::atomic<int> version{0};
 
 public:
     /**
@@ -362,7 +362,7 @@ public:
     /**
      * A default constructor initializing the lock.
      */
-    OptimisticReadWriteLock() : version(0) {}
+    OptimisticReadWriteLock() = default;
 
     /**
      * Starts a read phase, making sure that there is currently no

--- a/src/ParallelUtils.h
+++ b/src/ParallelUtils.h
@@ -202,10 +202,10 @@ namespace detail {
  * A utility class managing waiting operations for spin locks.
  */
 class Waiter {
-    int i;
+    int i = 0;
 
 public:
-    Waiter() : i(0) {}
+    Waiter() {}
 
     /**
      * Conducts a wait operation.

--- a/src/PrecedenceGraph.cpp
+++ b/src/PrecedenceGraph.cpp
@@ -78,7 +78,7 @@ void RedundantRelations::run(const AstTranslationUnit& translationUnit) {
 
     std::set<const AstRelation*> work;
     std::set<const AstRelation*> notRedundant;
-    IOType* ioType = translationUnit.getAnalysis<IOType>();
+    auto* ioType = translationUnit.getAnalysis<IOType>();
 
     const std::vector<AstRelation*>& relations = translationUnit.getProgram()->getRelations();
     /* Add all output relations to the work set */

--- a/src/RAMI.cpp
+++ b/src/RAMI.cpp
@@ -195,7 +195,7 @@ RamDomain RAMI::evalExpr(const RamExpression& expr, const InterpreterContext& ct
 
             // load DLL (if not done yet)
             void* handle = interpreter.loadDLL();
-            void (*fn)() = (void (*)())dlsym(handle, name.c_str());
+            auto fn = reinterpret_cast<void (*)()>(dlsym(handle, name.c_str()));
             if (fn == nullptr) {
                 std::cerr << "Cannot find user-defined operator " << name << " in " << SOUFFLE_DLL
                           << std::endl;

--- a/src/RAMI.cpp
+++ b/src/RAMI.cpp
@@ -873,7 +873,7 @@ void RAMI::evalStmt(const RamStatement& stmt) {
             // parallel execution
             bool cond = true;
 #pragma omp parallel for reduction(&& : cond)
-            for (size_t i = 0; i < stmts.size(); i++) {
+            for (size_t i = 0; i < stmts.size(); i++) {  // NOLINT (modernize-loop-convert)
                 cond = cond && visit(stmts[i]);
             }
             return cond;

--- a/src/RAMI.h
+++ b/src/RAMI.h
@@ -52,14 +52,14 @@ class SymbolTable;
 class RAMI : public Interpreter {
 public:
     RAMI(RamTranslationUnit& tUnit) : Interpreter(tUnit) {}
-    virtual ~RAMI() {}
+    ~RAMI() override = default;
 
     /** Execute main program */
-    void executeMain();
+    void executeMain() override;
 
     /* Execute subroutine */
     void executeSubroutine(const std::string& name, const std::vector<RamDomain>& arguments,
-            std::vector<RamDomain>& returnValues, std::vector<bool>& returnErrors);
+            std::vector<RamDomain>& returnValues, std::vector<bool>& returnErrors) override;
 
 protected:
     /** Evaluate value */

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -79,7 +79,7 @@ public:
 
     /** Create clone */
     RamConjunction* clone() const override {
-        RamConjunction* res = new RamConjunction(
+        auto* res = new RamConjunction(
                 std::unique_ptr<RamCondition>(lhs->clone()), std::unique_ptr<RamCondition>(rhs->clone()));
         return res;
     }
@@ -132,7 +132,7 @@ public:
 
     /** Create clone */
     RamNegation* clone() const override {
-        RamNegation* res = new RamNegation(std::unique_ptr<RamCondition>(operand->clone()));
+        auto* res = new RamNegation(std::unique_ptr<RamCondition>(operand->clone()));
         return res;
     }
 
@@ -192,7 +192,7 @@ public:
 
     /** Create clone */
     RamConstraint* clone() const override {
-        RamConstraint* res = new RamConstraint(op, std::unique_ptr<RamExpression>(lhs->clone()),
+        auto* res = new RamConstraint(op, std::unique_ptr<RamExpression>(lhs->clone()),
                 std::unique_ptr<RamExpression>(rhs->clone()));
         return res;
     }
@@ -308,7 +308,7 @@ public:
             }
             newValues.emplace_back(val);
         }
-        RamExistenceCheck* res = new RamExistenceCheck(
+        auto* res = new RamExistenceCheck(
                 std::unique_ptr<RamRelationReference>(relationRef->clone()), std::move(newValues));
         return res;
     }
@@ -354,7 +354,7 @@ public:
             }
             newValues.emplace_back(val);
         }
-        RamProvenanceExistenceCheck* res = new RamProvenanceExistenceCheck(
+        auto* res = new RamProvenanceExistenceCheck(
                 std::unique_ptr<RamRelationReference>(relationRef->clone()), std::move(newValues));
         return res;
     }
@@ -392,8 +392,7 @@ public:
 
     /** Create clone */
     RamEmptinessCheck* clone() const override {
-        RamEmptinessCheck* res =
-                new RamEmptinessCheck(std::unique_ptr<RamRelationReference>(relationRef->clone()));
+        auto* res = new RamEmptinessCheck(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
 

--- a/src/RamExpression.h
+++ b/src/RamExpression.h
@@ -191,7 +191,7 @@ public:
 
     /** Create clone */
     RamUserDefinedOperator* clone() const override {
-        RamUserDefinedOperator* res = new RamUserDefinedOperator(name, type, {});
+        auto* res = new RamUserDefinedOperator(name, type, {});
         for (auto& cur : arguments) {
             RamExpression* arg = cur->clone();
             res->arguments.emplace_back(arg);
@@ -406,7 +406,7 @@ public:
 
     /** Create clone */
     RamPackRecord* clone() const override {
-        RamPackRecord* res = new RamPackRecord({});
+        auto* res = new RamPackRecord({});
         for (auto& cur : arguments) {
             RamExpression* arg = nullptr;
             if (cur != nullptr) {

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -318,7 +318,7 @@ public:
                 resQueryPattern[i] = std::unique_ptr<RamExpression>(queryPattern[i]->clone());
             }
         }
-        RamIndexScan* res = new RamIndexScan(std::unique_ptr<RamRelationReference>(relationRef->clone()),
+        auto* res = new RamIndexScan(std::unique_ptr<RamRelationReference>(relationRef->clone()),
                 getTupleId(), std::move(resQueryPattern),
                 std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
         return res;
@@ -696,8 +696,8 @@ public:
         for (auto const& e : queryPattern) {
             pattern.push_back(std::unique_ptr<RamExpression>((e != nullptr) ? e->clone() : nullptr));
         }
-        RamIndexAggregate* res = new RamIndexAggregate(std::unique_ptr<RamOperation>(getOperation().clone()),
-                function, std::unique_ptr<RamRelationReference>(relationRef->clone()),
+        auto* res = new RamIndexAggregate(std::unique_ptr<RamOperation>(getOperation().clone()), function,
+                std::unique_ptr<RamRelationReference>(relationRef->clone()),
                 expression == nullptr ? nullptr : std::unique_ptr<RamExpression>(expression->clone()),
                 condition == nullptr ? nullptr : std::unique_ptr<RamCondition>(condition->clone()),
                 std::move(pattern), getTupleId());
@@ -802,7 +802,7 @@ public:
     }
 
     RamAggregate* clone() const override {
-        RamAggregate* res = new RamAggregate(std::unique_ptr<RamOperation>(getOperation().clone()), function,
+        auto* res = new RamAggregate(std::unique_ptr<RamOperation>(getOperation().clone()), function,
                 std::unique_ptr<RamRelationReference>(relationRef->clone()),
                 expression == nullptr ? nullptr : std::unique_ptr<RamExpression>(expression->clone()),
                 condition == nullptr ? nullptr : std::unique_ptr<RamCondition>(condition->clone()),
@@ -874,8 +874,8 @@ public:
     }
 
     RamUnpackRecord* clone() const override {
-        RamUnpackRecord* res = new RamUnpackRecord(std::unique_ptr<RamOperation>(getOperation().clone()),
-                getTupleId(), std::unique_ptr<RamExpression>(getExpression().clone()), arity);
+        auto* res = new RamUnpackRecord(std::unique_ptr<RamOperation>(getOperation().clone()), getTupleId(),
+                std::unique_ptr<RamExpression>(getExpression().clone()), arity);
         return res;
     }
 
@@ -1033,7 +1033,7 @@ public:
         for (auto& cur : expressions) {
             newValues.emplace_back(cur->clone());
         }
-        RamProject* res = new RamProject(
+        auto* res = new RamProject(
                 std::unique_ptr<RamRelationReference>(relationRef->clone()), std::move(newValues));
         return res;
     }

--- a/src/RamProgram.h
+++ b/src/RamProgram.h
@@ -109,7 +109,7 @@ public:
     /** Create clone */
     RamProgram* clone() const override {
         std::map<const RamRelation*, const RamRelation*> refMap;
-        RamProgram* res = new RamProgram(std::unique_ptr<RamStatement>(main->clone()));
+        auto* res = new RamProgram(std::unique_ptr<RamStatement>(main->clone()));
         for (auto& cur : relations) {
             RamRelation* newRel = cur.second->clone();
             refMap[cur.second.get()] = newRel;

--- a/src/RamProgram.h
+++ b/src/RamProgram.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "RamStatement.h"
+#include <memory>
 
 namespace souffle {
 
@@ -123,7 +124,7 @@ public:
             if (const RamRelationReference* relRef = dynamic_cast<RamRelationReference*>(node.get())) {
                 const RamRelation* rel = refMap[relRef->get()];
                 assert(rel != nullptr && "dangling RAM relation reference");
-                return std::unique_ptr<RamRelationReference>(new RamRelationReference(rel));
+                return std::make_unique<RamRelationReference>(rel);
             } else {
                 return node;
             }

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -135,8 +135,7 @@ public:
 
     /** Create clone */
     RamRelation* clone() const override {
-        RamRelation* res =
-                new RamRelation(name, arity, attributeNames, attributeTypeQualifiers, representation);
+        auto* res = new RamRelation(name, arity, attributeNames, attributeTypeQualifiers, representation);
         return res;
     }
 

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -102,7 +102,7 @@ public:
 
     /** Create clone */
     RamCreate* clone() const override {
-        RamCreate* res = new RamCreate(std::unique_ptr<RamRelationReference>(relationRef->clone()));
+        auto* res = new RamCreate(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
 };
@@ -132,7 +132,7 @@ public:
 
     /** Create clone */
     RamLoad* clone() const override {
-        RamLoad* res = new RamLoad(std::unique_ptr<RamRelationReference>(relationRef->clone()), ioDirectives);
+        auto* res = new RamLoad(std::unique_ptr<RamRelationReference>(relationRef->clone()), ioDirectives);
         return res;
     }
 
@@ -165,8 +165,7 @@ public:
 
     /** Create clone */
     RamStore* clone() const override {
-        RamStore* res =
-                new RamStore(std::unique_ptr<RamRelationReference>(relationRef->clone()), ioDirectives);
+        auto* res = new RamStore(std::unique_ptr<RamRelationReference>(relationRef->clone()), ioDirectives);
         return res;
     }
 
@@ -192,7 +191,7 @@ public:
 
     /** Create clone */
     RamClear* clone() const override {
-        RamClear* res = new RamClear(std::unique_ptr<RamRelationReference>(relationRef->clone()));
+        auto* res = new RamClear(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
 };
@@ -213,7 +212,7 @@ public:
     }
     /** Create clone */
     RamDrop* clone() const override {
-        RamDrop* res = new RamDrop(std::unique_ptr<RamRelationReference>(relationRef->clone()));
+        auto* res = new RamDrop(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
 };
@@ -258,7 +257,7 @@ public:
 
     /** Create clone */
     RamMerge* clone() const override {
-        RamMerge* res = new RamMerge(std::unique_ptr<RamRelationReference>(targetRef->clone()),
+        auto* res = new RamMerge(std::unique_ptr<RamRelationReference>(targetRef->clone()),
                 std::unique_ptr<RamRelationReference>(sourceRef->clone()));
         return res;
     }
@@ -320,7 +319,7 @@ public:
 
     /** Create clone */
     RamSwap* clone() const override {
-        RamSwap* res = new RamSwap(std::unique_ptr<RamRelationReference>(first->clone()),
+        auto* res = new RamSwap(std::unique_ptr<RamRelationReference>(first->clone()),
                 std::unique_ptr<RamRelationReference>(second->clone()));
         return res;
     }
@@ -379,7 +378,7 @@ public:
 
     /** Create clone */
     RamFact* clone() const override {
-        RamFact* res = new RamFact(std::unique_ptr<RamRelationReference>(relationRef->clone()), {});
+        auto* res = new RamFact(std::unique_ptr<RamRelationReference>(relationRef->clone()), {});
         for (auto& cur : values) {
             res->values.emplace_back(cur->clone());
         }
@@ -635,7 +634,7 @@ public:
 
     /** Create clone */
     RamLoop* clone() const override {
-        RamLoop* res = new RamLoop(std::unique_ptr<RamStatement>(body->clone()));
+        auto* res = new RamLoop(std::unique_ptr<RamStatement>(body->clone()));
         return res;
     }
 
@@ -683,7 +682,7 @@ public:
 
     /** Create clone */
     RamExit* clone() const override {
-        RamExit* res = new RamExit(std::unique_ptr<RamCondition>(condition->clone()));
+        auto* res = new RamExit(std::unique_ptr<RamCondition>(condition->clone()));
         return res;
     }
 
@@ -756,7 +755,7 @@ public:
 
     /** Create clone */
     RamLogTimer* clone() const override {
-        RamLogTimer* res = new RamLogTimer(std::unique_ptr<RamStatement>(statement->clone()), message,
+        auto* res = new RamLogTimer(std::unique_ptr<RamStatement>(statement->clone()), message,
                 std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
@@ -819,7 +818,7 @@ public:
 
     /** Create clone */
     RamDebugInfo* clone() const override {
-        RamDebugInfo* res = new RamDebugInfo(std::unique_ptr<RamStatement>(statement->clone()), message);
+        auto* res = new RamDebugInfo(std::unique_ptr<RamStatement>(statement->clone()), message);
         return res;
     }
 
@@ -878,7 +877,7 @@ public:
 
     /** Create clone */
     RamStratum* clone() const override {
-        RamStratum* res = new RamStratum(std::unique_ptr<RamStatement>(body->clone()), index);
+        auto* res = new RamStratum(std::unique_ptr<RamStatement>(body->clone()), index);
         return res;
     }
 
@@ -923,8 +922,7 @@ public:
 
     /** Create clone */
     RamLogSize* clone() const override {
-        RamLogSize* res =
-                new RamLogSize(std::unique_ptr<RamRelationReference>(relationRef->clone()), message);
+        auto* res = new RamLogSize(std::unique_ptr<RamRelationReference>(relationRef->clone()), message);
         return res;
     }
 

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -298,7 +298,7 @@ std::unique_ptr<RamOperation> IfConversionTransformer::rewriteIndexScan(const Ra
 
         // check if there is a break statement nested in the Scan - if so, remove it
         RamOperation* newOp;
-        if (const RamBreak* breakOp = dynamic_cast<const RamBreak*>(&indexScan->getOperation())) {
+        if (const auto* breakOp = dynamic_cast<const RamBreak*>(&indexScan->getOperation())) {
             newOp = breakOp->getOperation().clone();
         } else {
             newOp = indexScan->getOperation().clone();

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -247,7 +247,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 out << "IOSystem::getInstance().getReader(";
                 out << "std::vector<bool>({" << join(symbolMask) << "})";
                 out << ", symTable, ioDirectives";
-                out << ", " << Global::config().has("provenance");
+                out << ", " << (Global::config().has("provenance") ? "true" : "false");
                 out << ")->readAll(*" << synthesiser.getRelationName(load.getRelation());
                 out << ");\n";
                 out << "} catch (std::exception& e) {std::cerr << \"Error loading data: \" << e.what() << "
@@ -275,7 +275,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 out << "IOSystem::getInstance().getWriter(";
                 out << "std::vector<bool>({" << join(symbolMask) << "})";
                 out << ", symTable, ioDirectives";
-                out << ", " << Global::config().has("provenance");
+                out << ", " << (Global::config().has("provenance") ? "true" : "false");
                 out << ")->writeAll(*" << synthesiser.getRelationName(store.getRelation()) << ");\n";
                 out << "} catch (std::exception& e) {std::cerr << e.what();exit(1);}\n";
             }
@@ -407,7 +407,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
         void visitDrop(const RamDrop& drop, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
 
-            out << "if (!isHintsProfilingEnabled() && (performIO || " << drop.getRelation().isTemp() << ")) ";
+            out << "if (!isHintsProfilingEnabled()" << (drop.getRelation().isTemp() ? ")" : "&& performIO)");
             out << synthesiser.getRelationName(drop.getRelation()) << "->"
                 << "purge();\n";
 
@@ -2122,7 +2122,7 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
                 os << "IODirectives ioDirectives(directiveMap);\n";
                 os << "IOSystem::getInstance().getWriter(";
                 os << "std::vector<bool>({" << join(symbolMask) << "})";
-                os << ", symTable, ioDirectives, " << Global::config().has("provenance");
+                os << ", symTable, ioDirectives, " << (Global::config().has("provenance") ? "true" : "false");
                 os << ")->writeAll(*" << getRelationName(store->getRelation()) << ");\n";
 
                 os << "} catch (std::exception& e) {std::cerr << e.what();exit(1);}\n";
@@ -2167,7 +2167,7 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
             os << "IOSystem::getInstance().getReader(";
             os << "std::vector<bool>({" << join(symbolMask) << "})";
             os << ", symTable, ioDirectives";
-            os << ", " << Global::config().has("provenance");
+            os << ", " << (Global::config().has("provenance") ? "true" : "false");
             os << ")->readAll(*" << getRelationName(load.getRelation());
             os << ");\n";
             os << "} catch (std::exception& e) {std::cerr << \"Error loading data: \" << e.what() << "
@@ -2190,7 +2190,7 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
         os << "ioDirectives.setRelationName(\"" << name << "\");\n";
         os << "IOSystem::getInstance().getWriter(";
         os << "std::vector<bool>({" << join(symbolMask) << "})";
-        os << ", symTable, ioDirectives, " << Global::config().has("provenance");
+        os << ", symTable, ioDirectives, " << (Global::config().has("provenance") ? "true" : "false");
         os << ")->writeAll(*" << relName << ");\n";
         os << "} catch (std::exception& e) {std::cerr << e.what();exit(1);}\n";
     };
@@ -2218,7 +2218,7 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
     os << "}\n";  // end of dumpOutputs() method
 
     os << "public:\n";
-    os << "SymbolTable &getSymbolTable() override {\n";
+    os << "SymbolTable& getSymbolTable() override {\n";
     os << "return symTable;\n";
     os << "}\n";  // end of getSymbolTable() method
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -205,7 +205,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 
         std::function<void(std::ostream&, const RamNode*)> rec;
         std::ostringstream preamble;
-        bool preambleIssued;
+        bool preambleIssued = false;
 
     public:
         CodeEmitter(Synthesiser& syn)

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -407,7 +407,8 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
         void visitDrop(const RamDrop& drop, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
 
-            out << "if (!isHintsProfilingEnabled()" << (drop.getRelation().isTemp() ? ")" : "&& performIO)");
+            out << "if (!isHintsProfilingEnabled()"
+                << (drop.getRelation().isTemp() ? ") " : "&& performIO) ");
             out << synthesiser.getRelationName(drop.getRelation()) << "->"
                 << "purge();\n";
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -292,7 +292,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             const RamOperation* next = &query.getOperation();
             std::vector<std::unique_ptr<RamCondition>> requireCtx;
             std::vector<std::unique_ptr<RamCondition>> freeOfCtx;
-            if (const RamFilter* filter = dynamic_cast<const RamFilter*>(&query.getOperation())) {
+            if (const auto* filter = dynamic_cast<const RamFilter*>(&query.getOperation())) {
                 next = &filter->getOperation();
                 // Check terms of outer filter operation whether they can be pushed before
                 // the context-generation for speed imrovements

--- a/src/Util.h
+++ b/src/Util.h
@@ -1035,7 +1035,7 @@ inline bool isExecutable(const std::string& name) {
 inline std::string which(const std::string& name) {
     char buf[PATH_MAX];
     if (::realpath(name.c_str(), buf) && isExecutable(buf)) {
-        return std::string(buf);
+        return buf;
     }
     const char* syspath = ::getenv("PATH");
     if (syspath == nullptr) {
@@ -1047,7 +1047,7 @@ inline std::string which(const std::string& name) {
     while (std::getline(sstr, sub, ':')) {
         std::string path = sub + "/" + name;
         if (isExecutable(path) && realpath(path.c_str(), buf)) {
-            return std::string(buf);
+            return buf;
         }
     }
     return "";

--- a/src/profile/ProgramRun.h
+++ b/src/profile/ProgramRun.h
@@ -50,8 +50,8 @@ public:
     std::string toString() {
         std::ostringstream output;
         output << "ProgramRun:" << getRuntime() << "\nRelations:\n";
-        for (auto r = relationMap.begin(); r != relationMap.end(); ++r) {
-            output << r->second->toString() << "\n";
+        for (auto& r : relationMap) {
+            output << r.second->toString() << "\n";
         }
         return output.str();
     }

--- a/src/profile/StringUtils.h
+++ b/src/profile/StringUtils.h
@@ -235,10 +235,10 @@ inline std::vector<std::string> splitAtSemiColon(std::string str) {
     }
     bool changed = false;
     std::vector<std::string> result = split(str, ";");
-    for (size_t i = 0; i < result.size(); i++) {
-        for (size_t j = 0; j < result[i].size(); j++) {
-            if (result[i][j] == '\b') {
-                result[i][j] = ';';
+    for (auto& i : result) {
+        for (char& j : i) {
+            if (j == '\b') {
+                j = ';';
                 changed = true;
             }
         }

--- a/src/profile/UserInputReader.h
+++ b/src/profile/UserInputReader.h
@@ -304,8 +304,8 @@ public:
     }
     void showFullText(const std::string& text) {
         clearPrompt(text.size());
-        for (size_t i = 0; i < text.size(); i++) {
-            std::cout << text.at(i) << std::flush;
+        for (char i : text) {
+            std::cout << i << std::flush;
         }
 
         for (size_t i = cursor_pos; i < text.size(); i++) {

--- a/src/souffle2bdd.cpp
+++ b/src/souffle2bdd.cpp
@@ -80,7 +80,7 @@ class BddBddBTranslator : private AstVisitor<void, std::ostream&> {
     // literals aggregated to be added to the end of a rule while converting
     std::vector<std::string> extra_literals;
 
-    const IOType* ioTypes;
+    const IOType* ioTypes = nullptr;
 
     int varCounter = 0;
 

--- a/src/souffle2lb.cpp
+++ b/src/souffle2lb.cpp
@@ -76,7 +76,7 @@ public:
 class LogicbloxConverter : private AstVisitor<void, std::ostream&> {
     // literals aggregated to be added to the end of a rule while converting
     std::vector<std::string> extra_literals;
-    const IOType* ioTypes;
+    const IOType* ioTypes = nullptr;
 
     std::ostream& iout;
     std::ostream& eout;


### PR DESCRIPTION
This PR extends the list of clang-tidy checks allowed, and updates the remaining code to match. Code changes are all in keeping with our existing preferred style.

With this PR we can automate some of our basic review checks:
* misplaced semicolons,
* accidental temp objects
* slicing
* member initialisation
* modern for loops: for (T var : container)
* use of make_unique
* use of auto for doubly specified variables
* =default constructors
* use of nullptr
* override instead of virtual
* typedef vs using
