### PR TITLE
Allow multiple user libraries

### DIFF
--- a/src/LVM.cpp
+++ b/src/LVM.cpp
@@ -462,9 +462,7 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
                 const std::string name = symbolTable.resolve(code[ip + 1]);
                 const std::string type = symbolTable.resolve(code[ip + 2]);
 
-                // load DLL (if not done yet)
-                void* handle = this->loadDLL();
-                auto fn = reinterpret_cast<void (*)()>(dlsym(handle, name.c_str()));
+                auto fn = reinterpret_cast<void (*)()>(getMethodHandle(name));
                 if (fn == nullptr) {
                     std::cerr << "Cannot find user-defined operator " << name << " in " << SOUFFLE_DLL
                               << std::endl;

--- a/src/LVM.cpp
+++ b/src/LVM.cpp
@@ -464,8 +464,7 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
 
                 auto fn = reinterpret_cast<void (*)()>(getMethodHandle(name));
                 if (fn == nullptr) {
-                    std::cerr << "Cannot find user-defined operator " << name << " in " << SOUFFLE_DLL
-                              << std::endl;
+                    std::cerr << "Cannot find user-defined operator " << name << std::endl;
                     exit(1);
                 }
 

--- a/src/LVM.h
+++ b/src/LVM.h
@@ -173,20 +173,6 @@ protected:
         environment[ramRel2] = rel1;
     }
 
-    /** load dll */
-    void* loadDLL() {
-        if (dll == nullptr) {
-            // check environment variable
-            std::string fname = SOUFFLE_DLL;
-            dll = dlopen(SOUFFLE_DLL, RTLD_LAZY);
-            if (dll == nullptr) {
-                std::cerr << "Cannot find Souffle's DLL" << std::endl;
-                exit(1);
-            }
-        }
-        return dll;
-    }
-
     /** Lookup IndexScan iterator, resize the iterator pool if necessary */
     std::pair<index_set::iterator, index_set::iterator>& lookUpIndexScanIterator(size_t idx) {
         if (idx >= indexScanIteratorPool.size()) {

--- a/src/LVM.h
+++ b/src/LVM.h
@@ -37,8 +37,6 @@
 #include <vector>
 #include <dlfcn.h>
 
-#define SOUFFLE_DLL "libfunctors.so"
-
 namespace souffle {
 
 class InterpreterProgInterface;

--- a/src/LVMGenerator.h
+++ b/src/LVMGenerator.h
@@ -18,8 +18,6 @@
 #include "LVMCode.h"
 #include "RamVisitor.h"
 
-#define SOUFFLE_DLL "libfunctors.so"
-
 namespace souffle {
 
 /**

--- a/src/RAMI.cpp
+++ b/src/RAMI.cpp
@@ -193,15 +193,11 @@ RamDomain RAMI::evalExpr(const RamExpression& expr, const InterpreterContext& ct
             const std::string& name = op.getName();
             const std::string& type = op.getType();
 
-            // load DLL (if not done yet)
-            void* handle = interpreter.loadDLL();
-            auto fn = reinterpret_cast<void (*)()>(dlsym(handle, name.c_str()));
+            auto fn = reinterpret_cast<void (*)()>(interpreter.getMethodHandle(name));
             if (fn == nullptr) {
-                std::cerr << "Cannot find user-defined operator " << name << " in " << SOUFFLE_DLL
-                          << std::endl;
+                std::cerr << "Cannot find user-defined operator " << name << std::endl;
                 exit(1);
             }
-
             // prepare dynamic call environment
             size_t arity = op.getArgCount();
             ffi_cif cif;

--- a/src/RAMI.h
+++ b/src/RAMI.h
@@ -183,9 +183,6 @@ private:
 
     /** iteration number (in a fix-point calculation) */
     size_t iteration = 0;
-
-    /** Dynamic library for user-defined functors */
-    std::vector<void*> dll;
 };
 
 }  // end of namespace souffle

--- a/src/RAMI.h
+++ b/src/RAMI.h
@@ -141,34 +141,6 @@ protected:
         environment[ramRel2.getName()] = rel1;
     }
 
-    /** Load dll */
-    const std::vector<void*>& loadDLL() {
-        if (!dll.empty()) {
-            return dll;
-        }
-
-        if (!Global::config().has("libraries")) {
-            Global::config().set("libraries", SOUFFLE_DLL);
-        }
-        for (const std::string& library : splitString(Global::config().get("libraries"), ',')) {
-            dll.push_back(dlopen(library.c_str(), RTLD_LAZY));
-            if (dll.back() == nullptr) {
-                std::cerr << "Cannot find '" << library << "' DLL" << std::endl;
-                exit(1);
-            }
-        }
-
-        return dll;
-    }
-
-    void* getMethodHandle(const std::string& method) {
-        // load DLLs (if not done yet)
-        for (void* libHandle : loadDLL()) {
-            return dlsym(libHandle, method.c_str());
-        }
-        return nullptr;
-    }
-
 private:
     friend InterpreterProgInterface;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,6 +166,8 @@ int main(int argc, char** argv) {
                 {"generate", 'g', "FILE", "", false,
                         "Generate C++ source code for the given Datalog program and write it to "
                         "<FILE>."},
+                {"library-dir", 'L', "DIR", ".", true, "Specify directory for library files."},
+                {"libraries", 'l', "FILE", ".", true, "Specify libraries."},
                 {"no-warn", 'w', "", "", false, "Disable warnings."},
                 {"magic-transform", 'm', "RELATIONS", "", false,
                         "Enable magic set transformation changes on the given relations, use '*' "
@@ -176,7 +178,7 @@ int main(int argc, char** argv) {
                 {"dl-program", 'o', "FILE", "", false,
                         "Generate C++ source code, written to <FILE>, and compile this to a "
                         "binary executable (without executing it)."},
-                {"live-profile", 'l', "", "", false, "Enable live profiling."},
+                {"live-profile", '\4', "", "", false, "Enable live profiling."},
                 {"profile", 'p', "FILE", "", false, "Enable profiling, and write profile data to <FILE>."},
                 {"profile-use", 'u', "FILE", "", false,
                         "Use profile log-file <FILE> for profile-guided optimization."},

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv) {
                 {"generate", 'g', "FILE", "", false,
                         "Generate C++ source code for the given Datalog program and write it to "
                         "<FILE>."},
-                {"library-dir", 'L', "DIR", ".", true, "Specify directory for library files."},
+                {"library-dir", 'L', "DIR", "", true, "Specify directory for library files."},
                 {"libraries", 'l', "FILE", "", true, "Specify libraries."},
                 {"no-warn", 'w', "", "", false, "Disable warnings."},
                 {"magic-transform", 'm', "RELATIONS", "", false,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,7 +92,13 @@ void executeBinary(const std::string& binaryFilename
     } else
 #endif
     {
-        exitCode = system(binaryFilename.c_str());
+        std::string compileCmd = "LD_LIBRARY_PATH=";
+        for (const std::string& library : splitString(Global::config().get("library-dir"), ' ')) {
+            compileCmd += library + ':';
+        }
+        compileCmd.back() = ' ';
+        compileCmd += binaryFilename;
+        exitCode = system(compileCmd.c_str());
     }
 
     if (Global::config().get("dl-program").empty()) {
@@ -111,6 +117,22 @@ void executeBinary(const std::string& binaryFilename
  */
 void compileToBinary(std::string compileCmd, const std::string& sourceFilename) {
     // add source code
+    compileCmd += ' ';
+    for (const std::string& path : splitString(Global::config().get("library-dir"), ' ')) {
+        // The first entry may be blank
+        if (path.empty()) {
+            continue;
+        }
+        compileCmd += "-L" + path + ' ';
+    }
+    for (const std::string& library : splitString(Global::config().get("libraries"), ' ')) {
+        // The first entry may be blank
+        if (library.empty()) {
+            continue;
+        }
+        compileCmd += "-l" + library + ' ';
+    }
+
     compileCmd += sourceFilename;
 
     // run executable
@@ -167,7 +189,7 @@ int main(int argc, char** argv) {
                         "Generate C++ source code for the given Datalog program and write it to "
                         "<FILE>."},
                 {"library-dir", 'L', "DIR", ".", true, "Specify directory for library files."},
-                {"libraries", 'l', "FILE", ".", true, "Specify libraries."},
+                {"libraries", 'l', "FILE", "", true, "Specify libraries."},
                 {"no-warn", 'w', "", "", false, "Disable warnings."},
                 {"magic-transform", 'm', "RELATIONS", "", false,
                         "Enable magic set transformation changes on the given relations, use '*' "
@@ -595,7 +617,12 @@ int main(int argc, char** argv) {
             os.close();
 
             if (withSharedLibrary) {
-                compileCmd += "-s ";
+                if (!Global::config().has("libraries")) {
+                    Global::config().set("libraries", "functors");
+                }
+                if (!Global::config().has("library-dir")) {
+                    Global::config().set("library-dir", ".");
+                }
             }
 
             if (Global::config().has("compile")) {

--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -19,7 +19,8 @@ Usage:
 Options:
   -h           show usage
   -g           Build in debug mode
-  -s           enable shared library
+  -l           additional shared libraries
+  -L           library paths
   -v           verbose output
   -w           enable warnings\n"
   exit 1;
@@ -62,7 +63,7 @@ error "installation error: souffle header files cannot be found" $?
 
 # Options processing via getopts builtin, it is very limiting but on OSX the
 # default getopt is an old BSD getopt, so need this for portability
-while getopts "hwsvg" opt; do
+while getopts "hwl:L:vg" opt; do
   case "$opt" in
     h|\?) # Show usage and exit
       usage;
@@ -70,8 +71,11 @@ while getopts "hwsvg" opt; do
     g) # enable debug mode
       CXXFLAGS="$(echo $CXXFLAGS|sed 's/-O[0-9s]//g') -g -O0";
     ;;
-    s) # enable shared library
-      LDFLAGS="$LDFLAGS -L. -lfunctors";
+    L) # enable shared library
+      LDFLAGS="$LDFLAGS -L${OPTARG}";
+    ;;
+    l) # enable shared library
+      LIBS="$LIBS -l${OPTARG}";
     ;;
     w) # enable warnings
       WARNINGS="1"
@@ -105,7 +109,7 @@ cd "$OLDPWD"
 
 # Compile
 rm -f $dir/$exe
-$CXX $CXXFLAGS $CPPFLAGS -o$dir/$exe $1 $LIBS -I$HEADER_DIR $OMP_FLAG $LDFLAGS 2> $dir/$exe.$$.ccerr
+$CXX $CXXFLAGS $CPPFLAGS -o$dir/$exe $1 -I$HEADER_DIR $OMP_FLAG $LDFLAGS $LIBS 2> $dir/$exe.$$.ccerr
 if test -f $dir/$exe
 then
   if [ "$WARNINGS" = 1 ]


### PR DESCRIPTION
With this PR souffle will have `-l<library>` and `-L<library path>` flags to specify user libraries to include. Default options are `-lfunctor` and `-L.`

The live profiler currently uses `-l` and will now only be called with `--live-profiler`

Current limitations:
* compiled executables that are linked to a dynamic library that is not in the standard library paths will need LD_LIBRARY_PATH set to be run
* interpreted souffle has .so extensions hardcoded, limiting usefulness on other platforms
* LVM souffle segfaults for non-library related reasons (which is also the current behaviour)

Addresses #947 