### PR TITLE
Improve makeIndex transformer

### DIFF
--- a/src/RamTransformer.cpp
+++ b/src/RamTransformer.cpp
@@ -20,10 +20,27 @@
 namespace souffle {
 
 bool RamTransformer::apply(RamTranslationUnit& translationUnit) {
+
     bool changed = transform(translationUnit);
     if (changed) {
         translationUnit.invalidateAnalyses();
+        std::stringstream ramProgStr;
+        ramProgStr << *translationUnit.getProgram();
+        translationUnit.getDebugReport().addSection(DebugReporter::getCodeSection(
+                    getName(), "RAM Program after " + getName(), ramProgStr.str()));
+
+    } else {
+            translationUnit.getDebugReport().addSection(DebugReportSection(
+                    getName(), "After " + getName() + " " + " (unchanged)", {}, ""));
     }
+        /* Abort evaluation of the program if errors were encountered */
+        if (translationUnit.getErrorReport().getNumErrors() != 0) {
+            std::cerr << translationUnit.getErrorReport();
+            std::cerr << std::to_string(translationUnit.getErrorReport().getNumErrors()) +
+                                 " errors generated, evaluation aborted"
+                      << std::endl;
+            exit(1);
+        }
     return changed;
 }
 

--- a/src/RamTransformer.cpp
+++ b/src/RamTransformer.cpp
@@ -20,27 +20,26 @@
 namespace souffle {
 
 bool RamTransformer::apply(RamTranslationUnit& translationUnit) {
-
     bool changed = transform(translationUnit);
     if (changed) {
         translationUnit.invalidateAnalyses();
         std::stringstream ramProgStr;
         ramProgStr << *translationUnit.getProgram();
-        translationUnit.getDebugReport().addSection(DebugReporter::getCodeSection(
-                    getName(), "RAM Program after " + getName(), ramProgStr.str()));
+        translationUnit.getDebugReport().addSection(
+                DebugReporter::getCodeSection(getName(), "RAM Program after " + getName(), ramProgStr.str()));
 
     } else {
-            translationUnit.getDebugReport().addSection(DebugReportSection(
-                    getName(), "After " + getName() + " " + " (unchanged)", {}, ""));
+        translationUnit.getDebugReport().addSection(
+                DebugReportSection(getName(), "After " + getName() + " " + " (unchanged)", {}, ""));
     }
-        /* Abort evaluation of the program if errors were encountered */
-        if (translationUnit.getErrorReport().getNumErrors() != 0) {
-            std::cerr << translationUnit.getErrorReport();
-            std::cerr << std::to_string(translationUnit.getErrorReport().getNumErrors()) +
-                                 " errors generated, evaluation aborted"
-                      << std::endl;
-            exit(1);
-        }
+    /* Abort evaluation of the program if errors were encountered */
+    if (translationUnit.getErrorReport().getNumErrors() != 0) {
+        std::cerr << translationUnit.getErrorReport();
+        std::cerr << std::to_string(translationUnit.getErrorReport().getNumErrors()) +
+                             " errors generated, evaluation aborted"
+                  << std::endl;
+        exit(1);
+    }
     return changed;
 }
 

--- a/src/RamTransformer.h
+++ b/src/RamTransformer.h
@@ -88,13 +88,13 @@ protected:
  * Check whether predicate transformer changes code; if not stop; otherwise perform the body. 
  */
 
-class RamIfTransformer : public RamTransformer  {
+class RamChangedTransformer : public RamTransformer  {
 public:
-   RamIfTransformer(std::unique_ptr<RamTransformer> tPredicate, std::unique_ptr<RamTransformer> tBody) : 
+   RamChangedTransformer(std::unique_ptr<RamTransformer> tPredicate, std::unique_ptr<RamTransformer> tBody) : 
 	       predicate(std::move(tPredicate)), body(std::move(tBody)) { }
    
    std::string getName() const {
-       return "RamIfTransformer";
+       return "RamChangedTransformer";
    }
 
    bool transform(RamTranslationUnit& tU) {

--- a/src/RamTransformer.h
+++ b/src/RamTransformer.h
@@ -16,7 +16,9 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace souffle {
 
@@ -40,5 +42,83 @@ protected:
     /** Transform RAM translation unit */
     virtual bool transform(RamTranslationUnit& translationUnit) = 0;
 };
+
+/**
+ * Composite loop transformer iterating until the encapsulated transformer
+ * does not change the translation unit.
+ */
+
+class RamSequenceTransformer {
+public:
+   RamSequenceTransformer(std::vector<std::unique_ptr<RamTransformer>> tSeq) : transformerSequence(std::move(tSeq)){ }
+   
+   std::string getName() const {
+       return "RamSequenceTransformer";
+   }
+
+   bool transform(RamTranslationUnit& tU) {
+       bool changed = false; 
+       for(auto const &cur: transformerSequence) {
+	       if(cur->apply(tU)) { 
+		       changed = true; 
+	       }
+       }
+       return changed; 
+   }
+
+protected:
+   std::vector<std::unique_ptr<RamTransformer>> transformerSequence; 
+};
+
+/**
+ * Composite loop transformer checking for the change of a transformation.
+ */
+
+class RamIfTransformer {
+public:
+   RamIfTransformer(std::unique_ptr<RamTransformer> tPredicate, std::unique_ptr<RamTransformer> tBody) : 
+	       transformerPredicate(std::move(tPredicate)), transformerBody(std::move(tBody)) { }
+   
+   std::string getName() const {
+       return "RamIfTransformer";
+   }
+
+   bool transform(RamTranslationUnit& tU) {
+       if(transformerPredicate->apply(tU)) {
+          transformerBody->apply(tU);  
+	  return true; 
+       } else {
+	  return false;
+       }
+   }
+
+protected:
+   std::unique_ptr<RamTransformer> transformerPredicate;
+   std::unique_ptr<RamTransformer> transformerBody;
+};
+
+
+/**
+ * Composite sequence transformer that applies sequences of transformations 
+ */
+
+class RamLoopTransformer {
+public:
+   RamLoopTransformer(std::unique_ptr<RamTransformer> tLoop) : transformerLoop(std::move(tLoop)){ }
+
+   std::string getName() const {
+       return "RamLoopTransformer";
+   }
+
+   bool transform(RamTranslationUnit& tU) {
+       while(transformerLoop->apply(tU));
+       return false;
+   }
+
+protected:
+   std::unique_ptr<RamTransformer> transformerLoop;
+};
+
+
 
 }  // end of namespace souffle

--- a/src/RamTransformer.h
+++ b/src/RamTransformer.h
@@ -28,7 +28,23 @@ namespace souffle {
 class RamTranslationUnit;
 
 /**
- * Abstract Transformer Class for RAM
+ * @Class RamTransformer
+ * @Brief abstract transformer class for a translation unit
+ *
+ * This is an abstract class to implement transformers. A
+ * transformer takes a translation unit and changes its
+ * state.
+ *
+ * Transformers can be composed using other transformers.
+ *
+ * For debugging purposes, a transformer has a name
+ * (this will show up in the debug report) and a
+ * protected method transform(), that performs the
+ * actual transformation.
+ *
+ * The method apply is used to call transform() and
+ * does the reporting of the debug information.
+ *
  */
 
 class RamTransformer {
@@ -36,23 +52,38 @@ public:
     RamTransformer() = default;
     virtual ~RamTransformer() = default;
 
-    /** Apply transformer */
+    /**
+     * @Brief apply the transformer to a translation unit
+     * @Param translationUnit that will be transformed.
+     * @Return flag reporting whether the RAM program has changed
+     */
     bool apply(RamTranslationUnit& translationUnit);
 
+    /**
+     * @Brief get name of the transformer
+     * @Return flag reporting whether the RAM program has changed
+     */
     /** Get name of transformer */
     virtual std::string getName() const = 0;
 
 protected:
-    /** Transform RAM translation unit */
+    /**
+     * @Brief transform the translation unit / used by apply
+     * @Param translationUnit that will be transformed.
+     * @Return flag reporting whether the RAM program has changed
+     */
     virtual bool transform(RamTranslationUnit& translationUnit) = 0;
 };
 
 /**
- * Composite sequence transformer; a series of transformation is applied
+ * @Class RamTransformerSequence
+ * @Brief Composite sequence transformer
+ *
+ * A sequence of transformations is applied to a translation unit
  * sequentially. The last transformation decides the outcome whether
  * the code has been changed.
+ *
  */
-
 class RamTransformerSequence : public RamTransformer {
 public:
     template <typename... Tfs>
@@ -67,15 +98,15 @@ public:
         }
     }
     RamTransformerSequence() = default;
-
     std::string getName() const {
         return "RamTransformerSequence";
     }
-
     bool transform(RamTranslationUnit& tU) {
         bool changed = false;
-
-        // last transformer decides change flag
+        // The last transformer decides the status
+        // of the change flag.
+        // Note that for other semantics, new transformer
+        // sequence class needs to be introduced.
         for (auto const& cur : transformers) {
             changed = cur->apply(tU);
         }
@@ -83,45 +114,49 @@ public:
     }
 
 protected:
+    /** sequence of transformers */
     std::vector<std::unique_ptr<RamTransformer>> transformers;
 };
 
 /**
- * Composite loop transfomer; iterate until no change
+ * @Class RamLoopTransformer
+ * @Brief Composite loop transformer
+ *
+ * A transformation is invoked iteratively until no further change
+ * is made.
  */
-
 class RamLoopTransformer : public RamTransformer {
 public:
     RamLoopTransformer(std::unique_ptr<RamTransformer> tLoop) : loop(std::move(tLoop)) {}
-
     std::string getName() const {
         return "RamLoopTransformer";
     }
-
     bool transform(RamTranslationUnit& tU) {
-        while (loop->apply(tU))
-            ;
-        return false;
+        int ctr = 0;
+        while (loop->apply(tU)) {
+            ctr++;
+        }
+        return ctr > 0;
     }
 
 protected:
+    /** transformer of the loop */
     std::unique_ptr<RamTransformer> loop;
 };
 
 /**
- * Composite conditional transfomer; checks the condition and depending on the condition the transformer is
- * executed or not.
+ * @Class RamConditionalTransformer
+ * @Brief Composite conditional transformer
+ *
+ * A transformation is invoked if a condition holds.
  */
-
 class RamConditionalTransformer : public RamTransformer {
 public:
     RamConditionalTransformer(std::function<bool()> fn, std::unique_ptr<RamTransformer> tb)
             : func(fn), body(std::move(tb)) {}
-
     std::string getName() const {
         return "RamConditionalTransformer";
     }
-
     bool transform(RamTranslationUnit& tU) {
         if (func()) {
             return body->apply(tU);

--- a/src/RamTransformer.h
+++ b/src/RamTransformer.h
@@ -18,10 +18,10 @@
 
 #include <cassert>
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
-#include <iostream>
 
 namespace souffle {
 
@@ -49,8 +49,8 @@ protected:
 
 /**
  * Composite sequence transformer; a series of transformation is applied
- * sequentially. The last transformation decides the outcome whether 
- * the code has been changed. 
+ * sequentially. The last transformation decides the outcome whether
+ * the code has been changed.
  */
 
 class RamTransformerSequence : public RamTransformer {
@@ -100,7 +100,7 @@ public:
 
     bool transform(RamTranslationUnit& tU) {
         while (loop->apply(tU))
-		;
+            ;
         return false;
     }
 

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -261,28 +261,28 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteIndexScan(const RamIn
                 queryPattern, indexable, toConjunctionList(&filter->getCondition()), identifier);
         if (indexable) {
             // Merge Index Pattern here
-	    const auto prevPattern = iscan->getRangePattern(); 
-             auto addCondition = [&](std::unique_ptr<RamCondition> c) {
+            const auto prevPattern = iscan->getRangePattern();
+            auto addCondition = [&](std::unique_ptr<RamCondition> c) {
                 if (condition != nullptr) {
-                  condition = std::make_unique<RamConjunction>(std::move(condition), std::move(c));
+                    condition = std::make_unique<RamConjunction>(std::move(condition), std::move(c));
                 } else {
-                  condition = std::move(c);
+                    condition = std::move(c);
                 }
-             };
-	    for(std::size_t i=0;i<rel.getArity();i++) {
-	       if(prevPattern[i] != nullptr) {
-		   if(queryPattern[i] == nullptr) { 
-			// found a new indexable attribute
-		        queryPattern[i] = std::unique_ptr<RamExpression>(prevPattern[i]->clone()); 
-		   } else { 
-			// found a new constraint that is not dependent on the current scan level 
-			// and can be hoisted in a later transformation. 
-			addCondition(std::make_unique<RamConstraint>(BinaryConstraintOp::EQ, 
-                                                          std::unique_ptr<RamExpression>(prevPattern[i]->clone()),
-                                                          std::unique_ptr<RamExpression>(queryPattern[i]->clone())));
-		   }
-	       }
-	    }
+            };
+            for (std::size_t i = 0; i < rel.getArity(); i++) {
+                if (prevPattern[i] != nullptr) {
+                    if (queryPattern[i] == nullptr) {
+                        // found a new indexable attribute
+                        queryPattern[i] = std::unique_ptr<RamExpression>(prevPattern[i]->clone());
+                    } else {
+                        // found a new constraint that is not dependent on the current scan level
+                        // and can be hoisted in a later transformation.
+                        addCondition(std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
+                                std::unique_ptr<RamExpression>(prevPattern[i]->clone()),
+                                std::unique_ptr<RamExpression>(queryPattern[i]->clone())));
+                    }
+                }
+            }
             return std::make_unique<RamIndexScan>(std::make_unique<RamRelationReference>(&rel), identifier,
                     std::move(queryPattern),
                     condition == nullptr
@@ -305,7 +305,7 @@ bool MakeIndexTransformer::makeIndex(RamProgram& program) {
                     changed = true;
                     node = std::move(op);
                 }
-	    } else if (const RamIndexScan* iscan = dynamic_cast<RamIndexScan*>(node.get())) {
+            } else if (const RamIndexScan* iscan = dynamic_cast<RamIndexScan*>(node.get())) {
                 if (std::unique_ptr<RamOperation> op = rewriteIndexScan(iscan)) {
                     changed = true;
                     node = std::move(op);

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -251,6 +251,50 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteScan(const RamScan* s
     return nullptr;
 }
 
+std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteIndexScan(const RamIndexScan* iscan) {
+    if (const auto* filter = dynamic_cast<const RamFilter*>(&iscan->getOperation())) {
+        const RamRelation& rel = iscan->getRelation();
+        const int identifier = iscan->getTupleId();
+        std::vector<std::unique_ptr<RamExpression>> queryPattern(rel.getArity());
+        bool indexable = false;
+        std::unique_ptr<RamCondition> condition = constructPattern(
+                queryPattern, indexable, toConjunctionList(&filter->getCondition()), identifier);
+        if (indexable) {
+            // Merge Index Pattern here
+	    const auto prevPattern = iscan->getRangePattern(); 
+             auto addCondition = [&](std::unique_ptr<RamCondition> c) {
+                if (condition != nullptr) {
+                  condition = std::make_unique<RamConjunction>(std::move(condition), std::move(c));
+                } else {
+                  condition = std::move(c);
+                }
+             };
+	    for(std::size_t i=0;i<rel.getArity();i++) {
+	       if(prevPattern[i] != nullptr) {
+		   if(queryPattern[i] == nullptr) { 
+			// found a new indexable attribute
+		        queryPattern[i] = std::unique_ptr<RamExpression>(prevPattern[i]->clone()); 
+		   } else { 
+			// found a new constraint that is not dependent on the current scan level 
+			// and can be hoisted in a later transformation. 
+			addCondition(std::make_unique<RamConstraint>(BinaryConstraintOp::EQ, 
+                                                          std::unique_ptr<RamExpression>(prevPattern[i]->clone()),
+                                                          std::unique_ptr<RamExpression>(queryPattern[i]->clone())));
+		   }
+	       }
+	    }
+            return std::make_unique<RamIndexScan>(std::make_unique<RamRelationReference>(&rel), identifier,
+                    std::move(queryPattern),
+                    condition == nullptr
+                            ? std::unique_ptr<RamOperation>(filter->getOperation().clone())
+                            : std::make_unique<RamFilter>(std::move(condition),
+                                      std::unique_ptr<RamOperation>(filter->getOperation().clone())),
+                    iscan->getProfileText());
+        }
+    }
+    return nullptr;
+}
+
 bool MakeIndexTransformer::makeIndex(RamProgram& program) {
     bool changed = false;
     visitDepthFirst(program, [&](const RamQuery& query) {
@@ -258,6 +302,11 @@ bool MakeIndexTransformer::makeIndex(RamProgram& program) {
                 [&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {
             if (const RamScan* scan = dynamic_cast<RamScan*>(node.get())) {
                 if (std::unique_ptr<RamOperation> op = rewriteScan(scan)) {
+                    changed = true;
+                    node = std::move(op);
+                }
+	    } else if (const RamIndexScan* iscan = dynamic_cast<RamIndexScan*>(node.get())) {
+                if (std::unique_ptr<RamOperation> op = rewriteIndexScan(iscan)) {
                     changed = true;
                     node = std::move(op);
                 }

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -201,6 +201,14 @@ public:
     std::unique_ptr<RamOperation> rewriteScan(const RamScan* scan);
 
     /**
+     * @brief Rewrite an index scan operation to an amended index scan operation
+     * @param An IndexScan that can be amended with new index values 
+     * @result The result is null if the index scan cannot be amended;
+     *         otherwise the new IndexScan operation is returned.
+     */
+    std::unique_ptr<RamOperation> rewriteIndexScan(const RamIndexScan* iscan);
+
+    /**
      * @brief Rewrite an aggregate operation to an indexed aggregate operation
      * @param Aggregate operation that is potentially rewritten to an indexed version
      * @result The result is null if the aggregate could not be rewritten to an indexed version;

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -202,7 +202,7 @@ public:
 
     /**
      * @brief Rewrite an index scan operation to an amended index scan operation
-     * @param An IndexScan that can be amended with new index values 
+     * @param An IndexScan that can be amended with new index values
      * @result The result is null if the index scan cannot be amended;
      *         otherwise the new IndexScan operation is returned.
      */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -475,19 +475,18 @@ int main(int argc, char** argv) {
     std::unique_ptr<RamTranslationUnit> ramTranslationUnit =
             AstTranslator().translateUnit(*astTranslationUnit);
 
-
-    std::unique_ptr<RamTransformer> ramTransform = 
-    std::make_unique<RamTransformerSequence>(
-		    std::make_unique<ExpandFilterTransformer>(),
-		    std::make_unique<HoistConditionsTransformer>(),
-		    std::make_unique<MakeIndexTransformer>(),
-		    std::make_unique<IfConversionTransformer>(),
-		    std::make_unique<ChoiceConversionTransformer>(),
-		    std::make_unique<RamConditionalTransformer>(
-			     []()->bool {return std::stoi(Global::config().get("jobs")) > 1;},
-			     std::make_unique<ParallelTransformer>())); 
+    std::unique_ptr<RamTransformer> ramTransform = std::make_unique<RamTransformerSequence>(
+            std::make_unique<ExpandFilterTransformer>(), std::make_unique<HoistConditionsTransformer>(),
+            std::make_unique<MakeIndexTransformer>(), std::make_unique<IfConversionTransformer>(),
+            std::make_unique<ChoiceConversionTransformer>(),
+            std::make_unique<RamConditionalTransformer>(
+                    []() -> bool { return std::stoi(Global::config().get("jobs")) > 1; },
+                    std::make_unique<ParallelTransformer>()));
 
     ramTransform->apply(*ramTranslationUnit);
+    if (ramTranslationUnit->getErrorReport().getNumIssues() != 0) {
+        std::cerr << ramTranslationUnit->getErrorReport();
+    }
 
     if (!ramTranslationUnit->getProgram()->getMain()) {
         return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -476,9 +476,11 @@ int main(int argc, char** argv) {
             AstTranslator().translateUnit(*astTranslationUnit);
 
     std::unique_ptr<RamTransformer> ramTransform = std::make_unique<RamTransformerSequence>(
-            std::make_unique<ExpandFilterTransformer>(), std::make_unique<HoistConditionsTransformer>(),
-            std::make_unique<MakeIndexTransformer>(), std::make_unique<IfConversionTransformer>(),
-            std::make_unique<ChoiceConversionTransformer>(),
+            std::make_unique<RamLoopTransformer>(
+                    std::make_unique<RamTransformerSequence>(std::make_unique<ExpandFilterTransformer>(),
+                            std::make_unique<HoistConditionsTransformer>(),
+                            std::make_unique<MakeIndexTransformer>())),
+            std::make_unique<IfConversionTransformer>(), std::make_unique<ChoiceConversionTransformer>(),
             std::make_unique<RamConditionalTransformer>(
                     []() -> bool { return std::stoi(Global::config().get("jobs")) > 1; },
                     std::make_unique<ParallelTransformer>()));


### PR DESCRIPTION
The current make-index transformer does not transform RAM operations iteratively and in some cases, optimization opportunities may be lost. 

To overcome this, new composite transformers were introduced that perform iteratively the make-index transformation until no further changes can be realized. 

Addresses issue #1003.