### PR TITLE
Disable SignalHandler when env contains "SOUFFLE_ALLOW_SIGNALS"

### DIFF
--- a/src/SignalHandler.h
+++ b/src/SignalHandler.h
@@ -73,7 +73,7 @@ public:
      * set signal handlers
      */
     void set() {
-        if (!isSet) {
+        if (!isSet && std::getenv("SOUFFLE_ALLOW_SIGNALS") == nullptr) {
             // register signals
             // floating point exception
             if ((prevFpeHandler = signal(SIGFPE, handler)) == SIG_ERR) {


### PR DESCRIPTION
This PR is to simplify debugging of segfaults that are caught by the signal handler.

Core dumps are now possible with:
```
SOUFFLE_ALLOW_SIGNALS=1 ./souffle ...
```