### PR TITLE
Removed unnecessary equal() methods / removed boilerplate remarks

### DIFF
--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -39,7 +39,6 @@ class RamCondition : public RamNode {
 public:
     RamCondition() = default;
 
-    /** Create clone */
     RamCondition* clone() const override = 0;
 };
 
@@ -63,7 +62,6 @@ public:
         return *rhs;
     }
 
-    /** Print */
     void print(std::ostream& os) const override {
         os << "(";
         lhs->print(os);
@@ -72,19 +70,16 @@ public:
         os << ")";
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {lhs.get(), rhs.get()};
     }
 
-    /** Create clone */
     RamConjunction* clone() const override {
         auto* res = new RamConjunction(
                 std::unique_ptr<RamCondition>(lhs->clone()), std::unique_ptr<RamCondition>(rhs->clone()));
         return res;
     }
 
-    /** Apply */
     void apply(const RamNodeMapper& map) override {
         lhs = map(std::move(lhs));
         rhs = map(std::move(rhs));
@@ -97,7 +92,6 @@ protected:
     /** Right-hand side of conjunction */
     std::unique_ptr<RamCondition> rhs;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamConjunction*>(&node));
         const auto& other = static_cast<const RamConjunction&>(node);
@@ -118,25 +112,21 @@ public:
         return *operand;
     }
 
-    /** Print */
     void print(std::ostream& os) const override {
         os << "(not ";
         operand->print(os);
         os << ")";
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {operand.get()};
     }
 
-    /** Create clone */
     RamNegation* clone() const override {
         auto* res = new RamNegation(std::unique_ptr<RamCondition>(operand->clone()));
         return res;
     }
 
-    /** Apply */
     void apply(const RamNodeMapper& map) override {
         operand = map(std::move(operand));
     }
@@ -145,7 +135,6 @@ protected:
     /** Operand */
     std::unique_ptr<RamCondition> operand;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamNegation*>(&node));
         const auto& other = static_cast<const RamNegation&>(node);
@@ -161,7 +150,6 @@ public:
     RamConstraint(BinaryConstraintOp op, std::unique_ptr<RamExpression> l, std::unique_ptr<RamExpression> r)
             : RamCondition(), op(op), lhs(std::move(l)), rhs(std::move(r)) {}
 
-    /** Print */
     void print(std::ostream& os) const override {
         os << "(";
         lhs->print(os);
@@ -185,19 +173,16 @@ public:
         return op;
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {lhs.get(), rhs.get()};
     }
 
-    /** Create clone */
     RamConstraint* clone() const override {
         auto* res = new RamConstraint(op, std::unique_ptr<RamExpression>(lhs->clone()),
                 std::unique_ptr<RamExpression>(rhs->clone()));
         return res;
     }
 
-    /** Apply */
     void apply(const RamNodeMapper& map) override {
         lhs = map(std::move(lhs));
         rhs = map(std::move(rhs));
@@ -213,7 +198,6 @@ protected:
     /** Right-hand side of constraint */
     std::unique_ptr<RamExpression> rhs;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamConstraint*>(&node));
         const auto& other = static_cast<const RamConstraint&>(node);
@@ -241,7 +225,6 @@ public:
         return toPtrVector(values);
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> res = {relationRef.get()};
         for (const auto& cur : values) {
@@ -250,7 +233,6 @@ public:
         return res;
     }
 
-    /** Apply */
     void apply(const RamNodeMapper& map) override {
         relationRef = map(std::move(relationRef));
         for (auto& val : values) {
@@ -267,7 +249,6 @@ protected:
     /** Pattern -- nullptr if undefined */
     std::vector<std::unique_ptr<RamExpression>> values;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamAbstractExistenceCheck*>(&node));
         const auto& other = static_cast<const RamAbstractExistenceCheck&>(node);
@@ -284,7 +265,6 @@ public:
             std::unique_ptr<RamRelationReference> relRef, std::vector<std::unique_ptr<RamExpression>> vals)
             : RamAbstractExistenceCheck(std::move(relRef), std::move(vals)) {}
 
-    /** Print */
     void print(std::ostream& os) const override {
         os << "("
            << join(values, ",",
@@ -298,7 +278,6 @@ public:
            << ") ∈ " << getRelation().getName();
     }
 
-    /** Create clone */
     RamExistenceCheck* clone() const override {
         std::vector<std::unique_ptr<RamExpression>> newValues;
         for (auto& cur : values) {
@@ -312,13 +291,6 @@ public:
                 std::unique_ptr<RamRelationReference>(relationRef->clone()), std::move(newValues));
         return res;
     }
-
-protected:
-    /** Check equality */
-    bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamExistenceCheck*>(&node));
-        return RamAbstractExistenceCheck::equal(node);
-    }
 };
 
 /**
@@ -330,7 +302,6 @@ public:
             std::unique_ptr<RamRelationReference> relRef, std::vector<std::unique_ptr<RamExpression>> vals)
             : RamAbstractExistenceCheck(std::move(relRef), std::move(vals)) {}
 
-    /** Print */
     void print(std::ostream& os) const override {
         os << "("
            << join(values, ",",
@@ -344,7 +315,6 @@ public:
            << ") prov∈ " << getRelation().getName();
     }
 
-    /** Create clone */
     RamProvenanceExistenceCheck* clone() const override {
         std::vector<std::unique_ptr<RamExpression>> newValues;
         for (auto& cur : values) {
@@ -359,12 +329,6 @@ public:
         return res;
     }
 
-protected:
-    /** Check equality */
-    bool equal(const RamNode& node) const override {
-        assert(dynamic_cast<const RamProvenanceExistenceCheck*>(&node));
-        return RamAbstractExistenceCheck::equal(node);
-    }
 };
 
 /**
@@ -380,23 +344,19 @@ public:
         return *relationRef->get();
     }
 
-    /** Print */
     void print(std::ostream& os) const override {
         os << "(" << getRelation().getName() << " = ∅)";
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {relationRef.get()};
     }
 
-    /** Create clone */
     RamEmptinessCheck* clone() const override {
         auto* res = new RamEmptinessCheck(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
 
-    /** Apply */
     void apply(const RamNodeMapper& map) override {
         relationRef = map(std::move(relationRef));
     }
@@ -405,7 +365,6 @@ protected:
     /** Relation */
     std::unique_ptr<RamRelationReference> relationRef;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamEmptinessCheck*>(&node));
         const auto& other = static_cast<const RamEmptinessCheck&>(node);

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -328,7 +328,6 @@ public:
                 std::unique_ptr<RamRelationReference>(relationRef->clone()), std::move(newValues));
         return res;
     }
-
 };
 
 /**

--- a/src/RamExpression.h
+++ b/src/RamExpression.h
@@ -39,7 +39,6 @@ class RamExpression : public RamNode {
 public:
     RamExpression() = default;
 
-    /** Create clone */
     RamExpression* clone() const override = 0;
 };
 
@@ -61,7 +60,6 @@ public:
     RamIntrinsicOperator(FunctorOp op, std::vector<std::unique_ptr<RamExpression>> args)
             : RamExpression(), operation(op), arguments(std::move(args)) {}
 
-    /** Print */
     void print(std::ostream& os) const override {
         if (isInfixFunctorOp(operation)) {
             os << "(";
@@ -97,7 +95,6 @@ public:
         return arguments.size();
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> res;
         for (const auto& cur : arguments) {
@@ -106,7 +103,6 @@ public:
         return res;
     }
 
-    /* Clone */
     RamIntrinsicOperator* clone() const override {
         std::vector<std::unique_ptr<RamExpression>> argsCopy;
         for (auto& arg : arguments) {
@@ -116,7 +112,6 @@ public:
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         for (auto& arg : arguments) {
             arg = map(std::move(arg));
@@ -130,7 +125,6 @@ protected:
     /** Arguments of the function */
     std::vector<std::unique_ptr<RamExpression>> arguments;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamIntrinsicOperator*>(&node));
         const auto& other = static_cast<const RamIntrinsicOperator&>(node);
@@ -146,7 +140,6 @@ public:
     RamUserDefinedOperator(std::string n, std::string t, std::vector<std::unique_ptr<RamExpression>> args)
             : RamExpression(), arguments(std::move(args)), name(std::move(n)), type(std::move(t)) {}
 
-    /** Print */
     void print(std::ostream& os) const override {
         os << "@" << name << "_" << type << "(";
         os << join(arguments, ",",
@@ -180,7 +173,6 @@ public:
         return type;
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> res;
         for (const auto& cur : arguments) {
@@ -189,7 +181,6 @@ public:
         return res;
     }
 
-    /** Create clone */
     RamUserDefinedOperator* clone() const override {
         auto* res = new RamUserDefinedOperator(name, type, {});
         for (auto& cur : arguments) {
@@ -199,7 +190,6 @@ public:
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         for (auto& arg : arguments) {
             arg = map(std::move(arg));
@@ -216,7 +206,6 @@ protected:
     /** Argument types */
     const std::string type;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamUserDefinedOperator*>(&node));
         const auto& other = static_cast<const RamUserDefinedOperator&>(node);
@@ -232,7 +221,6 @@ public:
     RamElementAccess(size_t ident, size_t elem, std::unique_ptr<RamRelationReference> relRef = nullptr)
             : RamExpression(), identifier(ident), element(elem), relationRef(std::move(relRef)) {}
 
-    /** Print */
     void print(std::ostream& os) const override {
         if (nullptr == relationRef) {
             os << "t" << identifier << "." << element;
@@ -251,12 +239,10 @@ public:
         return element;
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {relationRef.get()};
     }
 
-    /** Create clone */
     RamElementAccess* clone() const override {
         if (relationRef != nullptr) {
             return new RamElementAccess(
@@ -266,7 +252,6 @@ public:
         }
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         if (relationRef != nullptr) {
             relationRef = map(std::move(relationRef));
@@ -285,7 +270,6 @@ protected:
      */
     std::unique_ptr<RamRelationReference> relationRef;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamElementAccess*>(&node));
         const auto& other = static_cast<const RamElementAccess&>(node);
@@ -305,12 +289,10 @@ public:
         return constant;
     }
 
-    /** Print */
     void print(std::ostream& os) const override {
         os << "number(" << constant << ")";
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {};
     }
@@ -321,14 +303,12 @@ public:
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {}
 
 protected:
     /** Constant value */
     const RamDomain constant;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamNumber*>(&node));
         const auto& other = static_cast<const RamNumber&>(node);
@@ -346,27 +326,22 @@ class RamAutoIncrement : public RamExpression {
 public:
     RamAutoIncrement() = default;
 
-    /** Print */
     void print(std::ostream& os) const override {
         os << "autoinc()";
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {};
     }
 
-    /** Create clone */
     RamAutoIncrement* clone() const override {
         auto* res = new RamAutoIncrement();
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {}
 
 protected:
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamAutoIncrement*>(&node));
         return true;
@@ -386,14 +361,12 @@ public:
         return toPtrVector(arguments);
     }
 
-    /** Print */
     void print(std::ostream& os) const override {
         os << "[" << join(arguments, ",", [](std::ostream& out, const std::unique_ptr<RamExpression>& arg) {
             out << *arg;
         }) << "]";
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> res;
         for (const auto& cur : arguments) {
@@ -404,7 +377,6 @@ public:
         return res;
     }
 
-    /** Create clone */
     RamPackRecord* clone() const override {
         auto* res = new RamPackRecord({});
         for (auto& cur : arguments) {
@@ -417,7 +389,6 @@ public:
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         for (auto& arg : arguments) {
             if (arg != nullptr) {
@@ -430,7 +401,6 @@ protected:
     /** Arguments */
     std::vector<std::unique_ptr<RamExpression>> arguments;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamPackRecord*>(&node));
         const auto& other = static_cast<const RamPackRecord&>(node);
@@ -454,30 +424,25 @@ public:
         return number;
     }
 
-    /** Print */
     void print(std::ostream& os) const override {
         os << "argument(" << number << ")";
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {};
     }
 
-    /** Create clone */
     RamArgument* clone() const override {
         auto* res = new RamArgument(number);
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {}
 
 protected:
     /** Argument number */
     const size_t number;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamArgument*>(&node));
         const auto& other = static_cast<const RamArgument&>(node);

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -358,7 +358,6 @@ public:
                         std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
         return res;
     }
-
 };
 
 /**
@@ -434,7 +433,6 @@ public:
                 getTupleId(), std::unique_ptr<RamCondition>(condition->clone()),
                 std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
     }
-
 };
 
 /**

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -190,12 +190,6 @@ public:
         return new RamScan(std::unique_ptr<RamRelationReference>(relationRef->clone()), getTupleId(),
                 std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
     }
-
-    bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamScan*>(&node));
-        const auto& other = static_cast<const RamScan&>(node);
-        return RamRelationSearch::equal(other);
-    }
 };
 
 /**
@@ -219,12 +213,6 @@ public:
     RamParallelScan* clone() const override {
         return new RamParallelScan(std::unique_ptr<RamRelationReference>(relationRef->clone()), getTupleId(),
                 std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
-    }
-
-    bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamParallelScan*>(&node));
-        const auto& other = static_cast<const RamParallelScan&>(node);
-        return RamScan::equal(other);
     }
 };
 
@@ -323,12 +311,6 @@ public:
                 std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
         return res;
     }
-
-    bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamIndexScan*>(&node));
-        const auto& other = static_cast<const RamIndexScan&>(node);
-        return RamIndexRelationSearch::equal(other);
-    }
 };
 
 /**
@@ -377,11 +359,6 @@ public:
         return res;
     }
 
-    bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamParallelIndexScan*>(&node));
-        const auto& other = static_cast<const RamParallelIndexScan&>(node);
-        return RamIndexScan::equal(other);
-    }
 };
 
 /**
@@ -423,14 +400,14 @@ public:
         return {nestedOperation.get(), relationRef.get(), condition.get()};
     }
 
+protected:
+    std::unique_ptr<RamCondition> condition;
+
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamChoice*>(&node));
         const auto& other = static_cast<const RamChoice&>(node);
         return RamRelationSearch::equal(other) && getCondition() == other.getCondition();
     }
-
-protected:
-    std::unique_ptr<RamCondition> condition;
 };
 
 /**
@@ -458,11 +435,6 @@ public:
                 std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
     }
 
-    bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamParallelChoice*>(&node));
-        const auto& other = static_cast<const RamParallelChoice&>(node);
-        return RamChoice::equal(other);
-    }
 };
 
 /**
@@ -541,7 +513,6 @@ public:
 protected:
     std::unique_ptr<RamCondition> condition;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamIndexChoice*>(&node));
         const auto& other = static_cast<const RamIndexChoice&>(node);
@@ -595,14 +566,6 @@ public:
                 std::unique_ptr<RamCondition>(condition->clone()), std::move(resQueryPattern),
                 std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
         return res;
-    }
-
-protected:
-    /** Check equality */
-    bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamParallelIndexChoice*>(&node));
-        const auto& other = static_cast<const RamParallelIndexChoice&>(node);
-        return RamIndexChoice::equal(other);
     }
 };
 

--- a/src/RamProgram.h
+++ b/src/RamProgram.h
@@ -26,7 +26,6 @@ public:
     RamProgram() = default;
     RamProgram(std::unique_ptr<RamStatement> main) : RamNode(), main(std::move(main)) {}
 
-    /** Obtain child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> children;
         if (main != nullptr) {
@@ -41,7 +40,6 @@ public:
         return children;
     }
 
-    /** Print */
     void print(std::ostream& out) const override {
         out << "PROGRAM" << std::endl;
         out << " DECLARATION" << std::endl;
@@ -62,7 +60,6 @@ public:
         out << "END PROGRAM" << std::endl;
     }
 
-    /** Set main program */
     void setMain(std::unique_ptr<RamStatement> stmt) {
         main = std::move(stmt);
     }
@@ -107,7 +104,6 @@ public:
         return *subroutines.at(name);
     }
 
-    /** Create clone */
     RamProgram* clone() const override {
         std::map<const RamRelation*, const RamRelation*> refMap;
         auto* res = new RamProgram(std::unique_ptr<RamStatement>(main->clone()));
@@ -132,7 +128,6 @@ public:
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         main = map(std::move(main));
         for (auto& cur : relations) {
@@ -153,7 +148,6 @@ protected:
     /** Subroutines for querying computed relations */
     std::map<std::string, std::unique_ptr<RamStatement>> subroutines;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamProgram*>(&node));
         const auto& other = static_cast<const RamProgram&>(node);

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -112,7 +112,6 @@ public:
         return name < other.name;
     }
 
-    /* Print */
     void print(std::ostream& out) const override {
         out << name;
         if (arity > 0) {
@@ -128,22 +127,18 @@ public:
         }
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return std::vector<const RamNode*>();  // no child nodes
     }
 
-    /** Create clone */
     RamRelation* clone() const override {
         auto* res = new RamRelation(name, arity, attributeNames, attributeTypeQualifiers, representation);
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {}
 
 protected:
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamRelation*>(&node));
         const auto& other = static_cast<const RamRelation&>(node);
@@ -168,30 +163,25 @@ public:
         return relation;
     }
 
-    /* Print */
     void print(std::ostream& out) const override {
         out << relation->getName();
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return std::vector<const RamNode*>();  // no child nodes
     }
 
-    /** Create clone */
     RamRelationReference* clone() const override {
         auto* res = new RamRelationReference(relation);
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {}
 
 protected:
     /** Name of relation */
     const RamRelation* relation;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamRelationReference*>(&node));
         const auto& other = static_cast<const RamRelationReference&>(node);

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -47,7 +47,6 @@ public:
         print(os, 0);
     }
 
-    /** Create clone */
     RamStatement* clone() const override = 0;
 };
 
@@ -64,12 +63,10 @@ public:
         return *relationRef->get();
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {relationRef.get()};
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         relationRef = map(std::move(relationRef));
     }
@@ -78,7 +75,6 @@ protected:
     /** Relation */
     std::unique_ptr<RamRelationReference> relationRef;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamRelationStatement*>(&node));
         const auto& other = static_cast<const RamRelationStatement&>(node);
@@ -93,14 +89,12 @@ class RamCreate : public RamRelationStatement {
 public:
     RamCreate(std::unique_ptr<RamRelationReference> relRef) : RamRelationStatement(std::move(relRef)) {}
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         const RamRelation& rel = getRelation();
         os << times(" ", tabpos);
         os << "CREATE " << rel.getName() << " " << rel.getRepresentation() << std::endl;
     };
 
-    /** Create clone */
     RamCreate* clone() const override {
         auto* res = new RamCreate(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
@@ -119,7 +113,6 @@ public:
         return ioDirectives;
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         const RamRelation& rel = getRelation();
         os << times(" ", tabpos);
@@ -130,7 +123,6 @@ public:
         os << std::endl;
     };
 
-    /** Create clone */
     RamLoad* clone() const override {
         auto* res = new RamLoad(std::unique_ptr<RamRelationReference>(relationRef->clone()), ioDirectives);
         return res;
@@ -152,7 +144,6 @@ public:
         return ioDirectives;
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         const RamRelation& rel = getRelation();
         os << times(" ", tabpos);
@@ -163,7 +154,6 @@ public:
         os << std::endl;
     };
 
-    /** Create clone */
     RamStore* clone() const override {
         auto* res = new RamStore(std::unique_ptr<RamRelationReference>(relationRef->clone()), ioDirectives);
         return res;
@@ -180,7 +170,6 @@ class RamClear : public RamRelationStatement {
 public:
     RamClear(std::unique_ptr<RamRelationReference> relRef) : RamRelationStatement(std::move(relRef)) {}
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         const RamRelation& rel = getRelation();
         os << times(" ", tabpos);
@@ -189,7 +178,6 @@ public:
         os << std::endl;
     }
 
-    /** Create clone */
     RamClear* clone() const override {
         auto* res = new RamClear(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
@@ -203,14 +191,12 @@ class RamDrop : public RamRelationStatement {
 public:
     RamDrop(std::unique_ptr<RamRelationReference> relRef) : RamRelationStatement(std::move(relRef)) {}
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         const RamRelation& rel = getRelation();
         os << times(" ", tabpos);
         os << "DROP " << rel.getName();
         os << std::endl;
     }
-    /** Create clone */
     RamDrop* clone() const override {
         auto* res = new RamDrop(std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
@@ -243,26 +229,22 @@ public:
         return *targetRef->get();
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
         os << "MERGE " << getTargetRelation().getName() << " WITH " << getSourceRelation().getName();
         os << std::endl;
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {sourceRef.get(), targetRef.get()};
     }
 
-    /** Create clone */
     RamMerge* clone() const override {
         auto* res = new RamMerge(std::unique_ptr<RamRelationReference>(targetRef->clone()),
                 std::unique_ptr<RamRelationReference>(sourceRef->clone()));
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         sourceRef = map(std::move(sourceRef));
         targetRef = map(std::move(targetRef));
@@ -272,7 +254,6 @@ protected:
     std::unique_ptr<RamRelationReference> targetRef;
     std::unique_ptr<RamRelationReference> sourceRef;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamMerge*>(&node));
         const auto& other = static_cast<const RamMerge&>(node);
@@ -305,26 +286,22 @@ public:
         return *second->get();
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
         os << "SWAP (" << getFirstRelation().getName() << ", " << getSecondRelation().getName() << ")";
         os << std::endl;
     };
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {first.get(), second.get()};
     }
 
-    /** Create clone */
     RamSwap* clone() const override {
         auto* res = new RamSwap(std::unique_ptr<RamRelationReference>(first->clone()),
                 std::unique_ptr<RamRelationReference>(second->clone()));
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         first = map(std::move(first));
         second = map(std::move(second));
@@ -337,7 +314,6 @@ protected:
     /** second argument of swap statement */
     std::unique_ptr<RamRelationReference> second;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamSwap*>(&node));
         const auto& other = static_cast<const RamSwap&>(node);
@@ -359,7 +335,6 @@ public:
         return toPtrVector(values);
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
         os << "INSERT (" << join(values, ",", print_deref<std::unique_ptr<RamExpression>>()) << ") INTO "
@@ -367,7 +342,6 @@ public:
         os << std::endl;
     };
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> res = RamRelationStatement::getChildNodes();
         for (const auto& cur : values) {
@@ -376,7 +350,6 @@ public:
         return res;
     }
 
-    /** Create clone */
     RamFact* clone() const override {
         auto* res = new RamFact(std::unique_ptr<RamRelationReference>(relationRef->clone()), {});
         for (auto& cur : values) {
@@ -385,7 +358,6 @@ public:
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         RamRelationStatement::apply(map);
         for (auto& val : values) {
@@ -397,7 +369,6 @@ protected:
     /** Arguments of fact */
     std::vector<std::unique_ptr<RamExpression>> values;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamFact*>(&node));
         const auto& other = static_cast<const RamFact&>(node);
@@ -418,25 +389,21 @@ public:
         return *operation;
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos) << "QUERY" << std::endl;
         operation->print(os, tabpos + 1);
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {operation.get()};
     }
 
-    /** Create clone */
     RamQuery* clone() const override {
         RamQuery* res;
         res = new RamQuery(std::unique_ptr<RamOperation>(operation->clone()));
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         operation = map(std::move(operation));
     }
@@ -445,7 +412,6 @@ protected:
     /** RAM operation */
     std::unique_ptr<RamOperation> operation;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamQuery*>(&node));
         const auto& other = static_cast<const RamQuery&>(node);
@@ -487,14 +453,12 @@ public:
         return toPtrVector(statements);
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         for (const auto& stmt : statements) {
             stmt->print(os, tabpos);
         }
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> res;
         for (const auto& cur : statements) {
@@ -503,7 +467,6 @@ public:
         return res;
     }
 
-    /** Create clone */
     RamSequence* clone() const override {
         auto* res = new RamSequence();
         for (auto& cur : statements) {
@@ -512,7 +475,6 @@ public:
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         for (auto& stmt : statements) {
             stmt = map(std::move(stmt));
@@ -523,7 +485,6 @@ protected:
     /** ordered list of RAM statements */
     std::vector<std::unique_ptr<RamStatement>> statements;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamSequence*>(&node));
         const auto& other = static_cast<const RamSequence&>(node);
@@ -555,7 +516,6 @@ public:
         return toPtrVector(statements);
     }
 
-    /* Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos) << "PARALLEL" << std::endl;
         for (auto const& stmt : statements) {
@@ -564,7 +524,6 @@ public:
         os << times(" ", tabpos) << "END PARALLEL" << std::endl;
     }
 
-    /** Obtains a list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> res;
         for (const auto& cur : statements) {
@@ -573,7 +532,6 @@ public:
         return res;
     }
 
-    /** Create clone */
     RamParallel* clone() const override {
         auto* res = new RamParallel();
         for (auto& cur : statements) {
@@ -582,7 +540,6 @@ public:
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         for (auto& stmt : statements) {
             stmt = map(std::move(stmt));
@@ -593,7 +550,6 @@ protected:
     /** list of statements executed in parallel */
     std::vector<std::unique_ptr<RamStatement>> statements;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamParallel*>(&node));
         const auto& other = static_cast<const RamParallel&>(node);
@@ -620,25 +576,21 @@ public:
         return *body;
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos) << "LOOP" << std::endl;
         body->print(os, tabpos + 1);
         os << times(" ", tabpos) << "END LOOP" << std::endl;
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {body.get()};
     }
 
-    /** Create clone */
     RamLoop* clone() const override {
         auto* res = new RamLoop(std::unique_ptr<RamStatement>(body->clone()));
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         body = map(std::move(body));
     }
@@ -647,7 +599,6 @@ protected:
     /** Body of loop */
     std::unique_ptr<RamStatement> body;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamLoop*>(&node));
         const auto& other = static_cast<const RamLoop&>(node);
@@ -670,23 +621,19 @@ public:
         return *condition;
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos) << "EXIT " << getCondition() << std::endl;
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {condition.get()};
     }
 
-    /** Create clone */
     RamExit* clone() const override {
         auto* res = new RamExit(std::unique_ptr<RamCondition>(condition->clone()));
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         condition = map(std::move(condition));
     }
@@ -695,7 +642,6 @@ protected:
     /** exit condition */
     std::unique_ptr<RamCondition> condition;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamExit*>(&node));
         const auto& other = static_cast<const RamExit&>(node);
@@ -741,26 +687,22 @@ public:
         }
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos) << "START_TIMER \"" << stringify(message) << "\"" << std::endl;
         statement->print(os, tabpos + 1);
         os << times(" ", tabpos) << "END_TIMER" << std::endl;
     }
 
-    /** Obtains a list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {statement.get()};
     }
 
-    /** Create clone */
     RamLogTimer* clone() const override {
         auto* res = new RamLogTimer(std::unique_ptr<RamStatement>(statement->clone()), message,
                 std::unique_ptr<RamRelationReference>(relationRef->clone()));
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         statement = map(std::move(statement));
     }
@@ -775,7 +717,6 @@ protected:
     /** Relation */
     std::unique_ptr<RamRelationReference> relationRef;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamLogTimer*>(&node));
         const auto& other = static_cast<const RamLogTimer&>(node);
@@ -804,25 +745,21 @@ public:
         return *statement;
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos) << "BEGIN_DEBUG \"" << stringify(message) << "\"" << std::endl;
         statement->print(os, tabpos + 1);
         os << times(" ", tabpos) << "END_DEBUG" << std::endl;
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {statement.get()};
     }
 
-    /** Create clone */
     RamDebugInfo* clone() const override {
         auto* res = new RamDebugInfo(std::unique_ptr<RamStatement>(statement->clone()), message);
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         statement = map(std::move(statement));
     }
@@ -834,7 +771,6 @@ protected:
     /** debugging message */
     std::string message;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamLogTimer*>(&node));
         const auto& other = static_cast<const RamLogTimer&>(node);
@@ -861,7 +797,6 @@ public:
         return index;
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
         os << "BEGIN_STRATUM " << index << std::endl;
@@ -870,18 +805,15 @@ public:
         os << "END_STRATUM " << index << std::endl;
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {body.get()};
     }
 
-    /** Create clone */
     RamStratum* clone() const override {
         auto* res = new RamStratum(std::unique_ptr<RamStatement>(body->clone()), index);
         return res;
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {
         body = map(std::move(body));
     }
@@ -889,9 +821,10 @@ public:
 protected:
     /** Body of stratum */
     std::unique_ptr<RamStatement> body;
+
+    /** Stratum number */
     const int index;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamStratum*>(&node));
         const auto& other = static_cast<const RamStratum&>(node);
@@ -912,7 +845,6 @@ public:
         return message;
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos) << "LOGSIZE " << getRelation().getName();
         os << " TEXT "
@@ -920,14 +852,15 @@ public:
         os << std::endl;
     }
 
-    /** Create clone */
     RamLogSize* clone() const override {
         auto* res = new RamLogSize(std::unique_ptr<RamRelationReference>(relationRef->clone()), message);
         return res;
     }
 
 protected:
-    /** Check equality */
+    /** logging message */
+    std::string message;
+
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamLogSize*>(&node));
         const auto& other = static_cast<const RamLogSize&>(node);
@@ -935,9 +868,6 @@ protected:
         return getMessage() == other.getMessage();
     }
 
-protected:
-    /** logging message */
-    std::string message;
 };
 
 #ifdef USE_MPI
@@ -951,13 +881,11 @@ public:
         return sourceStratum;
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
         os << "RECV DATA FOR " << getRelation().getName() << " FROM STRATUM {" << sourceStratum << "}";
     };
 
-    /** Create clone */
     RamRecv* clone() const override {
         RamRecv* res =
                 new RamRecv(std::unique_ptr<RamRelationReference>(relationRef->clone()), sourceStratum);
@@ -965,9 +893,9 @@ public:
     }
 
 protected:
+    /** source stratum */
     const int sourceStratum;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamRecv*>(&node));
         const auto& other = static_cast<const RamRecv&>(node);
@@ -985,7 +913,6 @@ public:
         return destinationStrata;
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
         os << "SEND DATA FOR " << getRelation().getName() << " TO STRATUM {";
@@ -999,7 +926,6 @@ public:
         os << "}";
     };
 
-    /** Create clone */
     RamSend* clone() const override {
         RamSend* res =
                 new RamSend(std::unique_ptr<RamRelationReference>(relationRef->clone()), destinationStrata);
@@ -1007,9 +933,9 @@ public:
     }
 
 protected:
+    /** destination stratum */
     const std::set<size_t> destinationStrata;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamSend*>(&node));
         const auto& other = static_cast<const RamSend&>(node);
@@ -1021,30 +947,20 @@ class RamNotify : public RamStatement {
 public:
     RamNotify() : RamStatement() {}
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
         os << "NOTIFY";
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {};
     }
 
-    /** Create clone */
     RamNotify* clone() const override {
         return new RamNotify();
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {}
-
-protected:
-    /** Check equality */
-    bool equal(const RamNode& node) const override {
-        return true;
-    }
 };
 
 class RamWait : public RamStatement {
@@ -1056,29 +972,25 @@ public:
         return count;
     }
 
-    /** Pretty print */
     void print(std::ostream& os, int tabpos) const override {
         os << std::string(tabpos, '\t');
         os << "WAIT";
     }
 
-    /** Obtain list of child nodes */
     std::vector<const RamNode*> getChildNodes() const override {
         return {};
     }
 
-    /** Create clone */
     RamWait* clone() const override {
         return new RamWait(count);
     }
 
-    /** Apply mapper */
     void apply(const RamNodeMapper& map) override {}
 
 protected:
+    /** counter */
     const size_t count;
 
-    /** Check equality */
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamWait*>(&node));
         const auto& other = static_cast<const RamWait&>(node);

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -867,7 +867,6 @@ protected:
         RamRelationStatement::equal(other);
         return getMessage() == other.getMessage();
     }
-
 };
 
 #ifdef USE_MPI

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -960,6 +960,11 @@ public:
     }
 
     void apply(const RamNodeMapper& map) override {}
+
+protected:
+    bool equal(const RamNode& node) const override {
+        return true;
+    }
 };
 
 class RamWait : public RamStatement {


### PR DESCRIPTION
There were unnecessary equal() methods that delegated the check to the super-class. The type-id is already checked in == hence there is no need for implementing equal() for classes that do not extend the state of the super-class.

Removed remarks that were related to boiler plate, e.g. apply/print etc.