### PR TITLE
Improvement on LVM index

### DIFF
--- a/src/InterpreterIndex.h
+++ b/src/InterpreterIndex.h
@@ -75,6 +75,9 @@ public:
     InterpreterIndex(LexOrder order)
             : theOrder(std::move(order)), set(comparator(theOrder), comparator(theOrder)) {}
 
+    InterpreterIndex(const InterpreterIndex&& index)
+            : theOrder(std::move(index.theOrder)), set(std::move(index.set)) {}
+
     const LexOrder& order() const {
         return theOrder;
     }

--- a/src/InterpreterIndex.h
+++ b/src/InterpreterIndex.h
@@ -125,6 +125,11 @@ public:
         return std::pair<iterator, iterator>(set.lower_bound(low), set.upper_bound(high));
     }
 
+    /** return start and end iterator of the index set */
+    inline std::pair<iterator, iterator> getIteratorPair() const {
+        return std::pair<iterator, iterator>(set.begin(), set.end());
+    }
+
 private:
     // retain the index order used to construct an object of this class
     const LexOrder theOrder;

--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -131,11 +131,11 @@ public:
         if (col == 0) {
             return getIndex(getTotalIndexKey());
         }
-        return getIndexRel(orderSet->getLexOrderNum(col));
+        return getIndexByOrderId(orderSet->getLexOrderNum(col));
     }
 
     /** get index for a given order. Order are encoded as bits for each column */
-    InterpreterIndex* getIndexRel(int idx) const {
+    InterpreterIndex* getIndexByOrderId(int idx) const {
         return &indices[idx];
     }
 

--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -126,12 +126,6 @@ public:
         num_tuples = 0;
     }
 
-    /** get index for a given set of keys using a cached index as a helper. Keys are encoded as bits for each
-     * column */
-    InterpreterIndex* getIndex(const SearchSignature& key, InterpreterIndex* cachedIndex) const {
-        return getIndex(key);
-    }
-
     /** get index for a given search signature. Order are encoded as bits for each column */
     InterpreterIndex* getIndex(const SearchSignature& col) const {
         if (col == 0) {

--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -131,11 +131,11 @@ public:
         if (col == 0) {
             return getIndex(getTotalIndexKey());
         }
-        return getIndexByOrderId(orderSet->getLexOrderNum(col));
+        return getIndexByPos(orderSet->getLexOrderNum(col));
     }
 
     /** get index for a given order. Order are encoded as bits for each column */
-    InterpreterIndex* getIndexByOrderId(int idx) const {
+    InterpreterIndex* getIndexByPos(int idx) const {
         return &indices[idx];
     }
 

--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -129,7 +129,7 @@ public:
 
     /** get index for a given search signature. Order are encoded as bits for each column */
     InterpreterIndex* getIndex(const SearchSignature& col) const {
-       // Handle Provenance program where a full index search perform on a 0-arity rleation
+        // Special case in provenance program, a 0 searchSignature is considered as a full search
         if (col == 0 && arity != 0) {
             return getIndex(getTotalIndexKey());
         }
@@ -148,12 +148,6 @@ public:
 
     /** check whether a tuple exists in the relation */
     bool exists(const RamDomain* tuple) const {
-        // handle arity 0
-       // if (getArity() == 0) {
-       //     // return !empty();
-       //     InterpreterIndex* index = getIndexByPos(0);
-       //     return index->exists(tuple);
-       // }
         InterpreterIndex* index = getIndex(getTotalIndexKey());
         return index->exists(tuple);
     }

--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -41,9 +41,9 @@ public:
         for (auto& order : orderSet->getAllOrders()) {
             indices.push_back(InterpreterIndex(order));
         }
-        if (orderSet->getAllOrders().size() == 0) {
-            indices.push_back(InterpreterIndex(LexOrder()));
-        }
+       // if (orderSet->getAllOrders().size() == 0) { TODO remove. handled in RIA
+       //     indices.push_back(InterpreterIndex(LexOrder()));
+       // }
     }
 
     InterpreterRelation(const InterpreterRelation& other) = delete;
@@ -86,9 +86,9 @@ public:
 
         // check for null-arity
         if (arity == 0) {
-           indices[0].insert(tuple);
-           num_tuples = 1;
-           return;
+            indices[0].insert(tuple);
+            num_tuples = 1;
+            return;
         }
 
         int blockIndex = num_tuples / (BLOCK_SIZE / arity);
@@ -131,6 +131,9 @@ public:
 
     /** get index for a given search signature. Order are encoded as bits for each column */
     InterpreterIndex* getIndex(const SearchSignature& col) const {
+        if (col == 0) {
+            return getIndex(getTotalIndexKey());
+        }
         return getIndexByPos(orderSet->getLexOrderNum(col));
     }
 
@@ -148,7 +151,7 @@ public:
     bool exists(const RamDomain* tuple) const {
         // handle arity 0
         if (getArity() == 0) {
-            //return !empty();
+            // return !empty();
             InterpreterIndex* index = getIndexByPos(0);
             return index->exists(tuple);
         }
@@ -241,11 +244,6 @@ public:
 
     /** Extend relation */
     virtual void extend(const InterpreterRelation& rel) {}
-
-    /** Index for zero-arity relation */
-   // using index_set = btree_multiset<const RamDomain*, InterpreterIndex::comparator,
-   //         std::allocator<const RamDomain*>, 512>;
-   // static index_set set;
 
 private:
     /** Arity of relation */

--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -107,7 +107,7 @@ public:
         for (auto& cur : indices) {
             cur.insert(newTuple);
         }
-        // totalIndex->insert(newTuple);
+
         // increment relation size
         num_tuples++;
     }
@@ -146,11 +146,13 @@ public:
 
     /** check whether a tuple exists in the relation */
     bool exists(const RamDomain* tuple) const {
-        //// handle arity 0
-        //if (getArity() == 0) {
-        //    return !empty();
-        //}
-        InterpreterIndex* index = getIndexByPos(0);
+        // handle arity 0
+        if (getArity() == 0) {
+            //return !empty();
+            InterpreterIndex* index = getIndexByPos(0);
+            return index->exists(tuple);
+        }
+        InterpreterIndex* index = getIndex(getTotalIndexKey());
         return index->exists(tuple);
     }
 

--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -30,6 +30,7 @@ namespace souffle {
 
 /**
  * Interpreter Relation
+ *
  */
 class InterpreterRelation {
     using LexOrder = std::vector<int>;
@@ -41,9 +42,6 @@ public:
         for (auto& order : orderSet->getAllOrders()) {
             indices.push_back(InterpreterIndex(order));
         }
-       // if (orderSet->getAllOrders().size() == 0) { TODO remove. handled in RIA
-       //     indices.push_back(InterpreterIndex(LexOrder()));
-       // }
     }
 
     InterpreterRelation(const InterpreterRelation& other) = delete;
@@ -131,7 +129,8 @@ public:
 
     /** get index for a given search signature. Order are encoded as bits for each column */
     InterpreterIndex* getIndex(const SearchSignature& col) const {
-        if (col == 0) {
+       // Handle Provenance program where a full index search perform on a 0-arity rleation
+        if (col == 0 && arity != 0) {
             return getIndex(getTotalIndexKey());
         }
         return getIndexByPos(orderSet->getLexOrderNum(col));
@@ -150,11 +149,11 @@ public:
     /** check whether a tuple exists in the relation */
     bool exists(const RamDomain* tuple) const {
         // handle arity 0
-        if (getArity() == 0) {
-            // return !empty();
-            InterpreterIndex* index = getIndexByPos(0);
-            return index->exists(tuple);
-        }
+       // if (getArity() == 0) {
+       //     // return !empty();
+       //     InterpreterIndex* index = getIndexByPos(0);
+       //     return index->exists(tuple);
+       // }
         InterpreterIndex* index = getIndex(getTotalIndexKey());
         return index->exists(tuple);
     }

--- a/src/LVM.cpp
+++ b/src/LVM.cpp
@@ -559,7 +559,7 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
             case LVM_ExistenceCheck: {
                 std::string relName = symbolTable.resolve(code[ip + 1]);
                 std::string patterns = symbolTable.resolve(code[ip + 2]);
-                RamDomain indexPos = code[ip+3];
+                RamDomain indexPos = code[ip + 3];
                 const InterpreterRelation& rel = getRelation(relName);
                 size_t arity = rel.getArity();
 
@@ -605,7 +605,7 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
             case LVM_ProvenanceExistenceCheck: {
                 std::string relName = symbolTable.resolve(code[ip + 1]);
                 std::string patterns = symbolTable.resolve(code[ip + 2]);
-                RamDomain indexPos = code[ip+3];
+                RamDomain indexPos = code[ip + 3];
                 const InterpreterRelation& rel = getRelation(relName);
                 auto arity = rel.getArity();
 
@@ -981,9 +981,9 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
                 break;
             };
             case LVM_ITER_InitFullIndex: {
-                RamDomain dest = code[ip+ 1];
+                RamDomain dest = code[ip + 1];
                 std::string relName = symbolTable.resolve(code[ip + 2]);
-                auto index = getRelation(relName).getIndexByPos(0); // Use the first order in the relation.
+                auto index = getRelation(relName).getIndexByPos(0);  // Use the first order in the relation.
                 lookUpIterator(dest) = index->getIteratorPair();
                 ip += 3;
                 break;
@@ -1019,7 +1019,7 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
             };
             case LVM_ITER_NotAtEnd: {
                 RamDomain idx = code[ip + 1];
-                auto iter = lookUpIterator(idx);
+                auto& iter = lookUpIterator(idx);
                 stack.push(iter.first != iter.second);
                 ip += 2;
                 break;
@@ -1027,7 +1027,7 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
             case LVM_ITER_Select: {
                 RamDomain idx = code[ip + 1];
                 RamDomain tupleId = code[ip + 2];
-                auto iter = lookUpIterator(idx);
+                auto& iter = lookUpIterator(idx);
                 ctxt[tupleId] = *iter.first;
                 ip += 3;
                 break;

--- a/src/LVM.cpp
+++ b/src/LVM.cpp
@@ -559,6 +559,7 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
             case LVM_ExistenceCheck: {
                 std::string relName = symbolTable.resolve(code[ip + 1]);
                 std::string patterns = symbolTable.resolve(code[ip + 2]);
+                RamDomain indexPos = code[ip+3];
                 const InterpreterRelation& rel = getRelation(relName);
                 size_t arity = rel.getArity();
 
@@ -574,7 +575,7 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
                         stack.pop();
                     }
                     stack.push(rel.exists(tuple));
-                    ip += 3;
+                    ip += 4;
                     break;
                 } else {  // for partial we search for lower and upper boundaries
                     RamDomain low[arity];
@@ -591,12 +592,11 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
                         }
                     }
 
-                    SearchSignature res = getSearchSignature(patterns, arity);
-                    auto idx = rel.getIndex(res);
+                    auto idx = rel.getIndexByPos(indexPos);
                     auto range = idx->lowerUpperBound(low, high);
 
                     stack.push(range.first != range.second);
-                    ip += 3;
+                    ip += 4;
                     break;
                 }
 
@@ -961,21 +961,13 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
             };
             case LVM_Aggregate_COUNT: {
                 RamDomain res = 0;
-                RamDomain idx = code[ip + 2];
-                if (code[ip + 1] == LVM_ITER_TypeScan) {
-                    auto& iters = scanIteratorPool[idx];
-                    for (auto i = iters.first; i != iters.second; ++i) {
-                        res++;
-                    }
-                    stack.push(res);
-                } else {
-                    auto& iters = indexScanIteratorPool[idx];
-                    for (auto i = iters.first; i != iters.second; ++i) {
-                        res++;
-                    }
-                    stack.push(res);
+                RamDomain idx = code[ip + 1];
+                auto& iter = iteratorPool[idx];
+                for (auto i = iter.first; i != iter.second; ++i) {
+                    res++;
                 }
-                ip += 3;
+                stack.push(res);
+                ip += 2;
                 break;
             };
             case LVM_Aggregate_Return: {
@@ -988,34 +980,16 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
                 ip += 2;
                 break;
             };
-            case LVM_ITER_TypeScan: {
-                RamDomain idx = code[ip + 1];
-
+            case LVM_ITER_InitFullIndex: {
+                RamDomain dest = code[ip+ 1];
                 std::string relName = symbolTable.resolve(code[ip + 2]);
-                InterpreterRelation& rel = getRelation(relName);
-                lookUpScanIterator(idx) =
-                        std::pair<InterpreterRelation::iterator, InterpreterRelation::iterator>(
-                                rel.begin(), rel.end());
-                assert(rel.begin() != rel.end() || rel.empty());
-
+                auto index = getRelation(relName).getIndexByPos(0); // Use the first order in the relation.
+                lookUpIterator(dest) = index->getIteratorPair();
                 ip += 3;
                 break;
-            }
-            case LVM_ITER_TypeChoice: {
-                RamDomain idx = code[ip + 1];
-
-                std::string relName = symbolTable.resolve(code[ip + 2]);
-                InterpreterRelation& rel = getRelation(relName);
-                lookUpChoiceIterator(idx) =
-                        std::pair<InterpreterRelation::iterator, InterpreterRelation::iterator>(
-                                rel.begin(), rel.end());
-                assert(rel.begin() != rel.end() || rel.empty());
-
-                ip += 3;
-                break;
-            }
-            case LVM_ITER_TypeIndexScan: {
-                RamDomain idx = code[ip + 1];
+            };
+            case LVM_ITER_InitRangeIndex: {
+                RamDomain dest = code[ip + 1];
                 std::string relName = symbolTable.resolve(code[ip + 2]);
                 InterpreterRelation& rel = getRelation(relName);
                 std::string pattern = symbolTable.resolve(code[ip + 3]);
@@ -1039,124 +1013,29 @@ void LVM::execute(std::unique_ptr<LVMCode>& codeStream, InterpreterContext& ctxt
                 auto index = rel.getIndexByPos(indexPos);
 
                 // get iterator range
-                lookUpIndexScanIterator(idx) = index->lowerUpperBound(low, hig);
+                lookUpIterator(dest) = index->lowerUpperBound(low, hig);
                 ip += 5;
                 break;
-            }
-            case LVM_ITER_TypeIndexChoice: {
-                RamDomain idx = code[ip + 1];
-                std::string relName = symbolTable.resolve(code[ip + 2]);
-                InterpreterRelation& rel = getRelation(relName);
-                std::string pattern = symbolTable.resolve(code[ip + 3]);
-                RamDomain indexPos = code[ip+4];
-
-                // create pattern tuple for range query
-                auto arity = rel.getArity();
-                RamDomain low[arity];
-                RamDomain hig[arity];
-                for (size_t i = 0; i < arity; i++) {
-                    if (pattern[arity - i - 1] == 'V') {
-                        low[arity - i - 1] = stack.top();
-                        stack.pop();
-                        hig[arity - i - 1] = low[arity - i - 1];
-                    } else {
-                        low[arity - i - 1] = MIN_RAM_DOMAIN;
-                        hig[arity - i - 1] = MAX_RAM_DOMAIN;
-                    }
-                }
-
-                auto index = rel.getIndexByPos(indexPos);
-
-                // get iterator range
-                lookUpIndexChoiceIterator(idx) = index->lowerUpperBound(low, hig);
-                ip += 5;
-                break;
-            }
+            };
             case LVM_ITER_NotAtEnd: {
                 RamDomain idx = code[ip + 1];
-                switch (code[ip + 2]) {
-                    case LVM_ITER_TypeScan: {
-                        auto iter = scanIteratorPool[idx];
-                        stack.push(iter.first != iter.second);
-                        break;
-                    }
-                    case LVM_ITER_TypeIndexScan: {
-                        auto iter = indexScanIteratorPool[idx];
-                        stack.push(iter.first != iter.second);
-                        break;
-                    }
-                    case LVM_ITER_TypeChoice: {
-                        auto iter = choiceIteratorPool[idx];
-                        stack.push(iter.first != iter.second);
-                        break;
-                    }
-                    case LVM_ITER_TypeIndexChoice: {
-                        auto iter = indexChoiceIteratorPool[idx];
-                        stack.push(iter.first != iter.second);
-                        break;
-                    }
-                    default:
-                        printf("Unknown iter type at LVM_ITER_NotAtEnd\n");
-                        break;
-                }
-                ip += 3;
+                auto iter = lookUpIterator(idx);
+                stack.push(iter.first != iter.second);
+                ip += 2;
                 break;
             }
             case LVM_ITER_Select: {
                 RamDomain idx = code[ip + 1];
-                RamDomain id = code[ip + 3];
-                switch (code[ip + 2]) {
-                    case LVM_ITER_TypeScan: {
-                        auto iter = scanIteratorPool[idx];
-                        ctxt[id] = *iter.first;
-                        break;
-                    }
-                    case LVM_ITER_TypeIndexScan: {
-                        auto iter = indexScanIteratorPool[idx];
-                        ctxt[id] = *iter.first;
-                        break;
-                    }
-                    case LVM_ITER_TypeChoice: {
-                        auto iter = choiceIteratorPool[idx];
-                        ctxt[id] = *iter.first;
-                        break;
-                    }
-                    case LVM_ITER_TypeIndexChoice: {
-                        auto iter = indexChoiceIteratorPool[idx];
-                        ctxt[id] = *iter.first;
-                        break;
-                    }
-                    default:
-                        printf("Unknown iter type at LVM_ITER_Select\n");
-                        break;
-                }
-                ip += 4;
+                RamDomain tupleId = code[ip + 2];
+                auto iter = lookUpIterator(idx);
+                ctxt[tupleId] = *iter.first;
+                ip += 3;
                 break;
             }
             case LVM_ITER_Inc: {
                 RamDomain idx = code[ip + 1];
-                switch (code[ip + 2]) {
-                    case LVM_ITER_TypeScan: {
-                        ++scanIteratorPool[idx].first;
-                        break;
-                    }
-                    case LVM_ITER_TypeIndexScan: {
-                        ++indexScanIteratorPool[idx].first;
-                        break;
-                    }
-                    case LVM_ITER_TypeChoice: {
-                        ++choiceIteratorPool[idx].first;
-                        break;
-                    }
-                    case LVM_ITER_TypeIndexChoice: {
-                        ++indexChoiceIteratorPool[idx].first;
-                        break;
-                    }
-                    default:
-                        printf("Unknown iter\n");
-                        break;
-                }
-                ip += 3;
+                ++iteratorPool[idx].first;
+                ip += 2;
                 break;
             }
             case LVM_STOP:

--- a/src/LVM.h
+++ b/src/LVM.h
@@ -90,8 +90,8 @@ public:
             execute(subroutines.at(name), ctxt);
         } else {
             // Parse and cache the program
-            LVMGenerator generator(
-                    translationUnit.getSymbolTable(), translationUnit.getProgram()->getSubroutine(name), *isa);
+            LVMGenerator generator(translationUnit.getSymbolTable(),
+                    translationUnit.getProgram()->getSubroutine(name), *isa);
             subroutines.emplace(std::make_pair(name, generator.getCodeStream()));
             execute(subroutines.at(name), ctxt);
         }

--- a/src/LVM.h
+++ b/src/LVM.h
@@ -91,7 +91,7 @@ public:
         } else {
             // Parse and cache the program
             LVMGenerator generator(
-                    translationUnit.getSymbolTable(), translationUnit.getProgram()->getSubroutine(name));
+                    translationUnit.getSymbolTable(), translationUnit.getProgram()->getSubroutine(name), *isa);
             subroutines.emplace(std::make_pair(name, generator.getCodeStream()));
             execute(subroutines.at(name), ctxt);
         }
@@ -101,7 +101,7 @@ public:
     void printMain() {
         if (mainProgram.get() == nullptr) {
             LVMGenerator generator(
-                    translationUnit.getSymbolTable(), *translationUnit.getProgram()->getMain());
+                    translationUnit.getSymbolTable(), *translationUnit.getProgram()->getMain(), *isa);
             mainProgram = generator.getCodeStream();
         }
         mainProgram->print();

--- a/src/LVM.h
+++ b/src/LVM.h
@@ -178,37 +178,12 @@ protected:
         environment[ramRel2] = rel1;
     }
 
-    /** Lookup IndexScan iterator, resize the iterator pool if necessary */
-    std::pair<index_set::iterator, index_set::iterator>& lookUpIndexScanIterator(size_t idx) {
-        if (idx >= indexScanIteratorPool.size()) {
-            indexScanIteratorPool.resize(idx + 1);
+    /** Lookup iterator, resize the iterator pool if necessary */
+    std::pair<index_set::iterator, index_set::iterator>& lookUpIterator(size_t idx) {
+        if (idx >= iteratorPool.size()) {
+            iteratorPool.resize(idx + 1);
         }
-        return indexScanIteratorPool[idx];
-    }
-
-    /** Lookup Scan iterator, resize the iterator pool if necessary */
-    std::pair<InterpreterRelation::iterator, InterpreterRelation::iterator>& lookUpScanIterator(size_t idx) {
-        if (idx >= scanIteratorPool.size()) {
-            scanIteratorPool.resize(idx + 1);
-        }
-        return scanIteratorPool[idx];
-    }
-
-    /** Lookup Choice iterator, resize the iterator pool if necessary */
-    std::pair<InterpreterRelation::iterator, InterpreterRelation::iterator>& lookUpChoiceIterator(
-            size_t idx) {
-        if (idx >= choiceIteratorPool.size()) {
-            choiceIteratorPool.resize(idx + 1);
-        }
-        return choiceIteratorPool[idx];
-    }
-
-    /** Lookup IndexChoice iterator, resize the iterator pool if necessary */
-    std::pair<index_set::iterator, index_set::iterator>& lookUpIndexChoiceIterator(size_t idx) {
-        if (idx >= indexChoiceIteratorPool.size()) {
-            indexChoiceIteratorPool.resize(idx + 1);
-        }
-        return indexChoiceIteratorPool[idx];
+        return iteratorPool[idx];
     }
 
     /** Obtain the search columns */
@@ -244,16 +219,7 @@ private:
     std::map<std::string, std::atomic<size_t>> reads;
 
     /** List of iters for indexScan operation */
-    std::vector<std::pair<index_set::iterator, index_set::iterator>> indexScanIteratorPool;
-
-    /** List of iters for Scan operation */
-    std::vector<std::pair<InterpreterRelation::iterator, InterpreterRelation::iterator>> scanIteratorPool;
-
-    /** List of iters for indexChoice operation */
-    std::vector<std::pair<index_set::iterator, index_set::iterator>> indexChoiceIteratorPool;
-
-    /** List of iters for Choice operation */
-    std::vector<std::pair<InterpreterRelation::iterator, InterpreterRelation::iterator>> choiceIteratorPool;
+    std::vector<std::pair<index_set::iterator, index_set::iterator>> iteratorPool;
 
     /** Map from relationName to RamRelationNode in RAM */
     std::map<std::string, const RamRelation*> relNameToNode;

--- a/src/LVMCode.cpp
+++ b/src/LVMCode.cpp
@@ -232,7 +232,7 @@ void LVMCode::print() const {
                 printf("%ld\tLVM_ExistenceCheck\t\n", ip);
                 printf("\tTarget: %s\tTypes: %s\n", symbolTable.resolve(code[ip + 1]).c_str(),
                         symbolTable.resolve(code[ip + 2]).c_str());
-                ip += 3;
+                ip += 4;
                 break;
             }
             case LVM_ProvenanceExistenceCheck: {
@@ -423,7 +423,7 @@ void LVMCode::print() const {
                 ip += 1;
                 break;
             case LVM_Aggregate_COUNT: {
-                printf("%ld\tLVM_Aggregate_COUNT\t IndexScanIterID:%d\n", ip, code[ip + 1]);
+                printf("%ld\tLVM_Aggregate_COUNT\t IterId:%d\n", ip, code[ip + 1]);
                 ip += 2;
                 break;
             };
@@ -432,72 +432,31 @@ void LVMCode::print() const {
                 ip += 2;
                 break;
             };
-            case LVM_ITER_TypeIndexChoice:
-                printf("%ld\tLVM_ITER_TypeIndexChoice\t RelationName:%s\n", ip,
-                        symbolTable.resolve(code[ip + 2]).c_str());
-                ip += 5;
-                break;
-            case LVM_ITER_TypeIndexScan:
-                printf("%ld\tLVM_ITER_TypeIndexScan\t RelationName:%s\n", ip,
-                        symbolTable.resolve(code[ip + 2]).c_str());
-                ip += 5;
-                break;
-            case LVM_ITER_TypeChoice:
-                printf("%ld\tLVM_ITER_TypeChoice\t RelationName:%s\n", ip,
-                        symbolTable.resolve(code[ip + 2]).c_str());
-                ip += 4;
-                break;
-            case LVM_ITER_TypeScan: {
-                printf("%ld\tLVM_ITER_TypeScan\t RelationName:%s\n", ip,
+            case LVM_ITER_InitFullIndex: {
+                printf("%ld\tLVM_ITER_InitFullIndex\t RelationName:%s\n", ip,
                         symbolTable.resolve(code[ip + 2]).c_str());
                 ip += 3;
                 break;
-            }
+            };
+            case LVM_ITER_InitRangeIndex: {
+                printf("%ld\tLVM_ITER_InitRangeIndex\t RelationName:%s\tPattern:%s\n", ip,
+                        symbolTable.resolve(code[ip + 2]).c_str(), symbolTable.resolve(code[ip + 3]).c_str());
+                ip += 5;
+                break;
+            };
             case LVM_ITER_NotAtEnd: {
-                std::string iterType;
-                if (code[ip + 2] == LVM_ITER_TypeScan) {
-                    iterType = "ScanIter";
-                } else if (code[ip + 2] == LVM_ITER_TypeIndexScan) {
-                    iterType = "IndexScanIter";
-                } else if (code[ip + 2] == LVM_ITER_TypeChoice) {
-                    iterType = "ChoiceIter";
-                } else {
-                    iterType = "IndexChoiceIter";
-                }
-                printf("%ld\tLVM_NotAtEnd\tIterID:%d\tType:%s\n", ip, code[ip + 1], iterType.c_str());
-                ip += 3;
+                printf("%ld\tLVM_NotAtEnd\tIterID:%d\\n", ip, code[ip + 1]);
+                ip += 2;
                 break;
             }
             case LVM_ITER_Select: {
-                std::string iterType;
-                if (code[ip + 2] == LVM_ITER_TypeScan) {
-                    iterType = "ScanIter";
-                } else if (code[ip + 2] == LVM_ITER_TypeIndexScan) {
-                    iterType = "IndexScanIter";
-                } else if (code[ip + 2] == LVM_ITER_TypeChoice) {
-                    iterType = "ChoiceIter";
-                } else {
-                    iterType = "IndexChoiceIter";
-                }
-                printf("%ld\tLVM_ITER_Select\t\n", ip);
-                printf("\tIterID:%d\tType:%s\tStore into CtxtId:%d\n", code[ip + 1], iterType.c_str(),
-                        code[ip + 3]);
-                ip += 4;
+                printf("%ld\tLVM_ITER_Select\t IterId:%d\n", ip, code[ip + 1]);
+                ip += 2;
                 break;
             }
             case LVM_ITER_Inc: {
-                std::string iterType;
-                if (code[ip + 2] == LVM_ITER_TypeScan) {
-                    iterType = "ScanIter";
-                } else if (code[ip + 2] == LVM_ITER_TypeIndexScan) {
-                    iterType = "IndexScanIter";
-                } else if (code[ip + 2] == LVM_ITER_TypeChoice) {
-                    iterType = "ChoiceIter";
-                } else {
-                    iterType = "IndexChoiceIter";
-                }
-                printf("%ld\tLVM_ITER_Inc\tIterID:%d\tType:%s\n", ip, code[ip + 1], iterType.c_str());
-                ip += 3;
+                printf("%ld\tLVM_ITER_Inc\tIterID:%d\t\n", ip, code[ip + 1]);
+                ip += 2;
                 break;
             }
             case LVM_NOP:

--- a/src/LVMCode.cpp
+++ b/src/LVMCode.cpp
@@ -235,11 +235,11 @@ void LVMCode::print() const {
                 ip += 3;
                 break;
             }
-            case LVM_ProvenanceExistenceCheck: {  // TODO Later
+            case LVM_ProvenanceExistenceCheck: {
                 printf("%ld\tLVM_ProvenanceExitenceChekck\t\n", ip);
                 printf("\tTarget: %s\tTypes: %s\n", symbolTable.resolve(code[ip + 1]).c_str(),
                         symbolTable.resolve(code[ip + 2]).c_str());
-                ip += 3;
+                ip += 4;
                 break;
             }
             case LVM_Constraint: {
@@ -435,7 +435,7 @@ void LVMCode::print() const {
             case LVM_ITER_TypeIndexChoice:
                 printf("%ld\tLVM_ITER_TypeIndexChoice\t RelationName:%s\n", ip,
                         symbolTable.resolve(code[ip + 2]).c_str());
-                ip += 4;
+                ip += 5;
                 break;
             case LVM_ITER_TypeIndexScan:
                 printf("%ld\tLVM_ITER_TypeIndexScan\t RelationName:%s\n", ip,

--- a/src/LVMCode.cpp
+++ b/src/LVMCode.cpp
@@ -445,7 +445,7 @@ void LVMCode::print() const {
                 break;
             };
             case LVM_ITER_NotAtEnd: {
-                printf("%ld\tLVM_NotAtEnd\tIterID:%d\\n", ip, code[ip + 1]);
+                printf("%ld\tLVM_NotAtEnd\tIterID:%d\n", ip, code[ip + 1]);
                 ip += 2;
                 break;
             }

--- a/src/LVMCode.cpp
+++ b/src/LVMCode.cpp
@@ -440,7 +440,7 @@ void LVMCode::print() const {
             case LVM_ITER_TypeIndexScan:
                 printf("%ld\tLVM_ITER_TypeIndexScan\t RelationName:%s\n", ip,
                         symbolTable.resolve(code[ip + 2]).c_str());
-                ip += 4;
+                ip += 5;
                 break;
             case LVM_ITER_TypeChoice:
                 printf("%ld\tLVM_ITER_TypeChoice\t RelationName:%s\n", ip,

--- a/src/LVMCode.h
+++ b/src/LVMCode.h
@@ -133,11 +133,6 @@ enum LVM_Type {
     LVM_EQREL,
     LVM_DEFAULT,
 
-    // LVM iterator Type
-    //LVM_ITER_TypeScan,
-    //LVM_ITER_TypeChoice,
-    //LVM_ITER_TypeIndexScan,
-    //LVM_ITER_TypeIndexChoice,
     LVM_ITER_InitFullIndex,
     LVM_ITER_InitRangeIndex,
     LVM_ITER_Select,

--- a/src/LVMCode.h
+++ b/src/LVMCode.h
@@ -134,11 +134,12 @@ enum LVM_Type {
     LVM_DEFAULT,
 
     // LVM iterator Type
-    LVM_ITER_TypeScan,
-    LVM_ITER_TypeChoice,
-    LVM_ITER_TypeIndexScan,
-    LVM_ITER_TypeIndexChoice,
-    LVM_ITER,
+    //LVM_ITER_TypeScan,
+    //LVM_ITER_TypeChoice,
+    //LVM_ITER_TypeIndexScan,
+    //LVM_ITER_TypeIndexChoice,
+    LVM_ITER_InitFullIndex,
+    LVM_ITER_InitRangeIndex,
     LVM_ITER_Select,
     LVM_ITER_Inc,
     LVM_ITER_NotAtEnd,

--- a/src/LVMCode.h
+++ b/src/LVMCode.h
@@ -138,6 +138,7 @@ enum LVM_Type {
     LVM_ITER_TypeChoice,
     LVM_ITER_TypeIndexScan,
     LVM_ITER_TypeIndexChoice,
+    LVM_ITER,
     LVM_ITER_Select,
     LVM_ITER_Inc,
     LVM_ITER_NotAtEnd,

--- a/src/LVMGenerator.h
+++ b/src/LVMGenerator.h
@@ -16,8 +16,8 @@
 #pragma once
 
 #include "LVMCode.h"
-#include "RamVisitor.h"
 #include "RamIndexAnalysis.h"
+#include "RamVisitor.h"
 
 namespace souffle {
 
@@ -620,7 +620,7 @@ protected:
         size_t counterLabel = getNewIterator();
         size_t L1 = getNewAddressLabel();
         size_t L2 = getNewAddressLabel();
-    
+
         // Obtain the pattern for index
         auto patterns = aggregate.getRangePattern();
         std::string types;
@@ -631,7 +631,7 @@ protected:
             }
             types += (patterns[i] == nullptr ? "_" : "V");
         }
-    
+
         // Init range index based on pattern
         code->push_back(LVM_ITER_InitRangeIndex);
         code->push_back(counterLabel);
@@ -1047,12 +1047,18 @@ private:
         }
         addressMap[addressLabel] = value;
     }
-    
+
     /** Get the index position in a relation based on the SearchSignature */
     template <class RamNode>
-    size_t getIndexPos(RamNode& node){
+    size_t getIndexPos(RamNode& node) {
         const MinIndexSelection& orderSet = isa.getIndexes(node.getRelation());
-        return orderSet.getLexOrderNum(isa.getSearchSignature(&node));
+        SearchSignature signature = isa.getSearchSignature(&node);
+        // A zero signature is equivalent as a full order signature.
+        if (signature == 0) {
+            signature = (1 << node.getRelation().getArity()) - 1;
+        }
+        auto i = orderSet.getLexOrderNum(signature);
+        return i;
     };
 };
 

--- a/src/LVMGenerator.h
+++ b/src/LVMGenerator.h
@@ -258,6 +258,10 @@ protected:
         code->push_back(LVM_ProvenanceExistenceCheck);
         code->push_back(symbolTable.lookup(provExists.getRelation().getName()));
         code->push_back(symbolTable.lookup(types));
+        // Cache the indexPos
+        const MinIndexSelection& orderSet = isa.getIndexes(provExists.getRelation());
+        size_t indexPos = orderSet.getLexOrderNum(isa.getSearchSignature(&provExists));
+        code->push_back(indexPos);
     }
 
     void visitConstraint(const RamConstraint& relOp, size_t exitAddress) override {
@@ -318,11 +322,11 @@ protected:
     }
 
     void visitScan(const RamScan& scan, size_t exitAddress) override {
+        code->push_back(LVM_Scan);
         size_t counterLabel = getNewScanIterator();
         size_t L1 = getNewAddressLabel();
 
         // Init the Iterator
-        code->push_back(LVM_Scan);
         code->push_back(LVM_ITER_TypeScan);
         code->push_back(counterLabel);
         code->push_back(symbolTable.lookup(scan.getRelation().getName()));
@@ -418,10 +422,10 @@ protected:
         code->push_back(counterLabel);
         code->push_back(symbolTable.lookup(scan.getRelation().getName()));
         code->push_back(symbolTable.lookup(types));
-        // Cache the indexId
+        // Cache the index position 
         const MinIndexSelection& orderSet = isa.getIndexes(scan.getRelation());
-        size_t indexNum = orderSet.getLexOrderNum(isa.getSearchSignature(&scan));
-        code->push_back(indexNum);
+        size_t indexPos = orderSet.getLexOrderNum(isa.getSearchSignature(&scan));
+        code->push_back(indexPos);
 
         // While iter is not at end
         size_t address_L0 = code->size();
@@ -471,6 +475,10 @@ protected:
         code->push_back(counterLabel);
         code->push_back(symbolTable.lookup(indexChoice.getRelation().getName()));
         code->push_back(symbolTable.lookup(types));
+        // Cache the index position
+        const MinIndexSelection& orderSet = isa.getIndexes(indexChoice.getRelation());
+        size_t indexPos = orderSet.getLexOrderNum(isa.getSearchSignature(&indexChoice));
+        code->push_back(indexPos);
 
         // While iter is not at end.
         size_t address_L0 = code->size();
@@ -648,10 +656,10 @@ protected:
         code->push_back(counterLabel);
         code->push_back(symbolTable.lookup(aggregate.getRelation().getName()));
         code->push_back(symbolTable.lookup(types));
-        // Cache the indexId
+        // Cache the indexPos
         const MinIndexSelection& orderSet = isa.getIndexes(aggregate.getRelation());
-        size_t indexNum = orderSet.getLexOrderNum(isa.getSearchSignature(&aggregate));
-        code->push_back(indexNum);
+        size_t indexPos = orderSet.getLexOrderNum(isa.getSearchSignature(&aggregate));
+        code->push_back(indexPos);
 
         if (aggregate.getFunction() == souffle::COUNT && aggregate.getCondition() == nullptr) {
             code->push_back(LVM_Aggregate_COUNT);

--- a/src/LVMGenerator.h
+++ b/src/LVMGenerator.h
@@ -1020,7 +1020,7 @@ private:
         return currentAddressLabel++;
     }
 
-    /** Get new scan iterator */
+    /** Get new iterator */
     size_t getNewIterator() {
         return iteratorIndex++;
     }

--- a/src/RAMI.cpp
+++ b/src/RAMI.cpp
@@ -495,7 +495,7 @@ void RAMI::evalOp(const RamOperation& op, const InterpreterContext& args) {
             }
 
             // obtain index
-            auto idx = rel.getIndex(interpreter.isa->getSearchSignature(&scan), nullptr);
+            auto idx = rel.getIndex(interpreter.isa->getSearchSignature(&scan));
 
             // get iterator range
             auto range = idx->lowerUpperBound(low, hig);
@@ -546,7 +546,7 @@ void RAMI::evalOp(const RamOperation& op, const InterpreterContext& args) {
             }
 
             // obtain index
-            auto idx = rel.getIndex(interpreter.isa->getSearchSignature(&choice), nullptr);
+            auto idx = rel.getIndex(interpreter.isa->getSearchSignature(&choice));
 
             // get iterator range
             auto range = idx->lowerUpperBound(low, hig);

--- a/src/RamIndexAnalysis.cpp
+++ b/src/RamIndexAnalysis.cpp
@@ -264,41 +264,28 @@ const MinIndexSelection::ChainOrderMap MinIndexSelection::getChainsFromMatching(
 
 void RamIndexAnalysis::run(const RamTranslationUnit& translationUnit) {
     // After complete:
-    // 1. All relation should have at least one index (for full-order search).
-    // 2. Two relation involved in a swap operation will have same set of indices.
+    // 1. All relations should have at least one index (for full-order search).
+    // 2. Two relations involved in a swap operation will have same set of indices.
     // 3. A 0-arity relation will have only one index where LexOrder is defined as empty. A comparator using
     // an empty order should regard all elements as equal and therefore only allow one arbitrary tuple to be
     // inserted.
     //
-    // Note:
-    // 0-arity relation in a provenance program still need to be revisited. Currently, a full-index
-    // operation on a 0-arity relation in a provenance program will have a search col == 0.
+    // TODO:
+    // 0-arity relation in a provenance program still need to be revisited.
 
     // visit all nodes to collect searches of each relation
     visitDepthFirst(*translationUnit.getProgram(), [&](const RamNode& node) {
         if (const auto* indexSearch = dynamic_cast<const RamIndexRelationSearch*>(&node)) {
             MinIndexSelection& indexes = getIndexes(indexSearch->getRelation());
-            if (getSearchSignature(indexSearch) == 0) {
-                // printf("indexSearch\n");
-            }
             indexes.addSearch(getSearchSignature(indexSearch));
         } else if (const auto* exists = dynamic_cast<const RamExistenceCheck*>(&node)) {
             MinIndexSelection& indexes = getIndexes(exists->getRelation());
-            if (getSearchSignature(exists) == 0) {
-                // printf("exists\n");
-            }
             indexes.addSearch(getSearchSignature(exists));
         } else if (const auto* provExists = dynamic_cast<const RamProvenanceExistenceCheck*>(&node)) {
             MinIndexSelection& indexes = getIndexes(provExists->getRelation());
-            if (getSearchSignature(provExists) == 0) {
-                // printf("indexSearch\n");
-            }
             indexes.addSearch(getSearchSignature(provExists));
         } else if (const auto* ramRel = dynamic_cast<const RamRelation*>(&node)) {
             MinIndexSelection& indexes = getIndexes(*ramRel);
-            if (getSearchSignature(ramRel) == 0) {
-                // printf("index\n");
-            }
             indexes.addSearch(getSearchSignature(ramRel));
         }
     });

--- a/src/RamIndexAnalysis.cpp
+++ b/src/RamIndexAnalysis.cpp
@@ -267,15 +267,27 @@ void RamIndexAnalysis::run(const RamTranslationUnit& translationUnit) {
     visitDepthFirst(*translationUnit.getProgram(), [&](const RamNode& node) {
         if (const auto* indexSearch = dynamic_cast<const RamIndexRelationSearch*>(&node)) {
             MinIndexSelection& indexes = getIndexes(indexSearch->getRelation());
+            if (getSearchSignature(indexSearch) == 0) {
+                printf("indexSearch\n");
+            }
             indexes.addSearch(getSearchSignature(indexSearch));
         } else if (const auto* exists = dynamic_cast<const RamExistenceCheck*>(&node)) {
             MinIndexSelection& indexes = getIndexes(exists->getRelation());
+            if (getSearchSignature(exists) == 0) {
+                printf("exists\n");
+            }
             indexes.addSearch(getSearchSignature(exists));
         } else if (const auto* provExists = dynamic_cast<const RamProvenanceExistenceCheck*>(&node)) {
             MinIndexSelection& indexes = getIndexes(provExists->getRelation());
+            if (getSearchSignature(provExists) == 0) {
+                printf("indexSearch\n");
+            }
             indexes.addSearch(getSearchSignature(provExists));
         } else if (const auto* ramRel = dynamic_cast<const RamRelation*>(&node)) {
             MinIndexSelection& indexes = getIndexes(*ramRel);
+            if (getSearchSignature(ramRel) == 0) {
+                printf("index\n");
+            }
             indexes.addSearch(getSearchSignature(ramRel));
         }
     });
@@ -308,6 +320,14 @@ void RamIndexAnalysis::run(const RamTranslationUnit& translationUnit) {
     for (auto& cur : minIndexCover) {
         MinIndexSelection& indexes = cur.second;
         indexes.solve();
+    }
+
+    // Only case where indexSet is still empty is when relation has arity == 0
+    for (auto& cur : minIndexCover) {
+        MinIndexSelection& indexes = cur.second;
+        if (indexes.getAllOrders().empty()) {
+            indexes.insertDefaultTotalIndex(0);
+        }
     }
 }
 
@@ -363,6 +383,9 @@ SearchSignature RamIndexAnalysis::getSearchSignature(const RamIndexRelationSearc
         if (rangePattern[i] != nullptr) {
             keys |= (1 << i);
         }
+    }
+    if (keys == 0) {
+        printf("IndexRelation\n");
     }
     return keys;
 }

--- a/src/RamIndexAnalysis.cpp
+++ b/src/RamIndexAnalysis.cpp
@@ -263,30 +263,41 @@ const MinIndexSelection::ChainOrderMap MinIndexSelection::getChainsFromMatching(
 }
 
 void RamIndexAnalysis::run(const RamTranslationUnit& translationUnit) {
+    // After complete:
+    // 1. All relation should have at least one index (for full-order search).
+    // 2. Two relation involved in a swap operation will have same set of indices.
+    // 3. A 0-arity relation will have only one index where LexOrder is defined as empty. A comparator using
+    // an empty order should regard all elements as equal and therefore only allow one arbitrary tuple to be
+    // inserted.
+    //
+    // Note:
+    // 0-arity relation in a provenance program still need to be revisited. Currently, a full-index
+    // operation on a 0-arity relation in a provenance program will have a search col == 0.
+
     // visit all nodes to collect searches of each relation
     visitDepthFirst(*translationUnit.getProgram(), [&](const RamNode& node) {
         if (const auto* indexSearch = dynamic_cast<const RamIndexRelationSearch*>(&node)) {
             MinIndexSelection& indexes = getIndexes(indexSearch->getRelation());
             if (getSearchSignature(indexSearch) == 0) {
-                printf("indexSearch\n");
+                // printf("indexSearch\n");
             }
             indexes.addSearch(getSearchSignature(indexSearch));
         } else if (const auto* exists = dynamic_cast<const RamExistenceCheck*>(&node)) {
             MinIndexSelection& indexes = getIndexes(exists->getRelation());
             if (getSearchSignature(exists) == 0) {
-                printf("exists\n");
+                // printf("exists\n");
             }
             indexes.addSearch(getSearchSignature(exists));
         } else if (const auto* provExists = dynamic_cast<const RamProvenanceExistenceCheck*>(&node)) {
             MinIndexSelection& indexes = getIndexes(provExists->getRelation());
             if (getSearchSignature(provExists) == 0) {
-                printf("indexSearch\n");
+                // printf("indexSearch\n");
             }
             indexes.addSearch(getSearchSignature(provExists));
         } else if (const auto* ramRel = dynamic_cast<const RamRelation*>(&node)) {
             MinIndexSelection& indexes = getIndexes(*ramRel);
             if (getSearchSignature(ramRel) == 0) {
-                printf("index\n");
+                // printf("index\n");
             }
             indexes.addSearch(getSearchSignature(ramRel));
         }

--- a/src/RamIndexAnalysis.cpp
+++ b/src/RamIndexAnalysis.cpp
@@ -384,9 +384,6 @@ SearchSignature RamIndexAnalysis::getSearchSignature(const RamIndexRelationSearc
             keys |= (1 << i);
         }
     }
-    if (keys == 0) {
-        printf("IndexRelation\n");
-    }
     return keys;
 }
 

--- a/src/RamIndexAnalysis.h
+++ b/src/RamIndexAnalysis.h
@@ -178,6 +178,11 @@ public:
         return orders[idx];
     }
 
+    /** @Brief Get index for a search */
+    const int getLexOrderNum(SearchSignature cols) const {
+        return map(cols);
+    }
+
     /** @Brief Get all indexes */
     const OrderCollection getAllOrders() const {
         return orders;

--- a/src/RamIndexAnalysis.h
+++ b/src/RamIndexAnalysis.h
@@ -229,7 +229,7 @@ public:
         for (size_t i = 0; i < arity; ++i) {
             totalOrder.push_back(i);
         }
-        orders.push_back(totalOrder);
+        orders.push_back(std::move(totalOrder));
     }
 
 protected:

--- a/src/WriteStream.h
+++ b/src/WriteStream.h
@@ -38,7 +38,7 @@ public:
         auto lease = symbolTable.acquireLock();
         (void)lease;
         if (arity == 0) {
-            if (relation.begin() != relation.end()) {
+            if (relation.size() != 0){
                 writeNullary();
             }
             return;

--- a/src/WriteStream.h
+++ b/src/WriteStream.h
@@ -38,7 +38,7 @@ public:
         auto lease = symbolTable.acquireLock();
         (void)lease;
         if (arity == 0) {
-            if (relation.size() != 0){
+            if (relation.begin() != relation.end()) {
                 writeNullary();
             }
             return;


### PR DESCRIPTION
1. Add fast index lookup in LVM. This is done during the code generation.
2. LVM does not rely on the iterator of `InterpreterRelation` anymore. Instead, it uses only `InterpreterIndex`. This simplifies the search-related operation in LVM, eliminates unnecessary type checking and reduces code size.
