### PR TITLE
Remove relation reference in RamElementAccess

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -65,12 +65,7 @@ class ErrorReport;
 class SymbolTable;
 
 std::unique_ptr<RamElementAccess> AstTranslator::makeRamElementAccess(const Location& loc) {
-    if (loc.relation != nullptr) {
-        return std::make_unique<RamElementAccess>(
-                loc.identifier, loc.element, std::unique_ptr<RamRelationReference>(loc.relation->clone()));
-    } else {
         return std::make_unique<RamElementAccess>(loc.identifier, loc.element);
-    }
 }
 
 void AstTranslator::makeIODirective(IODirectives& ioDirective, const AstRelation* rel,
@@ -691,8 +686,7 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
                 if (auto* agg = dynamic_cast<AstAggregator*>(atom->getArgument(pos))) {
                     auto loc = valueIndex.getAggregatorLocation(*agg);
                     op = std::make_unique<RamFilter>(std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
-                                                             std::make_unique<RamElementAccess>(curLevel, pos,
-                                                                     translator.translateRelation(atom)),
+                                                             std::make_unique<RamElementAccess>(curLevel, pos),
                                                              makeRamElementAccess(loc)),
                             std::move(op));
                 }
@@ -763,7 +757,7 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
                             std::unique_ptr<RamCondition> newCondition = std::make_unique<RamConstraint>(
                                     BinaryConstraintOp::EQ, makeRamElementAccess(loc),
                                     std::make_unique<RamElementAccess>(
-                                            level, pos, translator.translateRelation(atom)));
+                                            level, pos));
                             addAggCondition(newCondition);
                             break;
                         }
@@ -775,7 +769,7 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
                         std::unique_ptr<RamCondition> newCondition =
                                 std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
                                         std::make_unique<RamElementAccess>(
-                                                level, pos, translator.translateRelation(atom)),
+                                                level, pos),
                                         std::move(value));
                         addAggCondition(newCondition);
                     }
@@ -814,8 +808,7 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
             for (size_t pos = 0; pos < atom->argSize(); ++pos) {
                 if (auto* c = dynamic_cast<AstConstant*>(atom->getArgument(pos))) {
                     op = std::make_unique<RamFilter>(std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
-                                                             std::make_unique<RamElementAccess>(level, pos,
-                                                                     translator.translateRelation(atom)),
+                                                             std::make_unique<RamElementAccess>(level, pos),
                                                              std::make_unique<RamNumber>(c->getIndex())),
                             std::move(op));
                 }

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -65,7 +65,7 @@ class ErrorReport;
 class SymbolTable;
 
 std::unique_ptr<RamElementAccess> AstTranslator::makeRamElementAccess(const Location& loc) {
-        return std::make_unique<RamElementAccess>(loc.identifier, loc.element);
+    return std::make_unique<RamElementAccess>(loc.identifier, loc.element);
 }
 
 void AstTranslator::makeIODirective(IODirectives& ioDirective, const AstRelation* rel,
@@ -685,9 +685,10 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
             for (size_t pos = 0; pos < atom->argSize(); ++pos) {
                 if (auto* agg = dynamic_cast<AstAggregator*>(atom->getArgument(pos))) {
                     auto loc = valueIndex.getAggregatorLocation(*agg);
-                    op = std::make_unique<RamFilter>(std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
-                                                             std::make_unique<RamElementAccess>(curLevel, pos),
-                                                             makeRamElementAccess(loc)),
+                    op = std::make_unique<RamFilter>(
+                            std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
+                                    std::make_unique<RamElementAccess>(curLevel, pos),
+                                    makeRamElementAccess(loc)),
                             std::move(op));
                 }
             }
@@ -756,8 +757,7 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
                         if (level != loc.identifier || (int)pos != loc.element) {
                             std::unique_ptr<RamCondition> newCondition = std::make_unique<RamConstraint>(
                                     BinaryConstraintOp::EQ, makeRamElementAccess(loc),
-                                    std::make_unique<RamElementAccess>(
-                                            level, pos));
+                                    std::make_unique<RamElementAccess>(level, pos));
                             addAggCondition(newCondition);
                             break;
                         }
@@ -768,9 +768,7 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
                     if (value != nullptr) {
                         std::unique_ptr<RamCondition> newCondition =
                                 std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
-                                        std::make_unique<RamElementAccess>(
-                                                level, pos),
-                                        std::move(value));
+                                        std::make_unique<RamElementAccess>(level, pos), std::move(value));
                         addAggCondition(newCondition);
                     }
                 }

--- a/src/RamExpression.h
+++ b/src/RamExpression.h
@@ -219,7 +219,7 @@ public:
             : identifier(ident), element(elem) {}
 
     void print(std::ostream& os) const override {
-            os << "t" << identifier << "." << element;
+        os << "t" << identifier << "." << element;
     }
 
     /** Get identifier */
@@ -233,7 +233,7 @@ public:
     }
 
     RamElementAccess* clone() const override {
-            return new RamElementAccess(identifier, element);
+        return new RamElementAccess(identifier, element);
     }
 
 protected:

--- a/src/RamExpression.h
+++ b/src/RamExpression.h
@@ -216,14 +216,10 @@ protected:
 class RamElementAccess : public RamExpression {
 public:
     RamElementAccess(size_t ident, size_t elem, std::unique_ptr<RamRelationReference> relRef = nullptr)
-            : identifier(ident), element(elem), relationRef(std::move(relRef)) {}
+            : identifier(ident), element(elem) {}
 
     void print(std::ostream& os) const override {
-        if (nullptr == relationRef) {
             os << "t" << identifier << "." << element;
-        } else {
-            os << "t" << identifier << "." << relationRef->get()->getArg(element);
-        }
     }
 
     /** Get identifier */
@@ -236,27 +232,8 @@ public:
         return element;
     }
 
-    std::vector<const RamNode*> getChildNodes() const override {
-        if (relationRef != nullptr) {
-            return {relationRef.get()};
-        } else {
-            return {};
-        }
-    }
-
     RamElementAccess* clone() const override {
-        if (relationRef != nullptr) {
-            return new RamElementAccess(
-                    identifier, element, std::unique_ptr<RamRelationReference>(relationRef->clone()));
-        } else {
             return new RamElementAccess(identifier, element);
-        }
-    }
-
-    void apply(const RamNodeMapper& map) override {
-        if (relationRef != nullptr) {
-            relationRef = map(std::move(relationRef));
-        }
     }
 
 protected:
@@ -265,11 +242,6 @@ protected:
 
     /** Element number */
     const size_t element;
-
-    /** Relation for debugging purposes
-     *  Set to nullptr for non-existent relations
-     */
-    std::unique_ptr<RamRelationReference> relationRef;
 
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamElementAccess*>(&node));


### PR DESCRIPTION
Depending on the type of RamSearch operation there may or may not be a relation associated. 
Hence we have sometimes a null-pointer in the RamElementAcces (e.g. for RamUnpackRecord). 

This pull-request removes the RelationRef from the ElementAccess which avoids null-pointers causing issues with the transformers. As a down-side, we lose expressiveness in the debug report, i.e., we use element numbers instead of attribute names. 
