### PR TITLE
Handle CSV input of nullary relations

### DIFF
--- a/src/ReadStreamCSV.h
+++ b/src/ReadStreamCSV.h
@@ -50,7 +50,7 @@ public:
 
 protected:
     /**
-     * Read and return true if there is content..
+     * Read and return true if there is content.
      *
      * Returns true if there is data.
      * @return

--- a/src/ReadStreamCSV.h
+++ b/src/ReadStreamCSV.h
@@ -50,6 +50,22 @@ public:
 
 protected:
     /**
+     * Read and return true if there is content..
+     *
+     * Returns true if there is data.
+     * @return
+     */
+    bool readNullary() override {
+        if (file.eof()) {
+            return false;
+        }
+        std::string line;
+        if (!getline(file, line)) {
+            return false;
+        }
+        return true;
+    }
+    /**
      * Read and return the next tuple.
      *
      * Returns nullptr if no tuple was readable.
@@ -65,6 +81,7 @@ protected:
         if (!getline(file, line)) {
             return nullptr;
         }
+
         // Handle Windows line endings on non-Windows systems
         if (line.back() == '\r') {
             line = line.substr(0, line.length() - 1);


### PR DESCRIPTION
Add handling of nullary input from file. This already existed on most platforms, but relied on undefined behaviour.

Nullary input from other forms of IO is explicitly not handled. Current behaviour is to silently fail.