### PR TITLE
Updated record grammar and tests to match.

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -883,13 +883,12 @@ arg
         $$ = new AstNullConstant();
         $$->setSrcLoc(@$);
     }
-  /* TODO (azreika): in next version: prepend records with identifiers */
-  | LBRACKET RBRACKET {
-        $$ = new AstRecordInit();
+  | STAR identifier LBRACKET RBRACKET {
+        $$ = new AstRecordInit($identifier);
         $$->setSrcLoc(@$);
     }
-  | LBRACKET non_empty_arg_list RBRACKET {
-        auto record = new AstRecordInit();
+  | STAR identifier LBRACKET non_empty_arg_list RBRACKET {
+        auto record = new AstRecordInit($identifier);
 
         for (auto* arg : $non_empty_arg_list) {
             record->add(std::unique_ptr<AstArgument>(arg));

--- a/tests/semantic/records0/records0.dl
+++ b/tests/semantic/records0/records0.dl
@@ -13,7 +13,7 @@
 
 .decl A, B(x:empty)
 
-A([]).
-A([]).
+A(*empty[]).
+A(*empty[]).
 
 .printsize A, B

--- a/tests/semantic/records7/records7.dl
+++ b/tests/semantic/records7/records7.dl
@@ -1,7 +1,7 @@
 .type R=[x:number, y:number]
 .decl A(x:R)
-A([1,2]).
-A([2,3]).
+A(*R[1,2]).
+A(*R[2,3]).
 
 .decl B(x:number)
 B(y) :- A(x), y=ord(x).

--- a/tests/semantic/type_udef/type_udef.err
+++ b/tests/semantic/type_udef/type_udef.err
@@ -1,7 +1,3 @@
-Error: Undefined type undef in definition of field x in unknown source location.
-Error: Undefined type undef in definition of field y in unknown source location.
-Error: Undefined type undef in definition of union type c.U1 in unknown source location.
-Error: Undefined type undef in definition of union type c.U2 in unknown source location.
 Error: Undefined type undef in definition of union type U in file type_udef.dl at line 9
 .type U = symbol | undef                    // error
 ^----------------------------------------------------
@@ -20,6 +16,18 @@ B(as(1,undef)).                             // error
 Error: Type undef has not been declared in file type_udef.dl at line 14
 B(*undef[1]).                               // error
 --^--------------------------------------------------
+Error: Undefined type undef in definition of union type c.U1 in file type_udef.dl at line 16
+    .type U1 = undef | symbol               // error
+----^------------------------------------------------
+Error: Undefined type undef in definition of union type c.U2 in file type_udef.dl at line 17
+    .type U2 = number | T                   // error
+----^------------------------------------------------
+Error: Undefined type undef in definition of field x in file type_udef.dl at line 18
+    .type R1 = [ x : undef ]                // error
+----^------------------------------------------------
+Error: Undefined type undef in definition of field y in file type_udef.dl at line 19
+    .type R2 = [ y : T ]                    // error
+----^------------------------------------------------
 Warning: No rules/facts defined for relation c.A1 in file type_udef.dl at line 20
     .decl A1(x : undef)                     // error
 ----------^------------------------------------------


### PR DESCRIPTION
* Record initialiser grammar now in intermediate form - use `*rec[...]` to initialise a record of type `rec` in a rule.
    * This was done to unify it with existing record tests, which have already mostly been updated to use this form in the typesystem branch.
    * Previously, was just `[...]`.
    * Next step is changing this to `rec[...]` (removing the `*` prefix), and updating the tests accordingly.
* The few remaining record tests have been updated to use the `*rec[...]` syntax.
* Tests have been fixed to match the actual expected error/warning output.

All tests should now pass, except for `semantic/records7`. `records7` requires the type analysis to be changed for the new semantics of the `ord` functor given in PR #942.