### PR TITLE
Changed component scope delimiter from '.' to '::'.

### DIFF
--- a/src/AstRelationIdentifier.h
+++ b/src/AstRelationIdentifier.h
@@ -68,7 +68,7 @@ public:
 
     std::string getName() const {
         std::stringstream ss;
-        ss << join(names, ".");
+        ss << join(names, "::");
         return ss.str();
     }
 

--- a/src/AstRelationIdentifier.h
+++ b/src/AstRelationIdentifier.h
@@ -88,7 +88,7 @@ public:
     }
 
     void print(std::ostream& out) const {
-        out << join(names, ".");
+        out << getName();
     }
 
     friend std::ostream& operator<<(std::ostream& out, const AstRelationIdentifier& id) {

--- a/src/AstType.h
+++ b/src/AstType.h
@@ -89,7 +89,7 @@ public:
     }
 
     void print(std::ostream& out) const {
-        out << join(names, ".");
+        out << join(names, "::");
     }
 
     friend std::ostream& operator<<(std::ostream& out, const AstTypeIdentifier& id) {

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -330,8 +330,7 @@ identifier
   : IDENT {
         $$.push_back($IDENT);
     }
-    /* TODO (azreika): in next version: DOT -> DOUBLECOLON */
-  | identifier[curr_identifier] DOT IDENT {
+  | identifier[curr_identifier] DOUBLECOLON IDENT {
         $$ = $curr_identifier;
         $$.push_back($IDENT);
 

--- a/src/scanner.ll
+++ b/src/scanner.ll
@@ -138,6 +138,7 @@
 "}"                                   { return yy::parser::make_RBRACE(yylloc); }
 "<"                                   { return yy::parser::make_LT(yylloc); }
 ">"                                   { return yy::parser::make_GT(yylloc); }
+"::"                                  { return yy::parser::make_DOUBLECOLON(yylloc); }
 ":-"                                  { return yy::parser::make_IF(yylloc); }
 (!=|>=|<=)                            { return yy::parser::make_RELOP(SLOOKUP(yytext), yylloc); }
 [0-9]+"."[0-9]+"."[0-9]+"."[0-9]+     {

--- a/tests/evaluation/components/components.dl
+++ b/tests/evaluation/components/components.dl
@@ -67,9 +67,9 @@
 
     // reachability is defined over all edges
     .decl reachable(a:node,b:node)
-    reachable(X,Y) :- train.reachable(X,Y).
-    reachable(X,Y) :- ship.reachable(X,Y).
-    reachable(X,Y) :- cap.reachable(X,Y).
+    reachable(X,Y) :- train::reachable(X,Y).
+    reachable(X,Y) :- ship::reachable(X,Y).
+    reachable(X,Y) :- cap::reachable(X,Y).
 
     reachable(X,Z) :- reachable(X,Y), reachable(Y,Z).
 
@@ -80,29 +80,29 @@
 
 .init SocialNet = DiGraph
 
-SocialNet.edge("luke","leia").
-SocialNet.edge("han","luke").
+SocialNet::edge("luke","leia").
+SocialNet::edge("han","luke").
 
 
 .init Equal = Graph
 
-Equal.edge("5","five").
-Equal.edge("5","V").
+Equal::edge("5","five").
+Equal::edge("5","V").
 
 
 // some output
 .decl result (x:symbol)
 .output result ()
-result("Star Wars IV-VI happened!") :- SocialNet.reachable("han","leia").
-result("Luke isn't a good buddy!") :- !SocialNet.reachable("leia","han").
+result("Star Wars IV-VI happened!") :- SocialNet::reachable("han","leia").
+result("Luke isn't a good buddy!") :- !SocialNet::reachable("leia","han").
 
-result("V is five") :- Equal.reachable("V","five").
-result("five is V") :- Equal.reachable("five","V").
+result("V is five") :- Equal::reachable("V","five").
+result("five is V") :- Equal::reachable("five","V").
 
 .init London = Traffic
 
-London.train.edge("Airport","Waterloo").
-London.ship.edge("Waterloo","London Bridge").
-London.cap.edge("London Bridge", "Big Ben").
+London::train::edge("Airport","Waterloo").
+London::ship::edge("Waterloo","London Bridge").
+London::cap::edge("London Bridge", "Big Ben").
 
-result("Connected") :- London.reachable("Airport","Big Ben").
+result("Connected") :- London::reachable("Airport","Big Ben").

--- a/tests/evaluation/components3/components3.dl
+++ b/tests/evaluation/components3/components3.dl
@@ -18,8 +18,8 @@
 .comp C:B {
     .decl path(x:number, y:number)
 .output path()
-    path(x,y) :- a.edge(x,y).
-    path(x,y) :- a.edge(x,z), path(z,y).
+    path(x,y) :- a::edge(x,y).
+    path(x,y) :- a::edge(x,z), path(z,y).
 }
 
 .init c = C

--- a/tests/evaluation/components_generic/components_generic.dl
+++ b/tests/evaluation/components_generic/components_generic.dl
@@ -34,10 +34,10 @@
     .init G = Graph<N>
 
     .decl e(a:N,b:N)
-    G.edge(X,Y) :- e(X,Y).
+    G::edge(X,Y) :- e(X,Y).
 
     .decl r(a:N,b:N)
-    r(X,Y) :- G.reach(X,Y).
+    r(X,Y) :- G::reach(X,Y).
 }
 
 
@@ -48,8 +48,8 @@
 .type city
 .init StreetMap = Net<city>
 
-StreetMap.e("A","B").
-StreetMap.e("B","C").
+StreetMap::e("A","B").
+StreetMap::e("B","C").
 
 
 // -- use a record as node type --
@@ -65,13 +65,13 @@ StreetMap.e("B","C").
 #define Ned *Person["Ned","Evergreen Terrace 744"]
 #define Edna *Person["Ned","Evergreen Terrace 82"]
 
-SocialNet.e(Homer,Ned).
-SocialNet.e(Ned,Edna).
+SocialNet::e(Homer,Ned).
+SocialNet::e(Ned,Edna).
 
 
 // -- print some results --
 
 .decl result(n:symbol)
 .output result()
-result("Map Works") :- StreetMap.r("C","A").
-result("Social Net Works") :- SocialNet.r(Edna,Homer).
+result("Map Works") :- StreetMap::r("C","A").
+result("Social Net Works") :- SocialNet::r(Edna,Homer).

--- a/tests/evaluation/magic_components/magic_components.dl
+++ b/tests/evaluation/magic_components/magic_components.dl
@@ -8,7 +8,8 @@
 // the magic set transformation
 .pragma "magic-transform" "*"
 
-// ---- some type definitions -----
+
+// ---- some type definitions ----
 
 .type node
 
@@ -32,19 +33,19 @@
 
     .decl reachable (a:node,b:node)
     reachable(X,Y) :- edge(X,Y).
-	reachable(X,Z) :- reachable(X,Y),reachable(Y,Z).
+    reachable(X,Z) :- reachable(X,Y),reachable(Y,Z).
 
-//    .decl empty ()              // 0-ary relation is a comming up feature
-//	empty() :- !node(_).
+    .decl empty ()
+    empty() :- !node(_).
 
     .decl roots (n:node)
-	roots(X) :- node(X), !edge(_,X).
+    roots(X) :- node(X), !edge(_,X).
 
     .decl leafs (n:node)
-	leafs(X) :- node(X), !edge(X,_).
+    leafs(X) :- node(X), !edge(X,_).
 
     .decl clique (a:node,b:node)
-	clique(X,Y) :- reachable(X,Y), reachable(Y,X).
+    clique(X,Y) :- reachable(X,Y), reachable(Y,X).
 }
 
 // ---------------------------------
@@ -63,17 +64,17 @@
 .comp Traffic {
 
     // 3 nested instances of the directed graph
-	.init train = DiGraph
-	.init ship = DiGraph
-	.init cap = DiGraph
+    .init train = DiGraph
+    .init ship = DiGraph
+    .init cap = DiGraph
 
     // reachability is defined over all edges
     .decl reachable(a:node,b:node)
-	reachable(X,Y) :- train.reachable(X,Y).
-	reachable(X,Y) :- ship.reachable(X,Y).
-	reachable(X,Y) :- cap.reachable(X,Y).
+    reachable(X,Y) :- train::reachable(X,Y).
+    reachable(X,Y) :- ship::reachable(X,Y).
+    reachable(X,Y) :- cap::reachable(X,Y).
 
-	reachable(X,Z) :- reachable(X,Y), reachable(Y,Z).
+    reachable(X,Z) :- reachable(X,Y), reachable(Y,Z).
 
 }
 
@@ -82,29 +83,29 @@
 
 .init SocialNet = DiGraph
 
-SocialNet.edge("luke","leia").
-SocialNet.edge("han","luke").
+SocialNet::edge("luke","leia").
+SocialNet::edge("han","luke").
 
 
 .init Equal = Graph
 
-Equal.edge("5","five").
-Equal.edge("5","V").
+Equal::edge("5","five").
+Equal::edge("5","V").
 
 
 // some output
-.decl result ( x : symbol )
+.decl result (x:symbol)
 .output result ()
-result("Star Wars IV-VI happend!") :- SocialNet.reachable("han","leia").
-result("Luke isn't a good buddy!") :- !SocialNet.reachable("leia","han").
+result("Star Wars IV-VI happened!") :- SocialNet::reachable("han","leia").
+result("Luke isn't a good buddy!") :- !SocialNet::reachable("leia","han").
 
-result("V is five") :- Equal.reachable("V","five").
-result("five is V") :- Equal.reachable("five","V").
+result("V is five") :- Equal::reachable("V","five").
+result("five is V") :- Equal::reachable("five","V").
 
 .init London = Traffic
 
-London.train.edge("Airport","Waterloo").
-London.ship.edge("Waterloo","London Bridge").
-London.cap.edge("London Bridge", "Big Ben").
+London::train::edge("Airport","Waterloo").
+London::ship::edge("Waterloo","London Bridge").
+London::cap::edge("London Bridge", "Big Ben").
 
-result("Connected") :- London.reachable("Airport","Big Ben").
+result("Connected") :- London::reachable("Airport","Big Ben").

--- a/tests/evaluation/magic_components/result.csv
+++ b/tests/evaluation/magic_components/result.csv
@@ -1,4 +1,4 @@
-Star Wars IV-VI happend!
+Star Wars IV-VI happened!
 Luke isn't a good buddy!
 V is five
 five is V

--- a/tests/evaluation/magic_dfa/magic_dfa.dl
+++ b/tests/evaluation/magic_dfa/magic_dfa.dl
@@ -139,15 +139,15 @@
 
       .init   gen_kill_union = Gen_Kill_Union<Node,InfoLattice>
 
-      gen_kill_union.start(n) :- start(n).
+      gen_kill_union::start(n) :- start(n).
 
-      gen_kill_union.edge(x,y) :- edge(x,y).
+      gen_kill_union::edge(x,y) :- edge(x,y).
 
-      gen_kill_union.gen(node,inf) :- kill(node,inf), !gen(node,inf).
+      gen_kill_union::gen(node,inf) :- kill(node,inf), !gen(node,inf).
 
-      gen_kill_union.kill(node,inf) :- gen(node,inf).
+      gen_kill_union::kill(node,inf) :- gen(node,inf).
 
-      gen_kill_union.startvalue(inf) :- startvalue(inf).
+      gen_kill_union::startvalue(inf) :- startvalue(inf).
 
 
       //
@@ -158,7 +158,7 @@
       //  out
       //
 
-      out(node,inf) :- node(node), universe(inf), !gen_kill_union.out(node,inf).
+      out(node,inf) :- node(node), universe(inf), !gen_kill_union::out(node,inf).
 }
 
 
@@ -176,15 +176,15 @@
 
       .init gen_kill_union = Gen_Kill_Union<Node,InfoLattice>
 
-      gen_kill_union.start(node) :- start(node).
+      gen_kill_union::start(node) :- start(node).
 
-      gen_kill_union.edge(src,des) :- edge(des,src).
+      gen_kill_union::edge(src,des) :- edge(des,src).
 
-      gen_kill_union.gen(node,inf) :- gen(node,inf).
+      gen_kill_union::gen(node,inf) :- gen(node,inf).
 
-      gen_kill_union.kill(node,inf) :- kill(node,inf).
+      gen_kill_union::kill(node,inf) :- kill(node,inf).
 
-      gen_kill_union.startvalue(inf) :- startvalue(inf).
+      gen_kill_union::startvalue(inf) :- startvalue(inf).
 
 
       //
@@ -195,7 +195,7 @@
       //  out
       //
 
-      out(node,inf) :- gen_kill_union.out(node,inf).
+      out(node,inf) :- gen_kill_union::out(node,inf).
 }
 
 .comp Gen_Kill_Intersection_Backward<Node,InfoLattice> : Gen_Kill<Node,InfoLattice>, Graph<Node>{
@@ -213,15 +213,15 @@
       //  in
       //
 
-      gen_kill_intersection.start(node) :- start(node).
+      gen_kill_intersection::start(node) :- start(node).
 
-      gen_kill_intersection.edge(src,des) :- edge(des,src).
+      gen_kill_intersection::edge(src,des) :- edge(des,src).
 
-      gen_kill_intersection.gen(node,inf) :- gen(node,inf).
+      gen_kill_intersection::gen(node,inf) :- gen(node,inf).
 
-      gen_kill_intersection.kill(node,inf) :- kill(node,inf).
+      gen_kill_intersection::kill(node,inf) :- kill(node,inf).
 
-      gen_kill_intersection.startvalue(inf) :- startvalue(inf).
+      gen_kill_intersection::startvalue(inf) :- startvalue(inf).
 
 
       //
@@ -232,7 +232,7 @@
       //  out
       //
 
-      out(node,inf) :- gen_kill_intersection.out(node,inf).
+      out(node,inf) :- gen_kill_intersection::out(node,inf).
 
 }
 
@@ -284,32 +284,32 @@ universe(inf) :- kill(_,inf).
 
 .init Available_Expressions = Gen_Kill_Intersection<number,symbol>
 
-Available_Expressions.edge(x,y) :- edge(x,y).
-Available_Expressions.gen(x,i) :- gen(x,i).
-Available_Expressions.kill(x,i) :- kill(x,i).
-Available_Expressions.startvalue(inf) :-  universe(inf),!kill(1,inf).
-Available_Expressions.start(1).
+Available_Expressions::edge(x,y) :- edge(x,y).
+Available_Expressions::gen(x,i) :- gen(x,i).
+Available_Expressions::kill(x,i) :- kill(x,i).
+Available_Expressions::startvalue(inf) :-  universe(inf),!kill(1,inf).
+Available_Expressions::start(1).
 
 
 
 .init Reaching_Definitions = Gen_Kill_Union<number,symbol>
 
-Reaching_Definitions.edge(x,y) :- edge(x,y).
-Reaching_Definitions.gen(x,i) :- gen(x,i).
-Reaching_Definitions.kill(x,i) :- kill(x,i).
-Reaching_Definitions.startvalue(i) :- gen(1,i), !kill(1,i).
-Reaching_Definitions.start(1).
+Reaching_Definitions::edge(x,y) :- edge(x,y).
+Reaching_Definitions::gen(x,i) :- gen(x,i).
+Reaching_Definitions::kill(x,i) :- kill(x,i).
+Reaching_Definitions::startvalue(i) :- gen(1,i), !kill(1,i).
+Reaching_Definitions::start(1).
 
 
 
 
 .init Live_Variables = Gen_Kill_Union_Backward<number,symbol>
 
-Live_Variables.edge(x,y) :- edge(x,y).
-Live_Variables.gen(x,i) :- use(x,i).
-Live_Variables.kill(x,i) :- kill(x,i).
-Live_Variables.startvalue(i) :- use(8,i), !kill(8,i).
-Live_Variables.start(8).
+Live_Variables::edge(x,y) :- edge(x,y).
+Live_Variables::gen(x,i) :- use(x,i).
+Live_Variables::kill(x,i) :- kill(x,i).
+Live_Variables::startvalue(i) :- use(8,i), !kill(8,i).
+Live_Variables::start(8).
 
 
 //
@@ -318,14 +318,14 @@ Live_Variables.start(8).
 
 .decl available_expressions(n:number, i:symbol)
 .output available_expressions()
-available_expressions(x,i) :- Available_Expressions.out(x,i).
+available_expressions(x,i) :- Available_Expressions::out(x,i).
 
 
 .decl reaching_definitions(n:number, i:symbol)
 .output reaching_definitions()
-reaching_definitions(x,i) :- Reaching_Definitions.out(x,i).
+reaching_definitions(x,i) :- Reaching_Definitions::out(x,i).
 
 
 .decl live_variables(n:number, i:symbol)
 .output live_variables()
-live_variables(x,i) :- Live_Variables.out(x,i).
+live_variables(x,i) :- Live_Variables::out(x,i).

--- a/tests/evaluation/magic_dominance/magic_dominance.dl
+++ b/tests/evaluation/magic_dominance/magic_dominance.dl
@@ -123,23 +123,23 @@
 
 .init ImmDom = ImmediateDominance<number>
 
-ImmDom.edge(1, 2).
-ImmDom.edge(1, 3).
-ImmDom.edge(2, 3).
-ImmDom.edge(4, 3).
-ImmDom.edge(8, 3).
-ImmDom.edge(3, 4).
-ImmDom.edge(8, 4).
-ImmDom.edge(4, 5).
-ImmDom.edge(4, 6).
-ImmDom.edge(5, 7).
-ImmDom.edge(6, 7).
-ImmDom.edge(10, 7).
-ImmDom.edge(7, 8).
-ImmDom.edge(8, 9).
-ImmDom.edge(8, 10).
-ImmDom.edge(9, 1).
-ImmDom.start(1).
+ImmDom::edge(1, 2).
+ImmDom::edge(1, 3).
+ImmDom::edge(2, 3).
+ImmDom::edge(4, 3).
+ImmDom::edge(8, 3).
+ImmDom::edge(3, 4).
+ImmDom::edge(8, 4).
+ImmDom::edge(4, 5).
+ImmDom::edge(4, 6).
+ImmDom::edge(5, 7).
+ImmDom::edge(6, 7).
+ImmDom::edge(10, 7).
+ImmDom::edge(7, 8).
+ImmDom::edge(8, 9).
+ImmDom::edge(8, 10).
+ImmDom::edge(9, 1).
+ImmDom::start(1).
 
 
 //
@@ -148,7 +148,7 @@ ImmDom.start(1).
 
 .decl dominators(n:number,s:number)
 .output dominators()
-dominators(n,s) :- ImmDom.dom(n,s).
+dominators(n,s) :- ImmDom::dom(n,s).
 
 
 //
@@ -157,4 +157,4 @@ dominators(n,s) :- ImmDom.dom(n,s).
 
 .decl immediate_dom(n:number,s:number)
 .output immediate_dom()
-immediate_dom(n,s) :- ImmDom.imdom(n,s).
+immediate_dom(n,s) :- ImmDom::imdom(n,s).

--- a/tests/evaluation/magic_strategies/magic_strategies.dl
+++ b/tests/evaluation/magic_strategies/magic_strategies.dl
@@ -44,6 +44,6 @@ less(5,6).
 .init C = QuadraticRecursive
 
 // wire in input data
-A.edge(X,Y) :- less(X,Y).
-B.edge(X,Y) :- less(X,Y).
-C.edge(X,Y) :- less(X,Y).
+A::edge(X,Y) :- less(X,Y).
+B::edge(X,Y) :- less(X,Y).
+C::edge(X,Y) :- less(X,Y).

--- a/tests/example/comp-parametrized-inherit/comp-parametrized-inherit.dl
+++ b/tests/example/comp-parametrized-inherit/comp-parametrized-inherit.dl
@@ -13,7 +13,7 @@
 .comp A<T> {
     .init impl = T
     .decl Base(x: number)
-    Base(x) :- impl.R(x).
+    Base(x) :- impl::R(x).
 }
 
 .comp Derived<K> : A<K> {
@@ -30,5 +30,5 @@
 .decl AOut(x: number)
 .output AOut()
 
-DerivedOut(x) :- d.Deriv(x).
-AOut(x) :- a.Base(x).
+DerivedOut(x) :- d::Deriv(x).
+AOut(x) :- a::Base(x).

--- a/tests/example/comp-parametrized-multilvl/comp-parametrized-multilvl.dl
+++ b/tests/example/comp-parametrized-multilvl/comp-parametrized-multilvl.dl
@@ -22,7 +22,7 @@
 .comp NumSelector<T> {
     .init generator = T
     .decl Selected(n: number)
-    Selected(n) :- generator.R(n), generator.R(n*2).
+    Selected(n) :- generator::R(n), generator.R(n*2).
 }
 
 .comp GoodNumSelector<T> : NumSelector<T> {
@@ -33,7 +33,7 @@
     .init selector = TSelector<TGenerator>
     .decl Out(n:number)
 .output Out()
-    Out(x) :- selector.Selected(x).
+    Out(x) :- selector::Selected(x).
 }
 
 .init main1 = Main<NumSelector, LotsOfNumGenerator>

--- a/tests/example/comp-parametrized-multilvl/comp-parametrized-multilvl.dl
+++ b/tests/example/comp-parametrized-multilvl/comp-parametrized-multilvl.dl
@@ -22,7 +22,7 @@
 .comp NumSelector<T> {
     .init generator = T
     .decl Selected(n: number)
-    Selected(n) :- generator::R(n), generator.R(n*2).
+    Selected(n) :- generator::R(n), generator::R(n*2).
 }
 
 .comp GoodNumSelector<T> : NumSelector<T> {

--- a/tests/example/comp-parametrized/comp-parametrized.dl
+++ b/tests/example/comp-parametrized/comp-parametrized.dl
@@ -28,8 +28,8 @@
     .decl NoWayBack(x: number, y: number)
 .output NoWayBack()
     NoWayBack(x, y) :-
-        cg.Node(x), cg.Node(y),
-        cg.CallGraphEdge(x, y), !cg.CallGraphEdge(y, x).
+        cg::Node(x), cg::Node(y),
+        cg::CallGraphEdge(x, y), !cg::CallGraphEdge(y, x).
 }
 
 .init cha_main = Main<CHACallGraph>

--- a/tests/example/dfa/dfa.dl
+++ b/tests/example/dfa/dfa.dl
@@ -209,15 +209,15 @@
       //  in
       //
 
-      gen_kill_intersection.start(node) :- start(node).
+      gen_kill_intersection::start(node) :- start(node).
 
-      gen_kill_intersection.edge(src,des) :- edge(des,src).
+      gen_kill_intersection::edge(src,des) :- edge(des,src).
 
-      gen_kill_intersection.gen(node,inf) :- gen(node,inf).
+      gen_kill_intersection::gen(node,inf) :- gen(node,inf).
 
-      gen_kill_intersection.kill(node,inf) :- kill(node,inf).
+      gen_kill_intersection::kill(node,inf) :- kill(node,inf).
 
-      gen_kill_intersection.startvalue(inf) :- startvalue(inf).
+      gen_kill_intersection::startvalue(inf) :- startvalue(inf).
 
 
       //
@@ -228,7 +228,7 @@
       //  out
       //
 
-      out(node,inf) :- gen_kill_intersection.out(node,inf).
+      out(node,inf) :- gen_kill_intersection::out(node,inf).
 
 }
 
@@ -280,32 +280,32 @@ universe(inf) :- kill(_,inf).
 
 .init Available_Expressions = Gen_Kill_Intersection<number,symbol>
 
-Available_Expressions.edge(x,y) :- edge(x,y).
-Available_Expressions.gen(x,i) :- gen(x,i).
-Available_Expressions.kill(x,i) :- kill(x,i).
-Available_Expressions.startvalue(inf) :-  universe(inf),!kill(1,inf).
-Available_Expressions.start(1).
+Available_Expressions::edge(x,y) :- edge(x,y).
+Available_Expressions::gen(x,i) :- gen(x,i).
+Available_Expressions::kill(x,i) :- kill(x,i).
+Available_Expressions::startvalue(inf) :-  universe(inf),!kill(1,inf).
+Available_Expressions::start(1).
 
 
 
 .init Reaching_Definitions = Gen_Kill_Union<number,symbol>
 
-Reaching_Definitions.edge(x,y) :- edge(x,y).
-Reaching_Definitions.gen(x,i) :- gen(x,i).
-Reaching_Definitions.kill(x,i) :- kill(x,i).
-Reaching_Definitions.startvalue(i) :- gen(1,i), !kill(1,i).
-Reaching_Definitions.start(1).
+Reaching_Definitions::edge(x,y) :- edge(x,y).
+Reaching_Definitions::gen(x,i) :- gen(x,i).
+Reaching_Definitions::kill(x,i) :- kill(x,i).
+Reaching_Definitions::startvalue(i) :- gen(1,i), !kill(1,i).
+Reaching_Definitions::start(1).
 
 
 
 
 .init Live_Variables = Gen_Kill_Union_Backward<number,symbol>
 
-Live_Variables.edge(x,y) :- edge(x,y).
-Live_Variables.gen(x,i) :- use(x,i).
-Live_Variables.kill(x,i) :- kill(x,i).
-Live_Variables.startvalue(i) :- use(8,i), !kill(8,i).
-Live_Variables.start(8).
+Live_Variables::edge(x,y) :- edge(x,y).
+Live_Variables::gen(x,i) :- use(x,i).
+Live_Variables::kill(x,i) :- kill(x,i).
+Live_Variables::startvalue(i) :- use(8,i), !kill(8,i).
+Live_Variables::start(8).
 
 
 //
@@ -314,17 +314,17 @@ Live_Variables.start(8).
 
 .decl available_expressions(n:number, i:symbol)
 .output available_expressions()
-available_expressions(x,i) :- Available_Expressions.out(x,i).
+available_expressions(x,i) :- Available_Expressions::out(x,i).
 
 
 .decl reaching_definitions(n:number, i:symbol)
 .output reaching_definitions()
-reaching_definitions(x,i) :- Reaching_Definitions.out(x,i).
+reaching_definitions(x,i) :- Reaching_Definitions::out(x,i).
 
 
 .decl live_variables(n:number, i:symbol)
 .output live_variables()
-live_variables(x,i) :- Live_Variables.out(x,i).
+live_variables(x,i) :- Live_Variables::out(x,i).
 
 
 

--- a/tests/example/dfa/dfa.dl
+++ b/tests/example/dfa/dfa.dl
@@ -135,15 +135,15 @@
 
       .init   gen_kill_union = Gen_Kill_Union<Node,InfoLattice>
 
-      gen_kill_union.start(n) :- start(n).
+      gen_kill_union::start(n) :- start(n).
 
-      gen_kill_union.edge(x,y) :- edge(x,y).
+      gen_kill_union::edge(x,y) :- edge(x,y).
 
-      gen_kill_union.gen(node,inf) :- kill(node,inf), !gen(node,inf).
+      gen_kill_union::gen(node,inf) :- kill(node,inf), !gen(node,inf).
 
-      gen_kill_union.kill(node,inf) :- gen(node,inf).
+      gen_kill_union::kill(node,inf) :- gen(node,inf).
 
-      gen_kill_union.startvalue(inf) :- startvalue(inf).
+      gen_kill_union::startvalue(inf) :- startvalue(inf).
 
 
       //
@@ -154,7 +154,7 @@
       //  out
       //
 
-      out(node,inf) :- node(node), universe(inf), !gen_kill_union.out(node,inf).
+      out(node,inf) :- node(node), universe(inf), !gen_kill_union::out(node,inf).
 }
 
 
@@ -172,15 +172,15 @@
 
       .init gen_kill_union = Gen_Kill_Union<Node,InfoLattice>
 
-      gen_kill_union.start(node) :- start(node).
+      gen_kill_union::start(node) :- start(node).
 
-      gen_kill_union.edge(src,des) :- edge(des,src).
+      gen_kill_union::edge(src,des) :- edge(des,src).
 
-      gen_kill_union.gen(node,inf) :- gen(node,inf).
+      gen_kill_union::gen(node,inf) :- gen(node,inf).
 
-      gen_kill_union.kill(node,inf) :- kill(node,inf).
+      gen_kill_union::kill(node,inf) :- kill(node,inf).
 
-      gen_kill_union.startvalue(inf) :- startvalue(inf).
+      gen_kill_union::startvalue(inf) :- startvalue(inf).
 
 
       //
@@ -191,7 +191,7 @@
       //  out
       //
 
-      out(node,inf) :- gen_kill_union.out(node,inf).
+      out(node,inf) :- gen_kill_union::out(node,inf).
 }
 
 .comp Gen_Kill_Intersection_Backward<Node,InfoLattice> : Gen_Kill<Node,InfoLattice>, Graph<Node>{

--- a/tests/example/dfa_summary_function/dfa_summary_function.dl
+++ b/tests/example/dfa_summary_function/dfa_summary_function.dl
@@ -121,21 +121,21 @@
 
       .init   gen_kill_union = Gen_Kill_Union_Summary<Node,InfoLattice>
 
-      gen_kill_union.start(n) :- start(n).
+      gen_kill_union::start(n) :- start(n).
 
-      gen_kill_union.edge(x,y) :- edge(x,y).
+      gen_kill_union::edge(x,y) :- edge(x,y).
 
-      gen_kill_union.gen(node,inf) :- kill(node,inf), !gen(node,inf).
+      gen_kill_union::gen(node,inf) :- kill(node,inf), !gen(node,inf).
 
-      gen_kill_union.kill(node,inf) :- gen(node,inf).
+      gen_kill_union::kill(node,inf) :- gen(node,inf).
 
-      gen_kill_union.startvalue(inf) :- startvalue(inf).
+      gen_kill_union::startvalue(inf) :- startvalue(inf).
 
 
       //
       // output relations
       //
-      out(node,inf) :- node(node), universe(inf), !gen_kill_union.out(node,inf).
+      out(node,inf) :- node(node), universe(inf), !gen_kill_union::out(node,inf).
 }
 
 
@@ -149,21 +149,21 @@
       //  in
       //
 
-      gen_kill_union.start(n) :- start(n).
+      gen_kill_union::start(n) :- start(n).
 
-      gen_kill_union.edge(src,des) :- edge(des,src).
+      gen_kill_union::edge(src,des) :- edge(des,src).
 
-      gen_kill_union.gen(node,inf) :- gen(node,inf).
+      gen_kill_union::gen(node,inf) :- gen(node,inf).
 
-      gen_kill_union.kill(node,inf) :- kill(node,inf).
+      gen_kill_union::kill(node,inf) :- kill(node,inf).
 
-      gen_kill_union.startvalue(inf) :- startvalue(inf).
+      gen_kill_union::startvalue(inf) :- startvalue(inf).
 
       //
       // output relations
       //
 
-      out(node,inf) :- gen_kill_union.out(node,inf).
+      out(node,inf) :- gen_kill_union::out(node,inf).
 }
 
 .comp Gen_Kill_Intersection_Summary_Backward<Node,InfoLattice> : Gen_Kill_Summary<Node,InfoLattice>, Graph<Node>{
@@ -180,21 +180,21 @@
       //
       //  in
       //
-      gen_kill_intersection.start(n) :- start(n).
+      gen_kill_intersection::start(n) :- start(n).
 
-      gen_kill_intersection.edge(src,des) :- edge(des,src).
+      gen_kill_intersection::edge(src,des) :- edge(des,src).
 
-      gen_kill_intersection.gen(node,inf) :- gen(node,inf).
+      gen_kill_intersection::gen(node,inf) :- gen(node,inf).
 
-      gen_kill_intersection.kill(node,inf) :- kill(node,inf).
+      gen_kill_intersection::kill(node,inf) :- kill(node,inf).
 
-      gen_kill_intersection.startvalue(inf) :- startvalue(inf).
+      gen_kill_intersection::startvalue(inf) :- startvalue(inf).
 
       //
       // output relations
       //
 
-      out(node,inf) :- gen_kill_intersection.out(node,inf).
+      out(node,inf) :- gen_kill_intersection::out(node,inf).
 
 }
 
@@ -243,33 +243,33 @@ universe(inf) :- kill(_,inf).
 
 .init Available_Expressions = Gen_Kill_Intersection_Summary<number,symbol>
 
-Available_Expressions.edge(x,y) :- edge(x,y).
-Available_Expressions.gen(x,i) :- gen(x,i).
-Available_Expressions.kill(x,i) :- kill(x,i).
-//Available_Expressions.startvalue(i) :- gen(1,i), !kill(1,i).
-Available_Expressions.startvalue(inf) :-  universe(inf),!kill(1,inf).
-Available_Expressions.start(1).
+Available_Expressions::edge(x,y) :- edge(x,y).
+Available_Expressions::gen(x,i) :- gen(x,i).
+Available_Expressions::kill(x,i) :- kill(x,i).
+//Available_Expressions::startvalue(i) :- gen(1,i), !kill(1,i).
+Available_Expressions::startvalue(inf) :-  universe(inf),!kill(1,inf).
+Available_Expressions::start(1).
 
 
 
 .init Reaching_Definitions = Gen_Kill_Union_Summary<number,symbol>
 
-Reaching_Definitions.edge(x,y) :- edge(x,y).
-Reaching_Definitions.gen(x,i) :- gen(x,i).
-Reaching_Definitions.kill(x,i) :- kill(x,i).
-Reaching_Definitions.startvalue(i) :- gen(1,i), !kill(1,i).
-Reaching_Definitions.start(1).
+Reaching_Definitions::edge(x,y) :- edge(x,y).
+Reaching_Definitions::gen(x,i) :- gen(x,i).
+Reaching_Definitions::kill(x,i) :- kill(x,i).
+Reaching_Definitions::startvalue(i) :- gen(1,i), !kill(1,i).
+Reaching_Definitions::start(1).
 
 
 
 
 .init Live_Variables = Gen_Kill_Union_Summary_Backward<number,symbol>
 
-Live_Variables.edge(x,y) :- edge(x,y).
-Live_Variables.gen(x,i) :- use(x,i).
-Live_Variables.kill(x,i) :- kill(x,i).
-Live_Variables.startvalue(i) :- use(8,i), !kill(8,i).
-Live_Variables.start(8).
+Live_Variables::edge(x,y) :- edge(x,y).
+Live_Variables::gen(x,i) :- use(x,i).
+Live_Variables::kill(x,i) :- kill(x,i).
+Live_Variables::startvalue(i) :- use(8,i), !kill(8,i).
+Live_Variables::start(8).
 
 
 //
@@ -278,15 +278,15 @@ Live_Variables.start(8).
 
 .decl available_expressions(n:number, i:symbol)
 .output available_expressions()
-available_expressions(x,i) :- Available_Expressions.out(x,i).
+available_expressions(x,i) :- Available_Expressions::out(x,i).
 
 
 .decl reaching_definitions(n:number, i:symbol)
 .output reaching_definitions()
-reaching_definitions(x,i) :- Reaching_Definitions.out(x,i).
+reaching_definitions(x,i) :- Reaching_Definitions::out(x,i).
 
 
 .decl live_variables(n:number, i:symbol)
 .output live_variables()
-live_variables(x,i) :- Live_Variables.out(x,i).
+live_variables(x,i) :- Live_Variables::out(x,i).
 

--- a/tests/example/dominance/dominance.dl
+++ b/tests/example/dominance/dominance.dl
@@ -119,23 +119,23 @@
 
 .init ImmDom = ImmediateDominance<number>
 
-ImmDom.edge(1, 2).
-ImmDom.edge(1, 3).
-ImmDom.edge(2, 3).
-ImmDom.edge(4, 3).
-ImmDom.edge(8, 3).
-ImmDom.edge(3, 4).
-ImmDom.edge(8, 4).
-ImmDom.edge(4, 5).
-ImmDom.edge(4, 6).
-ImmDom.edge(5, 7).
-ImmDom.edge(6, 7).
-ImmDom.edge(10, 7).
-ImmDom.edge(7, 8).
-ImmDom.edge(8, 9).
-ImmDom.edge(8, 10).
-ImmDom.edge(9, 1).
-ImmDom.start(1).
+ImmDom::edge(1, 2).
+ImmDom::edge(1, 3).
+ImmDom::edge(2, 3).
+ImmDom::edge(4, 3).
+ImmDom::edge(8, 3).
+ImmDom::edge(3, 4).
+ImmDom::edge(8, 4).
+ImmDom::edge(4, 5).
+ImmDom::edge(4, 6).
+ImmDom::edge(5, 7).
+ImmDom::edge(6, 7).
+ImmDom::edge(10, 7).
+ImmDom::edge(7, 8).
+ImmDom::edge(8, 9).
+ImmDom::edge(8, 10).
+ImmDom::edge(9, 1).
+ImmDom::start(1).
 
 
 //
@@ -144,7 +144,7 @@ ImmDom.start(1).
 
 .decl dominators(n:number,s:number)
 .output dominators()
-dominators(n,s) :- ImmDom.dom(n,s).
+dominators(n,s) :- ImmDom::dom(n,s).
 
 
 //
@@ -153,6 +153,6 @@ dominators(n,s) :- ImmDom.dom(n,s).
 
 .decl immediate_dom(n:number,s:number)
 .output immediate_dom()
-immediate_dom(n,s) :- ImmDom.imdom(n,s).
+immediate_dom(n,s) :- ImmDom::imdom(n,s).
 
 

--- a/tests/example/nfsa2fsa/nfsa2fsa.dl
+++ b/tests/example/nfsa2fsa/nfsa2fsa.dl
@@ -72,18 +72,18 @@
 
 	// private
 	.init Word = Vector<TAlpha, TWord>
-	Word.size(x) :- max_acceptance_size(x).
-	Word.element(x) :- alphabet(x).
+	Word::size(x) :- max_acceptance_size(x).
+	Word::element(x) :- alphabet(x).
 
 	// output
 	.decl accepts(w: TWord)
 	.decl accepts_from_state(w: TWord, s: TState)
 
-	accepts(w) :- Word.sublist(w), start_state(s), accepts_from_state(w, s).
+	accepts(w) :- Word::sublist(w), start_state(s), accepts_from_state(w, s).
 
 	accepts_from_state(nil, s) :- final(s).
 	accepts_from_state(*TWord[h, t], s) :-
-		alphabet(h), state(s), Word.sublist(t),
+		alphabet(h), state(s), Word::sublist(t),
 		tr(s, q, h), accepts_from_state(t, q).
 }
 
@@ -95,55 +95,55 @@
 
 .type Word = [ c : Letter, r : Word ]
 .init Nfsa = Automaton<N, Letter, Word>
-Nfsa.start_state(1).
-Nfsa.state(s) :- state(s).
-Nfsa.final(fs) :- fs = max s : { state(s) }.
-Nfsa.alphabet(c) :- alphabet(c).
-Nfsa.max_acceptance_size(5).
-Nfsa.tr(s, q, c) :- tr(s, q, c).
+Nfsa::start_state(1).
+Nfsa::state(s) :- state(s).
+Nfsa::final(fs) :- fs = max s : { state(s) }.
+Nfsa::alphabet(c) :- alphabet(c).
+Nfsa::max_acceptance_size(5).
+Nfsa::tr(s, q, c) :- tr(s, q, c).
 
 // FSA state is bitvector that represents the set of NFSA states
 .init FsaState = Vector<N, NumberList>
-FsaState.size(sz) :- Nfsa.final(sz).
-FsaState.element(0).
-FsaState.element(1).
+FsaState::size(sz) :- Nfsa::final(sz).
+FsaState::element(0).
+FsaState::element(1).
 
 
 .decl not_fsa_start_state(s: NumberList)
-not_fsa_start_state(s) :- FsaState.member_at(s, x, 1), !Nfsa.start_state(as(x,N)).
+not_fsa_start_state(s) :- FsaState::member_at(s, x, 1), !Nfsa::start_state(as(x,N)).
 
 .init Fsa = Automaton<NumberList, Letter, Word>
-Fsa.state(s) :- FsaState.vector(s).
-Fsa.start_state(s) :- FsaState.member_at(s, nfsa_init, 1), Nfsa.start_state(nfsa_init), !not_fsa_start_state(s).
-Fsa.final(s) :- Nfsa.final(fin), FsaState.member_at(s, fin, 1).
-Fsa.alphabet(c) :- alphabet(c).
-Fsa.max_acceptance_size(5).
+Fsa::state(s) :- FsaState::vector(s).
+Fsa::start_state(s) :- FsaState::member_at(s, nfsa_init, 1), Nfsa::start_state(nfsa_init), !not_fsa_start_state(s).
+Fsa::final(s) :- Nfsa::final(fin), FsaState::member_at(s, fin, 1).
+Fsa::alphabet(c) :- alphabet(c).
+Fsa::max_acceptance_size(5).
 
 // the result of the conversion is this relation that
 // defines the transitions of the resulting FSA
-Fsa.tr(s, q, a) :-
-	FsaState.vector(s), FsaState.vector(q), Nfsa.alphabet(a),
+Fsa::tr(s, q, a) :-
+	FsaState::vector(s), FsaState::vector(q), Nfsa::alphabet(a),
 	!not_fsa_tr(s, q, a), // negation of negation helps us to get rid of quantification (for all)
-	Nfsa.tr(x, y, a),		// this is so that there is at least one transition between the two states
-	FsaState.member_at(s, x, 1), FsaState.member_at(q, y, 1). // this is so that s,q (the states) are not empty sets
+	Nfsa::tr(x, y, a),		// this is so that there is at least one transition between the two states
+	FsaState::member_at(s, x, 1), FsaState::member_at(q, y, 1). // this is so that s,q (the states) are not empty sets
 
 
 .decl has_x(s: NumberList, y: N, a: Letter) // does the list have some 'x' for which tr(x, y, a)?
-has_x(S, y, a) :- FsaState.member_at(S, x, 1), Nfsa.tr(x,y,a).
+has_x(S, y, a) :- FsaState::member_at(S, x, 1), Nfsa::tr(x,y,a).
 
 .decl not_fsa_tr(s: NumberList, q: NumberList, a: Letter)
 
 // it is not fsa transition if have some x from S and tr(x,y,a) for such y that is not member of Q
 // i.e. Q is missing some target states
 not_fsa_tr(s, q, a) :-
-	FsaState.vector(s), FsaState.vector(q), Nfsa.alphabet(a),
-	Nfsa.tr(x, y, a), FsaState.member_at(s, x, 1), !FsaState.member_at(q, y, 1).
+	FsaState::vector(s), FsaState::vector(q), Nfsa::alphabet(a),
+	Nfsa::tr(x, y, a), FsaState::member_at(s, x, 1), !FsaState::member_at(q, y, 1).
 
 // it is not fsa transition if for y from Q there is no x from S such that tr(x,y,a):
 // i.e. Q has got some more states than it should
 not_fsa_tr(s, q, a) :-
-	FsaState.vector(s), FsaState.vector(q), Nfsa.alphabet(a),
-	FsaState.member_at(q, y, 1), !has_x(s, as(y,N), a).
+	FsaState::vector(s), FsaState::vector(q), Nfsa::alphabet(a),
+	FsaState::member_at(q, y, 1), !has_x(s, as(y,N), a).
 
 
 // -------------------------------------------------------
@@ -158,21 +158,21 @@ not_fsa_tr(s, q, a) :-
 .type String
 .decl fsa_state_to_str(state: NumberList, str: String)
 fsa_state_to_str(nil, " ").
-fsa_state_to_str(*NumberList[0,t], as(cat("0", str),String)) :- FsaState.sublist(t), fsa_state_to_str(t, str).
-fsa_state_to_str(*NumberList[1,t], as(cat("1", str),String)) :- FsaState.sublist(t), fsa_state_to_str(t, str).
+fsa_state_to_str(*NumberList[0,t], as(cat("0", str),String)) :- FsaState::sublist(t), fsa_state_to_str(t, str).
+fsa_state_to_str(*NumberList[1,t], as(cat("1", str),String)) :- FsaState::sublist(t), fsa_state_to_str(t, str).
 
 .decl word_to_str(word: Word, str: String)
 word_to_str(nil, " ").
-word_to_str(*Word[h,t], as(cat(h, str),String)) :- Fsa.alphabet(h), Fsa.Word.sublist(t), word_to_str(t, str).
+word_to_str(*Word[h,t], as(cat(h, str),String)) :- Fsa::alphabet(h), Fsa::Word::sublist(t), word_to_str(t, str).
 
 .decl fsa_accepted(w: String)
 .output fsa_accepted()
-fsa_accepted(w) :- Fsa.accepts(list), word_to_str(list, w).
+fsa_accepted(w) :- Fsa::accepts(list), word_to_str(list, w).
 
 .decl nfsa_accepted(w: String)
 .output nfsa_accepted()
-nfsa_accepted(w) :- Nfsa.accepts(list), word_to_str(list, w).
+nfsa_accepted(w) :- Nfsa::accepts(list), word_to_str(list, w).
 
 .decl fsa_tr(s: String, q: String, c: Letter)
 .output fsa_tr()
-fsa_tr(s_str, q_str, c) :- Fsa.tr(s, q, c), fsa_state_to_str(s, s_str), fsa_state_to_str(q, q_str).
+fsa_tr(s_str, q_str, c) :- Fsa::tr(s, q, c), fsa_state_to_str(s, s_str), fsa_state_to_str(q, q_str).

--- a/tests/example/strategies/strategies.dl
+++ b/tests/example/strategies/strategies.dl
@@ -41,9 +41,9 @@ less(5,6).
 .init C = QuadraticRecursive
 
 // wire in input data
-A.edge(X,Y) :- less(X,Y).
-B.edge(X,Y) :- less(X,Y).
-C.edge(X,Y) :- less(X,Y).
+A::edge(X,Y) :- less(X,Y).
+B::edge(X,Y) :- less(X,Y).
+C::edge(X,Y) :- less(X,Y).
 
 
 

--- a/tests/semantic/comp_inner_types/comp_inner_types.dl
+++ b/tests/semantic/comp_inner_types/comp_inner_types.dl
@@ -34,16 +34,16 @@
 .init comp = Component
 
 // depends on the inner component types
-.decl outer_rel1(x: comp.InnerRecord)
-outer_rel1(*comp.InnerRecord["x", 1]).
-.decl out1(x: comp.T1, y: comp.T2)
-out1(x,y) :- outer_rel1(*comp.InnerRecord[x,y]).
+.decl outer_rel1(x: comp::InnerRecord)
+outer_rel1(*comp::InnerRecord["x", 1]).
+.decl out1(x: comp::T1, y: comp::T2)
+out1(x,y) :- outer_rel1(*comp::InnerRecord[x,y]).
 .output out1()
 
 // depends on the inner component types
-.decl outer_rel2(x: comp.InnerUnion)
+.decl outer_rel2(x: comp::InnerUnion)
 outer_rel2(1).
-.decl out2(x: comp.InnerUnion)
+.decl out2(x: comp::InnerUnion)
 out2(x) :- outer_rel2(x).
 .output out2()
 

--- a/tests/semantic/comp_nonexistent_type/comp_nonexistent_type.dl
+++ b/tests/semantic/comp_nonexistent_type/comp_nonexistent_type.dl
@@ -22,8 +22,8 @@
     .decl TwoWays(x: number, y: number)
 .output TwoWays()
     TwoWays(x, y) :-
-        cg.CallGraphEdge(x, y),
-        cg.CallGraphEdge(y, x).
+        cg::CallGraphEdge(x, y),
+        cg::CallGraphEdge(y, x).
 }
 
 .init cha_main = Main<CICallGraph>

--- a/tests/semantic/comp_params_inheritance/comp_params_inheritance.dl
+++ b/tests/semantic/comp_params_inheritance/comp_params_inheritance.dl
@@ -7,7 +7,7 @@
 .comp A<T> {
     .init impl = T
     .decl Base(x: number)
-    Base(x) :- impl.R(x).
+    Base(x) :- impl::R(x).
 }
 
 .comp Derived<K> : A<T> {
@@ -24,5 +24,5 @@
 .decl AOut(x: number)
 .output AOut()
 
-DerivedOut(x) :- d.Deriv(x).
-AOut(x) :- a.Base(x).
+DerivedOut(x) :- d::Deriv(x).
+AOut(x) :- a::Base(x).

--- a/tests/semantic/comp_params_inheritance/comp_params_inheritance.err
+++ b/tests/semantic/comp_params_inheritance/comp_params_inheritance.err
@@ -1,5 +1,5 @@
 Error: Undefined relation impl::R in file comp_params_inheritance.dl at line 10
     Base(x) :- impl::R(x).
----------------^----------
+---------------^-----------
 Error: Not all clauses could be typechecked due to other errors present
 2 errors generated, evaluation aborted

--- a/tests/semantic/comp_params_inheritance/comp_params_inheritance.err
+++ b/tests/semantic/comp_params_inheritance/comp_params_inheritance.err
@@ -1,5 +1,5 @@
-Error: Undefined relation impl.R in file comp_params_inheritance.dl at line 10
-    Base(x) :- impl.R(x).
+Error: Undefined relation impl::R in file comp_params_inheritance.dl at line 10
+    Base(x) :- impl::R(x).
 ---------------^----------
 Error: Not all clauses could be typechecked due to other errors present
 2 errors generated, evaluation aborted

--- a/tests/semantic/comp_types/comp_types.dl
+++ b/tests/semantic/comp_types/comp_types.dl
@@ -16,9 +16,9 @@
 
 
 // this should be fine
-.decl relX( a : x.inner )
-.decl relY( a : y.inner )
-.decl relZ( a : z.inner )
+.decl relX( a : x::inner )
+.decl relY( a : y::inner )
+.decl relZ( a : z::inner )
 
 
 // all relations should have different types

--- a/tests/semantic/comp_types/comp_types.err
+++ b/tests/semantic/comp_types/comp_types.err
@@ -1,19 +1,19 @@
-Error: Relation expects value of type x.inner but got argument of type y.inner in file comp_types.dl at line 26
+Error: Relation expects value of type x::inner but got argument of type y::inner in file comp_types.dl at line 26
 relX(x) :- relY(x).
 -----^--------------
-Error: Relation expects value of type x.inner but got argument of type z.inner in file comp_types.dl at line 27
+Error: Relation expects value of type x::inner but got argument of type z::inner in file comp_types.dl at line 27
 relX(x) :- relZ(x).
 -----^--------------
-Error: Relation expects value of type y.inner but got argument of type x.inner in file comp_types.dl at line 29
+Error: Relation expects value of type y::inner but got argument of type x::inner in file comp_types.dl at line 29
 relY(x) :- relX(x).
 -----^--------------
-Error: Relation expects value of type y.inner but got argument of type z.inner in file comp_types.dl at line 31
+Error: Relation expects value of type y::inner but got argument of type z::inner in file comp_types.dl at line 31
 relY(x) :- relZ(x).
 -----^--------------
-Error: Relation expects value of type z.inner but got argument of type x.inner in file comp_types.dl at line 33
+Error: Relation expects value of type z::inner but got argument of type x::inner in file comp_types.dl at line 33
 relZ(x) :- relX(x).
 -----^--------------
-Error: Relation expects value of type z.inner but got argument of type y.inner in file comp_types.dl at line 34
+Error: Relation expects value of type z::inner but got argument of type y::inner in file comp_types.dl at line 34
 relZ(x) :- relY(x).
 -----^--------------
 6 errors generated, evaluation aborted

--- a/tests/semantic/disjoint_names/disjoint_names.dl
+++ b/tests/semantic/disjoint_names/disjoint_names.dl
@@ -46,7 +46,7 @@ relinst(2).
 }
 
 .init nestedInst = nested
-typerel(X) :- nestedInst.nesteditem(X).
+typerel(X) :- nestedInst::nesteditem(X).
 
 .decl nesteditem(x:number)
 .output nesteditem()

--- a/tests/semantic/type_udef/type_udef.err
+++ b/tests/semantic/type_udef/type_udef.err
@@ -16,10 +16,10 @@ B(as(1,undef)).                             // error
 Error: Type undef has not been declared in file type_udef.dl at line 14
 B(*undef[1]).                               // error
 --^--------------------------------------------------
-Error: Undefined type undef in definition of union type c.U1 in file type_udef.dl at line 16
+Error: Undefined type undef in definition of union type c::U1 in file type_udef.dl at line 16
     .type U1 = undef | symbol               // error
 ----^------------------------------------------------
-Error: Undefined type undef in definition of union type c.U2 in file type_udef.dl at line 17
+Error: Undefined type undef in definition of union type c::U2 in file type_udef.dl at line 17
     .type U2 = number | T                   // error
 ----^------------------------------------------------
 Error: Undefined type undef in definition of field x in file type_udef.dl at line 18
@@ -28,13 +28,13 @@ Error: Undefined type undef in definition of field x in file type_udef.dl at lin
 Error: Undefined type undef in definition of field y in file type_udef.dl at line 19
     .type R2 = [ y : T ]                    // error
 ----^------------------------------------------------
-Warning: No rules/facts defined for relation c.A1 in file type_udef.dl at line 20
+Warning: No rules/facts defined for relation c::A1 in file type_udef.dl at line 20
     .decl A1(x : undef)                     // error
 ----------^------------------------------------------
 Error: Undefined type in attribute x:undef in file type_udef.dl at line 20
     .decl A1(x : undef)                     // error
 -----------------^-----------------------------------
-Warning: No rules/facts defined for relation c.A2 in file type_udef.dl at line 21
+Warning: No rules/facts defined for relation c::A2 in file type_udef.dl at line 21
     .decl A2(x : T)                         // error
 ----------^------------------------------------------
 Error: Undefined type in attribute x:undef in file type_udef.dl at line 21

--- a/tests/syntactic/name_clash/name_clash.dl
+++ b/tests/syntactic/name_clash/name_clash.dl
@@ -20,7 +20,7 @@
 .decl boolean_value(X:number)
 .output boolean_value()
 
-boolean_value(X) :- boolean.value(X).
+boolean_value(X) :- boolean::value(X).
 
-boolean.value(1).
+boolean::value(1).
 

--- a/tests/syntactic/syntax4/syntax4.err
+++ b/tests/syntactic/syntax4/syntax4.err
@@ -1,4 +1,4 @@
-Error: syntax error, unexpected /, expecting ( or . in file syntax4.dl at line 24
+Error: syntax error, unexpected /, expecting ( or :: in file syntax4.dl at line 24
 blah /
 -----^-
 1 errors generated, evaluation aborted

--- a/tests/syntactic/syntax7/syntax7.err
+++ b/tests/syntactic/syntax7/syntax7.err
@@ -1,4 +1,4 @@
-Error: syntax error, unexpected %, expecting ( or . in file syntax7.dl at line 7
+Error: syntax error, unexpected %, expecting ( or :: in file syntax7.dl at line 7
         blah %
 -------------^-
 1 errors generated, evaluation aborted

--- a/tests/syntactic/union_comp_type/union_comp_type.dl
+++ b/tests/syntactic/union_comp_type/union_comp_type.dl
@@ -22,5 +22,5 @@
 .init helloinit = hello
 .init byeinit = bye
 
-.type blah = helloinit.thing
-.type bleh = helloinit.thing | byeinit.thing1 | byeinit.thing2 | byeinit.subhello.thing | other_type
+.type blah = helloinit::thing
+.type bleh = helloinit::thing | byeinit::thing1 | byeinit::thing2 | byeinit::subhello::thing | other_type


### PR DESCRIPTION
(Typesystem Branch Change)

E.g.

```
.comp blah {
    .decl sub(x:number)
    sub(0).
}

.init x = comp
.output x.sub()
```

is now written as

```
.comp blah {
    .decl sub(x:number)
    sub(0).
}

.init x = comp
.output x::sub()
```

All tests have been (painfully) updated to match this change.

The only tests that should be failing are `semantic/records7` and `example/euclid`, which are unrelated.