### PR TITLE
RAM Refactoring: Abstract classes

### DIFF
--- a/src/RamExpression.h
+++ b/src/RamExpression.h
@@ -80,6 +80,12 @@ public:
 protected:
     /** Arguments of user defined operator */
     std::vector<std::unique_ptr<RamExpression>> arguments;
+
+    bool equal(const RamNode& node) const override {
+        assert(nullptr != dynamic_cast<const RamAbstractOperator*>(&node));
+        const auto& other = static_cast<const RamAbstractOperator&>(node);
+        return equal_targets(arguments, other.arguments);
+    }
 };
 
 /**
@@ -130,9 +136,8 @@ protected:
     const FunctorOp operation;
 
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamIntrinsicOperator*>(&node));
         const auto& other = static_cast<const RamIntrinsicOperator&>(node);
-        return getOperator() == other.getOperator() && equal_targets(arguments, other.arguments);
+        return getOperator() == other.getOperator() && RamAbstractOperator::equal(node);
     }
 };
 
@@ -178,9 +183,8 @@ protected:
     const std::string type;
 
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamUserDefinedOperator*>(&node));
         const auto& other = static_cast<const RamUserDefinedOperator&>(node);
-        return name == other.name && type == other.type && equal_targets(arguments, other.arguments);
+        return name == other.name && type == other.type && RamAbstractOperator::equal(node);
     }
 };
 

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -583,6 +583,13 @@ protected:
 
     /** Aggregation tuple condition */
     std::unique_ptr<RamCondition> condition;
+
+    bool equal(const RamNode& node) const {
+        assert(nullptr != dynamic_cast<const RamAbstractAggregate*>(&node));
+        const auto& other = dynamic_cast<const RamAbstractAggregate*>(&node);
+        return getCondition() == other->getCondition() && getFunction() == other->getFunction() &&
+               getExpression() == other->getExpression();
+    }
 };
 
 /**
@@ -630,10 +637,8 @@ public:
 
 protected:
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamAggregate*>(&node));
         const auto& other = static_cast<const RamAggregate&>(node);
-        return RamRelationSearch::equal(other) && getCondition() == other.getCondition() &&
-               getFunction() == other.getFunction() && getExpression() == other.getExpression();
+        return RamRelationSearch::equal(other) && RamAbstractAggregate::equal(node);
     }
 };
 
@@ -688,10 +693,8 @@ public:
 
 protected:
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamIndexAggregate*>(&node));
-        const auto& other = static_cast<const RamIndexAggregate&>(node);
-        return RamIndexRelationSearch::equal(other) && getCondition() == other.getCondition() &&
-               getFunction() == other.getFunction() && getExpression() == other.getExpression();
+        const auto& other = static_cast<const RamAggregate&>(node);
+        return RamIndexRelationSearch::equal(other) && RamAbstractAggregate::equal(node);
     }
 };
 
@@ -780,6 +783,12 @@ public:
 protected:
     /** Condition */
     std::unique_ptr<RamCondition> condition;
+
+    bool equal(const RamNode& node) const override {
+        assert(nullptr != dynamic_cast<const RamAbstractConditional*>(&node));
+        const auto& other = static_cast<const RamAbstractConditional&>(node);
+        return RamNestedOperation::equal(node) && getCondition() == other.getCondition();
+    }
 };
 
 /**
@@ -804,9 +813,7 @@ public:
 
 protected:
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamFilter*>(&node));
-        const auto& other = static_cast<const RamFilter&>(node);
-        return RamNestedOperation::equal(node) && getCondition() == other.getCondition();
+        return RamAbstractConditional::equal(node);
     }
 };
 
@@ -832,9 +839,7 @@ public:
 
 protected:
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamBreak*>(&node));
-        const auto& other = static_cast<const RamBreak&>(node);
-        return RamNestedOperation::equal(node) && getCondition() == other.getCondition();
+        return RamAbstractConditional::equal(node);
     }
 };
 

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -779,9 +779,9 @@ protected:
  */
 class RamAbstractConditional : public RamNestedOperation {
 public:
-	RamAbstractConditional(std::unique_ptr<RamCondition> cond, std::unique_ptr<RamOperation> nested,
+    RamAbstractConditional(std::unique_ptr<RamCondition> cond, std::unique_ptr<RamOperation> nested,
             std::string profileText = "")
-		: RamNestedOperation(std::move(nested), std::move(profileText)), condition(std::move(cond)) {}
+            : RamNestedOperation(std::move(nested), std::move(profileText)), condition(std::move(cond)) {}
 
     /** Get condition */
     const RamCondition& getCondition() const {
@@ -812,7 +812,7 @@ class RamFilter : public RamAbstractConditional {
 public:
     RamFilter(std::unique_ptr<RamCondition> cond, std::unique_ptr<RamOperation> nested,
             std::string profileText = "")
-			: RamAbstractConditional(std::move(cond), std::move(nested), std::move(profileText)) {}
+            : RamAbstractConditional(std::move(cond), std::move(nested), std::move(profileText)) {}
 
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
@@ -840,7 +840,7 @@ class RamBreak : public RamAbstractConditional {
 public:
     RamBreak(std::unique_ptr<RamCondition> cond, std::unique_ptr<RamOperation> nested,
             std::string profileText = "")
-			: RamAbstractConditional(std::move(cond), std::move(nested), std::move(profileText)) {}
+            : RamAbstractConditional(std::move(cond), std::move(nested), std::move(profileText)) {}
 
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -113,6 +113,12 @@ public:
 protected:
     /** load directives of a relation */
     const std::vector<IODirectives> ioDirectives;
+
+    bool equal(const RamNode& node) const override {
+        assert(nullptr != dynamic_cast<const RamAbstractLoadStore*>(&node));
+        const auto& other = static_cast<const RamAbstractLoadStore&>(node);
+        return RamRelationStatement::equal(other) && getIODirectives() == other.getIODirectives();
+    }
 };
 
 /**
@@ -139,9 +145,7 @@ public:
 
 protected:
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamLoad*>(&node));
-        const auto& other = static_cast<const RamLoad&>(node);
-        return RamRelationStatement::equal(other) && getIODirectives() == other.getIODirectives();
+        return RamAbstractLoadStore::equal(node);
     }
 };
 
@@ -169,9 +173,7 @@ public:
 
 protected:
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamStore*>(&node));
-        const auto& other = static_cast<const RamStore&>(node);
-        return RamRelationStatement::equal(other) && getIODirectives() == other.getIODirectives();
+        return RamAbstractLoadStore::equal(node);
     }
 };
 
@@ -255,6 +257,13 @@ protected:
 
     /** second argument of swap statement */
     std::unique_ptr<RamRelationReference> second;
+
+    bool equal(const RamNode& node) const override {
+        assert(nullptr != dynamic_cast<const RamBinRelationStatement*>(&node));
+        const auto& other = static_cast<const RamBinRelationStatement&>(node);
+        return getFirstRelation() == other.getFirstRelation() &&
+               getSecondRelation() == other.getSecondRelation();
+    }
 };
 
 /**
@@ -290,10 +299,7 @@ public:
 
 protected:
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamMerge*>(&node));
-        const auto& other = static_cast<const RamMerge&>(node);
-        return getTargetRelation() == other.getTargetRelation() &&
-               getSourceRelation() == other.getSourceRelation();
+        return RamBinRelationStatement::equal(node);
     }
 };
 
@@ -318,10 +324,7 @@ public:
 
 protected:
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamSwap*>(&node));
-        const auto& other = static_cast<const RamSwap&>(node);
-        return getFirstRelation() == other.getFirstRelation() &&
-               getSecondRelation() == other.getSecondRelation();
+        return RamBinRelationStatement::equal(node);
     }
 };
 
@@ -456,6 +459,12 @@ public:
 protected:
     /** ordered list of RAM statements */
     std::vector<std::unique_ptr<RamStatement>> statements;
+
+    bool equal(const RamNode& node) const override {
+        assert(nullptr != dynamic_cast<const RamListStatement*>(&node));
+        const auto& other = static_cast<const RamListStatement&>(node);
+        return equal_targets(statements, other.statements);
+    }
 };
 
 /**
@@ -496,9 +505,7 @@ public:
 
 protected:
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamSequence*>(&node));
-        const auto& other = static_cast<const RamSequence&>(node);
-        return equal_targets(statements, other.statements);
+        return RamListStatement::equal(node);
     }
 };
 
@@ -531,9 +538,7 @@ public:
 
 protected:
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamParallel*>(&node));
-        const auto& other = static_cast<const RamParallel&>(node);
-        return equal_targets(statements, other.statements);
+        return RamListStatement::equal(node);
     }
 };
 

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -249,7 +249,6 @@ public:
         second = map(std::move(second));
     }
 
-
 protected:
     /** first argument of swap statement */
     std::unique_ptr<RamRelationReference> first;
@@ -269,12 +268,12 @@ public:
 
     /** Get source relation */
     const RamRelation& getSourceRelation() const {
-		return RamBinRelationStatement::getFirstRelation();
+        return RamBinRelationStatement::getFirstRelation();
     }
 
     /** Get target relation */
     const RamRelation& getTargetRelation() const {
-		return RamBinRelationStatement::getSecondRelation();
+        return RamBinRelationStatement::getSecondRelation();
     }
 
     void print(std::ostream& os, int tabpos) const override {

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -264,16 +264,16 @@ protected:
 class RamMerge : public RamBinRelationStatement {
 public:
     RamMerge(std::unique_ptr<RamRelationReference> tRef, std::unique_ptr<RamRelationReference> sRef)
-            : RamBinRelationStatement(std::move(tRef), std::move(sRef)) {}
+            : RamBinRelationStatement(std::move(sRef), std::move(tRef)) {}
 
     /** Get source relation */
     const RamRelation& getSourceRelation() const {
-        return RamBinRelationStatement::getFirstRelation();
+        return getFirstRelation();
     }
 
     /** Get target relation */
     const RamRelation& getTargetRelation() const {
-        return RamBinRelationStatement::getSecondRelation();
+        return getSecondRelation();
     }
 
     void print(std::ostream& os, int tabpos) const override {

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -98,19 +98,30 @@ public:
 };
 
 /**
- * Load data into a relation
- *
- * TODO (b-scholz): introduce an abstract class for load/store
+ * Abstract class for load/store for a relation
  */
-class RamLoad : public RamRelationStatement {
+class RamAbstractLoadStore : public RamRelationStatement {
 public:
-    RamLoad(std::unique_ptr<RamRelationReference> relRef, std::vector<IODirectives> ioDirectives)
+    RamAbstractLoadStore(std::unique_ptr<RamRelationReference> relRef, std::vector<IODirectives> ioDirectives)
             : RamRelationStatement(std::move(relRef)), ioDirectives(std::move(ioDirectives)) {}
 
     /** Get load directives */
     const std::vector<IODirectives>& getIODirectives() const {
         return ioDirectives;
     }
+
+protected:
+    /** load directives of a relation */
+    const std::vector<IODirectives> ioDirectives;
+};
+
+/**
+ * Load data into a relation
+ */
+class RamLoad : public RamAbstractLoadStore {
+public:
+    RamLoad(std::unique_ptr<RamRelationReference> relRef, std::vector<IODirectives> ioDirectives)
+            : RamAbstractLoadStore(std::move(relRef), std::move(ioDirectives)) {}
 
     void print(std::ostream& os, int tabpos) const override {
         const RamRelation& rel = getRelation();
@@ -127,9 +138,6 @@ public:
     }
 
 protected:
-    /** load directives of a relation */
-    const std::vector<IODirectives> ioDirectives;
-
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamLoad*>(&node));
         const auto& other = static_cast<const RamLoad&>(node);
@@ -140,15 +148,10 @@ protected:
 /**
  * Store data of a relation
  */
-class RamStore : public RamRelationStatement {
+class RamStore : public RamAbstractLoadStore {
 public:
     RamStore(std::unique_ptr<RamRelationReference> relRef, std::vector<IODirectives> ioDirectives)
-            : RamRelationStatement(std::move(relRef)), ioDirectives(std::move(ioDirectives)) {}
-
-    /** Get store directives */
-    const std::vector<IODirectives>& getIODirectives() const {
-        return ioDirectives;
-    }
+            : RamAbstractLoadStore(std::move(relRef), std::move(ioDirectives)) {}
 
     void print(std::ostream& os, int tabpos) const override {
         const RamRelation& rel = getRelation();
@@ -165,9 +168,6 @@ public:
     }
 
 protected:
-    /** store directives of a relation */
-    const std::vector<IODirectives> ioDirectives;
-
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamStore*>(&node));
         const auto& other = static_cast<const RamStore&>(node);

--- a/src/RamVisitor.h
+++ b/src/RamVisitor.h
@@ -75,6 +75,7 @@ struct RamVisitor : public ram_visitor_tag {
 
 #define FORWARD(Kind) \
     if (const auto* n = dynamic_cast<const Ram##Kind*>(&node)) return visit##Kind(*n, args...);
+
         // Relation
         FORWARD(Relation);
         FORWARD(RelationReference);
@@ -170,8 +171,9 @@ protected:
     // -- statements --
     LINK(Create, RelationStatement);
     LINK(Fact, RelationStatement);
-    LINK(Load, RelationStatement);
-    LINK(Store, RelationStatement);
+    LINK(Load, AbstractLoadStore);
+    LINK(Store, AbstractLoadStore);
+    LINK(AbstractLoadStore, RelationStatement);
     LINK(Query, Statement);
     LINK(Clear, RelationStatement);
     LINK(Drop, RelationStatement);
@@ -179,12 +181,14 @@ protected:
 
     LINK(RelationStatement, Statement);
 
-    LINK(Merge, Statement);
-    LINK(Swap, Statement);
+    LINK(Merge, BinRelationStatement);
+    LINK(Swap, BinRelationStatement);
+    LINK(BinRelationStatement, Statement);
 
-    LINK(Sequence, Statement);
+    LINK(Sequence, ListStatement);
     LINK(Loop, Statement);
-    LINK(Parallel, Statement);
+    LINK(Parallel, ListStatement);
+    LINK(ListStatement, Statement);
     LINK(Exit, Statement);
     LINK(LogTimer, Statement);
     LINK(LogRelationTimer, Statement);
@@ -210,42 +214,45 @@ protected:
     LINK(IndexAggregate, IndexRelationSearch);
     LINK(IndexRelationSearch, RelationSearch);
     LINK(Search, NestedOperation);
-    LINK(Filter, NestedOperation);
-    LINK(Break, NestedOperation);
+    LINK(Filter, AbstractConditional);
+    LINK(Break, AbstractConditional);
+    LINK(AbstractConditional, NestedOperation);
     LINK(NestedOperation, Operation);
 
-    LINK(Operation, Node)
+    LINK(Operation, Node);
 
     // -- conditions --
-    LINK(True, Condition)
-    LINK(False, Condition)
-    LINK(Conjunction, Condition)
-    LINK(Negation, Condition)
-    LINK(Constraint, Condition)
-    LINK(ExistenceCheck, Condition)
-    LINK(ProvenanceExistenceCheck, Condition)
-    LINK(EmptinessCheck, Condition)
+    LINK(True, Condition);
+    LINK(False, Condition);
+    LINK(Conjunction, Condition);
+    LINK(Negation, Condition);
+    LINK(Constraint, Condition);
+    LINK(ExistenceCheck, AbstractExistenceCheck);
+    LINK(ProvenanceExistenceCheck, AbstractExistenceCheck);
+    LINK(EmptinessCheck, Condition);
+    LINK(AbstractExistenceCheck, Condition);
 
-    LINK(Condition, Node)
+    LINK(Condition, Node);
 
     // -- values --
-    LINK(Number, Expression)
-    LINK(UndefValue, Expression)
-    LINK(ElementAccess, Expression)
-    LINK(IntrinsicOperator, Expression)
-    LINK(UserDefinedOperator, Expression)
-    LINK(AutoIncrement, Expression)
-    LINK(PackRecord, Expression)
-    LINK(Argument, Expression)
+    LINK(Number, Expression);
+    LINK(UndefValue, Expression);
+    LINK(ElementAccess, Expression);
+    LINK(IntrinsicOperator, AbstractOperator);
+    LINK(UserDefinedOperator, AbstractOperator);
+    LINK(AbstractOperator, Expression);
+    LINK(AutoIncrement, Expression);
+    LINK(PackRecord, Expression);
+    LINK(Argument, Expression);
 
-    LINK(Expression, Node)
+    LINK(Expression, Node);
 
     // -- program --
-    LINK(Program, Node)
+    LINK(Program, Node);
 
     // -- relation
-    LINK(Relation, Node)
-    LINK(RelationReference, Node)
+    LINK(Relation, Node);
+    LINK(RelationReference, Node);
 
 #ifdef USE_MPI
     LINK(Send, RelationStatement);


### PR DESCRIPTION
As suggested by @b-scholz, the following abstract classes have been introduced in the RAM code to minimise code duplication as some classes share common functionality/state:
- RamAbstractOperator -> RamIntrinsicOperator, RamUserDefinedOperator
- RamAbstractAggregate -> RamAggregate, RamIndexAggregate
- RamAbstractCondtional -> RamFilter, RamBreak
- RamAbstractLoadStore -> RamLoad, RamStore
- RamBinRelationStatement -> RamSwap, RamMerge
- RamListStatement ->  RamParallel, RamSequence

Next is to rename some of the classes (as per issue #980), and then to add the appropriate documentation (as per issue #1001).