### PR TITLE
LVM Refactoring

### DIFF
--- a/src/LVM.h
+++ b/src/LVM.h
@@ -192,26 +192,6 @@ protected:
 private:
     friend LVMProgInterface;
 
-    /** relation environment type */
-    using relation_map = std::vector<std::unique_ptr<LVMRelation>>;
-
-    /** A string to relation map for InterpreterProgInterface */
-    std::map<std::string, LVMRelation*> stringToRel;
-
-    /** Get relation map */
-    virtual std::map<std::string, LVMRelation*>& getRelationMap() override {
-        // TODO(xiaowen): The transformation here is only needed in order to make RAMI and LVM share the same
-        // interface. Later when RAMI is removed, we can have a more elegant interface here.
-        for (auto& relPtr : environment) {
-            // Skip deleted relation
-            if (relPtr == nullptr) {
-                continue;
-            }
-            stringToRel[relPtr->getName()] = relPtr.get();
-        }
-        return stringToRel;
-    }
-
     /** Execute given program
      *
      * @param ip the instruction pointer start position, default is 0.

--- a/src/LVM.h
+++ b/src/LVM.h
@@ -213,8 +213,8 @@ private:
     /** List of iters for indexScan operation */
     std::vector<std::pair<index_set::iterator, index_set::iterator>> iteratorPool;
 
-    /** Map from relationName to RamRelationNode in RAM */
-    std::map<std::string, const RamRelation*> relNameToNode;
+    /** Hash map from relationName to RamRelationNode in RAM */
+    std::unordered_map<std::string, const RamRelation*> relNameToNode;
 
     /** stratum */
     size_t level = 0;

--- a/src/LVMContext.h
+++ b/src/LVMContext.h
@@ -49,7 +49,7 @@ public:
     }
 
     /** Allocate a tuple.
-     *  allocatedDataContainer has the ownership of those tuples. */
+     *  LVMContext has ownership of allocated tuples. */
     RamDomain* allocateNewTuple(size_t size) {
         std::unique_ptr<RamDomain[]> newTuple(new RamDomain[size]);
         allocatedDataContainer.push_back(std::move(newTuple));

--- a/src/LVMIndex.h
+++ b/src/LVMIndex.h
@@ -10,10 +10,7 @@
  *
  * @file LVMIndex.h
  *
- * An index is implemented either as a hash-index, a double-hash, as a
- * red-black tree or as a b-tree. The choice of the implementation is
- * set by preprocessor defines.
- *
+ * A b-tree implementation of an index
  ***********************************************************************/
 
 #pragma once
@@ -131,6 +128,14 @@ public:
     /** return start and end iterator of the index set */
     inline std::pair<iterator, iterator> getIteratorPair() const {
         return std::pair<iterator, iterator>(set.begin(), set.end());
+    }
+
+    inline iterator begin() const {
+        return set.begin();
+    }
+
+    inline iterator end() const {
+        return set.end();
     }
 
 private:

--- a/src/LVMInterface.h
+++ b/src/LVMInterface.h
@@ -125,8 +125,13 @@ protected:
         return translationUnit.getSymbolTable();
     }
 
+    /** relation environment type */
+    using relation_map = std::vector<std::unique_ptr<LVMRelation>>;
+
     /** Get relation map */
-    virtual std::map<std::string, LVMRelation*>& getRelationMap() = 0;
+    relation_map& getRelationMap(){
+        return environment;
+    }
 
     /** RAM translation Unit */
     RamTranslationUnit& translationUnit;
@@ -136,6 +141,9 @@ protected:
 
     /** Dynamic library for user-defined functors */
     std::vector<void*> dll;
+
+    /** Relation Environment */
+    relation_map environment;
 };
 
 }  // end of namespace souffle

--- a/src/LVMInterface.h
+++ b/src/LVMInterface.h
@@ -129,7 +129,7 @@ protected:
     using relation_map = std::vector<std::unique_ptr<LVMRelation>>;
 
     /** Get relation map */
-    relation_map& getRelationMap(){
+    relation_map& getRelationMap() {
         return environment;
     }
 

--- a/src/LVMProgInterface.h
+++ b/src/LVMProgInterface.h
@@ -183,9 +183,12 @@ public:
         visitDepthFirst(prog, [&](const RamRelation& rel) { map[rel.getName()] = &rel; });
 
         // Build wrapper relations for Souffle's interface
-        for (auto& rel_pair : exec.getRelationMap()) {
-            auto& name = rel_pair.first;
-            auto& interpreterRel = *rel_pair.second;
+        for (auto& relPtr : exec.getRelationMap()) {
+            if (relPtr == nullptr) {
+                continue;
+            }
+            const auto& name = relPtr->getName();
+            auto& interpreterRel = *relPtr;
             assert(map[name]);
             const RamRelation& rel = *map[name];
 

--- a/src/LVMRelation.h
+++ b/src/LVMRelation.h
@@ -31,7 +31,6 @@ namespace souffle {
 
 /**
  * Interpreter Relation
- *
  */
 class LVMRelation {
     using LexOrder = std::vector<int>;
@@ -169,71 +168,17 @@ public:
         return this->level;
     }
 
-    // --- iterator ---
+    using iterator = LVMIndex::iterator;
 
-    /** Iterator for relation */
-    class iterator : public std::iterator<std::forward_iterator_tag, RamDomain*> {
-    public:
-        iterator() = default;
-
-        iterator(const LVMRelation* const relation)
-                : relation(relation), tuple(relation->arity == 0 ? reinterpret_cast<RamDomain*>(this)
-                                                                 : &relation->blockList[0][0]) {}
-
-        const RamDomain* operator*() {
-            return tuple;
-        }
-
-        bool operator==(const iterator& other) const {
-            return tuple == other.tuple;
-        }
-
-        bool operator!=(const iterator& other) const {
-            return (tuple != other.tuple);
-        }
-
-        iterator& operator++() {
-            // support 0-arity
-            if (relation->arity == 0) {
-                tuple = nullptr;
-                return *this;
-            }
-
-            // support all other arities
-            ++index;
-            if (index == relation->num_tuples) {
-                tuple = nullptr;
-                return *this;
-            }
-
-            int blockIndex = index / (BLOCK_SIZE / relation->arity);
-            int tupleIndex = (index % (BLOCK_SIZE / relation->arity)) * relation->arity;
-
-            tuple = &relation->blockList[blockIndex][tupleIndex];
-            return *this;
-        }
-
-    private:
-        const LVMRelation* relation = nullptr;
-        size_t index = 0;
-        RamDomain* tuple = nullptr;
-    };
-
-    /** get iterator begin of relation */
-    inline iterator begin() const {
-        // check for emptiness
-        if (empty()) {
-            return end();
-        }
-
-        return iterator(this);
+    /** Iterator for relation, uses full-order index as default */
+    iterator begin() const {
+        return indices[0].begin();
     }
 
-    /** get iterator begin of relation */
-    inline iterator end() const {
-        return iterator();
+    iterator end() const {
+        return indices[0].end();
     }
-
+    
     /** Extend tuple */
     virtual std::vector<RamDomain*> extend(const RamDomain* tuple) {
         std::vector<RamDomain*> newTuples;

--- a/src/LVMRelation.h
+++ b/src/LVMRelation.h
@@ -178,7 +178,7 @@ public:
     iterator end() const {
         return indices[0].end();
     }
-    
+
     /** Extend tuple */
     virtual std::vector<RamDomain*> extend(const RamDomain* tuple) {
         std::vector<RamDomain*> newTuples;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -211,7 +211,7 @@ int main(int argc, char** argv) {
                         "Enable provenance instrumentation and interaction."},
                 {"engine", 'e', "[ file | mpi ]", "", false,
                         "Specify communication engine for distributed execution."},
-                {"interpreter", '\1', "[ RAMI | LVM ]", "", false, "Switch interpreter implementation."},
+                {"interpreter", '\1', "[ RAMI | LVM ]", "LVM", false, "Switch interpreter implementation."},
                 {"hostfile", '\2', "FILE", "", false,
                         "Specify --hostfile option for call to mpiexec when using mpi as "
                         "execution engine."},
@@ -534,7 +534,7 @@ int main(int argc, char** argv) {
         }
 
         // configure and execute interpreter
-        if (!Global::config().has("interpreter") || Global::config().get("Interpreter") == "LVM") {
+        if (Global::config().get("Interpreter") == "LVM") {
             std::unique_ptr<LVMInterface> lvm(std::make_unique<LVM>(*ramTranslationUnit));
             lvm->executeMain();
             // If the profiler was started, join back here once it exits.


### PR DESCRIPTION
Some code refactoring for LVM as suggested by @mmcgr and @b-scholz.

1. Remove extra transformation in `LVM::getRelationMap()`.
2. Redo the iterator in `LVMRelation.h`. It is now just a wrapper that returns the iterator of the full-order index stored in the relation. As we going to remove concrete tuples in LVMRelation.
3. Change some members structure from an ordered map to unordered map for performance.