### PR TITLE
Fix for LVM: typo and redundant member

### DIFF
--- a/src/LVM.h
+++ b/src/LVM.h
@@ -233,9 +233,6 @@ private:
 
     /** Relation Encode */
     RelationEncoder relationEncoder;
-
-    /** Relation Environment */
-    relation_map environment;
 };
 
 }  // end of namespace souffle

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -534,7 +534,7 @@ int main(int argc, char** argv) {
         }
 
         // configure and execute interpreter
-        if (Global::config().get("Interpreter") == "LVM") {
+        if (Global::config().get("interpreter") == "LVM") {
             std::unique_ptr<LVMInterface> lvm(std::make_unique<LVM>(*ramTranslationUnit));
             lvm->executeMain();
             // If the profiler was started, join back here once it exits.


### PR DESCRIPTION
Commit #1060 exposes a legacy typo in configs option in `main.cpp`. Causes RAMI to be run no matter what option is specified.

Also, LVM in #1060 was not working correctly: caused by a redundant class member in the dervied class.

This PR fixes both.
