### PR TITLE
Fixes issue #1069: scanner.ll can now parse file paths with spaces.

### DIFF
--- a/src/scanner.ll
+++ b/src/scanner.ll
@@ -195,14 +195,14 @@
 \#.*$                                 {
                                         char fname[yyleng+1];
                                         int lineno;
-                                        if(sscanf(yytext,"# %d \"%s",&lineno,fname)>=2) {
+                                        if(sscanf(yytext,"# %d \"%[^\"]",&lineno,fname)>=2) {
                                           assert(strlen(fname) > 0 && "failed conversion");
-                                          fname[strlen(fname)-1]='\0';
+                                          fname[strlen(fname)]='\0';
                                           yycolumn = 1; yylineno = lineno-1;
                                           yyfilename = SLOOKUP(fname);
-                                        } else if(sscanf(yytext,"#line %d \"%s",&lineno,fname)>=2) {
+                                        } else if(sscanf(yytext,"#line %d \"%[^\"]",&lineno,fname)>=2) {
                                           assert(strlen(fname) > 0 && "failed conversion");
-                                          fname[strlen(fname)-1]='\0';
+                                          fname[strlen(fname)]='\0';
                                           yycolumn = 1; yylineno = lineno-1;
                                           yyfilename = SLOOKUP(fname);
                                         }


### PR DESCRIPTION
Fixes #1069. From that discussion:

The problem is that `scanner.ll` cannot parse file paths with spaces. The relevant code is [this block](https://github.com/souffle-lang/souffle/blob/1ac310994792ebe57a34a05f00391963a02c1f68/src/scanner.ll#L198):

```c
if(sscanf(yytext,"# %d \"%s",&lineno,fname)>=2) {
  assert(strlen(fname) > 0 && "failed conversion");
  fname[strlen(fname)-1]='\0';
  yycolumn = 1; yylineno = lineno-1;
  yyfilename = SLOOKUP(fname);
} else if(sscanf(yytext,"#line %d \"%s",&lineno,fname)>=2) {
  assert(strlen(fname) > 0 && "failed conversion");
  fname[strlen(fname)-1]='\0';
  yycolumn = 1; yylineno = lineno-1;
  yyfilename = SLOOKUP(fname);
}
```

The fix is to change the pattern `"# %d \"%s"` to `"# %d \"%[^\"]"` and bump the location of the terminal `\0`, and likewise for the `else` branch:

```c
char fname[yyleng+1];
int lineno;
if(sscanf(yytext,"# %d \"%[^\"]",&lineno,fname)>=2) {
  assert(strlen(fname) > 0 && "failed conversion");
  fname[strlen(fname)]='\0';
  yycolumn = 1; yylineno = lineno-1;
  yyfilename = SLOOKUP(fname);
} else if(sscanf(yytext,"#line %d \"%[^\"]",&lineno,fname)>=2) {
  assert(strlen(fname) > 0 && "failed conversion");
  fname[strlen(fname)]='\0';
  yycolumn = 1; yylineno = lineno-1;
  yyfilename = SLOOKUP(fname);
}
```

