### PR TITLE
Bug fix for LVM range query

### DIFF
--- a/src/LVMGenerator.h
+++ b/src/LVMGenerator.h
@@ -341,16 +341,23 @@ protected:
         auto values = provExists.getValues();
         auto arity = provExists.getRelation().getArity();
         std::string types;
+        bool emptinessCheck = true;
         for (size_t i = 0; i < arity - 2; ++i) {
             if (!isRamUndefValue(values[i])) {
                 visit(values[i], exitAddress);
+                emptinessCheck = false;
             }
             types += (isRamUndefValue(values[i]) ? "_" : "V");
         }
-        code->push_back(LVM_ProvenanceExistenceCheck);
-        code->push_back(relationEncoder.encodeRelation(provExists.getRelation()));
-        code->push_back(symbolTable.lookup(types));
-        code->push_back(getIndexPos(provExists));
+        if (emptinessCheck == true) {
+            code->push_back(LVM_EmptinessCheck);
+            code->push_back(relationEncoder.encodeRelation(provExists.getRelation()));
+        } else {
+            code->push_back(LVM_ProvenanceExistenceCheck);
+            code->push_back(relationEncoder.encodeRelation(provExists.getRelation()));
+            code->push_back(symbolTable.lookup(types));
+            code->push_back(getIndexPos(provExists));
+        }
     }
 
     void visitConstraint(const RamConstraint& relOp, size_t exitAddress) override {

--- a/src/LVMGenerator.h
+++ b/src/LVMGenerator.h
@@ -324,16 +324,24 @@ protected:
         auto values = exists.getValues();
         auto arity = exists.getRelation().getArity();
         std::string types;
+        bool emptinessCheck = true;
         for (size_t i = 0; i < arity; ++i) {
             if (!isRamUndefValue(values[i])) {
                 visit(values[i], exitAddress);
+                emptinessCheck = false;
             }
             types += (isRamUndefValue(values[i]) ? "_" : "V");
         }
-        code->push_back(LVM_ExistenceCheck);
-        code->push_back(relationEncoder.encodeRelation(exists.getRelation()));
-        code->push_back(symbolTable.lookup(types));
-        code->push_back(getIndexPos(exists));
+        if (emptinessCheck == true) {
+            code->push_back(LVM_EmptinessCheck);
+            code->push_back(relationEncoder.encodeRelation(exists.getRelation()));
+            code->push_back(LVM_Negation);
+        } else {
+            code->push_back(LVM_ExistenceCheck);
+            code->push_back(relationEncoder.encodeRelation(exists.getRelation()));
+            code->push_back(symbolTable.lookup(types));
+            code->push_back(getIndexPos(exists));
+        }
     }
 
     void visitProvenanceExistenceCheck(
@@ -352,6 +360,7 @@ protected:
         if (emptinessCheck == true) {
             code->push_back(LVM_EmptinessCheck);
             code->push_back(relationEncoder.encodeRelation(provExists.getRelation()));
+            code->push_back(LVM_Negation);
         } else {
             code->push_back(LVM_ProvenanceExistenceCheck);
             code->push_back(relationEncoder.encodeRelation(provExists.getRelation()));

--- a/src/LVMIndex.cpp
+++ b/src/LVMIndex.cpp
@@ -238,6 +238,7 @@ public:
         Entry a = order.encode(low.asTuple<Arity>());
         Entry b = order.encode(high.asTuple<Arity>());
         // Transfer upper_bound to a equivalent lower bound
+        bool fullIndexSearch = true;
         for (size_t i = Arity; i-- > 0;) {
             if (a[i] == MIN_RAM_DOMAIN && b[i] == MAX_RAM_DOMAIN) {
                 b[i] = MIN_RAM_DOMAIN;
@@ -245,9 +246,11 @@ public:
             }
             if (a[i] == b[i]) {
                 b[i] += 1;
+                fullIndexSearch = false;
                 break;
             }
         }
+        assert(fullIndexSearch == false && "Full index search is not allowed in range query\n");
         return std::make_unique<Source>(order, data.lower_bound(a), data.lower_bound(b));
     }
 

--- a/src/LVMIndex.cpp
+++ b/src/LVMIndex.cpp
@@ -238,7 +238,7 @@ public:
         Entry a = order.encode(low.asTuple<Arity>());
         Entry b = order.encode(high.asTuple<Arity>());
         // Transfer upper_bound to a equivalent lower bound
-        for (size_t i = Arity - 1; i >= 0; --i) {
+        for (size_t i = Arity; i-- > 0;) {
             if (a[i] == MIN_RAM_DOMAIN && b[i] == MAX_RAM_DOMAIN) {
                 b[i] = MIN_RAM_DOMAIN;
                 continue;


### PR DESCRIPTION
Range query didn't handle implicit non-emptiness check from provenance existence query properly.

Fixed it by transforming an existence check into a non-emptiness check whenever possible during the code generation.