### PR TITLE
Fix travis ci debug output

### DIFF
--- a/.travis/init_make_package.sh
+++ b/.travis/init_make_package.sh
@@ -17,3 +17,6 @@ git describe --tags --abbrev=0 --always
 # create configure files
 ./bootstrap
 ./configure --enable-host-packaging
+
+set +e
+set +x

--- a/.travis/init_test.sh
+++ b/.travis/init_test.sh
@@ -13,3 +13,6 @@ set -x
 ./configure
 make -j2
 
+
+set +e
+set +x

--- a/.travis/init_test_64bit.sh
+++ b/.travis/init_test_64bit.sh
@@ -13,3 +13,6 @@ set -x
 ./configure --enable-64bit-domain
 make -j2
 
+
+set +e
+set +x

--- a/.travis/linux/install_debian_deps.sh
+++ b/.travis/linux/install_debian_deps.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 apt-get update -q
-apt-get install -y -q autoconf automake bash-completion bison build-essential clang debhelper devscripts doxygen fakeroot flex g++ git graphviz libffi-dev libncurses5-dev libsqlite3-dev libtool make mcpp pkg-config python sqlite zlib1g-dev
+apt-get install -y -q autoconf automake bash-completion bison build-essential clang debhelper devscripts doxygen fakeroot flex g++ gdb git graphviz libffi-dev libncurses5-dev libsqlite3-dev libtool make mcpp pkg-config python sqlite zlib1g-dev

--- a/.travis/osx/brew.sh
+++ b/.travis/osx/brew.sh
@@ -53,3 +53,6 @@ do
   git push
 done
 
+
+set +e
+set +x

--- a/.travis/osx/install.sh
+++ b/.travis/osx/install.sh
@@ -14,3 +14,6 @@ export PATH="/usr/local/opt/bison/bin:$PATH"
 export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig/
 
 rm /Users/travis/Library/Logs/DiagnosticReports/* || true
+
+set +e
+set +x

--- a/.travis/osx/install_withgcc.sh
+++ b/.travis/osx/install_withgcc.sh
@@ -18,3 +18,6 @@ g++-8 --version
 
 export CC=gcc-8
 export CXX=g++-8
+
+set +e
+set +x

--- a/.travis/osx/make_package.sh
+++ b/.travis/osx/make_package.sh
@@ -26,3 +26,5 @@ ls deploy/*
 #Create tarball for brew
 make dist
 
+set +x
+set +e

--- a/.travis/run_test.sh
+++ b/.travis/run_test.sh
@@ -12,3 +12,6 @@ then
   cd tests
 fi
 TESTSUITEFLAGS="-j2 $TESTRANGE" make check -j2
+
+set +e
+set +x

--- a/.travis/test_make_install.sh
+++ b/.travis/test_make_install.sh
@@ -17,3 +17,6 @@ echo "$A" > a.dl
 
 # test if an installed souffle compiles and runs
 souffle -c a.dl
+
+set +e
+set +x


### PR DESCRIPTION
Travis has two separate failure modes - fail and error. Currently OSX tests that fail are treated as errors, which does not run the after_failure script which shows the debug report for why the test failed. This PR will make OSX behave similarly to Linux - compilation/init problems are errors and test failures are failures

This PR also installs gdb in the debian docker images for stacktraces of coredumps.