### PR TITLE
Fix building of release sources

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,13 @@
 # - https://opensource.org/licenses/UPL
 # - <souffle root>/licenses/SOUFFLE-UPL.txt
 
-AC_INIT(souffle, m4_esyscmd([git describe --tags --always | tr -d '\n']), [souffle-talk@googlegroups.com])
+m4_define([SOUFFLE_VERSION], m4_esyscmd([
+  souffle_version=$(git describe --tags --always)
+  test -z "$souffle_version" && souffle_version=$(pwd | sed '/^.*souffle-[0-9\.]*$/!d' | sed 's/^.*souffle-//')
+  test -z "$souffle_version" && souffle_version="unknown"
+  echo $souffle_version| tr -d '\n']))
+
+AC_INIT(souffle, SOUFFLE_VERSION, [souffle-talk@googlegroups.com])
 AC_PREREQ(2.68)
 AC_COPYRIGHT(['2013-15 Oracle and/or its affiliates'])
 

--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -1,4 +1,8 @@
 souffle (@VERSION@-1) UNRELEASED; urgency=low
+
+ -- Kostyantyn Vorobyov <k.a.vorobyov@gmail.com>  Fri, 2 Aug 2019 13:30:33 +1100
+
+souffle (1.6.0); urgency=low
   * Low Level Machine Interpreter for improved non-synthesised performance (XiaowenHu96,HerbertJordan)
   * Provenance support for negation and equivalence relations (taipan-snake)
   * New semantics for RAM (b-scholz)


### PR DESCRIPTION
Use directory name for version if there is no git repo. Also increment version in preparation for a 1.6.1 release to complete the fix.

Github-prepared release sources do not contain the git repo, but are named with the version. As a fallback if the directory name is not in the expected format, 'unknown' is used for version.

Fixes #1091 