### PR TITLE
Remove unused configuration checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,17 +86,9 @@ AS_IF([test "x$enable_mpi" = "xyes"], [
 ])
 AM_CONDITIONAL([MPI], [test "x$enable_mpi" = "xyes"])
 
-AC_ISC_POSIX
-AC_PROG_CPP
-AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
-AM_PROG_CC_STDC
-
-# Check for flex and bison
-AM_PROG_LEX
-AC_PROG_YACC
 
 dnl Build doxygen documentation
 DX_DOXYGEN_FEATURE(ON)
@@ -343,29 +335,6 @@ AM_MISSING_PROG([AUTOM4TE], [autom4te])
 # Checks for header files.
 AC_FUNC_ALLOCA
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h float.h inttypes.h libintl.h limits.h malloc.h memory.h netdb.h stddef.h stdint.h stdlib.h string.h strings.h sys/time.h sys/timeb.h unistd.h wchar.h wctype.h])
-
-# Checks for typedefs, structures, and compiler characteristics.
-AC_C_INLINE
-AC_TYPE_INT16_T
-AC_TYPE_INT32_T
-AC_TYPE_INT64_T
-AC_TYPE_INT8_T
-AC_TYPE_PID_T
-AC_TYPE_SIZE_T
-AC_TYPE_UINT16_T
-AC_TYPE_UINT32_T
-AC_TYPE_UINT64_T
-AC_TYPE_UINT8_T
-AC_CHECK_TYPES([ptrdiff_t])
-
-# Checks for library functions.
-AC_FUNC_ERROR_AT_LINE
-AC_FUNC_FORK
-AC_FUNC_MALLOC
-AC_FUNC_MMAP
-AC_FUNC_REALLOC
-AC_FUNC_STRERROR_R
-AC_CHECK_FUNCS([dup2 fchdir getcwd getpagesize gettimeofday isascii memset mkdir munmap pow regcomp rmdir setenv socket strcasecmp strchr strdup strerror strrchr strstr strtol strtoull])
 
 SOUFFLE_CXXFLAGS="$CXXFLAGS"
 AC_SUBST(SOUFFLE_CXXFLAGS)


### PR DESCRIPTION
The removed configuration checks do mostly test for needed components, but can be reasonably expected to exist in any compiler that passes the other tests, or any standards compliant compiler.

e.g.
AC_ISC_POSIX is to add -lcposix for Posix facilities if using interactive Unix, which is no longer sold, and Sun said that they would drop support for it on 2006-07-23.
AM_PROG_LEX - tests for lex or flex, but is covered by the later check for flex.
AC_PROG_YACC - tests for bison, byacc or yacc, but we then check for, and use, bison.
Tests for types and functions that are now standard, and if missing will be reported as compilation errors.