### PR TITLE
add error check for a mutual dependency between two aggregates

### DIFF
--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -445,7 +445,7 @@ bool AstSemanticChecker::isDependent(const AstClause& agg1, const AstClause& agg
         // by string comparison
         const AstVariable* matchingVarPtr = nullptr;
         visitDepthFirst(agg2, [&](const AstVariable& var) {
-            if (var.getName() == searchVar.getName()) {
+            if (var == searchVar) {
                 matchingVarPtr = &var;
                 return;
             }

--- a/src/AstSemanticChecker.h
+++ b/src/AstSemanticChecker.h
@@ -56,6 +56,7 @@ private:
     static void checkLiteral(ErrorReport& report, const AstProgram& program, const AstLiteral& literal);
     static void checkAggregator(
             ErrorReport& report, const AstProgram& program, const AstAggregator& aggregator);
+    static bool isDependent(const AstClause& agg1, const AstClause& agg2);
     static void checkArgument(ErrorReport& report, const AstProgram& program, const AstArgument& arg);
     static void checkConstant(ErrorReport& report, const AstArgument& argument);
     static void checkFact(ErrorReport& report, const AstProgram& program, const AstClause& fact);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,305 +1,378 @@
-#Souffle - A Datalog Compiler
-#Copyright(c) 2013, Oracle and / or its affiliates.All rights reserved.
-#Licensed under the Universal Permissive License v 1.0 as shown at:
-#- https: //opensource.org/licenses/UPL
-#- <souffle root> / licenses / SOUFFLE - UPL.txt
+# Souffle - A Datalog Compiler
+# Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at:
+# - https://opensource.org/licenses/UPL
+# - <souffle root>/licenses/SOUFFLE-UPL.txt
 
-SUFFIXES =.cpp.h.yy.ll.cc.hh.h
+SUFFIXES = .cpp .h .yy .ll .cc .hh .h
 
-                  bin_PROGRAMS =
-        souffle souffle - profile souffle2bdd souffle2lb
+bin_PROGRAMS = souffle souffle-profile souffle2bdd souffle2lb
 
-                                  nodist_souffle_profile_SOURCES = $(BUILT_SOURCES)
+nodist_souffle_profile_SOURCES = $(BUILT_SOURCES)
 
-                souffle_profile_sources =
-                        ProfileDatabase.h json11.h profile / Cell.h profile / CellInterface.h profile /
-                        Cli.h profile / DataComparator.h profile / Iteration.h profile /
-                        OutputProcessor.h profile / ProgramRun.h profile / Reader.h profile /
-                        Relation.h profile / Row.h profile / Rule.h profile / StringUtils.h profile /
-                        Table.h profile / Tui.h profile / UserInputReader.h profile /
-                        htmlCssChartist.h profile / htmlJsChartistMin.h profile / htmlJsMain.h profile /
-                        htmlJsUtil.h profile / htmlCssStyle.h profile / htmlJsChartistPlugin.h profile /
-                        htmlJsTableSort.h profile / htmlMain.h profile /
-                        HtmlGenerator.h
+souffle_profile_sources = \
+                          ProfileDatabase.h                 \
+                          json11.h                          \
+                          profile/Cell.h                    \
+                          profile/CellInterface.h           \
+                          profile/Cli.h                     \
+                          profile/DataComparator.h          \
+                          profile/Iteration.h               \
+                          profile/OutputProcessor.h         \
+                          profile/ProgramRun.h              \
+                          profile/Reader.h                  \
+                          profile/Relation.h                \
+                          profile/Row.h                     \
+                          profile/Rule.h                    \
+                          profile/StringUtils.h             \
+                          profile/Table.h                   \
+                          profile/Tui.h                     \
+                          profile/UserInputReader.h         \
+                          profile/htmlCssChartist.h         \
+                          profile/htmlJsChartistMin.h       \
+                          profile/htmlJsMain.h              \
+                          profile/htmlJsUtil.h              \
+                          profile/htmlCssStyle.h            \
+                          profile/htmlJsChartistPlugin.h    \
+                          profile/htmlJsTableSort.h         \
+                          profile/htmlMain.h                \
+                          profile/HtmlGenerator.h
 
-                                DIR : = $ {
-    CURDIR
-}
+DIR := ${CURDIR}
 
-#... which should no go to distribution
+# ... which should no go to distribution
 nodist_souffle_SOURCES = $(BUILT_SOURCES)
 
-        if LIBZ libz_sources = gzfstream.h endif
+if LIBZ
+libz_sources = gzfstream.h
+endif
 
-                               if SQLITE sqlite_sources = ReadStreamSQLite.h WriteStreamSQLite.h endif
+if SQLITE
+sqlite_sources = ReadStreamSQLite.h WriteStreamSQLite.h
+endif
 
-                                                          if MPI mpi_sources = Mpi.h endif
+if MPI
+mpi_sources = Mpi.h
+endif
 
-                                                                                       souffle_sources =
-                AstAnalysis.h AstArgument.cpp AstArgument.h AstAttribute.h AstClause.cpp AstClause
-                        .h AstComponent.h AstComponentChecker.cpp AstComponentChecker.h AstConstraintAnalysis
-                        .h AstFunctorDeclaration.h AstGroundAnalysis.cpp AstGroundAnalysis.h AstIO
-                        .h AstIOTypeAnalysis.cpp AstIOTypeAnalysis.h AstLiteral.h AstNode.h AstParserUtils
-                        .cpp AstParserUtils.h AstPragma.cpp AstPragma.h AstProgram.cpp AstProgram
-                        .h AstProfileUse.cpp AstProfileUse.h AstRelation.h AstRelationIdentifier
-                        .h AstSemanticChecker.cpp AstSemanticChecker.h AstTransformer.cpp AstTransformer
-                        .h AstTransforms.cpp AstTransforms.h AstTranslationUnit.h ErrorReport.h AstTranslator
-                        .cpp AstTranslator.h AstType.h AstTypeAnalysis.cpp AstTypeAnalysis
-                        .h AstTypeEnvironmentAnalysis.cpp AstTypeEnvironmentAnalysis.h AstTypes.h AstUtils
-                        .cpp AstUtils.h AstVisitor.h BinaryConstraintOps.h ComponentModel.cpp ComponentModel
-                        .h Constraints.h DebugReport.cpp DebugReport.h EventProcessor.h FunctorOps.h Global
-                        .cpp Global.h GraphUtils.h IODirectives.h IOSystem.h RamIndexAnalysis
-                        .cpp RamIndexAnalysis.h InlineRelationsTransformer.cpp LogStatement.h LVM.cpp LVM
-                        .h LVMCode.cpp LVMCode.h LVMContext.h LVMGenerator.h LVMIndex.h LVMIndex
-                        .cpp LVMInterface.h LVMProgInterface.h LVMRecords.h LVMRecords.cpp LVMRelation
-                        .h LVMRelation.cpp MagicSet.cpp MagicSet.h MinimiseProgramTransformer.cpp ParserDriver
-                        .cpp ParserDriver.h PrecedenceGraph.cpp PrecedenceGraph.h ProfileEvent
-                        .h ProvenanceTransformer.cpp RamAnalysis.h RAMI.cpp RAMI.h RAMIContext.h RAMIIndex
-                        .h RAMIInterface.h RAMIProgInterface.h RAMIRecords.h RAMIRecords.cpp RAMIRelation
-                        .h RamLevelAnalysis.cpp RamLevelAnalysis.h RamCondition.h RamNode.h RamOperation
-                        .h RamProgram.h RamRelation.h RamStatement.h RamTransformer.cpp RamTransformer
-                        .h RamTransforms.cpp RamTransforms.h RamTranslationUnit.h RamExpression.h RamVisitor
-                        .h ReadStream.h ReadStreamCSV.h RelationRepresentation.h ReorderLiteralsTransformer
-                        .cpp ResolveAliasesTransformer.cpp SignalHandler.h SrcLocation.cpp SrcLocation
-                        .h StringPool.h Synthesiser.cpp Synthesiser.h SynthesiserRelation
-                        .cpp SynthesiserRelation.h TypeSystem.cpp TypeSystem.h WriteStream.h WriteStreamCSV
-                        .h parser.cc parser.hh scanner.cc stack.hh $(sqlite_sources) $(libz_sources)
-                                $(souffle_profile_sources) $(mpi_sources)
+souffle_sources = \
+              AstAnalysis.h                             \
+              AstArgument.cpp       AstArgument.h       \
+              AstAttribute.h                            \
+              AstClause.cpp         AstClause.h         \
+              AstComponent.h                            \
+              AstComponentChecker.cpp                   \
+              AstComponentChecker.h                     \
+              AstConstraintAnalysis.h                   \
+              AstFunctorDeclaration.h                   \
+              AstGroundAnalysis.cpp AstGroundAnalysis.h \
+              AstIO.h                                   \
+              AstIOTypeAnalysis.cpp AstIOTypeAnalysis.h \
+              AstLiteral.h                              \
+              AstNode.h                                 \
+              AstParserUtils.cpp    AstParserUtils.h    \
+              AstPragma.cpp         AstPragma.h         \
+              AstProgram.cpp        AstProgram.h        \
+              AstProfileUse.cpp     AstProfileUse.h     \
+              AstRelation.h                             \
+              AstRelationIdentifier.h                   \
+              AstSemanticChecker.cpp                    \
+              AstSemanticChecker.h                      \
+              AstTransformer.cpp    AstTransformer.h    \
+              AstTransforms.cpp     AstTransforms.h     \
+              AstTranslationUnit.h  ErrorReport.h       \
+              AstTranslator.cpp     AstTranslator.h     \
+              AstType.h                                 \
+              AstTypeAnalysis.cpp   AstTypeAnalysis.h   \
+              AstTypeEnvironmentAnalysis.cpp            \
+              AstTypeEnvironmentAnalysis.h              \
+              AstTypes.h                                \
+              AstUtils.cpp          AstUtils.h          \
+              AstVisitor.h                              \
+              BinaryConstraintOps.h                     \
+              ComponentModel.cpp    ComponentModel.h    \
+              Constraints.h                             \
+              DebugReport.cpp       DebugReport.h       \
+              EventProcessor.h                          \
+              FunctorOps.h                              \
+              Global.cpp            Global.h            \
+              GraphUtils.h                              \
+              IODirectives.h                            \
+              IOSystem.h                                \
+              RamIndexAnalysis.cpp   RamIndexAnalysis.h \
+              InlineRelationsTransformer.cpp            \
+              LogStatement.h                            \
+			  LVM.cpp 				LVM.h 				\
+			  LVMCode.cpp			LVMCode.h			\
+			  LVMContext.h								\
+			  LVMGenerator.h							\
+			  LVMIndex.h			LVMIndex.cpp		\
+			  LVMInterface.h							\
+			  LVMProgInterface.h						\
+			  LVMRecords.h			LVMRecords.cpp		\
+			  LVMRelation.h			LVMRelation.cpp		\
+              MagicSet.cpp          MagicSet.h          \
+              MinimiseProgramTransformer.cpp            \
+              ParserDriver.cpp      ParserDriver.h      \
+              PrecedenceGraph.cpp   PrecedenceGraph.h   \
+              ProfileEvent.h                            \
+              ProvenanceTransformer.cpp                 \
+              RamAnalysis.h                             \
+			  RAMI.cpp 				RAMI.h 				\
+			  RAMIContext.h 							\
+			  RAMIIndex.h 								\
+			  RAMIInterface.h							\
+			  RAMIProgInterface.h 						\
+			  RAMIRecords.h			RAMIRecords.cpp 	\
+			  RAMIRelation.h 							\
+              RamLevelAnalysis.cpp 	RamLevelAnalysis.h  \
+              RamCondition.h                            \
+              RamNode.h                                 \
+              RamOperation.h                            \
+              RamProgram.h                              \
+              RamRelation.h                             \
+              RamStatement.h                            \
+              RamTransformer.cpp    RamTransformer.h    \
+              RamTransforms.cpp     RamTransforms.h     \
+              RamTranslationUnit.h                      \
+              RamExpression.h                           \
+              RamVisitor.h                              \
+              ReadStream.h                              \
+              ReadStreamCSV.h                           \
+              RelationRepresentation.h                  \
+              ReorderLiteralsTransformer.cpp            \
+              ResolveAliasesTransformer.cpp             \
+              SignalHandler.h                           \
+              SrcLocation.cpp    SrcLocation.h          \
+              StringPool.h                              \
+              Synthesiser.cpp       Synthesiser.h       \
+              SynthesiserRelation.cpp                   \
+              SynthesiserRelation.h                     \
+              TypeSystem.cpp        TypeSystem.h        \
+              WriteStream.h                             \
+              WriteStreamCSV.h                          \
+              parser.cc             parser.hh           \
+              scanner.cc            stack.hh            \
+              $(sqlite_sources)                         \
+              $(libz_sources)                           \
+              $(souffle_profile_sources)                \
+              $(mpi_sources)
 
-#-- build souffle as a library so it can be reused in testing
-                                        noinst_LTLIBRARIES = libsouffle.la libsouffle_la_SOURCES =
-                        $(souffle_sources) libsouffle_la_CXXFLAGS =
-                                $(souffle_CPPFLAGS) $(FFI_CFLAGS) libsouffle_la_LDFLAGS =
-                                        --static --dlopen-- pic - ldl -
-                                        lffi
+# -- build souffle as a library so it can be reused in testing
+noinst_LTLIBRARIES = libsouffle.la
+libsouffle_la_SOURCES  = $(souffle_sources)
+libsouffle_la_CXXFLAGS = $(souffle_CPPFLAGS) $(FFI_CFLAGS)
+libsouffle_la_LDFLAGS = --static --dlopen --pic -ldl -lffi
 
-                                                souffle_SOURCES = main.cpp souffle_LDADD =
-                                                libsouffle.la
+souffle_SOURCES = main.cpp
+souffle_LDADD = libsouffle.la
 
-                                                        souffle_profile_SOURCES =
-                                                        souffle_prof.cpp souffle_profile_CXXFLAGS =
-                                                                $(souffle_CPPFLAGS) - DMAKEDIR = '"$(DIR)"'
+souffle_profile_SOURCES = souffle_prof.cpp
+souffle_profile_CXXFLAGS = $(souffle_CPPFLAGS) -DMAKEDIR='"$(DIR)"'
 
-        souffle2bdd_SOURCES = souffle2bdd.cpp souffle2bdd_LDADD = libsouffle.la
+souffle2bdd_SOURCES = souffle2bdd.cpp
+souffle2bdd_LDADD = libsouffle.la
 
-                                                                          souffle2lb_SOURCES =
-                souffle2lb.cpp souffle2lb_LDADD = libsouffle.la
+souffle2lb_SOURCES = souffle2lb.cpp
+souffle2lb_LDADD = libsouffle.la
 
-                                                          dist_bin_SCRIPTS =
-                        souffle - compile souffle -
-                        config
+dist_bin_SCRIPTS = souffle-compile souffle-config
 
-                                EXTRA_DIST =
-                                parser.yy scanner.ll test / test.h
+EXTRA_DIST = parser.yy scanner.ll  test/test.h
 
-                                                                    soufflepublicdir =
-                                        $(includedir) / souffle
+soufflepublicdir = $(includedir)/souffle
 
-                                                                soufflepublic_HEADERS =
-                                                CompiledOptions.h BinaryConstraintOps.h Brie.h BTree
-                                                        .h CompiledIndexUtils.h CompiledRecord
-                                                        .h CompiledRelation.h CompiledSouffle.h CompiledTuple
-                                                        .h EventProcessor.h Explain.h ExplainProvenance
-                                                        .h ExplainProvenanceImpl.h ExplainTree
-                                                        .h EquivalenceRelation.h IODirectives.h IOSystem
-                                                        .h IterUtils.h LambdaBTree.h Logger.h ParallelUtils
-                                                        .h PiggyList.h ProfileDatabase.h ProfileEvent
-                                                        .h RamTypes.h ReadStream.h ReadStreamCSV
-                                                        .h SignalHandler.h SouffleInterface.h SymbolTable
-                                                        .h Table.h UnionFind.h Util.h WriteStream
-                                                        .h WriteStreamCSV.h json11.h $(libz_sources)
-                                                                $(sqlite_sources) $(mpi_sources)
+soufflepublic_HEADERS = \
+						CompiledOptions.h       \
+						BinaryConstraintOps.h   \
+                        Brie.h                  \
+                        BTree.h                 \
+                        CompiledIndexUtils.h    \
+                        CompiledRecord.h        \
+                        CompiledRelation.h      \
+                        CompiledSouffle.h       \
+                        CompiledTuple.h         \
+                        EventProcessor.h        \
+                        Explain.h               \
+                        ExplainProvenance.h     \
+                        ExplainProvenanceImpl.h \
+                        ExplainTree.h           \
+                        EquivalenceRelation.h 	\
+                        IODirectives.h          \
+                        IOSystem.h              \
+                        IterUtils.h             \
+                        LambdaBTree.h           \
+                        Logger.h                \
+                        ParallelUtils.h         \
+                        PiggyList.h             \
+                        ProfileDatabase.h       \
+                        ProfileEvent.h          \
+                        RamTypes.h              \
+                        ReadStream.h            \
+                        ReadStreamCSV.h         \
+                        SignalHandler.h         \
+                        SouffleInterface.h      \
+                        SymbolTable.h           \
+                        Table.h                 \
+                        UnionFind.h             \
+                        Util.h                  \
+                        WriteStream.h           \
+                        WriteStreamCSV.h        \
+                        json11.h                \
+                        $(libz_sources)         \
+                        $(sqlite_sources)       \
+                        $(mpi_sources)
 
-                                                                        souffleprofiledir =
-                                                        $(soufflepublicdir) /
-                                                        profile
+souffleprofiledir = $(soufflepublicdir)/profile
 
-                                                                souffleprofile_HEADERS = $(
-                                                                souffle_profile_sources)
+souffleprofile_HEADERS = $(souffle_profile_sources)
 
-#files to clean
-                                                                CLEANFILES =
-                                                                        $(BUILT_SOURCES) parser.cc scanner
-                                                                                        .cc parser.hh stack.hh
+# files to clean
+CLEANFILES = $(BUILT_SOURCES)  parser.cc scanner.cc parser.hh stack.hh
 
-#run Bison
-                                                                                                $(builddir) /
-                                                                                parser.hh
-        : $(srcdir) / parser.yy $(BISON) - Wall - Werror - Wno - error = deprecated - Wno - error =
-                                                                                 other - v - d -
-                                                                                 o parser.cc $(srcdir) /
-                                                                                         parser.yy
+# run Bison
+$(builddir)/parser.hh: $(srcdir)/parser.yy
+	$(BISON) -Wall -Werror -Wno-error=deprecated -Wno-error=other -v -d -o parser.cc $(srcdir)/parser.yy
 
-#and FLEX
-                                                                                                 $(builddir) /
-                                                                                         scanner.cc
-        : $(srcdir) / scanner.ll $(FLEX) -
-                                                                                 o scanner.cc $(srcdir) /
-                                                                                         scanner.ll
+# and FLEX
+$(builddir)/scanner.cc: $(srcdir)/scanner.ll
+	$(FLEX) -o scanner.cc $(srcdir)/scanner.ll
 
-#driver depends on the generated header
-                                                                                                 $(builddir) /
-                                                                                         parser.cc $(
-                                                                                                 builddir) /
-                                                                                         stack.hh $(
-                                                                                                 builddir) /
-                                                                                         scanner.cc $(
-                                                                                                 builddir) /
-                                                                                         souffle2bdd.cpp $(
-                                                                                                 builddir) /
-                                                                                         souffle2lb.cpp $(
-                                                                                                 builddir) /
-                                                                                         main.cpp $(
-                                                                                                 builddir) /
-                                                                                         ParserDriver.cpp
-        : $(builddir) /
-                                                                                         parser.hh
+# driver depends on the generated header
+$(builddir)/parser.cc $(builddir)/stack.hh $(builddir)/scanner.cc \
+    $(builddir)/souffle2bdd.cpp $(builddir)/souffle2lb.cpp \
+    $(builddir)/main.cpp $(builddir)/ParserDriver.cpp: $(builddir)/parser.hh
 
-                                                                                         ##########Unit Tests
+########## Unit Tests
 
-                                                                                                 AM_COLOR_TESTS = always
+AM_COLOR_TESTS=always
 
-#-- -- -- -- -- -- -- -- -- -- -- -- -
+# -------------------------
 
-#init check programs
-                                                                                         check_PROGRAMS =
+# init check programs
+check_PROGRAMS =
 
-#utils test
-                                                                                                 check_PROGRAMS +=
-        test / util_test test_util_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_util_test_SOURCES =
-                        test / util_test.cpp test_util_test_LDADD = libsouffle.la
+# utils test
+check_PROGRAMS += test/util_test
+test_util_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_util_test_SOURCES = test/util_test.cpp
+test_util_test_LDADD = libsouffle.la
 
-#matching test
-                                                                            check_PROGRAMS +=
-        test / matching_test test_matching_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_matching_test_SOURCES =
-                        test / matching_test.cpp test_matching_test_LDADD = libsouffle.la
+# matching test
+check_PROGRAMS += test/matching_test
+test_matching_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_matching_test_SOURCES = test/matching_test.cpp
+test_matching_test_LDADD = libsouffle.la
 
-#table test
-                                                                                    check_PROGRAMS +=
-        test / table_test test_table_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_table_test_SOURCES =
-                        test / table_test.cpp test_table_test_LDADD = libsouffle.la
+# table test
+check_PROGRAMS += test/table_test
+test_table_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_table_test_SOURCES = test/table_test.cpp
+test_table_test_LDADD = libsouffle.la
 
-#b - tree set test
-                                                                              check_PROGRAMS +=
-        test / btree_set_test test_btree_set_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_btree_set_test_SOURCES =
-                        test / btree_set_test.cpp test_btree_set_test_LDADD = libsouffle.la
+# b-tree set test
+check_PROGRAMS += test/btree_set_test
+test_btree_set_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_btree_set_test_SOURCES = test/btree_set_test.cpp
+test_btree_set_test_LDADD = libsouffle.la
 
-#b - tree multi - set test
-                                                                                      check_PROGRAMS +=
-        test / btree_multiset_test test_btree_multiset_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_btree_multiset_test_SOURCES =
-                        test / btree_multiset_test.cpp test_btree_multiset_test_LDADD =
-                                libsouffle.la
+# b-tree multi-set test
+check_PROGRAMS += test/btree_multiset_test
+test_btree_multiset_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_btree_multiset_test_SOURCES = test/btree_multiset_test.cpp
+test_btree_multiset_test_LDADD = libsouffle.la
 
-#binary relation tests
-                                        check_PROGRAMS +=
-        test / binary_relation_test test_binary_relation_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_binary_relation_test_SOURCES =
-                        test / binary_relation_test.cpp test_binary_relation_test_LDADD =
-                                libsouffle.la
+# binary relation tests
+check_PROGRAMS += test/binary_relation_test
+test_binary_relation_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_binary_relation_test_SOURCES = test/binary_relation_test.cpp
+test_binary_relation_test_LDADD = libsouffle.la
 
-#pnappa's good ol fashioned data structure tests (auxilliary structures to binrel, and potentially useful outside)
-                                        check_PROGRAMS +=
-        test / eqrel_datastructure_test test_eqrel_datastructure_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_eqrel_datastructure_test_SOURCES =
-                        test / eqrel_datastructure_test.cpp test_eqrel_datastructure_test_LDADD =
-                                libsouffle.la
+# pnappa's good ol fashioned data structure tests (auxilliary structures to binrel, and potentially useful outside)
+check_PROGRAMS += test/eqrel_datastructure_test
+test_eqrel_datastructure_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_eqrel_datastructure_test_SOURCES = test/eqrel_datastructure_test.cpp
+test_eqrel_datastructure_test_LDADD = libsouffle.la
 
-#compiled ram tuple test
-                                        check_PROGRAMS +=
-        test / compiled_tuple_test test_compiled_tuple_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_compiled_tuple_test_SOURCES =
-                        test / compiled_tuple_test.cpp test_compiled_tuple_test_LDADD =
-                                libsouffle.la
+# compiled ram tuple test
+check_PROGRAMS += test/compiled_tuple_test
+test_compiled_tuple_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_compiled_tuple_test_SOURCES = test/compiled_tuple_test.cpp
+test_compiled_tuple_test_LDADD = libsouffle.la
 
-#compiled ram index utils test
-                                        check_PROGRAMS +=
-        test / compiled_index_utils_test test_compiled_index_utils_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) -
-                I @abs_top_srcdir @ / src / test test_compiled_index_utils_test_SOURCES =
-                        test / compiled_index_utils_test.cpp test_compiled_index_utils_test_LDADD =
-                                libsouffle.la
+# compiled ram index utils test
+check_PROGRAMS += test/compiled_index_utils_test
+test_compiled_index_utils_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_compiled_index_utils_test_SOURCES = test/compiled_index_utils_test.cpp
+test_compiled_index_utils_test_LDADD = libsouffle.la
 
-#compiled ram relation test
-                                        check_PROGRAMS +=
-        test / compiled_relation_test test_compiled_relation_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_compiled_relation_test_SOURCES =
-                        test / compiled_relation_test.cpp test_compiled_relation_test_LDADD =
-                                libsouffle.la
+# compiled ram relation test
+check_PROGRAMS += test/compiled_relation_test
+test_compiled_relation_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_compiled_relation_test_SOURCES = test/compiled_relation_test.cpp
+test_compiled_relation_test_LDADD = libsouffle.la
 
-#type system test
-                                        check_PROGRAMS +=
-        test / type_system_test test_type_system_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_type_system_test_SOURCES =
-                        test / type_system_test.cpp test_type_system_test_LDADD = libsouffle.la
+# type system test
+check_PROGRAMS += test/type_system_test
+test_type_system_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_type_system_test_SOURCES = test/type_system_test.cpp
+test_type_system_test_LDADD = libsouffle.la
 
-#constraints test
-                                                                                          check_PROGRAMS +=
-        test / constraints_test test_constraints_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_constraints_test_SOURCES =
-                        test / constraints_test.cpp test_constraints_test_LDADD = libsouffle.la
+# constraints test
+check_PROGRAMS += test/constraints_test
+test_constraints_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_constraints_test_SOURCES = test/constraints_test.cpp
+test_constraints_test_LDADD = libsouffle.la
 
-#ast program test
-                                                                                          check_PROGRAMS +=
-        test / ast_program_test test_ast_program_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_ast_program_test_SOURCES =
-                        test / ast_program_test.cpp test_ast_program_test_LDADD = libsouffle.la
+# ast program test
+check_PROGRAMS += test/ast_program_test
+test_ast_program_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_ast_program_test_SOURCES = test/ast_program_test.cpp
+test_ast_program_test_LDADD = libsouffle.la
 
-#ast utils test
-                                                                                          check_PROGRAMS +=
-        test / ast_utils_test test_ast_utils_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_ast_utils_test_SOURCES =
-                        test / ast_utils_test.cpp test_ast_utils_test_LDADD = libsouffle.la
+# ast utils test
+check_PROGRAMS += test/ast_utils_test
+test_ast_utils_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_ast_utils_test_SOURCES = test/ast_utils_test.cpp
+test_ast_utils_test_LDADD = libsouffle.la
 
-#ast parser utils test
-                                                                                      check_PROGRAMS +=
-        test / ast_parser_utils_test test_ast_parser_utils_test_CXXFLAGS =
-                $(souffle_CPPFLAGS) - I @abs_top_srcdir @ / src / test test_ast_parser_utils_test_SOURCES =
-                        test / ast_parser_utils_test.cpp test_ast_parser_utils_test_LDADD =
-                                libsouffle.la
+# ast parser utils test
+check_PROGRAMS += test/ast_parser_utils_test
+test_ast_parser_utils_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_ast_parser_utils_test_SOURCES = test/ast_parser_utils_test.cpp
+test_ast_parser_utils_test_LDADD = libsouffle.la
 
-#symbol table
-                                        check_PROGRAMS +=
-        test / symbol_table_test test_symbol_table_test_CXXFLAGS =
-                $(souffle_bin_CPPFLAGS) - I @abs_top_srcdir @ / src / test - DBUILDDIR =
-                        '"@abs_top_builddir@/src/"' test_symbol_table_test_SOURCES =
-                                test / symbol_table_test.cpp test_symbol_table_test_LDADD =
-                                        libsouffle.la
+# symbol table
+check_PROGRAMS += test/symbol_table_test
+test_symbol_table_test_CXXFLAGS = $(souffle_bin_CPPFLAGS) -I @abs_top_srcdir@/src/test -DBUILDDIR='"@abs_top_builddir@/src/"'
+test_symbol_table_test_SOURCES = test/symbol_table_test.cpp
+test_symbol_table_test_LDADD = libsouffle.la
 
-#graph utils
-                                                check_PROGRAMS +=
-        test / graph_utils_test test_graph_utils_test_CXXFLAGS =
-                $(souffle_bin_CPPFLAGS) - I @abs_top_srcdir @ / src / test - DBUILDDIR =
-                        '"@abs_top_builddir@/src/"' test_graph_utils_test_SOURCES =
-                                test / graph_utils_test.cpp test_graph_utils_test_LDADD =
-                                        libsouffle.la
+# graph utils
+check_PROGRAMS += test/graph_utils_test
+test_graph_utils_test_CXXFLAGS = $(souffle_bin_CPPFLAGS) -I @abs_top_srcdir@/src/test -DBUILDDIR='"@abs_top_builddir@/src/"'
+test_graph_utils_test_SOURCES = test/graph_utils_test.cpp
+test_graph_utils_test_LDADD = libsouffle.la
 
-#trie implementation
-                                                check_PROGRAMS +=
-        test / brie_test test_brie_test_CXXFLAGS =
-                $(souffle_bin_CPPFLAGS) - I @abs_top_srcdir @ / src / test - DBUILDDIR =
-                        '"@abs_top_builddir@/src/"' test_brie_test_SOURCES =
-                                test / brie_test.cpp test_brie_test_LDADD = libsouffle.la
+# trie implementation
+check_PROGRAMS += test/brie_test
+test_brie_test_CXXFLAGS = $(souffle_bin_CPPFLAGS) -I @abs_top_srcdir@/src/test -DBUILDDIR='"@abs_top_builddir@/src/"'
+test_brie_test_SOURCES = test/brie_test.cpp
+test_brie_test_LDADD = libsouffle.la
 
-#parallel utils implementation
-                                                                                    check_PROGRAMS +=
-        test / parallel_utils_test test_parallel_utils_test_CXXFLAGS =
-                $(souffle_bin_CPPFLAGS) - I @abs_top_srcdir @ / src / test - DBUILDDIR =
-                        '"@abs_top_builddir@/src/"' test_parallel_utils_test_SOURCES =
-                                test / parallel_utils_test.cpp test_parallel_utils_test_LDADD =
-                                        libsouffle.la
+# parallel utils implementation
+check_PROGRAMS += test/parallel_utils_test
+test_parallel_utils_test_CXXFLAGS = $(souffle_bin_CPPFLAGS) -I @abs_top_srcdir@/src/test -DBUILDDIR='"@abs_top_builddir@/src/"'
+test_parallel_utils_test_SOURCES = test/parallel_utils_test.cpp
+test_parallel_utils_test_LDADD = libsouffle.la
 
-                                        if MPI
-#mpi interface
-                                                check_PROGRAMS +=
-        test / mpi_test test_mpi_test_CXXFLAGS =
-                $(souffle_bin_CPPFLAGS) - I @abs_top_srcdir @ / src / test - DBUILDDIR =
-                        '"@abs_top_builddir@/src/"' test_mpi_test_SOURCES =
-                                test / mpi_test.cpp test_mpi_test_LDADD = libsouffle.la endif
+if MPI
+# mpi interface
+check_PROGRAMS += test/mpi_test
+test_mpi_test_CXXFLAGS = $(souffle_bin_CPPFLAGS) -I @abs_top_srcdir@/src/test -DBUILDDIR='"@abs_top_builddir@/src/"'
+test_mpi_test_SOURCES = test/mpi_test.cpp
+test_mpi_test_LDADD = libsouffle.la
+endif
 
-#make all check - programs tests
-                                                                                  TESTS = $(check_PROGRAMS)
+# make all check-programs tests
+TESTS = $(check_PROGRAMS)


### PR DESCRIPTION
These two aggregates are mutually dependent in the following rule:

(1) R(Z) :-  X = sum y : { A(y), B(y), y < Z }, Z = sum p : { A(p), B(p), p < X }.

So instead of it throwing an error about the variable X not being grounded (old behaviour), it gives a better message that each of these is mutually dependent. The way the error comes up, it raises it once for each aggregate that is identified to be mutually dependent with another, so it comes up twice for every case which is maybe not the best. I couldn't figure out when I give the source location to the report how I am going to tell it about two locations instead of just one because the user should see that both of the aggregates are a problem, not just one of them. 

The way I have done it is a bit dodgy I think. I defined an aggregate to be dependent on another if: When considering the literal containing this aggregate in isolation, it has a variable that is ungrounded, and that variable is grounded by another literal which contains the other aggregate.

So two aggregates are mutually dependent if the first is dependent upon the second and the second is dependent upon the first. In (1), Z has no grounding when you consider the first literal in isolation, and Z receives a grounding with the second literal. The same applies to X in the second literal (it has no grounding in the second literal, and receives a grounding in the first).

I am not saying this is right, this is just what I understand at this stage. There may be something missing/wrong from/about this definition and I need someone to double check this for sanity. I am open to changing the entire thing.

When I check the condition about the variable being grounded by another literal, I do some really dodgy string comparisons because once I make some dummy clauses to separate out the literals and test groundedness in isolation, the variable Z in each are considered distinct and I have to remove this distinction by literally comparing the variable name. I don't know that this is considered appropriate but at this point I would need a suggestion about another way to do it that is more appropriate and works.

Please don't approve this easily. I am worried. By the way there is another problem with a 'disguised nested aggregate', ie,

D(x) :- x = sum y : { A(y), y < m }, m = count : A(_).

It does not terminate. I think this is the fault of my MaterializeAggregates transformer and I am not sure about it. I need some advice and maybe need to go fix it next.