### PR TITLE
Refactoring of HoistAggregate-Transformer

### DIFF
--- a/src/RamNode.h
+++ b/src/RamNode.h
@@ -25,74 +25,7 @@
 
 namespace souffle {
 
-class RamNodeMapper;
-
-/**
- *  @class RamNode
- *  @brief RamNode is a superclass for all RAM IR classes.
- */
-class RamNode {
-public:
-    RamNode() = default;
-
-    /*
-     * @brief A virtual destructor for RAM nodes
-     */
-    virtual ~RamNode() = default;
-
-    /**
-     * @brief Equivalence check for two RAM nodes
-     */
-    bool operator==(const RamNode& other) const {
-        return this == &other || (typeid(*this) == typeid(other) && equal(other));
-    }
-
-    /**
-     * @brief Inequality check for two RAM nodes
-     */
-    bool operator!=(const RamNode& other) const {
-        return !(*this == other);
-    }
-
-    /**
-     * @brief Create a clone (i.e. deep copy) of this node
-     */
-    virtual RamNode* clone() const = 0;
-
-    /**
-     * @brief Apply the mapper to all child nodes
-     */
-    virtual void apply(const RamNodeMapper& mapper) {}
-
-    /**
-     * @brief Obtain list of all embedded child nodes
-     */
-    virtual std::vector<const RamNode*> getChildNodes() const {
-        return {};
-    }
-
-    /**
-     * @brief Print RAM node
-     */
-    virtual void print(std::ostream& out = std::cout) const = 0;
-
-    /**
-     * Print RAM on a stream
-     */
-    friend std::ostream& operator<<(std::ostream& out, const RamNode& node) {
-        node.print(out);
-        return out;
-    }
-
-protected:
-    /**
-     * @brief Equality check for two RAM nodes.
-     * Default action is that nothing needs to be checked.
-     */
-    virtual bool equal(const RamNode& other) const {
-        return true;
-    }
-};
+class RamNode;
 
 /**
  * @class RamNodeMapper
@@ -146,6 +79,7 @@ public:
         return lambda(std::move(node));
     }
 };
+
 }  // namespace detail
 
 /**
@@ -155,5 +89,88 @@ template <typename Lambda>
 detail::LambdaRamNodeMapper<Lambda> makeLambdaRamMapper(const Lambda& lambda) {
     return detail::LambdaRamNodeMapper<Lambda>(lambda);
 }
+
+/**
+ *  @class RamNode
+ *  @brief RamNode is a superclass for all RAM IR classes.
+ */
+class RamNode {
+public:
+    RamNode() = default;
+
+    /*
+     * @brief A virtual destructor for RAM nodes
+     */
+    virtual ~RamNode() = default;
+
+    /**
+     * @brief Equivalence check for two RAM nodes
+     */
+    bool operator==(const RamNode& other) const {
+        return this == &other || (typeid(*this) == typeid(other) && equal(other));
+    }
+
+    /**
+     * @brief Inequality check for two RAM nodes
+     */
+    bool operator!=(const RamNode& other) const {
+        return !(*this == other);
+    }
+
+    /**
+     * @brief Create a clone (i.e. deep copy) of this node
+     */
+    virtual RamNode* clone() const = 0;
+
+    /**
+     * @brief Apply the mapper to all child nodes
+     */
+    virtual void apply(const RamNodeMapper& mapper) {}
+
+    /**
+     * @brief Rewrite a child node
+     */
+    virtual void rewrite(const RamNode* oldNode, std::unique_ptr<RamNode> newNode) {
+        std::function<std::unique_ptr<RamNode>(std::unique_ptr<RamNode>)> rewriter =
+                [&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {
+            if (oldNode == node.get()) {
+                return std::move(newNode);
+            } else {
+                node->apply(makeLambdaRamMapper(rewriter));
+                return node;
+            }
+        };
+        apply(makeLambdaRamMapper(rewriter));
+    };
+
+    /**
+     * @brief Obtain list of all embedded child nodes
+     */
+    virtual std::vector<const RamNode*> getChildNodes() const {
+        return {};
+    }
+
+    /**
+     * @brief Print RAM node
+     */
+    virtual void print(std::ostream& out = std::cout) const = 0;
+
+    /**
+     * Print RAM on a stream
+     */
+    friend std::ostream& operator<<(std::ostream& out, const RamNode& node) {
+        node.print(out);
+        return out;
+    }
+
+protected:
+    /**
+     * @brief Equality check for two RAM nodes.
+     * Default action is that nothing needs to be checked.
+     */
+    virtual bool equal(const RamNode& other) const {
+        return true;
+    }
+};
 
 }  // end of namespace souffle

--- a/src/RamNode.h
+++ b/src/RamNode.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cassert>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <typeinfo>


### PR DESCRIPTION
The bug-fixes of #1093 did not refactored the hoist-aggregate transformer. 
Instead of describing the aggregates via various state variables, we keep a copy and rewrite it via a newly introduced rewrite() method in RamNode. 