### PR TITLE
Stop adding extra brackets to synthesised conjunctions

### DIFF
--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1163,11 +1163,9 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 
         void visitConjunction(const RamConjunction& conj, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
-            out << "((";
             visit(conj.getLHS(), out);
-            out << ") && (";
+            out << " && ";
             visit(conj.getRHS(), out);
-            out << "))";
             PRINT_END_COMMENT(out);
         }
 


### PR DESCRIPTION
A partial fix for #1104 

This reduces the number of brackets used in conjunctions, reducing the nesting that causes problems during compilation.

A more comprehensive fix would establish bracket responsibility for all conditions and use of conditions, but conjunctions are the main culprit in producing surplus brackets due to nesting.