### PR TITLE
Ambiguous HoistCondition Transformation 

### DIFF
--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -119,17 +119,6 @@ bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
         }
     };
 
-    // insert a new filter
-    auto insertFilter = [](RamOperation* op, std::unique_ptr<RamCondition>& condition) {
-        op->apply(makeLambdaRamMapper([&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {
-            if (nullptr != dynamic_cast<RamOperation*>(node.get())) {
-                return std::make_unique<RamFilter>(std::move(condition),
-                        std::unique_ptr<RamOperation>(dynamic_cast<RamOperation*>(node.release())));
-            }
-            return node;
-        }));
-    };
-
     // hoist conditions to the most outer scope if they
     // don't depend on RamTupleOperations
     visitDepthFirst(program, [&](const RamQuery& query) {
@@ -150,11 +139,14 @@ bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
             node->apply(makeLambdaRamMapper(filterRewriter));
             return node;
         };
-        const_cast<RamQuery*>(&query)->apply(makeLambdaRamMapper(filterRewriter));
+        RamQuery* mQuery = const_cast<RamQuery*>(&query);
+        mQuery->apply(makeLambdaRamMapper(filterRewriter));
         if (newCondition != nullptr) {
             // insert new filter operation at outer-most level of the query
             changed = true;
-            insertFilter((RamOperation*)&query, newCondition);
+            RamOperation* nestedOp = const_cast<RamOperation*>(&mQuery->getOperation());
+            mQuery->rewrite(nestedOp, std::make_unique<RamFilter>(std::move(newCondition),
+                                              std::unique_ptr<RamOperation>(nestedOp->clone())));
         }
     });
 
@@ -177,11 +169,14 @@ bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
             node->apply(makeLambdaRamMapper(filterRewriter));
             return node;
         };
-        const_cast<RamTupleOperation*>(&search)->apply(makeLambdaRamMapper(filterRewriter));
+        RamTupleOperation* tupleOp = const_cast<RamTupleOperation*>(&search);
+        tupleOp->apply(makeLambdaRamMapper(filterRewriter));
         if (newCondition != nullptr) {
             // insert new filter operation after the search operation
             changed = true;
-            insertFilter((RamOperation*)&search, newCondition);
+            tupleOp->rewrite(&tupleOp->getOperation(),
+                    std::make_unique<RamFilter>(std::move(newCondition),
+                            std::unique_ptr<RamOperation>(tupleOp->getOperation().clone())));
         }
     });
     return changed;


### PR DESCRIPTION
The insertFilter() implementation was ambiguous - if a RamOperation has several RamOperation children, the operation is applied to the first RamOperation.
This semantics is dangerous since it depends on the getChildren() implementation of a RamOperation, which of the Operations will be rewritten.