### PR TITLE
Update clang-format style check to a less buggy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
         packages:
         # The formatting may change with different versions of clang-format.
         # Check before modifying!
-        - clang-format-6.0
+        - clang-format-7
     script: ".travis/run_test_format.sh"
 
 # Testing stage (-j8,-c -j8)

--- a/.travis/checkStyle.sh
+++ b/.travis/checkStyle.sh
@@ -3,7 +3,7 @@
 # Find the changed lines in the diff. Arguments 1 and 2 are appended to the
 #git diff command
 
-CLANGFORMAT=clang-format-6.0
+CLANGFORMAT=clang-format-7
 
 # Move to the root of the repo if we aren't there already so the paths returned
 # by git are correct.


### PR DESCRIPTION
clang-format-6.0 has an issue with `^`
e.g.
```
#define BINARY_OP (op) return execute(node->getChild(0), ctxt) op execute(node->getChild(1), ctxt)
BINARY_OP(^)
```
is handled differently to
```
#define BINARY_OP (op) return execute(node->getChild(0), ctxt) op execute(node->getChild(1), ctxt)
BINARY_OP(|)
```

This PR switches us to clang-format-7