### PR TITLE
Fix and improve handling of -j flag

### DIFF
--- a/src/CompiledOptions.h
+++ b/src/CompiledOptions.h
@@ -214,12 +214,6 @@ public:
         input_dir = fact_dir;
         output_dir = out_dir;
 
-#ifdef _OPENMP
-        if (num_jobs > 0) {
-            omp_set_num_threads(num_jobs);
-        }
-#endif
-
         // return success state
         return ok;
     }

--- a/src/SouffleInterface.h
+++ b/src/SouffleInterface.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include <cassert>
+#include <cstddef>
 
 namespace souffle {
 
@@ -246,6 +247,7 @@ private:
     std::vector<Relation*> outputRelations;
     std::vector<Relation*> internalRelations;
     std::vector<Relation*> allRelations;
+    std::size_t numThreads = 1;
 
 protected:
     // add relation to relation map
@@ -284,6 +286,16 @@ public:
 
     // dump output relations (for debug purposes)
     virtual void dumpOutputs(std::ostream& out = std::cout) = 0;
+
+    // Set the number of threads to be used
+    virtual void setNumThreads(std::size_t numThreads) {
+        this->numThreads = numThreads;
+    }
+
+    // Get the number of threads to be used
+    virtual std::size_t getNumThreads() {
+        return numThreads;
+    }
 
     // get Relation
     Relation* getRelation(const std::string& name) const {

--- a/src/SouffleInterface.h
+++ b/src/SouffleInterface.h
@@ -288,12 +288,12 @@ public:
     virtual void dumpOutputs(std::ostream& out = std::cout) = 0;
 
     // Set the number of threads to be used
-    virtual void setNumThreads(std::size_t numThreads) {
+    void setNumThreads(std::size_t numThreads) {
         this->numThreads = numThreads;
     }
 
     // Get the number of threads to be used
-    virtual std::size_t getNumThreads() {
+    std::size_t getNumThreads() {
         return numThreads;
     }
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -2325,7 +2325,6 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
 
     os << "#if defined(_OPENMP) \n";
     os << "obj.setNumThreads(opt.getNumJobs());\n";
-    os << "omp_set_nested(true);\n";
     os << "\n#endif\n";
 
     if (Global::config().has("profile")) {

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1998,6 +1998,7 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
     os << "std::atomic<size_t> iter(0);\n\n";
 
     // set default threads (in embedded mode)
+    // if this is not set, and omp is used, the default omp setting of number of cores is used.
     os << "#if defined(_OPENMP)\n";
     os << "if (getNumThreads() > 0) {omp_set_num_threads(getNumThreads());}\n";
     os << "#endif\n\n";

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1998,11 +1998,9 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
     os << "std::atomic<size_t> iter(0);\n\n";
 
     // set default threads (in embedded mode)
-    if (std::stoi(Global::config().get("jobs")) > 1) {
-        os << "#if defined(__EMBEDDED_SOUFFLE__) && defined(_OPENMP)\n";
-        os << "omp_set_num_threads(" << std::stoi(Global::config().get("jobs")) << ");\n";
-        os << "#endif\n\n";
-    }
+    os << "#if defined(_OPENMP)\n";
+    os << "if (getNumThreads() > 0) {omp_set_num_threads(getNumThreads());}\n";
+    os << "#endif\n\n";
 
     // add actual program body
     os << "// -- query evaluation --\n";
@@ -2317,16 +2315,17 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
 
     os << "if (!opt.parse(argc,argv)) return 1;\n";
 
-    os << "#if defined(_OPENMP) \n";
-    os << "omp_set_nested(true);\n";
-    os << "\n#endif\n";
-
     os << "souffle::";
     if (Global::config().has("profile")) {
         os << classname + " obj(opt.getProfileName());\n";
     } else {
         os << classname + " obj;\n";
     }
+
+    os << "#if defined(_OPENMP) \n";
+    os << "obj.setNumThreads(opt.getNumJobs());\n";
+    os << "omp_set_nested(true);\n";
+    os << "\n#endif\n";
 
     if (Global::config().has("profile")) {
         os << R"_(souffle::ProfileEventSingleton::instance().makeConfigRecord("", opt.getSourceFileName());)_"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -508,7 +508,7 @@ int main(int argc, char** argv) {
                     std::make_unique<HoistAggregateTransformer>(), std::make_unique<TupleIdTransformer>())),
             std::make_unique<ExpandFilterTransformer>(), std::make_unique<HoistConditionsTransformer>(),
             std::make_unique<RamConditionalTransformer>(
-                    []() -> bool { return std::stoi(Global::config().get("jobs")) > 1; },
+                    []() -> bool { return std::stoi(Global::config().get("jobs")) != 1; },
                     std::make_unique<ParallelTransformer>()),
             std::make_unique<ReportIndexTransfomer>());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -243,30 +243,25 @@ int main(int argc, char** argv) {
         }
 
         /* for the jobs option, to determine the number of threads used */
-        if (Global::config().has("jobs")) {
 #ifdef _OPENMP
-            if (isNumber(Global::config().get("jobs").c_str())) {
-                if (std::stoi(Global::config().get("jobs")) < 1) {
-                    throw std::runtime_error(
-                            "Number of jobs in the -j/--jobs options must be greater than zero!");
-                }
-            } else {
-                if (!Global::config().has("jobs", "auto")) {
-                    throw std::runtime_error(
-                            "Wrong parameter " + Global::config().get("jobs") + " for option -j/--jobs!");
-                }
-                Global::config().set("jobs", "0");
+        if (isNumber(Global::config().get("jobs").c_str())) {
+            if (std::stoi(Global::config().get("jobs")) < 1) {
+                throw std::runtime_error(
+                        "Number of jobs in the -j/--jobs options must be greater than zero!");
             }
-#else
-            // Check that -j option has not been changed from the default
-            if (Global::config().get("jobs") != "1") {
-                std::cerr << "\nWarning: OpenMP is not enabled\n";
-            }
-#endif
         } else {
-            throw std::runtime_error(
-                    "Wrong parameter " + Global::config().get("jobs") + " for option -j/--jobs!");
+            if (!Global::config().has("jobs", "auto")) {
+                throw std::runtime_error(
+                        "Wrong parameter " + Global::config().get("jobs") + " for option -j/--jobs!");
+            }
+            Global::config().set("jobs", "0");
         }
+#else
+        // Check that -j option has not been changed from the default
+        if (Global::config().get("jobs") != "1") {
+            std::cerr << "\nWarning: OpenMP is not enabled\n";
+        }
+#endif
 
         /* if an output directory is given, check it exists */
         if (Global::config().has("output-dir") && !Global::config().has("output-dir", "-") &&

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -246,20 +246,18 @@ int main(int argc, char** argv) {
 #ifdef _OPENMP
         if (isNumber(Global::config().get("jobs").c_str())) {
             if (std::stoi(Global::config().get("jobs")) < 1) {
-                throw std::runtime_error(
-                        "Number of jobs in the -j/--jobs options must be greater than zero!");
+                throw std::runtime_error("-j/--jobs may only be set to 'auto' or an integer greater than 0.");
             }
         } else {
             if (!Global::config().has("jobs", "auto")) {
-                throw std::runtime_error(
-                        "Wrong parameter " + Global::config().get("jobs") + " for option -j/--jobs!");
+                throw std::runtime_error("-j/--jobs may only be set to 'auto' or an integer greater than 0.");
             }
             Global::config().set("jobs", "0");
         }
 #else
         // Check that -j option has not been changed from the default
         if (Global::config().get("jobs") != "1") {
-            std::cerr << "\nWarning: OpenMP is not enabled\n";
+            std::cerr << "\nThis installation of Souffle does not support concurrent jobs.\n";
         }
 #endif
 
@@ -508,6 +506,7 @@ int main(int argc, char** argv) {
                     std::make_unique<HoistAggregateTransformer>(), std::make_unique<TupleIdTransformer>())),
             std::make_unique<ExpandFilterTransformer>(), std::make_unique<HoistConditionsTransformer>(),
             std::make_unique<RamConditionalTransformer>(
+                    // job count of 0 means all cores are used.
                     []() -> bool { return std::stoi(Global::config().get("jobs")) != 1; },
                     std::make_unique<ParallelTransformer>()),
             std::make_unique<ReportIndexTransfomer>());


### PR DESCRIPTION
Fixes #1128 
ParallelTransformer is run for all parallel programs
Number of threads can be configured by embedded souffle
Responsibility for setting number of threads in compiled code is moved from option parsing to the souffle program.