### PR TITLE
Fix memory issues

### DIFF
--- a/src/InterpreterEngine.cpp
+++ b/src/InterpreterEngine.cpp
@@ -44,7 +44,7 @@ void InterpreterEngine::createRelation(
                     id.getArity(), id.getName(), std::vector<std::string>(), orderSet);
         }
     }
-    relations[idx] = std::move(res);
+    std::swap(relations[idx], res);
 }
 
 InterpreterRelation& InterpreterEngine::getRelation(const size_t idx) {
@@ -56,7 +56,7 @@ InterpreterEngine::RelationHandle& InterpreterEngine::getRelationHandle(const si
 }
 
 void InterpreterEngine::dropRelation(const size_t relId) {
-    relations[relId].release();
+    relations[relId].reset(nullptr);
 }
 
 void InterpreterEngine::swapRelation(const size_t ramRel1, const size_t ramRel2) {

--- a/src/InterpreterEngine.h
+++ b/src/InterpreterEngine.h
@@ -23,6 +23,11 @@
 #include "InterpreterRelation.h"
 #include "RamTranslationUnit.h"
 #include "RamVisitor.h"
+#include <deque>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 #include <dlfcn.h>
 
 namespace souffle {
@@ -102,7 +107,7 @@ private:
     /** Loop iteration counter */
     size_t iteration = 0;
     /** Profile for rule frequencies */
-    std::map<std::string, std::map<size_t, size_t>> frequencies;
+    std::map<std::string, std::deque<std::atomic<size_t>>> frequencies;
     /** Profile for relation reads */
     std::map<std::string, std::atomic<size_t>> reads;
     /** DLL */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,13 +91,14 @@ void executeBinary(const std::string& binaryFilename
     } else
 #endif
     {
-        std::string ldPath = "LD_LIBRARY_PATH=";
-        for (const std::string& library : splitString(Global::config().get("library-dir"), ' ')) {
-            ldPath += library + ':';
+        if (Global::config().has("library-dir")) {
+            std::string ldPath;
+            for (const std::string& library : splitString(Global::config().get("library-dir"), ' ')) {
+                ldPath += library + ':';
+            }
+            ldPath.back() = ' ';
+            setenv("LD_LIBRARY_PATH", ldPath.c_str(), true);
         }
-        ldPath.back() = ' ';
-        std::vector<char> ldPathChars(ldPath.begin(), ldPath.end());
-        putenv(&ldPathChars[0]);
 
         exitCode = system(binaryFilename.c_str());
     }


### PR DESCRIPTION
#1130 introduced a memory leak (suggesting the memory leak tests have bugs themselves). It also improved parallelisation of the code, causing problems for profile frequency counts.

This PR is to fix both issues.

Note that the frequency counts are still a little fragile. A more complete fix would be to either use a slower, concurrency-safe structure, or in each stratum, for each iteration, find all potential frequency count uses and emplace initial counts.