### PR TITLE
Update osx travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ aliases:
   - &osxgcc
     stage: Testing
     os: osx
-    osx_image: xcode10.1
+    osx_image: xcode11.2
     compiler: gcc
     install: ". .travis/osx/install_withgcc.sh"
     before_script: ".travis/init_test.sh"

--- a/.travis/osx/install.sh
+++ b/.travis/osx/install.sh
@@ -6,9 +6,9 @@ set -e
 set -x
 
 # Install requirements of MAC OS X
-brew install md5sha1sum bison libtool mcpp libffi
-brew link bison --force
-brew link libffi --force
+brew install bison libtool mcpp libffi || echo "brew install failed"
+brew link bison --force || echo "brew link bison failed"
+brew link libffi --force || echo "brew link libffi failed"
 
 export PATH="/usr/local/opt/bison/bin:$PATH"
 export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig/


### PR DESCRIPTION
The travis osx image we're currently using has issues with brew. This PR uses a different image, which also fails, and applies a fix to the new image.

The fix is to capture errors from brew to allow progress from non-fatal errors. Note that no errors are seen, so it's odd that the fix helps.