### PR TITLE
Add options to see transformed input and errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -217,6 +217,7 @@ int main(int argc, char** argv) {
                         "execution engine."},
                 {"verbose", 'v', "", "", false, "Verbose output."},
                 {"version", '\3', "", "", false, "Version."},
+                {"transformed-datalog", '\4', "", "", false, "Output dl after all transformations."},
                 {"help", 'h', "", "", false, "Display this help message."}};
         Global::config().processArgs(argc, argv, header.str(), footer.str(), options);
 
@@ -489,6 +490,11 @@ int main(int argc, char** argv) {
     // Apply all the transformations
     pipeline->apply(*astTranslationUnit);
 
+    // Output the transformed datalog and return
+    if (Global::config().has("transformed-datalog")) {
+        std::cout << *astTranslationUnit->getProgram() << std::endl;
+        return 0;
+    }
     // ------- execution -------------
 
     /* translate AST to RAM */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -218,6 +218,7 @@ int main(int argc, char** argv) {
                 {"verbose", 'v', "", "", false, "Verbose output."},
                 {"version", '\3', "", "", false, "Version."},
                 {"transformed-datalog", '\4', "", "", false, "Output dl after all transformations."},
+                {"parse-errors", '\5', "", "", false, "Show parsing errors, if any, then exit."},
                 {"help", 'h', "", "", false, "Display this help message."}};
         Global::config().processArgs(argc, argv, header.str(), footer.str(), options);
 
@@ -402,6 +403,11 @@ int main(int argc, char** argv) {
         auto parser_end = std::chrono::high_resolution_clock::now();
         std::cout << "Parse Time: " << std::chrono::duration<double>(parser_end - parser_start).count()
                   << "sec\n";
+    }
+
+    if (Global::config().has("parse-errors")) {
+        std::cout << astTranslationUnit->getErrorReport();
+        return astTranslationUnit->getErrorReport().getNumErrors();
     }
 
     // ------- check for parse errors -------------


### PR DESCRIPTION
Add option to see the datalog produced by applying all selected Ast transformations.
  `souffle --transformed-datalog foo.dl`

Add option to only return parse errors - a start for providing help to IDEs using souffle datalog.
  `souffle --parse-errors foo.dl`

Parse error output sets exit code to the count of errors, thus zero for no errors, non-zero for errors