### PR TITLE
Refactor interface & iterators

### DIFF
--- a/src/InterpreterIndex.cpp
+++ b/src/InterpreterIndex.cpp
@@ -104,7 +104,7 @@ class NullaryIndex : public InterpreterIndex {
         }
 
         std::unique_ptr<Stream::Source> clone() override {
-            return std::unique_ptr<Stream::Source>(new Source(present));
+            return std::make_unique<Source>(present);
         }
     };
 

--- a/src/InterpreterIndex.h
+++ b/src/InterpreterIndex.h
@@ -60,7 +60,7 @@ public:
  */
 class TupleRef {
     // The address of the first component of the tuple.
-    const RamDomain* base{};
+    const RamDomain* base = nullptr;
 
     // The size of the tuple.
     std::size_t arity = 0;
@@ -211,7 +211,7 @@ public:
 
 private:
     // the source to read data from
-    std::unique_ptr<Source> source;
+    std::unique_ptr<Source> source = nullptr;
 
     // an internal buffer for decoded elements
     std::array<TupleRef, BUFFER_SIZE> buffer{};
@@ -227,7 +227,7 @@ public:
         loadNext();
     }
 
-    Stream() : source(nullptr) {}
+    Stream() = default;
 
     Stream(Stream& other) = delete;
 
@@ -303,10 +303,10 @@ public:
 
     // support for ranged based for loops
     Iterator begin() {
-        return *this;
+        return Iterator(*this);
     }
     Iterator end() const {
-        return {};
+        return Iterator();
     }
 
 private:

--- a/src/InterpreterProgInterface.h
+++ b/src/InterpreterProgInterface.h
@@ -142,7 +142,7 @@ protected:
         /** Check equivalence */
         bool equal(const Relation::iterator_base& o) const override {
             try {
-                auto iter = dynamic_cast<const InterpreterRelInterface::iterator_base&>(o);
+                auto& iter = dynamic_cast<const InterpreterRelInterface::iterator_base&>(o);
                 return ramRelationInterface == iter.ramRelationInterface && it == iter.it;
             } catch (const std::bad_cast& e) {
                 return false;

--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -70,7 +70,7 @@ public:
     };
 
     Iterator begin() const {
-        return *this;
+        return Iterator(*this);
     }
 
     Iterator end() const {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -316,6 +316,12 @@ test_compiled_relation_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/s
 test_compiled_relation_test_SOURCES = test/compiled_relation_test.cpp
 test_compiled_relation_test_LDADD = libsouffle.la
 
+# interpreter relation test
+check_PROGRAMS += test/interpreter_relation_test
+test_interpreter_relation_test_CXXFLAGS = $(souffle_bin_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_interpreter_relation_test_SOURCES = test/interpreter_relation_test.cpp
+test_interpreter_relation_test_LDADD = libsouffle.la
+
 # type system test
 check_PROGRAMS += test/type_system_test
 test_type_system_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test

--- a/src/SouffleInterface.h
+++ b/src/SouffleInterface.h
@@ -152,11 +152,10 @@ public:
     class iterator {
     protected:
         /*
-         * Iterator_base class pointer.
+         * iterator_base class pointer.
          *
-         * TODO (Honghyw) : Provide a documentation that explains why we need to set iter to null prt.
          */
-        iterator_base* iter = nullptr;
+        std::unique_ptr<iterator_base> iter = nullptr;
 
     public:
         /**
@@ -165,11 +164,20 @@ public:
         iterator() = default;
 
         /**
+         * Move constructor.
+         *
+         * The new iterator now has ownerhsip of the iterator base.
+         *
+         * @param arg lvalue reference to an iterator object
+         */
+        iterator(iterator&& arg) = default;
+
+        /**
          * Constructor.
          *
-         * Initialize the iter to be the same as arg.
+         * Initialise this iterator with a given iterator base
          *
-         * TODO (Honghyw) : Provide a documentation explaining why this is useful.
+         * The new iterator has ownership of the iterator base.
          *
          * @param arg An iterator_base class pointer
          */
@@ -180,16 +188,12 @@ public:
          *
          * The iterator_base instance iter is pointing is destructed.
          */
-        ~iterator() {
-            delete iter;
-        }
+        ~iterator() = default;
 
         /**
          * Constructor.
          *
-         * Initialize the iter to be the clone of arg.
-         *
-         * TODO (Honghyw) : Provide a documentation explaining why this is useful
+         * Initialise the iter to be the clone of arg.
          *
          * @param o Reference to an iterator object
          */
@@ -201,8 +205,12 @@ public:
          * The original iterator_base instance is destructed.
          */
         iterator& operator=(const iterator& o) {
-            delete iter;
-            iter = o.iter->clone();
+            iter.reset(o.iter->clone());
+            return *this;
+        }
+
+        iterator& operator=(iterator&& o) {
+            iter.swap(o.iter);
             return *this;
         }
 
@@ -574,12 +582,11 @@ public:
     }
 
     /**
-     * Direct constructor using initialization list.
-     *
-     * TODO (Honghyw) : Provide a ducumentation explainning what this is doing.
+     * Construct using initialisation list.
      */
-    tuple(Relation* r, std::initializer_list<RamDomain> il) : relation(*r), array(il), pos(il.size()) {
-        assert(il.size() == r->getArity() && "wrong tuple arity");
+    tuple(const Relation* relation, std::initializer_list<RamDomain> tupleList)
+            : relation(*relation), array(tupleList), pos(tupleList.size()), data(array.data()) {
+        assert(tupleList.size() == relation->getArity() && "tuple arity does not match relation arity");
     }
 };
 

--- a/src/test/interpreter_relation_test.cpp
+++ b/src/test/interpreter_relation_test.cpp
@@ -19,9 +19,6 @@
 #include "SouffleInterface.h"
 #include "test.h"
 
-#include <fstream>
-#include <memory>
-
 using namespace souffle;
 
 namespace test {
@@ -81,7 +78,9 @@ TEST(Basic, Iteration) {
     Relation::iterator it = relInt.begin();
     std::size_t count = 0;
     while (it != relInt.end()) {
+        // Check the 'deref' doesn't crash
         auto value = (*it)[0];
+        (void)value;
         ++it;
         ++count;
     }
@@ -116,7 +115,7 @@ TEST(Independence, Iteration) {
     EXPECT_EQ(1, (*it3)[0]);
 }
 
-TEST(IndepedentMoving, Iteration) {
+TEST(IndependentMoving, Iteration) {
     // create a table
     SymbolTable symbolTable;
     MinIndexSelection order{};

--- a/src/test/interpreter_relation_test.cpp
+++ b/src/test/interpreter_relation_test.cpp
@@ -1,0 +1,142 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2019, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file interpreter_relation_test.h
+ *
+ * Tests InterpreterRelation
+ *
+ ***********************************************************************/
+
+#include "InterpreterProgInterface.h"
+#include "InterpreterRelation.h"
+#include "SouffleInterface.h"
+#include "test.h"
+
+#include <fstream>
+#include <memory>
+
+using namespace souffle;
+
+namespace test {
+
+TEST(Relation0, Construction) {
+    // create a nullary relation
+    SymbolTable symbolTable;
+    MinIndexSelection order{};
+    order.insertDefaultTotalIndex(0);
+    InterpreterRelation rel(0, 0, "test", {}, order);
+    InterpreterRelInterface relInt(rel, symbolTable, "test", {}, {}, 0);
+
+    // add some values
+    EXPECT_EQ(0, rel.size());
+    relInt.insert(tuple(&relInt, {}));
+    EXPECT_EQ(1, rel.size());
+    relInt.insert(tuple(&relInt, {}));
+    EXPECT_EQ(1, rel.size());
+}
+
+TEST(Relation1, Construction) {
+    // create a single attribute relation
+    SymbolTable symbolTable;
+    MinIndexSelection order{};
+    order.insertDefaultTotalIndex(1);
+    InterpreterRelation rel(1, 0, "test", {"i"}, order);
+    InterpreterRelInterface relInt(rel, symbolTable, "test", {"i"}, {"i"}, 0);
+
+    tuple d1(&relInt, {1});
+    // add some values
+    EXPECT_EQ(0, rel.size());
+    relInt.insert(d1);
+    EXPECT_EQ(1, rel.size());
+    relInt.insert(tuple(&relInt, {2}));
+    EXPECT_EQ(2, rel.size());
+    relInt.insert(tuple(&relInt, {3}));
+    EXPECT_EQ(3, rel.size());
+    relInt.insert(tuple(&relInt, {4}));
+    EXPECT_EQ(4, rel.size());
+}
+
+TEST(Basic, Iteration) {
+    // create a relation
+    SymbolTable symbolTable;
+    MinIndexSelection order{};
+    order.insertDefaultTotalIndex(1);
+    InterpreterRelation rel(1, 0, "test", {"i"}, order);
+    InterpreterRelInterface relInt(rel, symbolTable, "test", {"i"}, {"i"}, 0);
+
+    // add some values
+    relInt.insert(tuple(&relInt, {1}));
+    relInt.insert(tuple(&relInt, {2}));
+    relInt.insert(tuple(&relInt, {3}));
+    relInt.insert(tuple(&relInt, {4}));
+
+    // Iterate
+    Relation::iterator it = relInt.begin();
+    std::size_t count = 0;
+    while (it != relInt.end()) {
+        auto value = (*it)[0];
+        ++it;
+        ++count;
+    }
+    EXPECT_EQ(4, count);
+}
+
+TEST(Independence, Iteration) {
+    // create a table
+    SymbolTable symbolTable;
+    MinIndexSelection order{};
+    order.insertDefaultTotalIndex(1);
+    InterpreterRelation rel(1, 0, "test", {"i"}, order);
+    InterpreterRelInterface relInt(rel, symbolTable, "test", {"i"}, {"i"}, 0);
+
+    // add a value
+    relInt.insert(tuple(&relInt, {1}));
+
+    // Test a iterator returns the correct value
+    Relation::iterator it = relInt.begin();
+    EXPECT_EQ(1, (*it)[0]);
+
+    // Copy the iterator and modify the copy
+    {
+        Relation::iterator it2(it);
+        EXPECT_EQ(1, (*it2)[0]);
+        ++it2;
+    }
+    EXPECT_EQ(1, (*it)[0]);
+
+    // Test that a new iterator is also valid
+    Relation::iterator it3 = std::move(relInt.begin());
+    EXPECT_EQ(1, (*it3)[0]);
+}
+
+TEST(IndepedentMoving, Iteration) {
+    // create a table
+    SymbolTable symbolTable;
+    MinIndexSelection order{};
+    order.insertDefaultTotalIndex(1);
+    InterpreterRelation rel(1, 0, "test", {"i"}, order);
+    InterpreterRelInterface relInt(rel, symbolTable, "test", {"i"}, {"i"}, 0);
+
+    // add a value
+    relInt.insert(tuple(&relInt, {1}));
+
+    Relation::iterator it = relInt.begin();
+    EXPECT_EQ(1, (*it)[0]);
+
+    // Make a new iterator, move it to the first iterator, then let the new iterator go out of scope
+    {
+        Relation::iterator it2(relInt.begin());
+        EXPECT_EQ(1, (*it2)[0]);
+        it = std::move(it2);
+    }
+    EXPECT_EQ(1, (*it)[0]);
+}
+
+}  // end namespace test


### PR DESCRIPTION
* Some cosmetic implementation changes for clarity
* Used unique_ptr to manage a raw pointer
* Added move assignment operator

This PR helps with issues copying/moving interface iterators. I'm not entirely sure where the problem starts, but the move assignment operator, and changes to handling of the base iterator, make the issues stop happening.

(Unit tests will follow soon.)