### PR TITLE
Nesting break-filter reordering

### DIFF
--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -396,6 +396,31 @@ bool MakeIndexTransformer::makeIndex(RamProgram& program) {
     return changed;
 }
 
+bool ReorderFilterBreak::reorderFilterBreak(RamProgram& program) {
+    bool changed = false;
+    visitDepthFirst(program, [&](const RamQuery& query) {
+        std::function<std::unique_ptr<RamNode>(std::unique_ptr<RamNode>)> filterRewriter =
+                [&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {
+            // find filter-break nesting
+            if (const RamFilter* filter = dynamic_cast<RamFilter*>(node.get())) {
+                if (const RamBreak* br = dynamic_cast<RamBreak*>(&filter->getOperation())) {
+                    changed = true;
+                    // convert to break-filter nesting
+                    node = std::make_unique<RamBreak>(
+                            std::unique_ptr<RamCondition>(br->getCondition().clone()),
+                            std::make_unique<RamFilter>(
+                                    std::unique_ptr<RamCondition>(filter->getCondition().clone()),
+                                    std::unique_ptr<RamOperation>(br->getOperation().clone())));
+                }
+            }
+            node->apply(makeLambdaRamMapper(filterRewriter));
+            return node;
+        };
+        const_cast<RamQuery*>(&query)->apply(makeLambdaRamMapper(filterRewriter));
+    });
+    return changed;
+}
+
 std::unique_ptr<RamOperation> IfConversionTransformer::rewriteIndexScan(const RamIndexScan* indexScan) {
     // check whether tuple is used in subsequent operations
     bool tupleNotUsed = true;

--- a/src/RamTransforms.h
+++ b/src/RamTransforms.h
@@ -234,6 +234,50 @@ protected:
 };
 
 /**
+ * @class ReorderBreak
+ * @brief Reorder filter-break nesting to a break-filter nesting
+ *
+ * For example ..
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *  QUERY
+ *   ...
+ *    IF C1
+ *     BREAK C2
+ *      ...
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * will be rewritten to
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *  QUERY
+ *   ...
+ *    BREAK C2
+ *     IF C1
+ *      ...
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ */
+class ReorderFilterBreak : public RamTransformer {
+public:
+    std::string getName() const override {
+        return "ReorderFilterBreak";
+    }
+
+    /**
+     * @brief reorder filter-break nesting to break-filter nesting
+     * @param program Program that is transform
+     * @return Flag showing whether the program has been changed by the transformation
+     */
+    bool reorderFilterBreak(RamProgram& program);
+
+protected:
+    bool transform(RamTranslationUnit& translationUnit) override {
+        return reorderFilterBreak(*translationUnit.getProgram());
+    }
+};
+
+/**
  * @class MakeIndexTransformer
  * @brief Make indexable operations to indexed operations.
  *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -490,6 +490,7 @@ int main(int argc, char** argv) {
                     std::make_unique<HoistAggregateTransformer>(), std::make_unique<TupleIdTransformer>())),
             std::make_unique<ExpandFilterTransformer>(), std::make_unique<HoistConditionsTransformer>(),
             std::make_unique<CollapseFiltersTransformer>(), std::make_unique<ReorderConditionsTransformer>(),
+            std::make_unique<RamLoopTransformer>(std::make_unique<ReorderFilterBreak>()),
             std::make_unique<RamConditionalTransformer>(
                     // job count of 0 means all cores are used.
                     []() -> bool { return std::stoi(Global::config().get("jobs")) != 1; },


### PR DESCRIPTION
The optimisation is not fully completed. We need to swap a filter-break nesting to a break-filter nesting to complete the job of #1164 

An example case for this optimisation is the following Datalog code
```
.decl block_points(x: number)
.decl block_is_overlaping(x: number)
.decl data_byte(x:number, y:number)
.decl printable_char(x:number)
.output block_points

block_is_overlaping(0).
data_byte(0,0).
data_byte(1,1).
data_byte(2,2).
data_byte(3,3).
data_byte(4,4).
printable_char(1).

block_points(Block):-
    block_is_overlaping(Block),
    data_byte(EA,Byte),(printable_char(Byte); Byte = 0),
    data_byte(EA+1,Byte1),(printable_char(Byte1); Byte1 = 0),
    data_byte(EA+2,Byte2),(printable_char(Byte2); Byte2 = 0),
    data_byte(EA+3,Byte3),(printable_char(Byte3); Byte3 = 0),
    data_byte(EA+4,Byte4),(printable_char(Byte4); Byte4 = 0).
```
