### PR TITLE
Remove ifdef specific for unusable compilers

### DIFF
--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -317,13 +317,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             }
 
             // outline each search operation to improve compilation time
-#ifdef __clang__
-#if __clang_major > 3
             out << "[&]()";
-#endif
-#else
-            out << "[&]()";
-#endif
             // enclose operation in its own scope
             out << "{\n";
 
@@ -372,13 +366,8 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             }
 
             out << "}\n";
-#ifdef __clang__
-#if __clang_major > 3
             out << "();";  // call lambda
-#endif
-#else
-            out << "();";  // call lambda
-#endif
+
             if (freeOfCtx.size() > 0) {
                 out << "}\n";
             }


### PR DESCRIPTION
This PR removes some clang 3 specific code. Since a newer clang is needed to compile souffle now, the ifdef is not needed.