### PR TITLE
Added handling of unnamed variables during partitioning transformation.

### DIFF
--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1036,7 +1036,7 @@ bool NameUnnamedVariablesTransformer::transform(AstTranslationUnit& translationU
         nameVariables() : changed(false), count(0) {}
 
         std::unique_ptr<AstNode> operator()(std::unique_ptr<AstNode> node) const override {
-            if (dynamic_cast<AstUnnamedVariable*>(node.get())) {
+            if (dynamic_cast<AstUnnamedVariable*>(node.get()) != nullptr) {
                 changed = true;
                 std::stringstream name;
                 name << boundPrefix << "_" << count++;

--- a/src/AstTransforms.h
+++ b/src/AstTransforms.h
@@ -294,6 +294,21 @@ private:
 };
 
 /**
+ * Transformation pass to replace unnamed variables
+ * with singletons.
+ * E.g.: a() :- b(_). -> a() :- b(x).
+ */
+class NameUnnamedVariablesTransformer : public AstTransformer {
+public:
+    std::string getName() const override {
+        return "NameUnnamedVariablesTransformer";
+    }
+
+private:
+    bool transform(AstTranslationUnit& translationUnit) override;
+};
+
+/**
  * Transformation pass to reorder body literals.
  */
 class ReorderLiteralsTransformer : public AstTransformer {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -413,6 +413,12 @@ int main(int argc, char** argv) {
                     std::make_unique<RemoveEmptyRelationsTransformer>(),
                     std::make_unique<RemoveRedundantRelationsTransformer>());
 
+    // Partitioning pipeline
+    auto partitionPipeline =
+            std::make_unique<PipelineTransformer>(std::make_unique<NameUnnamedVariablesTransformer>(),
+                    std::make_unique<PartitionBodyLiteralsTransformer>(),
+                    std::make_unique<ReplaceSingletonVariablesTransformer>());
+
     // Provenance pipeline
     auto provenancePipeline = std::make_unique<PipelineTransformer>(std::make_unique<ConditionalTransformer>(
             Global::config().has("provenance"), std::make_unique<ProvenanceTransformer>()));
@@ -432,8 +438,7 @@ int main(int argc, char** argv) {
             std::make_unique<FixpointTransformer>(
                     std::make_unique<PipelineTransformer>(std::make_unique<ReduceExistentialsTransformer>(),
                             std::make_unique<RemoveRedundantRelationsTransformer>())),
-            std::make_unique<RemoveRelationCopiesTransformer>(),
-            std::make_unique<PartitionBodyLiteralsTransformer>(),
+            std::make_unique<RemoveRelationCopiesTransformer>(), std::move(partitionPipeline),
             std::make_unique<MinimiseProgramTransformer>(),
             std::make_unique<RemoveRelationCopiesTransformer>(),
             std::make_unique<ReorderLiteralsTransformer>(),


### PR DESCRIPTION
Solves issue #1173.

```
.decl B(x:number, y:number)
B(1,1).
.decl A(x:number)
A(1).
A(x+1) :- A(x), x < 100, B(_,1).
.printsize A
```

is now transformed to

```
.decl B(x:number, y:number)
B(1,1).
.decl disconnected1() 
disconnected1() :- B(_,1). 
.decl A(x:number)
A(1).
A(x+1) :- A(x), x < 100, disconnected1.
.printsize A
```

Previously, unnamed variables were being treated in the same way as constants, and so did not trigger disconnection.