### PR TITLE
Extended program-minimiser to handle bijectively equivalent singleton relations.

### DIFF
--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -796,18 +796,6 @@ bool PartitionBodyLiteralsTransformer::transform(AstTranslationUnit& translation
 bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUnit) {
     AstProgram& program = *translationUnit.getProgram();
 
-    // Checks whether a given clause is recursive
-    auto isRecursiveClause = [&](const AstClause& clause) {
-        AstRelationIdentifier relationName = clause.getHead()->getName();
-        bool recursive = false;
-        visitDepthFirst(clause.getBodyLiterals(), [&](const AstAtom& atom) {
-            if (atom.getName() == relationName) {
-                recursive = true;
-            }
-        });
-        return recursive;
-    };
-
     // Checks whether an atom is of the form a(_,_,...,_)
     auto isExistentialAtom = [&](const AstAtom& atom) {
         for (AstArgument* arg : atom.getArguments()) {

--- a/src/AstUtils.cpp
+++ b/src/AstUtils.cpp
@@ -111,4 +111,15 @@ bool hasClauseWithAggregatedRelation(const AstRelation* relation, const AstRelat
     return false;
 }
 
+bool isRecursiveClause(const AstClause& clause) {
+    AstRelationIdentifier relationName = clause.getHead()->getName();
+    bool recursive = false;
+    visitDepthFirst(clause.getBodyLiterals(), [&](const AstAtom& atom) {
+        if (atom.getName() == relationName) {
+            recursive = true;
+        }
+    });
+    return recursive;
+}
+
 }  // end of namespace souffle

--- a/src/AstUtils.cpp
+++ b/src/AstUtils.cpp
@@ -124,9 +124,7 @@ bool isRecursiveClause(const AstClause& clause) {
 
 bool isIORelation(const AstRelation& relation) {
     int qualifier = relation.getQualifier();
-    if ((qualifier & INPUT_RELATION) ||
-            (qualifier & OUTPUT_RELATION) ||
-            (qualifier & PRINTSIZE_RELATION)) {
+    if ((qualifier & INPUT_RELATION) || (qualifier & OUTPUT_RELATION) || (qualifier & PRINTSIZE_RELATION)) {
         return true;
     }
     return false;

--- a/src/AstUtils.cpp
+++ b/src/AstUtils.cpp
@@ -122,12 +122,4 @@ bool isRecursiveClause(const AstClause& clause) {
     return recursive;
 }
 
-bool isIORelation(const AstRelation& relation) {
-    int qualifier = relation.getQualifier();
-    if ((qualifier & INPUT_RELATION) || (qualifier & OUTPUT_RELATION) || (qualifier & PRINTSIZE_RELATION)) {
-        return true;
-    }
-    return false;
-}
-
 }  // end of namespace souffle

--- a/src/AstUtils.cpp
+++ b/src/AstUtils.cpp
@@ -122,4 +122,14 @@ bool isRecursiveClause(const AstClause& clause) {
     return recursive;
 }
 
+bool isIORelation(const AstRelation& relation) {
+    int qualifier = relation.getQualifier();
+    if ((qualifier & INPUT_RELATION) ||
+            (qualifier & OUTPUT_RELATION) ||
+            (qualifier & PRINTSIZE_RELATION)) {
+        return true;
+    }
+    return false;
+}
+
 }  // end of namespace souffle

--- a/src/AstUtils.h
+++ b/src/AstUtils.h
@@ -125,4 +125,11 @@ bool hasClauseWithNegatedRelation(const AstRelation* relation, const AstRelation
 bool hasClauseWithAggregatedRelation(const AstRelation* relation, const AstRelation* aggRelation,
         const AstProgram* program, const AstLiteral*& foundLiteral);
 
+/**
+ * Returns whether the given clause is recursive.
+ * @param clause the clause to check
+ * @return true iff the clause is recursive
+ */
+bool isRecursiveClause(const AstClause& clause);
+
 }  // end of namespace souffle

--- a/src/AstUtils.h
+++ b/src/AstUtils.h
@@ -132,11 +132,4 @@ bool hasClauseWithAggregatedRelation(const AstRelation* relation, const AstRelat
  */
 bool isRecursiveClause(const AstClause& clause);
 
-/**
- * Returns whether the given relation is IO.
- * @param relation the relation to check
- * @return true iff the relation is an input or output relation
- */
-bool isIORelation(const AstRelation& relation);
-
 }  // end of namespace souffle

--- a/src/AstUtils.h
+++ b/src/AstUtils.h
@@ -132,4 +132,11 @@ bool hasClauseWithAggregatedRelation(const AstRelation* relation, const AstRelat
  */
 bool isRecursiveClause(const AstClause& clause);
 
+/**
+ * Returns whether the given relation is IO.
+ * @param relation the relation to check
+ * @return true iff the relation is an input or output relation
+ */
+bool isIORelation(const AstRelation& relation);
+
 }  // end of namespace souffle

--- a/src/MinimiseProgramTransformer.cpp
+++ b/src/MinimiseProgramTransformer.cpp
@@ -22,6 +22,7 @@
 #include "AstRelationIdentifier.h"
 #include "AstTransforms.h"
 #include "AstTranslationUnit.h"
+#include "AstUtils.h"
 #include "AstVisitor.h"
 #include <map>
 #include <memory>
@@ -358,18 +359,6 @@ bool reduceLocallyEquivalentClauses(AstProgram& program) {
 }
 
 bool reduceEquivalentRelations(AstProgram& program) {
-    // TODO: move to some utils thing
-    auto isRecursiveClause = [&](const AstClause& clause) {
-        AstRelationIdentifier relationName = clause.getHead()->getName();
-        bool recursive = false;
-        visitDepthFirst(clause.getBodyLiterals(), [&](const AstAtom& atom) {
-            if (atom.getName() == relationName) {
-                recursive = true;
-            }
-        });
-        return recursive;
-    };
-
     std::vector<AstClause*> singletonRelationClauses;
     for (AstRelation* rel : program.getRelations()) {
         if (rel->getClauses().size() == 1) {

--- a/src/MinimiseProgramTransformer.cpp
+++ b/src/MinimiseProgramTransformer.cpp
@@ -316,12 +316,10 @@ bool areBijectivelyEquivalent(const AstClause* left, const AstClause* right) {
     return false;
 }
 
-bool MinimiseProgramTransformer::transform(AstTranslationUnit& translationUnit) {
-    AstProgram& program = *translationUnit.getProgram();
-
+bool reduceLocallyEquivalentClauses(AstProgram& program) {
     std::vector<AstClause*> clausesToDelete;
 
-    // split up each relation's rules into equivalene classes
+    // split up each relation's rules into equivalence classes
     // TODO (azreika): consider turning this into an ast analysis instead
     for (AstRelation* rel : program.getRelations()) {
         std::vector<std::vector<AstClause*>> equivalenceClasses;
@@ -356,6 +354,19 @@ bool MinimiseProgramTransformer::transform(AstTranslationUnit& translationUnit) 
 
     // changed iff any clauses were deleted
     return !clausesToDelete.empty();
+}
+
+bool reduceEquivalentRelations(AstProgram& program) {
+    return false;
+}
+
+bool MinimiseProgramTransformer::transform(AstTranslationUnit& translationUnit) {
+    AstProgram& program = *translationUnit.getProgram();
+
+    bool changed = false;
+    changed |= reduceLocallyEquivalentClauses(program);
+    changed |= reduceEquivalentRelations(program);
+    return changed;
 }
 
 }  // namespace souffle

--- a/src/MinimiseProgramTransformer.cpp
+++ b/src/MinimiseProgramTransformer.cpp
@@ -287,6 +287,11 @@ bool areBijectivelyEquivalent(const AstClause* left, const AstClause* right) {
         return false;
     }
 
+    // head atoms must have the same arity
+    if (left->getHead()->getArity() != right->getHead()->getArity()) {
+        return false;
+    }
+
     // set up the n x n permutation matrix, where n is the number of
     // atoms in the clause, including the head atom
     size_t size = left->getBodyLiterals().size() + 1;

--- a/src/MinimiseProgramTransformer.cpp
+++ b/src/MinimiseProgramTransformer.cpp
@@ -430,7 +430,8 @@ bool reduceSingletonRelations(AstProgram& program) {
     struct replaceRedundantRelations : public AstNodeMapper {
         const std::map<AstRelationIdentifier, AstRelationIdentifier>& canonicalName;
 
-        replaceRedundantRelations(const std::map<AstRelationIdentifier, AstRelationIdentifier>& canonicalName) : canonicalName(canonicalName) {}
+        replaceRedundantRelations(const std::map<AstRelationIdentifier, AstRelationIdentifier>& canonicalName)
+                : canonicalName(canonicalName) {}
 
         std::unique_ptr<AstNode> operator()(std::unique_ptr<AstNode> node) const override {
             // Remove appearances from children nodes

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -434,7 +434,7 @@ int main(int argc, char** argv) {
                             std::make_unique<RemoveRedundantRelationsTransformer>())),
             std::make_unique<RemoveRelationCopiesTransformer>(),
             std::make_unique<PartitionBodyLiteralsTransformer>(),
-            std::make_unique<MinimiseProgramTransformer>(),
+            std::make_unique<FixpointTransformer>(std::make_unique<MinimiseProgramTransformer>()),
             std::make_unique<RemoveRelationCopiesTransformer>(),
             std::make_unique<ReorderLiteralsTransformer>(),
             std::make_unique<PipelineTransformer>(std::make_unique<ResolveAliasesTransformer>(),


### PR DESCRIPTION
### Overview 
A singleton relation is a relation with a single clause defined. For example, relations `B`, `C`, and `D` in the following program.

```
.decl A(x:number)
A(1). A(2).

.decl B(x:number, y:number)
B(x, y) :- A(x), D(y).

.decl C(a:number, d:number)
C(a, d) :- D(d), A(a).

.decl D(x:number)
D(x) :- A(x), x != 2.

.decl E(x:number, y:number)
.output E()
E(x, y) :- B(x,z), C(z,y), D(y), z != 0.
```
This PR extends the program-minimiser to reduce equivalent singleton relations. For example, `B` and `C` are equivalent, as they both compute the same set of tuples (the cross-product `A x D`). The transformed program will be:
```
.decl A(x:number)
A(1). A(2).

.decl B(x:number, y:number)
B(x, y) :- A(x), D(y).

.decl D(x:number)
D(x) :- A(x), x != 2.

.decl E(x:number, y:number)
.output E()
E(x, y) :- B(x,z), B(z,y), D(y), z != 0.
```
The new program does not perform the redundant cross-product computation, which could be extremely expensive for large relations `A` and `D`.

### Body Partitioning

Extending the program-minimiser to handle singleton relations is particularly useful, because of how common equivalent singleton relations appear during the body-partitioning AST transformation. For example, from issue #1176:

```
.decl A(x:number)
A(1).
.decl B(x:number)
B(2).
.decl C(x:number)
.printsize C
C(1) :- A(x), B(x).
C(2) :- A(x), B(x).
```

produces equivalent relations `+disconnected0` and `+disconnected1`:

```
.decl +disconnected0()  
+disconnected0() :- 
   A(x),
   B(x).
.decl +disconnected1()  
+disconnected1() :- 
   A(x),
   B(x).
.decl A(x:number)  
A(1).
.decl B(x:number)  
B(2).
.decl C(x:number)  
C(1) :- 
   +disconnected0().
C(2) :- 
   +disconnected1().
.printsize C(IO="stdoutprintsize")
```
which is now handled by this PR to produce:
```
.decl +disconnected0()  
+disconnected0() :- 
   A(x),
   B(x).
.decl A(x:number)  
A(1).
.decl B(x:number)  
B(2).
.decl C(x:number)  
C(1) :- 
   +disconnected0().
C(2) :- 
   +disconnected0().
.printsize C(IO="stdoutprintsize")
```

### Fixpoint

Note that applying this transformation once may introduce new opportunities for the transformation. For example:

```
.decl A(x:number)
A(1). A(2).

.decl B(x:number, y:number)
B(x, y) :- R(x, z), D(z, y).

.decl C(x:number, y:number)
C(x, y) :- R(x, z), E(z, y).

.decl D(x:number, y:number)
D(x, y) :- A(x), F(y).

.decl E(x:number, y:number)
E(x, y) :- A(x), F(y).

.decl F(x:number)
F(0).

.decl R(x:number, y:number)
R(0, 0).

.decl G(x:number, y:number)
G(x,y) :- B(x,z), C(z,w), D(w,y).
.output G
```

One application yields:
```
.decl A(x:number)
A(1). A(2).

.decl B(x:number, y:number)
B(x, y) :- R(x, z), D(z, y).

.decl C(x:number, y:number)
C(x, y) :- R(x, z), D(z, y).

.decl D(x:number, y:number)
D(x, y) :- A(x), F(y).

.decl F(x:number)
F(0).

.decl R(x:number, y:number)
R(0, 0).

.decl G(x:number, y:number)
G(x,y) :- B(x,z), C(z,w), D(w,y).
.output G
```

Another application yields:
```
.decl A(x:number)
A(1). A(2).

.decl B(x:number, y:number)
B(x, y) :- R(x, z), D(z, y).

.decl D(x:number, y:number)
D(x, y) :- A(x), F(y).

.decl F(x:number)
F(0).

.decl R(x:number, y:number)
R(0, 0).

.decl G(x:number, y:number)
G(x,y) :- B(x,z), B(z,w), D(w,y).
.output G
```
We handle this using the fixpoint metatransformer on the final `MinimiseProgram` transformation application.