### PR TITLE
Re-instantiate transformer in pipeline

### DIFF
--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -985,7 +985,7 @@ public:
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
         os << "IF " << getCondition() << " BREAK" << std::endl;
-        RamNestedOperation::print(os, tabpos);
+        RamNestedOperation::print(os, tabpos + 1);
     }
 
     RamBreak* clone() const override {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -497,6 +497,7 @@ int main(int argc, char** argv) {
             std::make_unique<CollapseFiltersTransformer>(),
             std::make_unique<EliminateDuplicatesTransformer>(),
             std::make_unique<ReorderConditionsTransformer>(),
+            std::make_unique<RamLoopTransformer>(std::make_unique<ReorderFilterBreak>()),
             std::make_unique<RamConditionalTransformer>(
                     // job count of 0 means all cores are used.
                     []() -> bool { return std::stoi(Global::config().get("jobs")) != 1; },


### PR DESCRIPTION
 - The transformer for reordering nesting filter-break to break-filter has been removed accidentally. 
 - The output of the RamBreak has not increased the indentation. 