### PR TITLE
Amend ordering of toConjunctionList

### DIFF
--- a/src/InterpreterGenerator.h
+++ b/src/InterpreterGenerator.h
@@ -628,22 +628,22 @@ private:
      * to a list {C1, C2, ..., Cn}.
      */
     inline std::vector<const RamCondition*> toConjunctionList(const RamCondition* condition) {
-        std::vector<const RamCondition*> list;
-        std::queue<const RamCondition*> queue;
+        std::vector<const RamCondition*> conditionList;
+        std::queue<const RamCondition*> conditionsToProcess;
         if (condition != nullptr) {
-            queue.push(condition);
-            while (!queue.empty()) {
-                condition = queue.front();
-                queue.pop();
+            conditionsToProcess.push(condition);
+            while (!conditionsToProcess.empty()) {
+                condition = conditionsToProcess.front();
+                conditionsToProcess.pop();
                 if (const auto* ramConj = dynamic_cast<const RamConjunction*>(condition)) {
-                    queue.push(&ramConj->getLHS());
-                    queue.push(&ramConj->getRHS());
+                    conditionsToProcess.push(&ramConj->getLHS());
+                    conditionsToProcess.push(&ramConj->getRHS());
                 } else {
-                    list.emplace_back(condition);
+                    conditionList.emplace_back(condition);
                 }
             }
         }
-        return list;
+        return conditionList;
     }
 };
 }  // namespace souffle

--- a/src/InterpreterGenerator.h
+++ b/src/InterpreterGenerator.h
@@ -23,6 +23,7 @@
 #include "RamIndexAnalysis.h"
 #include "RamVisitor.h"
 #include <memory>
+#include <queue>
 
 namespace souffle {
 
@@ -628,15 +629,15 @@ private:
      */
     inline std::vector<const RamCondition*> toConjunctionList(const RamCondition* condition) {
         std::vector<const RamCondition*> list;
-        std::stack<const RamCondition*> stack;
+        std::queue<const RamCondition*> queue;
         if (condition != nullptr) {
-            stack.push(condition);
-            while (!stack.empty()) {
-                condition = stack.top();
-                stack.pop();
+            queue.push(condition);
+            while (!queue.empty()) {
+                condition = queue.front();
+                queue.pop();
                 if (const auto* ramConj = dynamic_cast<const RamConjunction*>(condition)) {
-                    stack.push(&ramConj->getLHS());
-                    stack.push(&ramConj->getRHS());
+                    queue.push(&ramConj->getLHS());
+                    queue.push(&ramConj->getRHS());
                 } else {
                     list.emplace_back(condition);
                 }

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -24,8 +24,8 @@
 #include "SymbolTable.h"
 
 #include <algorithm>
+#include <queue>
 #include <sstream>
-#include <stack>
 #include <string>
 
 #include <cstdlib>
@@ -454,15 +454,15 @@ protected:
  */
 inline std::vector<std::unique_ptr<RamCondition>> toConjunctionList(const RamCondition* condition) {
     std::vector<std::unique_ptr<RamCondition>> list;
-    std::stack<const RamCondition*> stack;
+    std::queue<const RamCondition*> queue;
     if (condition != nullptr) {
-        stack.push(condition);
-        while (!stack.empty()) {
-            condition = stack.top();
-            stack.pop();
+        queue.push(condition);
+        while (!queue.empty()) {
+            condition = queue.front();
+            queue.pop();
             if (const auto* ramConj = dynamic_cast<const RamConjunction*>(condition)) {
-                stack.push(&ramConj->getLHS());
-                stack.push(&ramConj->getRHS());
+                queue.push(&ramConj->getLHS());
+                queue.push(&ramConj->getRHS());
             } else {
                 list.emplace_back(condition->clone());
             }

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -453,22 +453,22 @@ protected:
  * to a list {C1, C2, ..., Cn}.
  */
 inline std::vector<std::unique_ptr<RamCondition>> toConjunctionList(const RamCondition* condition) {
-    std::vector<std::unique_ptr<RamCondition>> list;
-    std::queue<const RamCondition*> queue;
+    std::vector<std::unique_ptr<RamCondition>> conditionList;
+    std::queue<const RamCondition*> conditionsToProcess;
     if (condition != nullptr) {
-        queue.push(condition);
-        while (!queue.empty()) {
-            condition = queue.front();
-            queue.pop();
+        conditionsToProcess.push(condition);
+        while (!conditionsToProcess.empty()) {
+            condition = conditionsToProcess.front();
+            conditionsToProcess.pop();
             if (const auto* ramConj = dynamic_cast<const RamConjunction*>(condition)) {
-                queue.push(&ramConj->getLHS());
-                queue.push(&ramConj->getRHS());
+                conditionsToProcess.push(&ramConj->getLHS());
+                conditionsToProcess.push(&ramConj->getRHS());
             } else {
-                list.emplace_back(condition->clone());
+                conditionList.emplace_back(condition->clone());
             }
         }
     }
-    return list;
+    return conditionList;
 }
 
 /**


### PR DESCRIPTION
* Order the list of conditions correctly when constructing from a conjunction
* Should help with the condition ordering RAM optimisation