### PR TITLE
Refactoring of RAM

### DIFF
--- a/src/InterpreterEngine.cpp
+++ b/src/InterpreterEngine.cpp
@@ -358,7 +358,7 @@ RamDomain InterpreterEngine::execute(const InterpreterNode* node, InterpreterCon
             exit(1);
         }
         // prepare dynamic call environment
-        size_t arity = cur->getArgCount();
+        size_t arity = cur->getArguments().size();
         ffi_cif cif;
         ffi_type* args[arity];
         void* values[arity];

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -278,7 +278,7 @@ public:
     RamAbstractExistenceCheck(
             std::unique_ptr<RamRelationReference> relRef, std::vector<std::unique_ptr<RamExpression>> vals)
             : relationRef(std::move(relRef)), values(std::move(vals)) {
-        assert(relationRef != nullptr && "Relation reference is a nullptr"); 
+        assert(relationRef != nullptr && "Relation reference is a nullptr");
     }
 
     /** @brief Get relation */
@@ -321,7 +321,7 @@ public:
         for (auto& val : values) {
             val = map(std::move(val));
         }
-        assert(relationRef != nullptr && "Relation reference is a nullptr"); 
+        assert(relationRef != nullptr && "Relation reference is a nullptr");
     }
 
 protected:
@@ -405,8 +405,8 @@ public:
 class RamEmptinessCheck : public RamCondition {
 public:
     RamEmptinessCheck(std::unique_ptr<RamRelationReference> relRef) : relationRef(std::move(relRef)) {
-        assert(relationRef != nullptr && "Relation reference is a nullptr"); 
-    } 
+        assert(relationRef != nullptr && "Relation reference is a nullptr");
+    }
 
     /** @brief Get relation */
     const RamRelation& getRelation() const {
@@ -427,7 +427,7 @@ public:
 
     void apply(const RamNodeMapper& map) override {
         relationRef = map(std::move(relationRef));
-        assert(relationRef != nullptr && "Relation reference is a nullptr"); 
+        assert(relationRef != nullptr && "Relation reference is a nullptr");
     }
 
 protected:

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -287,6 +287,19 @@ public:
         return toPtrVector(values);
     }
 
+    void print(std::ostream& os) const override {
+        os << "("
+           << join(values, ",",
+                      [](std::ostream& out, const std::unique_ptr<RamExpression>& value) {
+                          if (!value) {
+                              out << "_";
+                          } else {
+                              out << *value;
+                          }
+                      })
+           << ") ∈ " << getRelation().getName();
+    }
+
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> res = {relationRef.get()};
         for (const auto& cur : values) {
@@ -334,19 +347,6 @@ public:
             std::unique_ptr<RamRelationReference> relRef, std::vector<std::unique_ptr<RamExpression>> vals)
             : RamAbstractExistenceCheck(std::move(relRef), std::move(vals)) {}
 
-    void print(std::ostream& os) const override {
-        os << "("
-           << join(values, ",",
-                      [](std::ostream& out, const std::unique_ptr<RamExpression>& value) {
-                          if (!value) {
-                              out << "_";
-                          } else {
-                              out << *value;
-                          }
-                      })
-           << ") ∈ " << getRelation().getName();
-    }
-
     RamExistenceCheck* clone() const override {
         std::vector<std::unique_ptr<RamExpression>> newValues;
         for (auto& cur : values) {
@@ -368,16 +368,8 @@ public:
             : RamAbstractExistenceCheck(std::move(relRef), std::move(vals)) {}
 
     void print(std::ostream& os) const override {
-        os << "("
-           << join(values, ",",
-                      [](std::ostream& out, const std::unique_ptr<RamExpression>& value) {
-                          if (!value) {
-                              out << "_";
-                          } else {
-                              out << *value;
-                          }
-                      })
-           << ") prov∈ " << getRelation().getName();
+        os << "prov";
+        RamAbstractExistenceCheck::print(os);
     }
 
     RamProvenanceExistenceCheck* clone() const override {

--- a/src/RamCondition.h
+++ b/src/RamCondition.h
@@ -127,6 +127,8 @@ public:
     void apply(const RamNodeMapper& map) override {
         lhs = map(std::move(lhs));
         rhs = map(std::move(rhs));
+        assert(lhs != nullptr && "left-hand side of conjunction is a nullptr");
+        assert(rhs != nullptr && "right-hand side of conjunction is a nullptr");
     }
 
 protected:
@@ -154,11 +156,12 @@ protected:
  */
 class RamNegation : public RamCondition {
 public:
-    RamNegation(std::unique_ptr<RamCondition> operand) : operand(std::move(operand)) {}
+    RamNegation(std::unique_ptr<RamCondition> op) : operand(std::move(op)) {
+        assert(nullptr != operand && "operand of negation is a null-pointer");
+    }
 
     /** @brief Get operand of negation */
     const RamCondition& getOperand() const {
-        assert(nullptr != operand && "operand of negation is a null-pointer");
         return *operand;
     }
 
@@ -176,6 +179,7 @@ public:
 
     void apply(const RamNodeMapper& map) override {
         operand = map(std::move(operand));
+        assert(nullptr != operand && "operand of negation is a null-pointer");
     }
 
 protected:
@@ -243,6 +247,8 @@ public:
     void apply(const RamNodeMapper& map) override {
         lhs = map(std::move(lhs));
         rhs = map(std::move(rhs));
+        assert(lhs != nullptr && "left-hand side of constraint is a null-pointer");
+        assert(rhs != nullptr && "right-hand side of constraint is a null-pointer");
     }
 
 protected:
@@ -271,7 +277,9 @@ class RamAbstractExistenceCheck : public RamCondition {
 public:
     RamAbstractExistenceCheck(
             std::unique_ptr<RamRelationReference> relRef, std::vector<std::unique_ptr<RamExpression>> vals)
-            : relationRef(std::move(relRef)), values(std::move(vals)) {}
+            : relationRef(std::move(relRef)), values(std::move(vals)) {
+        assert(relationRef != nullptr && "Relation reference is a nullptr"); 
+    }
 
     /** @brief Get relation */
     const RamRelation& getRelation() const {
@@ -313,6 +321,7 @@ public:
         for (auto& val : values) {
             val = map(std::move(val));
         }
+        assert(relationRef != nullptr && "Relation reference is a nullptr"); 
     }
 
 protected:
@@ -395,7 +404,9 @@ public:
  */
 class RamEmptinessCheck : public RamCondition {
 public:
-    RamEmptinessCheck(std::unique_ptr<RamRelationReference> relRef) : relationRef(std::move(relRef)) {}
+    RamEmptinessCheck(std::unique_ptr<RamRelationReference> relRef) : relationRef(std::move(relRef)) {
+        assert(relationRef != nullptr && "Relation reference is a nullptr"); 
+    } 
 
     /** @brief Get relation */
     const RamRelation& getRelation() const {
@@ -416,6 +427,7 @@ public:
 
     void apply(const RamNodeMapper& map) override {
         relationRef = map(std::move(relationRef));
+        assert(relationRef != nullptr && "Relation reference is a nullptr"); 
     }
 
 protected:

--- a/src/RamExpression.h
+++ b/src/RamExpression.h
@@ -189,8 +189,7 @@ protected:
  */
 class RamTupleElement : public RamExpression {
 public:
-    RamTupleElement(size_t ident, size_t elem) 
-            : identifier(ident), element(elem) {}
+    RamTupleElement(size_t ident, size_t elem) : identifier(ident), element(elem) {}
 
     void print(std::ostream& os) const override {
         os << "t" << identifier << "." << element;

--- a/src/RamExpression.h
+++ b/src/RamExpression.h
@@ -54,17 +54,6 @@ public:
         return toPtrVector(arguments);
     }
 
-    /** @brief Get i-th argument value */
-    const RamExpression& getArgument(size_t i) const {
-        assert(i >= 0 && i < arguments.size() && "argument index out of bounds");
-        return *arguments[i];
-    }
-
-    /** @brief Get number of arguments */
-    size_t getArgCount() const {
-        return arguments.size();
-    }
-
     std::vector<const RamNode*> getChildNodes() const override {
         std::vector<const RamNode*> res;
         for (const auto& cur : arguments) {
@@ -200,7 +189,7 @@ protected:
  */
 class RamTupleElement : public RamExpression {
 public:
-    RamTupleElement(size_t ident, size_t elem, std::unique_ptr<RamRelationReference> relRef = nullptr)
+    RamTupleElement(size_t ident, size_t elem) 
             : identifier(ident), element(elem) {}
 
     void print(std::ostream& os) const override {

--- a/src/RamIndexAnalysis.cpp
+++ b/src/RamIndexAnalysis.cpp
@@ -414,16 +414,11 @@ SearchSignature RamIndexAnalysis::getSearchSignature(const RamRelation* ramRel) 
 }
 
 bool RamIndexAnalysis::isTotalSignature(const RamAbstractExistenceCheck* existCheck) const {
-    if (existCheck->isTotal != 0) {
-        return existCheck->isTotal == 1;
-    }
     for (const auto& cur : existCheck->getValues()) {
         if (isRamUndefValue(cur)) {
-            existCheck->isTotal = 2;
             return false;
         }
     }
-    existCheck->isTotal = 1;
     return true;
 }
 

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -70,11 +70,12 @@ class RamAbstractParallel {};
 class RamNestedOperation : public RamOperation {
 public:
     RamNestedOperation(std::unique_ptr<RamOperation> nested, std::string profileText = "")
-            : nestedOperation(std::move(nested)), profileText(std::move(profileText)) {}
+            : nestedOperation(std::move(nested)), profileText(std::move(profileText)) {
+        assert(nullptr != nestedOperation);
+    }
 
     /** @brief Get nested operation */
     RamOperation& getOperation() const {
-        assert(nullptr != nestedOperation);
         return *nestedOperation;
     }
 
@@ -93,6 +94,7 @@ public:
 
     void apply(const RamNodeMapper& map) override {
         nestedOperation = map(std::move(nestedOperation));
+        assert(nullptr != nestedOperation);
     }
 
 protected:

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -54,11 +54,12 @@ public:
  */
 class RamRelationStatement : public RamStatement {
 public:
-    RamRelationStatement(std::unique_ptr<RamRelationReference> relRef) : relationRef(std::move(relRef)) {}
+    RamRelationStatement(std::unique_ptr<RamRelationReference> relRef) : relationRef(std::move(relRef)) {
+        assert(relationRef != nullptr && "Relation reference is a null-pointer");
+    }
 
     /** @brief Get RAM relation */
     const RamRelation& getRelation() const {
-        assert(relationRef != nullptr && "Relation reference is a null-pointer");
         return *relationRef->get();
     }
 
@@ -226,17 +227,17 @@ public:
             assert(first->get()->getArgTypeQualifier(i) == second->get()->getArgTypeQualifier(i) &&
                     "mismatching type");
         }
+        assert(first != nullptr && "First relation is a null-pointer");
+        assert(second != nullptr && "Second relation is a null-pointer");
     }
 
     /** @brief Get first relation */
     const RamRelation& getFirstRelation() const {
-        assert(first != nullptr && "First relation is a null-pointer");
         return *first->get();
     }
 
     /** @brief Get second relation */
     const RamRelation& getSecondRelation() const {
-        assert(second != nullptr && "Second relation is a null-pointer");
         return *second->get();
     }
 
@@ -357,11 +358,12 @@ protected:
  */
 class RamQuery : public RamStatement {
 public:
-    RamQuery(std::unique_ptr<RamOperation> o) : operation(std::move(o)) {}
+    RamQuery(std::unique_ptr<RamOperation> o) : operation(std::move(o)) {
+        assert(operation && "operation is a nullptr");
+    }
 
     /** @brief Get RAM operation */
     const RamOperation& getOperation() const {
-        assert(operation);
         return *operation;
     }
 
@@ -457,7 +459,7 @@ public:
         }
         for (const auto& cur : statements) {
             (void)cur;
-            assert(cur);
+            assert(cur && "statement is a nullptr");
         }
     }
 
@@ -539,7 +541,9 @@ protected:
  */
 class RamLoop : public RamStatement {
 public:
-    RamLoop(std::unique_ptr<RamStatement> b) : body(std::move(b)) {}
+    RamLoop(std::unique_ptr<RamStatement> b) : body(std::move(b)) {
+        assert(body != nullptr && "Loop body is a null-pointer");
+    }
 
     template <typename... Stmts>
     RamLoop(std::unique_ptr<RamStatement> f, std::unique_ptr<RamStatement> s, std::unique_ptr<Stmts>... rest)
@@ -547,7 +551,6 @@ public:
 
     /** @brief Get loop body */
     const RamStatement& getBody() const {
-        assert(body != nullptr && "Loop body is a null-pointer");
         return *body;
     }
 
@@ -594,11 +597,12 @@ protected:
  */
 class RamExit : public RamStatement {
 public:
-    RamExit(std::unique_ptr<RamCondition> c) : condition(std::move(c)) {}
+    RamExit(std::unique_ptr<RamCondition> c) : condition(std::move(c)) {
+        assert(condition && "condition is a nullptr");
+    }
 
     /** @brief Get exit condition */
     const RamCondition& getCondition() const {
-        assert(condition);
         return *condition;
     }
 
@@ -639,7 +643,7 @@ class RamAbstractLog {
 public:
     RamAbstractLog(std::unique_ptr<RamStatement> stmt, std::string msg)
             : statement(std::move(stmt)), message(std::move(msg)) {
-        assert(statement);
+        assert(statement && "log statement is a nullptr");
     }
 
     std::vector<const RamNode*> getChildNodes() const {
@@ -653,7 +657,6 @@ public:
 
     /** @brief Get logging statement */
     const RamStatement& getStatement() const {
-        assert(statement);
         return *statement;
     }
 
@@ -841,11 +844,12 @@ protected:
  */
 class RamStratum : public RamStatement {
 public:
-    RamStratum(std::unique_ptr<RamStatement> b, const int i) : body(std::move(b)), index(i) {}
+    RamStratum(std::unique_ptr<RamStatement> b, const int i) : body(std::move(b)), index(i) {
+        assert(body != nullptr && "Body of stratum is a null-pointer");
+    }
 
     /** @brief Get stratum body */
     const RamStatement& getBody() const {
-        assert(body != nullptr && "Body of stratum is a null-pointer");
         return *body;
     }
 

--- a/src/RamTranslationUnit.h
+++ b/src/RamTranslationUnit.h
@@ -53,7 +53,6 @@ public:
             auto analysis = std::make_unique<Analysis>(Analysis::name);
             analysis->run(*this);
             // Check it hasn't been created by someone else, and insert if not
-            std::lock_guard<std::mutex> guard(analysisLock);
             it = analyses.find(name);
             if (it == analyses.end()) {
                 analyses[name] = std::move(analysis);
@@ -126,9 +125,6 @@ protected:
 
     /* Debug report for logging information */
     DebugReport& debugReport;
-
-    /* TODO (b-scholz): this should disappear with the new interpreter */
-    mutable std::mutex analysisLock;
 };
 
 }  // end of namespace souffle

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1371,45 +1371,46 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
         void visitIntrinsicOperator(const RamIntrinsicOperator& op, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
 
+            auto args = op.getArguments(); 
             switch (op.getOperator()) {
                 /** Unary Functor Operators */
                 case FunctorOp::ORD: {
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     break;
                 }
                 case FunctorOp::STRLEN: {
                     out << "static_cast<RamDomain>(symTable.resolve(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ").size())";
                     break;
                 }
                 case FunctorOp::NEG: {
                     out << "(-(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << "))";
                     break;
                 }
                 case FunctorOp::BNOT: {
                     out << "(~(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << "))";
                     break;
                 }
                 case FunctorOp::LNOT: {
                     out << "(!(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << "))";
                     break;
                 }
                 case FunctorOp::TOSTRING: {
                     out << "symTable.lookup(std::to_string(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << "))";
                     break;
                 }
                 case FunctorOp::TONUMBER: {
                     out << "(wrapper_tonumber(symTable.resolve((size_t)";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ")))";
                     break;
                 }
@@ -1418,33 +1419,33 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 // arithmetic
                 case FunctorOp::ADD: {
                     out << "(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ") + (";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << ")";
                     break;
                 }
                 case FunctorOp::SUB: {
                     out << "(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ") - (";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << ")";
                     break;
                 }
                 case FunctorOp::MUL: {
                     out << "(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ") * (";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << ")";
                     break;
                 }
                 case FunctorOp::DIV: {
                     out << "(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ") / (";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << ")";
                     break;
                 }
@@ -1452,63 +1453,63 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                     // Cast as int64, then back to RamDomain of int32 to avoid wrapping to negative
                     // when using int32 RamDomains
                     out << "static_cast<int64_t>(std::pow(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ",";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << "))";
                     break;
                 }
                 case FunctorOp::MOD: {
                     out << "(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ") % (";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << ")";
                     break;
                 }
                 case FunctorOp::BAND: {
                     out << "(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ") & (";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << ")";
                     break;
                 }
                 case FunctorOp::BOR: {
                     out << "(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ") | (";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << ")";
                     break;
                 }
                 case FunctorOp::BXOR: {
                     out << "(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ") ^ (";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << ")";
                     break;
                 }
                 case FunctorOp::LAND: {
                     out << "(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ") && (";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << ")";
                     break;
                 }
                 case FunctorOp::LOR: {
                     out << "(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << ") || (";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << ")";
                     break;
                 }
                 case FunctorOp::MAX: {
                     out << "std::max({";
-                    for (auto& cur : op.getArguments()) {
+                    for (auto& cur : args) {
                         visit(cur, out);
                         out << ", ";
                     }
@@ -1517,7 +1518,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 }
                 case FunctorOp::MIN: {
                     out << "std::min({";
-                    for (auto& cur : op.getArguments()) {
+                    for (auto& cur : args) {
                         visit(cur, out);
                         out << ", ";
                     }
@@ -1528,13 +1529,15 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 // strings
                 case FunctorOp::CAT: {
                     out << "symTable.lookup(";
-                    for (size_t i = 0; i < op.getArgCount() - 1; i++) {
+                    size_t i = 0; 
+                    while (i < args.size() - 1) {
                         out << "symTable.resolve(";
-                        visit(op.getArgument(i), out);
+                        visit(args[i], out);
                         out << ") + ";
+                        i++;
                     }
                     out << "symTable.resolve(";
-                    visit(op.getArgument(op.getArgCount() - 1), out);
+                    visit(args[i], out);
                     out << "))";
                     break;
                 }
@@ -1543,11 +1546,11 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 case FunctorOp::SUBSTR: {
                     out << "symTable.lookup(";
                     out << "substr_wrapper(symTable.resolve(";
-                    visit(op.getArgument(0), out);
+                    visit(args[0], out);
                     out << "),(";
-                    visit(op.getArgument(1), out);
+                    visit(args[1], out);
                     out << "),(";
-                    visit(op.getArgument(2), out);
+                    visit(args[2], out);
                     out << ")))";
                     break;
                 }
@@ -1565,6 +1568,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             const std::string& name = op.getName();
             const std::string& type = op.getType();
             size_t arity = type.length() - 1;
+            auto args = op.getArguments(); 
 
             if (type[arity] == 'S') {
                 out << "symTable.lookup(";
@@ -1577,11 +1581,11 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 }
                 if (type[i] == 'N') {
                     out << "((RamDomain)";
-                    visit(op.getArgument(i), out);
+                    visit(args[i], out);
                     out << ")";
                 } else {
                     out << "symTable.resolve((RamDomain)";
-                    visit(op.getArgument(i), out);
+                    visit(args[i], out);
                     out << ").c_str()";
                 }
             }

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1371,7 +1371,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
         void visitIntrinsicOperator(const RamIntrinsicOperator& op, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
 
-            auto args = op.getArguments(); 
+            auto args = op.getArguments();
             switch (op.getOperator()) {
                 /** Unary Functor Operators */
                 case FunctorOp::ORD: {
@@ -1529,7 +1529,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 // strings
                 case FunctorOp::CAT: {
                     out << "symTable.lookup(";
-                    size_t i = 0; 
+                    size_t i = 0;
                     while (i < args.size() - 1) {
                         out << "symTable.resolve(";
                         visit(args[i], out);
@@ -1568,7 +1568,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             const std::string& name = op.getName();
             const std::string& type = op.getType();
             size_t arity = type.length() - 1;
-            auto args = op.getArguments(); 
+            auto args = op.getArguments();
 
             if (type[arity] == 'S') {
                 out << "symTable.lookup(";


### PR DESCRIPTION
Rough tidy-up of RAM: 
 - assertions in getters are pushed to constructors and apply methods
 - there were some locks for RAM analysis; since we have a new interpreter that generates a new intermediate representation for interpretation, we can remove the locks.
 - totalSignature values were stored in AbstractExistenceCheck: that was removed. If too slow, we need to add a cache in the IndexAnalysis. 