### PR TITLE
Make the magic set transformation 64-bit aware

### DIFF
--- a/src/MagicSet.cpp
+++ b/src/MagicSet.cpp
@@ -1000,7 +1000,7 @@ AstArgument* extractConstant(SymbolTable& symbolTable, const std::string& normal
         return new AstStringConstant(symbolTable, stringRep);
     } else if (indicatorChar == 'n') {
         // numeric argument
-        return new AstNumberConstant(stoi(stringRep));
+        return new AstNumberConstant(static_cast<RamDomain>(stoll(stringRep)));
     } else {
         // invalid format
         return nullptr;


### PR DESCRIPTION
When switching to a 64-bit RAM domain, AstNumberConstants are still
instantiated based on a call to stoi. This call would fail if the
constant exceeded the value range for a 32-bit signed integer.

Fixes #1225.