### PR TITLE
Simplify travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,20 +138,20 @@ jobs:
 # Testing stage (-j8,-c -j8)
   - <<: *linuxgcc
     env:
-    - "gcc-evaluation"
+    - "gcc-fast-evaluation"
     - *gcc_environment
-    - SOUFFLE_CATEGORY=Evaluation SOUFFLE_CONFS="-j8,-c -j8"
+    - SOUFFLE_CATEGORY=FastEvaluation SOUFFLE_CONFS="-j8,-c -j8"
 
 # Testing stage for clang without OpenMP (,-c)
   - <<: *linuxclang
     env:
-    - "clang-evaluation"
+    - "clang-fast-evaluation"
     - *clang_environment
-    - SOUFFLE_CATEGORY=Evaluation SOUFFLE_CONFS=",-c"
+    - SOUFFLE_CATEGORY=FastEvaluation SOUFFLE_CONFS=",-c"
   - <<: *osxclang
     env:
-    - "clang-evaluation"
-    - SOUFFLE_CATEGORY=Evaluation SOUFFLE_CONFS=",-c"
+    - "clang-fast-evaluation"
+    - SOUFFLE_CATEGORY=FastEvaluation SOUFFLE_CONFS=",-c"
 
 # Packaging stage
   # Test make install installs a working souffle.

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ jobs:
   include:
 # Style check stage
   - stage: Style
+    name: "Style check"
     os: linux
     sudo: false
     addons:
@@ -87,82 +88,82 @@ jobs:
 
 # Testing stage (-j8,-c -j8)
   - <<: *linuxgcc
+    name: "Linux gcc non-eval"
     env:
-    - "gcc-setup"
     - *gcc_environment
     - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
   - <<: *osxgcc
+    name: "OSX gcc non-eval"
     env:
-    - "gcc-setup"
     - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
-
-# Testing stage for clang without OpenMP (,-c)
-  - <<: *linuxclang
-    env:
-    - "clang-setup"
-    - *clang_environment
-    - SOUFFLE_CATEGORY=Unit,Interface,Profile,Provenance SOUFFLE_CONFS=",-c"
-  - <<: *osxclang
-    env:
-    - "clang-setup"
-    - SOUFFLE_CATEGORY=Unit,Interface,Profile,Provenance SOUFFLE_CONFS=",-c"
 
 # Testing stage with 64bit RamDomains (-j8,-c -j8)
   - <<: *linuxgcc
     before_script: ".travis/init_test_64bit.sh"
+    name: "Linux gcc 64-bit non-eval"
     env:
-    - "gcc-64bit-setup"
     - *gcc_environment
     - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
 
-    # Testing stage with Swig tests enabled (-j8,-c -j8)
+# Testing stage for clang without OpenMP (,-c)
+  - <<: *linuxclang
+    name: "Linux clang single threaded"
+    env:
+    - *clang_environment
+    - SOUFFLE_CATEGORY=Unit,Interface,Profile,Provenance SOUFFLE_CONFS=",-c"
+  - <<: *osxclang
+    name: "OSX clang single threaded"
+    env:
+    - SOUFFLE_CATEGORY=Unit,Interface,Profile,Provenance SOUFFLE_CONFS=",-c"
+
+# Testing stage with Swig tests enabled (-j8,-c -j8)
   - <<: *linuxgcc
     before_script: ".travis/init_test_swig.sh"
+    name: "Linux gcc swig"
     env:
-    - "gcc-swig"
     - *gcc_environment
     - SOUFFLE_CATEGORY=Swig SOUFFLE_CONFS="-j8,-c -j8"
   - <<: *osxgcc
     before_script: ".travis/init_test_swig.sh"
+    name: "OSX gcc swig"
     env:
-    - "gcc-swig"
     - SOUFFLE_CATEGORY=Swig SOUFFLE_CONFS="-j8,-c -j8"
 
 # Testing stage with engine option (-c -j8 -efile, FastEvaluation and select others)
   - <<: *linuxgcc
+    name: "Linux file engine"
     env:
-    - "gcc-efile"
     - *gcc_environment
     - SOUFFLE_CATEGORY=FastEvaluation,Interface,Profile SOUFFLE_CONFS="-c -j8 -efile"
 
 # Testing stage (-j8,-c -j8)
   - <<: *linuxgcc
+    name: "Linux gcc fast evaluation tests"
     env:
-    - "gcc-fast-evaluation"
     - *gcc_environment
     - SOUFFLE_CATEGORY=FastEvaluation SOUFFLE_CONFS="-j8,-c -j8"
 
 # Testing stage for clang without OpenMP (,-c)
   - <<: *linuxclang
+    name: "Linux clang fast evaluation tests"
     env:
-    - "clang-fast-evaluation"
     - *clang_environment
     - SOUFFLE_CATEGORY=FastEvaluation SOUFFLE_CONFS=",-c"
   - <<: *osxclang
+    name: "OSX clang fast evaluation tests"
     env:
-    - "clang-fast-evaluation"
     - SOUFFLE_CATEGORY=FastEvaluation SOUFFLE_CONFS=",-c"
 
 # Packaging stage
   # Test make install installs a working souffle.
   - <<: *linuxpackage
     script: docker run -v `pwd`:/souffle ubuntu:bionic /bin/sh -c "cd /souffle && .travis/linux/install_debian_deps.sh && .travis/init_make_package.sh && .travis/test_make_install.sh"
-    env: "debian-make-install"
+    name: "Debian make install"
   # Make the linux deb packages and if successful upload to github releases and bintray
   # All PRs go to bintray unstable, tagged releases to bintray stable
   - <<: *linuxpackage
     script: docker run -v `pwd`:/souffle ubuntu:bionic /bin/sh -c "cd /souffle && .travis/linux/install_debian_deps.sh && .travis/init_make_package.sh && .travis/linux/make_package.sh"
-    env: "debian-package"
+    name: "Debian package"
     before_deploy:
       - .travis/bintray_json.sh debian
     # deploy to bintray if we're in the souffle-lang repo
@@ -197,7 +198,7 @@ jobs:
   # Try to build in a raw centos container to test that our dependencies are correct
   - <<: *linuxpackage
     script: docker run -v `pwd`:/souffle centos:7 /bin/sh -c "cd /souffle && .travis/linux/install_centos_deps.sh && .travis/linux/make_centos_package.sh"
-    env: "centos-package"
+    name: "CentOS package"
     before_deploy:
       - .travis/bintray_json.sh centos
     # deploy to bintray if we're in the souffle-lang repo
@@ -225,7 +226,7 @@ jobs:
   # Try to build in a raw fedora container to test that our dependencies are correct
   - <<: *linuxpackage
     script: docker run -v `pwd`:/souffle fedora:27 /bin/sh -c "cd /souffle && .travis/linux/install_fedora_deps.sh && .travis/linux/make_fedora_package.sh"
-    env: "fedora-package"
+    name: "Fedora package"
     before_deploy:
       - .travis/bintray_json.sh fedora
     # deploy to bintray if we're in the souffle-lang repo
@@ -249,7 +250,7 @@ jobs:
           tags: true
   # Make the OSX packages and if successful upload to github releases.
   - <<: *osxpackage
-    env: "osx-package"
+    name: "OSX package"
     before_deploy: .travis/bintray_json.sh osx
     deploy:
       - provider: releases
@@ -276,7 +277,7 @@ jobs:
           repo: souffle-lang/souffle
   # Generate doxygen html
   - stage: Packaging
-    env: "documenting"
+    name: "Documenting"
     os: linux
     sudo: false
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,11 +101,11 @@ jobs:
     env:
     - "clang-setup"
     - *clang_environment
-    - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile,Provenance SOUFFLE_CONFS=",-c"
+    - SOUFFLE_CATEGORY=Unit,Interface,Profile,Provenance SOUFFLE_CONFS=",-c"
   - <<: *osxclang
     env:
     - "clang-setup"
-    - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile,Provenance SOUFFLE_CONFS=",-c"
+    - SOUFFLE_CATEGORY=Unit,Interface,Profile,Provenance SOUFFLE_CONFS=",-c"
 
 # Testing stage with 64bit RamDomains (-j8,-c -j8)
   - <<: *linuxgcc
@@ -119,14 +119,14 @@ jobs:
   - <<: *linuxgcc
     before_script: ".travis/init_test_swig.sh"
     env:
-    - "gcc-setup"
+    - "gcc-swig"
     - *gcc_environment
-    - SOUFFLE_CATEGORY=Unit,Swig,Syntactic,Semantic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
+    - SOUFFLE_CATEGORY=Swig SOUFFLE_CONFS="-j8,-c -j8"
   - <<: *osxgcc
     before_script: ".travis/init_test_swig.sh"
     env:
-    - "gcc-setup"
-    - SOUFFLE_CATEGORY=Unit,Swig,Syntactic,Semantic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
+    - "gcc-swig"
+    - SOUFFLE_CATEGORY=Swig SOUFFLE_CONFS="-j8,-c -j8"
 
 # Testing stage with engine option (-c -j8 -efile, FastEvaluation and select others)
   - <<: *linuxgcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,19 +116,6 @@ jobs:
     env:
     - SOUFFLE_CATEGORY=Unit,Interface,Profile,Provenance SOUFFLE_CONFS=",-c"
 
-# Testing stage with Swig tests enabled (-j8,-c -j8)
-  - <<: *linuxgcc
-    before_script: ".travis/init_test_swig.sh"
-    name: "Linux gcc swig"
-    env:
-    - *gcc_environment
-    - SOUFFLE_CATEGORY=Swig SOUFFLE_CONFS="-j8,-c -j8"
-  - <<: *osxgcc
-    before_script: ".travis/init_test_swig.sh"
-    name: "OSX gcc swig"
-    env:
-    - SOUFFLE_CATEGORY=Swig SOUFFLE_CONFS="-j8,-c -j8"
-
 # Testing stage with engine option (-c -j8 -efile, FastEvaluation and select others)
   - <<: *linuxgcc
     name: "Linux file engine"
@@ -139,20 +126,23 @@ jobs:
 # Testing stage (-j8,-c -j8)
   - <<: *linuxgcc
     name: "Linux gcc fast evaluation tests"
+    before_script: ".travis/init_test_swig.sh"
     env:
     - *gcc_environment
-    - SOUFFLE_CATEGORY=FastEvaluation SOUFFLE_CONFS="-j8,-c -j8"
+    - SOUFFLE_CATEGORY=Swig,FastEvaluation SOUFFLE_CONFS="-j8,-c -j8"
 
 # Testing stage for clang without OpenMP (,-c)
   - <<: *linuxclang
     name: "Linux clang fast evaluation tests"
+    before_script: ".travis/init_test_swig.sh"
     env:
     - *clang_environment
-    - SOUFFLE_CATEGORY=FastEvaluation SOUFFLE_CONFS=",-c"
+    - SOUFFLE_CATEGORY=Swig,FastEvaluation SOUFFLE_CONFS=",-c"
   - <<: *osxclang
     name: "OSX clang fast evaluation tests"
+    before_script: ".travis/init_test_swig.sh"
     env:
-    - SOUFFLE_CATEGORY=FastEvaluation SOUFFLE_CONFS=",-c"
+    - SOUFFLE_CATEGORY=Swig,FastEvaluation SOUFFLE_CONFS=",-c"
 
 # Packaging stage
   # Test make install installs a working souffle.

--- a/.travis/init_test_swig.sh
+++ b/.travis/init_test_swig.sh
@@ -6,9 +6,12 @@
 set -e
 set -x
 
+JOBS=$(nproc || sysctl -n hw.ncpu || echo 2)
+
 # create configure files
 ./bootstrap
 ./configure --enable-swig
+make -j$JOBS
 
 
 set +e

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,8 @@ AS_IF([test "x$enable_ncurses" != "xno"], [
 ])
 AM_CONDITIONAL([NCURSES], [test "x$enable_ncurses" != "xno"])
 
+AC_LANG(C++)
+
 # Enable sanitise memory mode
 AC_ARG_ENABLE(
   [sanitise-memory],
@@ -261,7 +263,7 @@ AC_CHECK_LIB(dl, dlopen,,
 
 dnl Enables OpenMP in the souffle compiler and interpreter
 AC_OPENMP
-AS_VAR_APPEND(CXXFLAGS, [" $OPENMP_CFLAGS "])
+AS_VAR_APPEND(CXXFLAGS, [" $OPENMP_CXXFLAGS "])
 AC_MSG_CHECKING( for target cpu)
 
 AC_CONFIG_TESTDIR([tests])


### PR DESCRIPTION
* Add names for all tests to ease reading the test output
* Remove redundant tests (Swig tests repeated unrelated tests)
* Use FastEvaluation instead of Evaluation (almost the same coverage. Jenkins tests more thoroughly.)

Tangentially related, also use C++ to determine what flags to use with C++ (except for ncurses, as those tests fail without C).