### PR TITLE
Reformatting for readability and safety

### DIFF
--- a/src/AstClause.cpp
+++ b/src/AstClause.cpp
@@ -30,13 +30,13 @@ class AstAggregator;
 
 /* Add literal to body */
 void AstClause::addToBody(std::unique_ptr<AstLiteral> l) {
-    if (dynamic_cast<AstAtom*>(l.get())) {
+    if (dynamic_cast<AstAtom*>(l.get()) != nullptr) {
         atoms.emplace_back(static_cast<AstAtom*>(l.release()));
-    } else if (dynamic_cast<AstNegation*>(l.get())) {
+    } else if (dynamic_cast<AstNegation*>(l.get()) != nullptr) {
         negations.emplace_back(static_cast<AstNegation*>(l.release()));
-    } else if (dynamic_cast<AstProvenanceNegation*>(l.get())) {
+    } else if (dynamic_cast<AstProvenanceNegation*>(l.get()) != nullptr) {
         provNegations.emplace_back(static_cast<AstProvenanceNegation*>(l.release()));
-    } else if (dynamic_cast<AstConstraint*>(l.get())) {
+    } else if (dynamic_cast<AstConstraint*>(l.get()) != nullptr) {
         constraints.emplace_back(static_cast<AstConstraint*>(l.release()));
     } else {
         assert(false && "Unsupported literal type!");
@@ -106,7 +106,7 @@ void AstClause::print(std::ostream& os) const {
         os << join(getBodyLiterals(), ",\n   ", print_deref<AstLiteral*>());
     }
     os << ".";
-    if (getExecutionPlan()) {
+    if (getExecutionPlan() != nullptr) {
         getExecutionPlan()->print(os);
     }
 }

--- a/src/AstClause.h
+++ b/src/AstClause.h
@@ -360,7 +360,7 @@ public:
     AstClause* clone() const override {
         auto res = new AstClause();
         res->setSrcLoc(getSrcLoc());
-        if (getExecutionPlan()) {
+        if (getExecutionPlan() != nullptr) {
             res->setExecutionPlan(std::unique_ptr<AstExecutionPlan>(plan->clone()));
         }
         res->head = (head) ? std::unique_ptr<AstAtom>(head->clone()) : nullptr;
@@ -403,7 +403,7 @@ public:
         auto* clone = new AstClause();
         clone->setSrcLoc(getSrcLoc());
         clone->setHead(std::unique_ptr<AstAtom>(getHead()->clone()));
-        if (getExecutionPlan()) {
+        if (getExecutionPlan() != nullptr) {
             clone->setExecutionPlan(std::unique_ptr<AstExecutionPlan>(getExecutionPlan()->clone()));
         }
         clone->setFixedExecutionPlan(hasFixedExecutionPlan());

--- a/src/AstComponentChecker.cpp
+++ b/src/AstComponentChecker.cpp
@@ -53,7 +53,7 @@ const AstComponent* AstComponentChecker::checkComponentNameReference(ErrorReport
     }
 
     const AstComponent* c = componentLookup.getComponent(enclosingComponent, name, binding);
-    if (!c) {
+    if (c == nullptr) {
         report.addError("Referencing undefined component " + name, loc);
         return nullptr;
     }
@@ -67,7 +67,7 @@ void AstComponentChecker::checkComponentReference(ErrorReport& report, const Ast
     // check whether targeted component exists
     const AstComponent* c = checkComponentNameReference(
             report, enclosingComponent, componentLookup, type.getName(), loc, binding);
-    if (!c) {
+    if (c == nullptr) {
         return;
     }
 
@@ -127,7 +127,7 @@ void AstComponentChecker::checkComponent(ErrorReport& report, const AstComponent
     std::function<void(const AstComponent&)> collectParents = [&](const AstComponent& cur) {
         for (const auto& base : cur.getBaseComponents()) {
             auto c = componentLookup.getComponent(enclosingComponent, base->getName(), binding);
-            if (!c) {
+            if (c == nullptr) {
                 continue;
             }
             if (parents.insert(c).second) {
@@ -139,7 +139,7 @@ void AstComponentChecker::checkComponent(ErrorReport& report, const AstComponent
 
     // check overrides
     for (const AstRelation* relation : component.getRelations()) {
-        if (component.getOverridden().count(relation->getName().getNames()[0])) {
+        if (component.getOverridden().count(relation->getName().getNames()[0]) != 0u) {
             report.addError("Override of non-inherited relation " + relation->getName().getNames()[0] +
                                     " in component " + component.getComponentType()->getName(),
                     component.getSrcLoc());
@@ -147,7 +147,7 @@ void AstComponentChecker::checkComponent(ErrorReport& report, const AstComponent
     }
     for (const AstComponent* parent : parents) {
         for (const AstRelation* relation : parent->getRelations()) {
-            if (component.getOverridden().count(relation->getName().getNames()[0]) &&
+            if ((component.getOverridden().count(relation->getName().getNames()[0]) != 0u) &&
                     !relation->isOverridable()) {
                 report.addError("Override of non-overridable relation " + relation->getName().getNames()[0] +
                                         " in component " + component.getComponentType()->getName(),
@@ -196,14 +196,14 @@ void AstComponentChecker::checkComponentNamespaces(ErrorReport& report, const As
     // Find all names and report redeclarations as we go.
     for (const auto& type : program.getTypes()) {
         const std::string name = toString(type->getName());
-        if (!names.count(name)) {
+        if (names.count(name) == 0u) {
             names[name] = type->getSrcLoc();
         }
     }
 
     for (const auto& rel : program.getRelations()) {
         const std::string name = toString(rel->getName());
-        if (!names.count(name)) {
+        if (names.count(name) == 0u) {
             names[name] = rel->getSrcLoc();
         }
     }
@@ -211,7 +211,7 @@ void AstComponentChecker::checkComponentNamespaces(ErrorReport& report, const As
     // Note: Nested component and instance names are not obtained.
     for (const auto& comp : program.getComponents()) {
         const std::string name = toString(comp->getComponentType()->getName());
-        if (names.count(name)) {
+        if (names.count(name) != 0u) {
             report.addError("Name clash on component " + name, comp->getSrcLoc());
         } else {
             names[name] = comp->getSrcLoc();
@@ -220,7 +220,7 @@ void AstComponentChecker::checkComponentNamespaces(ErrorReport& report, const As
 
     for (const auto& inst : program.getComponentInstantiations()) {
         const std::string name = toString(inst->getInstanceName());
-        if (names.count(name)) {
+        if (names.count(name) != 0u) {
             report.addError("Name clash on instantiation " + name, inst->getSrcLoc());
         } else {
             names[name] = inst->getSrcLoc();

--- a/src/AstConstraintAnalysis.h
+++ b/src/AstConstraintAnalysis.h
@@ -102,7 +102,7 @@ protected:
      */
     AnalysisVar getVar(const AstArgument& arg) {
         const auto* var = dynamic_cast<const AstVariable*>(&arg);
-        if (!var) {
+        if (var == nullptr) {
             // no mapping required
             return AnalysisVar(arg);
         }

--- a/src/AstRelation.h
+++ b/src/AstRelation.h
@@ -118,25 +118,25 @@ public:
     /** Set qualifier associated with this relation */
     void setQualifier(int q) {
         qualifier = q;
-        if (q & EQREL_RELATION) {
+        if ((q & EQREL_RELATION) != 0) {
             representation = RelationRepresentation::EQREL;
-        } else if (q & BRIE_RELATION) {
+        } else if ((q & BRIE_RELATION) != 0) {
             representation = RelationRepresentation::BRIE;
-        } else if (q & BTREE_RELATION) {
+        } else if ((q & BTREE_RELATION) != 0) {
             representation = RelationRepresentation::BTREE;
         }
 
-        if (q & INPUT_RELATION) {
+        if ((q & INPUT_RELATION) != 0) {
             loads.emplace_back(new AstLoad());
             loads.back()->setName(getName());
             loads.back()->setSrcLoc(getSrcLoc());
         }
-        if (q & OUTPUT_RELATION) {
+        if ((q & OUTPUT_RELATION) != 0) {
             stores.emplace_back(new AstStore());
             stores.back()->setName(getName());
             stores.back()->setSrcLoc(getSrcLoc());
         }
-        if (q & PRINTSIZE_RELATION) {
+        if ((q & PRINTSIZE_RELATION) != 0) {
             stores.emplace_back(new AstPrintSize());
             stores.back()->setName(getName());
             stores.back()->setSrcLoc(getSrcLoc());
@@ -171,7 +171,7 @@ public:
     bool hasRecordInHead() const {
         for (auto& cur : clauses) {
             for (auto* arg : cur->getHead()->getArguments()) {
-                if (dynamic_cast<AstRecordInit*>(arg)) {
+                if (dynamic_cast<AstRecordInit*>(arg) != nullptr) {
                     return true;
                 }
             };

--- a/src/AstRelation.h
+++ b/src/AstRelation.h
@@ -185,7 +185,9 @@ public:
             size_t maxNrOfPremises = 0;
             for (auto& cur : clauses) {
                 size_t numberOfAtoms = cur->getAtoms().size();
-                if (numberOfAtoms > maxNrOfPremises) maxNrOfPremises = numberOfAtoms;
+                if (numberOfAtoms > maxNrOfPremises) {
+                    maxNrOfPremises = numberOfAtoms;
+                }
             }
             return maxNrOfPremises + 1;
         } else {

--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -335,12 +335,12 @@ void AstSemanticChecker::checkProgram(AstTranslationUnit& translationUnit) {
 void AstSemanticChecker::checkAtom(ErrorReport& report, const AstProgram& program, const AstAtom& atom) {
     // check existence of relation
     auto* r = program.getRelation(atom.getName());
-    if (!r) {
+    if (r == nullptr) {
         report.addError("Undefined relation " + toString(atom.getName()), atom.getSrcLoc());
     }
 
     // check arity
-    if (r && r->getArity() != atom.getArity()) {
+    if ((r != nullptr) && r->getArity() != atom.getArity()) {
         report.addError("Mismatching arity of relation " + toString(atom.getName()), atom.getSrcLoc());
     }
 
@@ -352,16 +352,16 @@ void AstSemanticChecker::checkAtom(ErrorReport& report, const AstProgram& progra
 /* Check whether an unnamed variable occurs in an argument (expression) */
 // TODO (azreika): use a visitor instead
 static bool hasUnnamedVariable(const AstArgument* arg) {
-    if (dynamic_cast<const AstUnnamedVariable*>(arg)) {
+    if (dynamic_cast<const AstUnnamedVariable*>(arg) != nullptr) {
         return true;
     }
-    if (dynamic_cast<const AstVariable*>(arg)) {
+    if (dynamic_cast<const AstVariable*>(arg) != nullptr) {
         return false;
     }
-    if (dynamic_cast<const AstConstant*>(arg)) {
+    if (dynamic_cast<const AstConstant*>(arg) != nullptr) {
         return false;
     }
-    if (dynamic_cast<const AstCounter*>(arg)) {
+    if (dynamic_cast<const AstCounter*>(arg) != nullptr) {
         return false;
     }
     if (const auto* cast = dynamic_cast<const AstTypeCast*>(arg)) {
@@ -376,7 +376,7 @@ static bool hasUnnamedVariable(const AstArgument* arg) {
     if (const auto* ri = dynamic_cast<const AstRecordInit*>(arg)) {
         return any_of(ri->getArguments(), (bool (*)(const AstArgument*))hasUnnamedVariable);
     }
-    if (dynamic_cast<const AstAggregator*>(arg)) {
+    if (dynamic_cast<const AstAggregator*>(arg) != nullptr) {
         return false;
     }
     std::cout << "Unsupported Argument type: " << typeid(*arg).name() << "\n";
@@ -391,8 +391,8 @@ static bool hasUnnamedVariable(const AstLiteral* lit) {
     if (const auto* neg = dynamic_cast<const AstNegation*>(lit)) {
         return hasUnnamedVariable(neg->getAtom());
     }
-    if (dynamic_cast<const AstConstraint*>(lit)) {
-        if (dynamic_cast<const AstBooleanConstraint*>(lit)) {
+    if (dynamic_cast<const AstConstraint*>(lit) != nullptr) {
+        if (dynamic_cast<const AstBooleanConstraint*>(lit) != nullptr) {
             return false;
         }
         if (const auto* br = dynamic_cast<const AstBinaryConstraint*>(lit)) {
@@ -418,11 +418,11 @@ void AstSemanticChecker::checkLiteral(
 
     // check for invalid underscore utilization
     if (hasUnnamedVariable(&literal)) {
-        if (dynamic_cast<const AstAtom*>(&literal)) {
+        if (dynamic_cast<const AstAtom*>(&literal) != nullptr) {
             // nothing to check since underscores are allowed
-        } else if (dynamic_cast<const AstNegation*>(&literal)) {
+        } else if (dynamic_cast<const AstNegation*>(&literal) != nullptr) {
             // nothing to check since underscores are allowed
-        } else if (dynamic_cast<const AstBinaryConstraint*>(&literal)) {
+        } else if (dynamic_cast<const AstBinaryConstraint*>(&literal) != nullptr) {
             report.addError("Underscore in binary relation", literal.getSrcLoc());
         } else {
             std::cout << "Unsupported Literal type: " << typeid(literal).name() << "\n";
@@ -522,7 +522,7 @@ void AstSemanticChecker::checkArgument(
 }
 
 static bool isConstantArithExpr(const AstArgument& argument) {
-    if (dynamic_cast<const AstNumberConstant*>(&argument)) {
+    if (dynamic_cast<const AstNumberConstant*>(&argument) != nullptr) {
         return true;
     }
     if (const auto* inf = dynamic_cast<const AstIntrinsicFunctor*>(&argument)) {
@@ -546,19 +546,19 @@ static bool isConstantArithExpr(const AstArgument& argument) {
 void AstSemanticChecker::checkConstant(ErrorReport& report, const AstArgument& argument) {
     if (const auto* var = dynamic_cast<const AstVariable*>(&argument)) {
         report.addError("Variable " + var->getName() + " in fact", var->getSrcLoc());
-    } else if (dynamic_cast<const AstUnnamedVariable*>(&argument)) {
+    } else if (dynamic_cast<const AstUnnamedVariable*>(&argument) != nullptr) {
         report.addError("Underscore in fact", argument.getSrcLoc());
-    } else if (dynamic_cast<const AstIntrinsicFunctor*>(&argument)) {
+    } else if (dynamic_cast<const AstIntrinsicFunctor*>(&argument) != nullptr) {
         if (!isConstantArithExpr(argument)) {
             report.addError("Function in fact", argument.getSrcLoc());
         }
-    } else if (dynamic_cast<const AstUserDefinedFunctor*>(&argument)) {
+    } else if (dynamic_cast<const AstUserDefinedFunctor*>(&argument) != nullptr) {
         report.addError("User-defined functor in fact", argument.getSrcLoc());
     } else if (auto* cast = dynamic_cast<const AstTypeCast*>(&argument)) {
         checkConstant(report, *cast->getValue());
-    } else if (dynamic_cast<const AstCounter*>(&argument)) {
+    } else if (dynamic_cast<const AstCounter*>(&argument) != nullptr) {
         report.addError("Counter in fact", argument.getSrcLoc());
-    } else if (dynamic_cast<const AstConstant*>(&argument)) {
+    } else if (dynamic_cast<const AstConstant*>(&argument) != nullptr) {
         // this one is fine - type checker will make sure of number and symbol constants
     } else if (auto* ri = dynamic_cast<const AstRecordInit*>(&argument)) {
         for (auto* arg : ri->getArguments()) {
@@ -635,7 +635,7 @@ void AstSemanticChecker::checkClause(ErrorReport& report, const AstProgram& prog
     }
 
     // check execution plan
-    if (clause.getExecutionPlan()) {
+    if (clause.getExecutionPlan() != nullptr) {
         auto numAtoms = clause.getAtoms().size();
         for (const auto& cur : clause.getExecutionPlan()->getOrders()) {
             if (cur.second->size() != numAtoms || !cur.second->isComplete()) {
@@ -658,7 +658,7 @@ void AstSemanticChecker::checkRelationDeclaration(ErrorReport& report, const Typ
         AstTypeIdentifier typeName = attr->getTypeName();
 
         /* check whether type exists */
-        if (typeName != "number" && typeName != "symbol" && !program.getType(typeName)) {
+        if (typeName != "number" && typeName != "symbol" && (program.getType(typeName) == nullptr)) {
             report.addError("Undefined type in attribute " + attr->getAttributeName() + ":" +
                                     toString(attr->getTypeName()),
                     attr->getSrcLoc());
@@ -814,12 +814,12 @@ void AstSemanticChecker::checkUnionType(
     for (const AstTypeIdentifier& sub : type.getTypes()) {
         if (sub != "number" && sub != "symbol") {
             const AstType* subt = program.getType(sub);
-            if (!subt) {
+            if (subt == nullptr) {
                 report.addError("Undefined type " + toString(sub) + " in definition of union type " +
                                         toString(type.getName()),
                         type.getSrcLoc());
-            } else if (!dynamic_cast<const AstUnionType*>(subt) &&
-                       !dynamic_cast<const AstPrimitiveType*>(subt)) {
+            } else if ((dynamic_cast<const AstUnionType*>(subt) == nullptr) &&
+                       (dynamic_cast<const AstPrimitiveType*>(subt) == nullptr)) {
                 report.addError("Union type " + toString(type.getName()) +
                                         " contains the non-primitive type " + toString(sub),
                         type.getSrcLoc());
@@ -839,7 +839,7 @@ void AstSemanticChecker::checkRecordType(
         ErrorReport& report, const AstProgram& program, const AstRecordType& type) {
     // check proper definition of all field types
     for (const auto& field : type.getFields()) {
-        if (field.type != "number" && field.type != "symbol" && !program.getType(field.type)) {
+        if (field.type != "number" && field.type != "symbol" && (program.getType(field.type) == nullptr)) {
             report.addError(
                     "Undefined type " + toString(field.type) + " in definition of field " + field.name,
                     type.getSrcLoc());
@@ -1005,7 +1005,7 @@ static const std::vector<SrcLocation> usesInvalidWitness(const std::vector<AstLi
 
         std::unique_ptr<AstNode> operator()(std::unique_ptr<AstNode> node) const override {
             static int numReplaced = 0;
-            if (dynamic_cast<AstAggregator*>(node.get())) {
+            if (dynamic_cast<AstAggregator*>(node.get()) != nullptr) {
                 // Replace the aggregator with a variable
                 std::stringstream newVariableName;
                 newVariableName << "+aggr_var_" << numReplaced++;
@@ -1287,7 +1287,7 @@ void AstSemanticChecker::checkInlining(ErrorReport& report, const AstProgram& pr
         AstRelation* associatedRelation = program.getRelation(atom.getName());
         if (associatedRelation != nullptr && associatedRelation->isInline()) {
             visitDepthFirst(atom, [&](const AstArgument& arg) {
-                if (dynamic_cast<const AstCounter*>(&arg)) {
+                if (dynamic_cast<const AstCounter*>(&arg) != nullptr) {
                     report.addError(
                             "Cannot inline literal containing a counter argument '$'", arg.getSrcLoc());
                 }
@@ -1299,7 +1299,7 @@ void AstSemanticChecker::checkInlining(ErrorReport& report, const AstProgram& pr
     for (const AstRelation* rel : inlinedRelations) {
         for (AstClause* clause : rel->getClauses()) {
             visitDepthFirst(*clause, [&](const AstArgument& arg) {
-                if (dynamic_cast<const AstCounter*>(&arg)) {
+                if (dynamic_cast<const AstCounter*>(&arg) != nullptr) {
                     report.addError(
                             "Cannot inline clause containing a counter argument '$'", arg.getSrcLoc());
                 }
@@ -1392,10 +1392,10 @@ void AstSemanticChecker::checkInlining(ErrorReport& report, const AstProgram& pr
     //  - lastSrcLoc is the source location of the last visited node
     std::function<std::pair<bool, SrcLocation>(const AstNode*)> checkInvalidUnderscore =
             [&](const AstNode* node) {
-                if (dynamic_cast<const AstUnnamedVariable*>(node)) {
+                if (dynamic_cast<const AstUnnamedVariable*>(node) != nullptr) {
                     // Found an invalid underscore
                     return std::make_pair(true, node->getSrcLoc());
-                } else if (dynamic_cast<const AstAggregator*>(node)) {
+                } else if (dynamic_cast<const AstAggregator*>(node) != nullptr) {
                     // Don't care about underscores within aggregators
                     return std::make_pair(false, node->getSrcLoc());
                 }
@@ -1435,7 +1435,7 @@ void AstSemanticChecker::checkNamespaces(ErrorReport& report, const AstProgram& 
     // Find all names and report redeclarations as we go.
     for (const auto& type : program.getTypes()) {
         const std::string name = toString(type->getName());
-        if (names.count(name)) {
+        if (names.count(name) != 0u) {
             report.addError("Name clash on type " + name, type->getSrcLoc());
         } else {
             names[name] = type->getSrcLoc();
@@ -1444,7 +1444,7 @@ void AstSemanticChecker::checkNamespaces(ErrorReport& report, const AstProgram& 
 
     for (const auto& rel : program.getRelations()) {
         const std::string name = toString(rel->getName());
-        if (names.count(name)) {
+        if (names.count(name) != 0u) {
             report.addError("Name clash on relation " + name, rel->getSrcLoc());
         } else {
             names[name] = rel->getSrcLoc();
@@ -1463,12 +1463,12 @@ bool AstExecutionPlanChecker::transform(AstTranslationUnit& translationUnit) {
                 if (!recursiveClauses->recursive(clause)) {
                     continue;
                 }
-                if (!clause->getExecutionPlan()) {
+                if (clause->getExecutionPlan() == nullptr) {
                     continue;
                 }
                 int version = 0;
                 for (const AstAtom* atom : clause->getAtoms()) {
-                    if (scc.count(getAtomRelation(atom, translationUnit.getProgram()))) {
+                    if (scc.count(getAtomRelation(atom, translationUnit.getProgram())) != 0u) {
                         version++;
                     }
                 }

--- a/src/AstTransformer.cpp
+++ b/src/AstTransformer.cpp
@@ -36,7 +36,7 @@ bool MetaTransformer::applySubtransformer(AstTranslationUnit& translationUnit, A
     bool changed = transformer->apply(translationUnit);
     auto end = std::chrono::high_resolution_clock::now();
 
-    if (verbose && !dynamic_cast<MetaTransformer*>(transformer)) {
+    if (verbose && (dynamic_cast<MetaTransformer*>(transformer) == nullptr)) {
         std::string changedString = changed ? "changed" : "unchanged";
         std::cout << transformer->getName() << " time: " << std::chrono::duration<double>(end - start).count()
                   << "sec [" << changedString << "]" << std::endl;

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -1019,9 +1019,9 @@ bool NameUnnamedVariablesTransformer::transform(AstTranslationUnit& translationU
     static constexpr const char* boundPrefix = "+underscore";
 
     struct nameVariables : public AstNodeMapper {
-        mutable bool changed;
-        mutable size_t count;
-        nameVariables() : changed(false), count(0) {}
+        mutable bool changed = false;
+        mutable size_t count = 0;
+        nameVariables() = default;
 
         std::unique_ptr<AstNode> operator()(std::unique_ptr<AstNode> node) const override {
             if (dynamic_cast<AstUnnamedVariable*>(node.get()) != nullptr) {
@@ -1049,7 +1049,7 @@ bool NameUnnamedVariablesTransformer::transform(AstTranslationUnit& translationU
 
 bool RemoveRedundantSumsTransformer::transform(AstTranslationUnit& translationUnit) {
     struct ReplaceSumWithCount : public AstNodeMapper {
-        ReplaceSumWithCount() {}
+        ReplaceSumWithCount() = default;
 
         std::unique_ptr<AstNode> operator()(std::unique_ptr<AstNode> node) const override {
             // Apply to all aggregates of the form

--- a/src/AstTransforms.cpp
+++ b/src/AstTransforms.cpp
@@ -77,10 +77,10 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(AstTranslationUnit& t
     using alias_map = std::map<AstRelationIdentifier, AstRelationIdentifier>;
 
     // tests whether something is a variable
-    auto isVar = [&](const AstArgument& arg) { return dynamic_cast<const AstVariable*>(&arg); };
+    auto isVar = [&](const AstArgument& arg) { return dynamic_cast<const AstVariable*>(&arg) != nullptr; };
 
     // tests whether something is a record
-    auto isRec = [&](const AstArgument& arg) { return dynamic_cast<const AstRecordInit*>(&arg); };
+    auto isRec = [&](const AstArgument& arg) { return dynamic_cast<const AstRecordInit*>(&arg) != nullptr; };
 
     // collect aliases
     alias_map isDirectAliasOf;
@@ -141,7 +141,7 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(AstTranslationUnit& t
 
         auto pos = isDirectAliasOf.find(cur.second);
         while (pos != isDirectAliasOf.end()) {
-            if (visited.count(pos->second)) {
+            if (visited.count(pos->second) != 0u) {
                 cycle_reps.insert(cur.second);
                 break;
             }
@@ -171,7 +171,7 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(AstTranslationUnit& t
 
     // remove unused relations
     for (const auto& cur : isAliasOf) {
-        if (!cycle_reps.count(cur.first)) {
+        if (cycle_reps.count(cur.first) == 0u) {
             program.removeRelation(program.getRelation(cur.first)->getName());
         }
     }
@@ -186,7 +186,7 @@ bool UniqueAggregationVariablesTransformer::transform(AstTranslationUnit& transl
     int aggNumber = 0;
     visitDepthFirstPostOrder(*translationUnit.getProgram(), [&](const AstAggregator& agg) {
         // only applicable for aggregates with target expression
-        if (!agg.getTargetExpression()) {
+        if (agg.getTargetExpression() == nullptr) {
             return;
         }
 
@@ -258,7 +258,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
                     for (const auto& arg : atom->getArguments()) {
                         const auto* atomVariable = dynamic_cast<const AstVariable*>(arg);
                         // if this atom contains the variable I need to ground, add it
-                        if (atomVariable && variable->getName() == atomVariable->getName()) {
+                        if ((atomVariable != nullptr) && variable->getName() == atomVariable->getName()) {
                             // expand the body with this one so that it will ground this variable
                             aggClause->addToBody(std::unique_ptr<AstLiteral>(atom->clone()));
                             break;
@@ -290,7 +290,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
                             [&](std::unique_ptr<AstNode> node) -> std::unique_ptr<AstNode> {
                                 // check whether it is a unnamed variable
                                 auto* var = dynamic_cast<AstUnnamedVariable*>(node.get());
-                                if (!var) {
+                                if (var == nullptr) {
                                     return node;
                                 }
 
@@ -367,7 +367,7 @@ bool MaterializeAggregationQueriesTransformer::needsMaterializedRelation(const A
 
     // inspect remaining atom more closely
     const AstAtom* atom = dynamic_cast<const AstAtom*>(agg.getBodyLiterals()[0]);
-    if (!atom) {
+    if (atom == nullptr) {
         // no atoms, so materialize
         return true;
     }
@@ -376,7 +376,7 @@ bool MaterializeAggregationQueriesTransformer::needsMaterializedRelation(const A
     bool duplicates = false;
     std::set<std::string> vars;
     visitDepthFirst(*atom,
-            [&](const AstVariable& var) { duplicates = duplicates | !vars.insert(var.getName()).second; });
+            [&](const AstVariable& var) { duplicates = duplicates || !vars.insert(var.getName()).second; });
 
     // if there are duplicates a materialization is required
     if (duplicates) {
@@ -531,7 +531,7 @@ bool RemoveBooleanConstraintsTransformer::transform(AstTranslationUnit& translat
                     if (!containsFalse) {
                         for (AstLiteral* lit : aggr->getBodyLiterals()) {
                             // Don't add in 'true' boolean constraints
-                            if (!dynamic_cast<AstBooleanConstraint*>(lit)) {
+                            if (dynamic_cast<AstBooleanConstraint*>(lit) == nullptr) {
                                 isEmpty = false;
                                 replacementAggregator->addBodyLiteral(
                                         std::unique_ptr<AstLiteral>(lit->clone()));
@@ -584,7 +584,7 @@ bool RemoveBooleanConstraintsTransformer::transform(AstTranslationUnit& translat
 
                 // Only keep non-'true' literals
                 for (AstLiteral* lit : clause->getBodyLiterals()) {
-                    if (!dynamic_cast<AstBooleanConstraint*>(lit)) {
+                    if (dynamic_cast<AstBooleanConstraint*>(lit) == nullptr) {
                         replacementClause->addToBody(std::unique_ptr<AstLiteral>(lit->clone()));
                     }
                 }
@@ -799,7 +799,7 @@ bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUni
     // Checks whether an atom is of the form a(_,_,...,_)
     auto isExistentialAtom = [&](const AstAtom& atom) {
         for (AstArgument* arg : atom.getArguments()) {
-            if (!dynamic_cast<AstUnnamedVariable*>(arg)) {
+            if (dynamic_cast<AstUnnamedVariable*>(arg) == nullptr) {
                 return false;
             }
         }
@@ -1152,7 +1152,7 @@ bool NormaliseConstraintsTransformer::transform(AstTranslationUnit& translationU
 
                 // update constant to be the variable created
                 return std::move(newVariable);
-            } else if (dynamic_cast<AstUnnamedVariable*>(node.get())) {
+            } else if (dynamic_cast<AstUnnamedVariable*>(node.get()) != nullptr) {
                 // underscore found
                 changeCount++;
 

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -408,8 +408,9 @@ std::unique_ptr<RamCondition> AstTranslator::translateConstraint(
             if (Global::config().has("provenance")) {
                 values.push_back(std::make_unique<RamUndefValue>());
                 // add the height annotation for provenanceNotExists
-                for (size_t h = 0; h < numberOfHeightParameters; h++)
+                for (size_t h = 0; h < numberOfHeightParameters; h++) {
                     values.push_back(translator.translateValue(atom->getArgument(arity + h + 1), index));
+                }
             }
 
             // add constraint
@@ -620,8 +621,9 @@ std::unique_ptr<RamOperation> AstTranslator::ProvenanceClauseTranslator::createO
             }
 
             // provenance annotation arguments
-            for (size_t i = 0; i < numberOfHeights + 1; ++i)
+            for (size_t i = 0; i < numberOfHeights + 1; ++i) {
                 values.push_back(std::make_unique<RamNumber>(-1));
+            }
         }
     }
 
@@ -1129,9 +1131,10 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
                     r1->addToBody(std::make_unique<AstProvenanceNegation>(
                             std::unique_ptr<AstAtom>(cl->getHead()->clone())));
                 } else {
-                    if (r1->getHead()->getArity() > 0)
+                    if (r1->getHead()->getArity() > 0) {
                         r1->addToBody(std::make_unique<AstNegation>(
                                 std::unique_ptr<AstAtom>(cl->getHead()->clone())));
+                    }
                 }
 
                 // replace wildcards with variables (reduces indices when wildcards are used in recursive
@@ -1212,7 +1215,9 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
 
     /* construct fixpoint loop  */
     std::unique_ptr<RamStatement> res;
-    if (preamble) appendStmt(res, std::move(preamble));
+    if (preamble) {
+        appendStmt(res, std::move(preamble));
+    }
     if (!loopSeq->getStatements().empty() && exitCond && updateTable) {
         appendStmt(res, std::make_unique<RamLoop>(std::move(loopSeq),
                                 std::make_unique<RamExit>(std::move(exitCond)), std::move(updateTable)));

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -230,7 +230,7 @@ std::unique_ptr<RamRelationReference> AstTranslator::translateRelation(
     std::vector<std::string> attributeTypeQualifiers;
     for (size_t i = 0; i < rel->getArity(); ++i) {
         attributeNames.push_back(rel->getAttribute(i)->getAttributeName());
-        if (typeEnv) {
+        if (typeEnv != nullptr) {
             attributeTypeQualifiers.push_back(
                     getTypeQualifier(typeEnv->getType(rel->getAttribute(i)->getTypeName())));
         }
@@ -454,7 +454,7 @@ std::unique_ptr<AstClause> AstTranslator::ClauseTranslator::getReorderedClause(
 
 AstTranslator::ClauseTranslator::arg_list* AstTranslator::ClauseTranslator::getArgList(
         const AstNode* curNode, std::map<const AstNode*, std::unique_ptr<arg_list>>& nodeArgs) const {
-    if (!nodeArgs.count(curNode)) {
+    if (nodeArgs.count(curNode) == 0u) {
         if (auto rec = dynamic_cast<const AstRecordInit*>(curNode)) {
             nodeArgs[curNode] = std::make_unique<arg_list>(rec->getArguments());
         } else if (auto atom = dynamic_cast<const AstAtom*>(curNode)) {
@@ -918,7 +918,7 @@ void AstTranslator::appendStmt(std::unique_ptr<RamStatement>& stmtList, std::uni
     if (stmt) {
         if (stmtList) {
             RamSequence* stmtSeq;
-            if ((stmtSeq = dynamic_cast<RamSequence*>(stmtList.get()))) {
+            if ((stmtSeq = dynamic_cast<RamSequence*>(stmtList.get())) != nullptr) {
                 stmtSeq->add(std::move(stmt));
             } else {
                 stmtList = std::make_unique<RamSequence>(std::move(stmtList), std::move(stmt));
@@ -1010,7 +1010,7 @@ void AstTranslator::nameUnnamedVariables(AstClause* clause) {
             node->apply(*this);
 
             // replace unknown variables
-            if (dynamic_cast<AstUnnamedVariable*>(node.get())) {
+            if (dynamic_cast<AstUnnamedVariable*>(node.get()) != nullptr) {
                 auto name = " _unnamed_var" + toString(++counter);
                 return std::make_unique<AstVariable>(name);
             }
@@ -1183,7 +1183,7 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
         }
 
         // if there was no rule, continue
-        if (!loopRelSeq) {
+        if (loopRelSeq == nullptr) {
             continue;
         }
 
@@ -1215,17 +1215,19 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
 
     /* construct fixpoint loop  */
     std::unique_ptr<RamStatement> res;
-    if (preamble) {
+    if (preamble != nullptr) {
         appendStmt(res, std::move(preamble));
     }
     if (!loopSeq->getStatements().empty() && exitCond && updateTable) {
         appendStmt(res, std::make_unique<RamLoop>(std::move(loopSeq),
                                 std::make_unique<RamExit>(std::move(exitCond)), std::move(updateTable)));
     }
-    if (postamble) {
+    if (postamble != nullptr) {
         appendStmt(res, std::move(postamble));
     }
-    if (res) return res;
+    if (res != nullptr) {
+        return res;
+    }
 
     assert(false && "Not Implemented");
     return nullptr;
@@ -1312,7 +1314,7 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
         AggregatesToVariables(int& aggNumber) : aggNumber(aggNumber) {}
 
         std::unique_ptr<AstNode> operator()(std::unique_ptr<AstNode> node) const override {
-            if (dynamic_cast<AstAggregator*>(node.get())) {
+            if (dynamic_cast<AstAggregator*>(node.get()) != nullptr) {
                 return std::make_unique<AstVariable>("agg_" + std::to_string(aggNumber++));
             }
 

--- a/src/AstTypeAnalysis.cpp
+++ b/src/AstTypeAnalysis.cpp
@@ -374,7 +374,7 @@ std::map<const AstArgument*, TypeSet> TypeAnalysis::analyseTypes(
         void visitAtom(const AstAtom& atom) override {
             // get relation
             auto rel = getAtomRelation(&atom, program);
-            if (!rel) {
+            if (rel == nullptr) {
                 return;  // error in input program
             }
 

--- a/src/AstTypeEnvironmentAnalysis.cpp
+++ b/src/AstTypeEnvironmentAnalysis.cpp
@@ -56,10 +56,10 @@ void TypeEnvironmentAnalysis::updateTypeEnvironment(const AstProgram& program) {
             } else {
                 env.createSymbolType(cur->getName());
             }
-        } else if (dynamic_cast<const AstUnionType*>(cur)) {
+        } else if (dynamic_cast<const AstUnionType*>(cur) != nullptr) {
             // initialize the union
             env.createUnionType(cur->getName());
-        } else if (dynamic_cast<const AstRecordType*>(cur)) {
+        } else if (dynamic_cast<const AstRecordType*>(cur) != nullptr) {
             // initialize the record
             env.createRecordType(cur->getName());
         } else {
@@ -73,12 +73,12 @@ void TypeEnvironmentAnalysis::updateTypeEnvironment(const AstProgram& program) {
         Type* type = env.getModifiableType(cur->getName());
         assert(type && "It should be there!");
 
-        if (dynamic_cast<const AstPrimitiveType*>(cur)) {
+        if (dynamic_cast<const AstPrimitiveType*>(cur) != nullptr) {
             // nothing to do here
         } else if (auto* t = dynamic_cast<const AstUnionType*>(cur)) {
             // get type as union type
             auto* ut = dynamic_cast<UnionType*>(type);
-            if (!ut) {
+            if (ut == nullptr) {
                 continue;  // support faulty input
             }
 
@@ -91,7 +91,7 @@ void TypeEnvironmentAnalysis::updateTypeEnvironment(const AstProgram& program) {
         } else if (auto* t = dynamic_cast<const AstRecordType*>(cur)) {
             // get type as record type
             auto* rt = dynamic_cast<RecordType*>(type);
-            if (!rt) {
+            if (rt == nullptr) {
                 continue;  // support faulty input
             }
 

--- a/src/BTree.h
+++ b/src/BTree.h
@@ -814,8 +814,11 @@ protected:
 
                     // search for new position (since other may have been altered in the meanwhile)
                     size_type i = 0;
-                    for (; i <= other->numElements; ++i)
-                        if (other->getChild(i) == predecessor) break;
+                    for (; i <= other->numElements; ++i) {
+                        if (other->getChild(i) == predecessor) {
+                            break;
+                        }
+                    }
 
                     pos = (i > other->numElements) ? 0 : i;
                     other->insert_inner(root, root_lock, pos, predecessor, key, newNode, locked_nodes);
@@ -879,7 +882,9 @@ protected:
 
 #ifdef IS_PARALLEL
             // print the lock state
-            if (this->lock.is_write_locked()) std::cout << " locked";
+            if (this->lock.is_write_locked()) {
+                std::cout << " locked";
+            }
 #endif
 
             out << "\n";
@@ -1377,7 +1382,9 @@ public:
                 cur_lease = cur->lock.start_read();
 
                 // check validity of root pointer
-                if (root_lock.end_read(root_lease)) break;
+                if (root_lock.end_read(root_lease)) {
+                    break;
+                }
 
             } while (true);
         }
@@ -1486,7 +1493,9 @@ public:
                         parent->lock.start_write();
                         while (true) {
                             // check whether parent is correct
-                            if (parent == priv->parent) break;
+                            if (parent == priv->parent) {
+                                break;
+                            }
                             // switch parent
                             parent->lock.abort_write();
                             parent = priv->parent;
@@ -1501,7 +1510,9 @@ public:
                     parents.push_back(parent);
 
                     // stop at "sphere of influence"
-                    if (!parent || !parent->isFull()) break;
+                    if (!parent || !parent->isFull()) {
+                        break;
+                    }
 
                     // go one step higher
                     priv = parent;

--- a/src/Brie.h
+++ b/src/Brie.h
@@ -394,7 +394,7 @@ private:
      * Obtains a snapshot of the current root information.
      */
     RootInfoSnapshot getRootInfo() const {
-        RootInfoSnapshot res;
+        RootInfoSnapshot res{};
         do {
             // first take the mod counter
             do {
@@ -468,7 +468,7 @@ private:
      * Obtains a snapshot of the current first-node information.
      */
     FirstInfoSnapshot getFirstInfo() const {
-        FirstInfoSnapshot res;
+        FirstInfoSnapshot res{};
         do {
             // first take the version
             do {
@@ -1572,7 +1572,7 @@ public:
         uint64_t mask = 0;
 
         // the value currently pointed to
-        index_type value;
+        index_type value{};
 
     public:
         // default constructor -- creating an end-iterator

--- a/src/Brie.h
+++ b/src/Brie.h
@@ -783,14 +783,14 @@ private:
      */
     static void merge(const Node* parent, Node*& trg, const Node* src, int levels) {
         // if other side is null => done
-        if (!src) {
+        if (src == nullptr) {
             return;
         }
 
         // if the trg sub-tree is empty, clone the corresponding branch
         if (trg == nullptr) {
             trg = clone(src, levels);
-            if (trg) {
+            if (trg != nullptr) {
                 trg->parent = parent;
             }
             return;  // done
@@ -958,7 +958,7 @@ public:
             while (level > 0 && node) {
                 // search for next child
                 while (x < NUM_CELLS) {
-                    if (node->cell[x].ptr) {
+                    if (node->cell[x].ptr != nullptr) {
                         break;
                     }
                     x++;
@@ -984,7 +984,7 @@ public:
             }
 
             // check whether it is the end of range
-            if (!node) {
+            if (node == nullptr) {
                 return *this;
             }
 
@@ -1253,7 +1253,7 @@ private:
      */
     static Node* clone(const Node* node, int level) {
         // support null-pointers
-        if (!node) {
+        if (node == nullptr) {
             return nullptr;
         }
 
@@ -1272,7 +1272,7 @@ private:
         // for inner nodes clone each child
         for (int i = 0; i < NUM_CELLS; i++) {
             auto cur = clone(node->cell[i].ptr, level - 1);
-            if (cur) {
+            if (cur != nullptr) {
                 cur->parent = res;
             }
             res->cell[i].ptr = cur;
@@ -1504,7 +1504,7 @@ public:
 #endif
 
         value_t old = val.fetch_or(bit, std::memory_order::memory_order_relaxed);
-        return !(old & bit);
+        return (old & bit) == 0u;
     }
 
     /**

--- a/src/Brie.h
+++ b/src/Brie.h
@@ -245,7 +245,9 @@ public:
         // copy content
         unsynced.levels = other.unsynced.levels;
         unsynced.root = clone(other.unsynced.root, unsynced.levels);
-        if (unsynced.root) unsynced.root->parent = nullptr;
+        if (unsynced.root) {
+            unsynced.root->parent = nullptr;
+        }
         unsynced.offset = other.unsynced.offset;
         unsynced.first = (unsynced.root) ? findFirst(unsynced.root, unsynced.levels) : nullptr;
         unsynced.firstOffset = other.unsynced.firstOffset;
@@ -781,12 +783,16 @@ private:
      */
     static void merge(const Node* parent, Node*& trg, const Node* src, int levels) {
         // if other side is null => done
-        if (!src) return;
+        if (!src) {
+            return;
+        }
 
         // if the trg sub-tree is empty, clone the corresponding branch
         if (trg == nullptr) {
             trg = clone(src, levels);
-            if (trg) trg->parent = parent;
+            if (trg) {
+                trg->parent = parent;
+            }
             return;  // done
         }
 
@@ -952,7 +958,9 @@ public:
             while (level > 0 && node) {
                 // search for next child
                 while (x < NUM_CELLS) {
-                    if (node->cell[x].ptr) break;
+                    if (node->cell[x].ptr) {
+                        break;
+                    }
                     x++;
                 }
 
@@ -976,7 +984,9 @@ public:
             }
 
             // check whether it is the end of range
-            if (!node) return *this;
+            if (!node) {
+                return *this;
+            }
 
             // search the first value in this node
             x = 0;
@@ -1243,7 +1253,9 @@ private:
      */
     static Node* clone(const Node* node, int level) {
         // support null-pointers
-        if (!node) return nullptr;
+        if (!node) {
+            return nullptr;
+        }
 
         // create a clone
         auto* res = new Node();
@@ -1260,7 +1272,9 @@ private:
         // for inner nodes clone each child
         for (int i = 0; i < NUM_CELLS; i++) {
             auto cur = clone(node->cell[i].ptr, level - 1);
-            if (cur) cur->parent = res;
+            if (cur) {
+                cur->parent = res;
+            }
             res->cell[i].ptr = cur;
         }
 
@@ -2529,7 +2543,9 @@ public:
         int c = 1;
         auto priv = begin();
         for (auto it = store.begin(); it != store.end(); ++it, c++) {
-            if (c % step != 0 || c == 1) continue;
+            if (c % step != 0 || c == 1) {
+                continue;
+            }
             auto cur = iterator(it);
             res.push_back(make_range(priv, cur));
             priv = cur;
@@ -3096,7 +3112,9 @@ public:
         int c = 1;
         auto priv = begin();
         for (auto it = map.begin(); it != map.end(); ++it, c++) {
-            if (c % step != 0 || c == 1) continue;
+            if (c % step != 0 || c == 1) {
+                continue;
+            }
             auto cur = iterator(it);
             res.push_back(make_range(priv, cur));
             priv = cur;

--- a/src/CompiledIndexUtils.h
+++ b/src/CompiledIndexUtils.h
@@ -1075,7 +1075,7 @@ public:
         nested_iterator nested;
 
         // the value currently pointed to
-        tuple_type value;
+        tuple_type value{};
 
     public:
         // default constructor -- creating an end-iterator

--- a/src/CompiledIndexUtils.h
+++ b/src/CompiledIndexUtils.h
@@ -522,7 +522,9 @@ template <unsigned F, unsigned... R, unsigned... M, RamDomain value>
 struct mask<index<F, R...>, index<M...>, value> {
     template <typename T>
     void operator()(T& t) const {
-        if (!column_utils::contains<F, M...>::value) t[F] = value;
+        if (!column_utils::contains<F, M...>::value) {
+            t[F] = value;
+        }
         mask<index<R...>, index<M...>, value>()(t);
     }
 };

--- a/src/CompiledIndexUtils.h
+++ b/src/CompiledIndexUtils.h
@@ -48,7 +48,7 @@ struct contains;
 
 template <unsigned E>
 struct contains<E> {
-    static constexpr size_t value = false;
+    static constexpr size_t value = 0u;
 };
 
 template <unsigned E, unsigned F, unsigned... Rest>
@@ -63,7 +63,7 @@ struct unique;
 
 template <>
 struct unique<> {
-    static constexpr size_t value = true;
+    static constexpr size_t value = 1u;
 };
 
 template <unsigned E, unsigned... Rest>
@@ -209,12 +209,12 @@ namespace index_utils {
 
 template <typename... Index>
 struct all_indices {
-    static constexpr size_t value = false;
+    static constexpr size_t value = 0u;
 };
 
 template <>
 struct all_indices<> {
-    static constexpr size_t value = true;
+    static constexpr size_t value = 1u;
 };
 
 template <unsigned... Columns, typename... Rest>
@@ -229,7 +229,7 @@ struct contains;
 
 template <typename E>
 struct contains<E> {
-    static constexpr size_t value = false;
+    static constexpr size_t value = 0u;
 };
 
 template <typename E, typename F, typename... Rest>
@@ -239,7 +239,7 @@ struct contains<E, F, Rest...> {
 
 template <typename E, typename... Rest>
 struct contains<E, E, Rest...> {
-    static constexpr size_t value = true;
+    static constexpr size_t value = 1u;
 };
 
 // -- check whether a given list is a list of unique indices --
@@ -249,7 +249,7 @@ struct unique;
 
 template <>
 struct unique<> {
-    static constexpr size_t value = true;
+    static constexpr size_t value = 1u;
 };
 
 template <typename First, typename... Rest>
@@ -261,12 +261,12 @@ struct unique<First, Rest...> {
 
 template <unsigned arity, typename Index>
 struct check_index_arity {
-    static constexpr size_t value = false;
+    static constexpr size_t value = 0u;
 };
 
 template <unsigned arity>
 struct check_index_arity<arity, index<>> {
-    static constexpr size_t value = true;
+    static constexpr size_t value = 1u;
 };
 
 template <unsigned arity, unsigned F, unsigned... Rest>
@@ -281,7 +281,7 @@ struct check_arity;
 
 template <unsigned arity>
 struct check_arity<arity> {
-    static constexpr size_t value = true;
+    static constexpr size_t value = 1u;
 };
 
 template <unsigned arity, typename F, typename... Rest>
@@ -355,12 +355,12 @@ struct extend_to_full_index : public detail::extend_to_full_index_aux<0, arity, 
 
 template <typename I1, typename I2>
 struct is_prefix {
-    static constexpr size_t value = false;
+    static constexpr size_t value = 0u;
 };
 
 template <unsigned... Rest>
 struct is_prefix<index<>, index<Rest...>> {
-    static constexpr size_t value = true;
+    static constexpr size_t value = 1u;
 };
 
 template <unsigned F, unsigned... Ra, unsigned... Rb>
@@ -403,7 +403,7 @@ struct get_prefix<L, index<Rest...>> {
 
 template <typename I1, typename I2>
 struct is_subset_of {
-    static constexpr size_t value = false;
+    static constexpr size_t value = 0u;
 };
 
 template <unsigned First, unsigned... Rest, unsigned... Full>
@@ -414,14 +414,14 @@ struct is_subset_of<index<First, Rest...>, index<Full...>> {
 
 template <unsigned... Full>
 struct is_subset_of<index<>, index<Full...>> {
-    static constexpr size_t value = true;
+    static constexpr size_t value = 1u;
 };
 
 // -- checks whether one index is a permutation of another index --
 
 template <typename I1, typename I2>
 struct is_permutation {
-    static constexpr size_t value = false;
+    static constexpr size_t value = 0u;
 };
 
 template <unsigned... C1, unsigned... C2>
@@ -436,7 +436,7 @@ namespace detail {
 
 template <typename P1, typename R1, typename P2, typename R2>
 struct is_compatible_with_aux {
-    static constexpr size_t value = false;
+    static constexpr size_t value = 0u;
 };
 
 template <unsigned... A1, unsigned A, unsigned... A2, unsigned... B1, unsigned B, unsigned... B2>
@@ -453,7 +453,7 @@ struct is_compatible_with_aux<index<A...>, index<>, index<B...>, index<R...>> {
 
 template <typename I1, typename I2>
 struct is_compatible_with {
-    static constexpr size_t value = false;
+    static constexpr size_t value = 0u;
 };
 
 template <unsigned... C1, unsigned... C2>
@@ -482,7 +482,7 @@ struct contains_full_index<arity, First, Rest...> {
 
 template <unsigned arity>
 struct contains_full_index<arity> {
-    static constexpr size_t value = false;
+    static constexpr size_t value = 0u;
 };
 
 // -- get first full index from a list of indices --
@@ -1410,7 +1410,7 @@ public:
 
     template <typename I>
     struct is_covered {
-        static constexpr size_t value = false;
+        static constexpr size_t value = 0u;
     };
 
     void insert(const T&, operation_context&) {}

--- a/src/ComponentModel.cpp
+++ b/src/ComponentModel.cpp
@@ -190,7 +190,7 @@ void collectContent(const AstComponent& component, const TypeBinding& binding,
     // start with relations and clauses of the base components
     for (const auto& base : component.getBaseComponents()) {
         const AstComponent* comp = componentLookup.getComponent(enclosingComponent, base->getName(), binding);
-        if (comp) {
+        if (comp != nullptr) {
             // link formal with actual type parameters
             const auto& formalParams = comp->getComponentType()->getTypeParameters();
             const auto& actualParams = base->getTypeParameters();
@@ -310,7 +310,7 @@ void collectContent(const AstComponent& component, const TypeBinding& binding,
     for (const auto& cur : component.getClauses()) {
         if (overridden.count(cur->getHead()->getName().getNames()[0]) == 0) {
             AstRelation* rel = index[cur->getHead()->getName()];
-            if (rel) {
+            if (rel != nullptr) {
                 rel->addClause(std::unique_ptr<AstClause>(cur->clone()));
             } else {
                 orphans.emplace_back(cur->clone());
@@ -322,7 +322,7 @@ void collectContent(const AstComponent& component, const TypeBinding& binding,
     for (auto iter = orphans.begin(); iter != orphans.end();) {
         auto& cur = *iter;
         AstRelation* rel = index[cur->getHead()->getName()];
-        if (rel) {
+        if (rel != nullptr) {
             // add orphan to current instance and delete from orphan list
             rel->addClause(std::unique_ptr<AstClause>(cur->clone()));
             iter = orphans.erase(iter);
@@ -347,7 +347,7 @@ ComponentContent getInstantiatedContent(const AstComponentInit& componentInit,
     // get referenced component
     const AstComponent* component = componentLookup.getComponent(
             enclosingComponent, componentInit.getComponentType()->getName(), binding);
-    if (!component) {
+    if (component == nullptr) {
         // this component is not defined => will trigger a semantic error
         return res;
     }

--- a/src/DebugReport.cpp
+++ b/src/DebugReport.cpp
@@ -177,7 +177,7 @@ DebugReportSection DebugReporter::getDotGraphSection(
     std::stringstream data;
     while (in != nullptr) {
         char c = fgetc(in);
-        if (feof(in)) {
+        if (feof(in) != 0) {
             break;
         }
         data << c;

--- a/src/EquivalenceRelation.h
+++ b/src/EquivalenceRelation.h
@@ -333,7 +333,9 @@ public:
 
         /* pre-increment */
         iterator& operator++() {
-            if (isEndVal) throw std::out_of_range("error: incrementing an out of range iterator");
+            if (isEndVal) {
+                throw std::out_of_range("error: incrementing an out of range iterator");
+            }
 
             switch (ityp) {
                 case IterType::ALL:
@@ -352,8 +354,9 @@ public:
 
                             // we can't iterate along this djset if it is empty
                             djSetList = (*djSetMapListIt).second;
-                            if (djSetList->size() == 0)
+                            if (djSetList->size() == 0) {
                                 throw std::out_of_range("error: encountered a zero size djset");
+                            }
 
                             // update our cAnterior and cPosterior
                             cAnteriorIndex = 0;

--- a/src/EventProcessor.h
+++ b/src/EventProcessor.h
@@ -127,8 +127,9 @@ private:
         for (size_t i = 0; i < str.size(); i++) {
             if (repeat) {
                 if (str.at(i) == split_str.at(0)) {
-                    while (str.at(++i) == split_str.at(0))
+                    while (str.at(++i) == split_str.at(0)) {
                         ;  // set i to be at the end of the search string
+                    }
                     elems.push_back(temp);
                     temp = "";
                 }

--- a/src/EventProcessor.h
+++ b/src/EventProcessor.h
@@ -118,7 +118,7 @@ private:
     /** split string */
     static std::vector<std::string> split(std::string str, std::string split_str) {
         // repeat value when splitting so "a   b" -> ["a","b"] not ["a","","","","b"]
-        bool repeat = (split_str.compare(" ") == 0);
+        bool repeat = (split_str == " ");
 
         std::vector<std::string> elems;
 

--- a/src/Explain.h
+++ b/src/Explain.h
@@ -405,7 +405,7 @@ private:
 
     /* Print a command prompt, disabled for non-terminal outputs */
     void printPrompt(const std::string& prompt) override {
-        if (!isatty(fileno(stdin))) {
+        if (isatty(fileno(stdin)) == 0) {
             return;
         }
         std::cout << prompt;
@@ -441,7 +441,7 @@ private:
 
     /* Print any other information, disabled for non-terminal outputs */
     void printInfo(const std::string& info) override {
-        if (!isatty(fileno(stdin))) {
+        if (isatty(fileno(stdin)) == 0) {
             return;
         }
         std::cout << info;

--- a/src/ExplainProvenance.h
+++ b/src/ExplainProvenance.h
@@ -250,7 +250,7 @@ protected:
         }
 
         for (size_t i = 0; i < nums.size(); i++) {
-            if (err && (*err)[i]) {
+            if ((err != nullptr) && (*err)[i]) {
                 args.push_back("_");
             } else {
                 if (*rel->getAttrType(i) == 's') {

--- a/src/ExplainProvenance.h
+++ b/src/ExplainProvenance.h
@@ -23,6 +23,7 @@
 
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace souffle {
@@ -39,7 +40,7 @@ public:
      * @param s, symbol of the variable
      * @param idx, first occurence of the variable
      * */
-    Equivalence(char t, std::string s, std::pair<size_t, size_t> idx) : type(t), symbol(s) {
+    Equivalence(char t, std::string s, std::pair<size_t, size_t> idx) : type(t), symbol(std::move(s)) {
         indices.push_back(idx);
     }
 

--- a/src/ExplainProvenanceImpl.h
+++ b/src/ExplainProvenanceImpl.h
@@ -29,7 +29,7 @@
 #include <string>
 #include <vector>
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace souffle {
 
@@ -617,18 +617,18 @@ public:
         size_t idx = 0;
 
         // parse arguments in each relation Tuple
-        for (size_t i = 0; i < rels.size(); ++i) {
-            Relation* relation = prog.getRelation(rels[i].first);
+        for (const auto& rel : rels) {
+            Relation* relation = prog.getRelation(rel.first);
             // number/symbol index for constant arguments in tuple
             std::vector<RamDomain> constTuple;
             // relation does not exist
             if (relation == nullptr) {
-                std::cout << "Relation <" << rels[i].first << "> does not exist" << std::endl;
+                std::cout << "Relation <" << rel.first << "> does not exist" << std::endl;
                 return;
             }
             // arity error
-            if (relation->getArity() - 1 - relation->getNumberOfHeights() != rels[i].second.size()) {
-                std::cout << "<" + rels[i].first << "> has arity of "
+            if (relation->getArity() - 1 - relation->getNumberOfHeights() != rel.second.size()) {
+                std::cout << "<" + rel.first << "> has arity of "
                           << std::to_string(relation->getArity() - 1 - relation->getNumberOfHeights())
                           << std::endl;
                 return;
@@ -636,9 +636,9 @@ public:
 
             // check if args contain variable
             bool containVar = false;
-            for (size_t j = 0; j < rels[i].second.size(); ++j) {
+            for (size_t j = 0; j < rel.second.size(); ++j) {
                 // arg is a variable
-                if (std::regex_match(rels[i].second[j], argsMatcher, varRegex)) {
+                if (std::regex_match(rel.second[j], argsMatcher, varRegex)) {
                     containVar = true;
                     auto nameToEquivalenceIter = nameToEquivalence.find(argsMatcher[0]);
                     // if variable has not shown up before, create an equivalence class for add it to
@@ -651,7 +651,7 @@ public:
                         nameToEquivalenceIter->second.push_back(std::make_pair(idx, j));
                     }
                     // arg is a symbol
-                } else if (std::regex_match(rels[i].second[j], argsMatcher, symbolRegex)) {
+                } else if (std::regex_match(rel.second[j], argsMatcher, symbolRegex)) {
                     if (*(relation->getAttrType(j)) != 's') {
                         std::cout << argsMatcher.str(0) << " does not match type defined in relation"
                                   << std::endl;
@@ -664,7 +664,7 @@ public:
                         constTuple.push_back(rd);
                     }
                     // arg is number
-                } else if (std::regex_match(rels[i].second[j], argsMatcher, numberRegex)) {
+                } else if (std::regex_match(rel.second[j], argsMatcher, numberRegex)) {
                     if (*(relation->getAttrType(j)) != 'i') {
                         std::cout << argsMatcher.str(0) << " does not match type defined in relation"
                                   << std::endl;
@@ -692,11 +692,11 @@ public:
                     // otherwise, there is no solution for given query
                 } else {
                     std::cout << "false." << std::endl;
-                    std::cout << "Tuple " << rels[i].first << "(";
-                    for (size_t l = 0; l < rels[i].second.size() - 1; ++l) {
-                        std::cout << rels[i].second[l] << ", ";
+                    std::cout << "Tuple " << rel.first << "(";
+                    for (size_t l = 0; l < rel.second.size() - 1; ++l) {
+                        std::cout << rel.second[l] << ", ";
                     }
-                    std::cout << rels[i].second.back() << ") does not exist" << std::endl;
+                    std::cout << rel.second.back() << ") does not exist" << std::endl;
                     return;
                 }
             } else {

--- a/src/ExplainProvenanceImpl.h
+++ b/src/ExplainProvenanceImpl.h
@@ -113,12 +113,12 @@ public:
         std::vector<RamDomain> ret;
         std::vector<bool> err;
 
-        if (useSublevels)
+        if (useSublevels) {
             // add subtree level numbers to tuple
             for (auto subtreeLevel : subtreeLevels) {
                 tuple.push_back(subtreeLevel);
             }
-        else {
+        } else {
             tuple.push_back(levelNum);
         }
 
@@ -517,7 +517,9 @@ public:
         auto size = rel->size();
         int skip = size / 10;
 
-        if (skip == 0) skip = 1;
+        if (skip == 0) {
+            skip = 1;
+        }
 
         std::stringstream ss;
 
@@ -587,10 +589,11 @@ public:
         os << "\"rules\": [\n";
         bool first = true;
         for (auto const& cur : rules) {
-            if (first)
+            if (first) {
                 first = false;
-            else
+            } else {
                 os << ",\n";
+            }
             os << "\t{ \"rule-number\": \"(R" << cur.first.second << ")\", \"rule\": \""
                << stringify(cur.second) << "\"}";
         }

--- a/src/ExplainTree.h
+++ b/src/ExplainTree.h
@@ -176,10 +176,11 @@ public:
         os << tab << "  \"children\": [\n";
         bool first = true;
         for (const std::unique_ptr<TreeNode>& k : children) {
-            if (first)
+            if (first) {
                 first = false;
-            else
+            } else {
                 os << ",\n";
+            }
             k->printJSON(os, pos + 1);
         }
         os << tab << "]\n";

--- a/src/Global.cpp
+++ b/src/Global.cpp
@@ -62,7 +62,7 @@ void MainConfig::processArgs(int argc, char** argv, const std::string& header, c
             // print the short form name and the argument parameter
             length = 0;
             ss << "\t";
-            if (isalpha(opt.shortName)) {
+            if (isalpha(opt.shortName) != 0) {
                 ss << "-" << opt.shortName;
                 if (!opt.argument.empty()) {
                     ss << "<" << opt.argument << ">";
@@ -127,7 +127,7 @@ void MainConfig::processArgs(int argc, char** argv, const std::string& header, c
                 continue;
             }
             // convert the main option to a plain old getopt option and put it in the array
-            longNames[i] = (option){opt.longName.c_str(), (!opt.argument.empty()), nullptr, opt.shortName};
+            longNames[i] = {opt.longName.c_str(), opt.argument.empty() ? 0 : 1, nullptr, opt.shortName};
             // append the short name of the option to the string of short names
             shortNames += opt.shortName;
             // indicating with a ':' if it takes an argument
@@ -138,7 +138,7 @@ void MainConfig::processArgs(int argc, char** argv, const std::string& header, c
             ++i;
         }
         // the terminal option, needs to be null
-        longNames[i] = {nullptr, false, nullptr, 0};
+        longNames[i] = {nullptr, 0, nullptr, 0};
 
         // use getopt to process the arguments given to the command line, with the parameters being the
         // short and long names from above
@@ -155,7 +155,7 @@ void MainConfig::processArgs(int argc, char** argv, const std::string& header, c
             assert(iter != optionTable.end() && "unexpected case in getopt");
             // define the value for the option in the global configuration as its argument or an empty string
             //  if no argument exists
-            std::string arg = (optarg) ? std::string(optarg) : std::string();
+            std::string arg = optarg != nullptr ? std::string(optarg) : std::string();
             // if the option allows multiple arguments
             if (iter->second->takesMany) {
                 // set the value of the option in the global config to the concatenation of its previous

--- a/src/InlineRelationsTransformer.cpp
+++ b/src/InlineRelationsTransformer.cpp
@@ -135,7 +135,7 @@ void nameInlinedUnderscores(AstProgram& program) {
                         return node;
                     }
                 }
-            } else if (dynamic_cast<AstUnnamedVariable*>(node.get())) {
+            } else if (dynamic_cast<AstUnnamedVariable*>(node.get()) != nullptr) {
                 // Give a unique name to the underscored variable
                 // TODO (azreika): need a more consistent way of handling internally generated variables in
                 // general
@@ -184,8 +184,8 @@ bool containsInlinedAtom(const AstProgram& program, const AstClause& clause) {
  */
 bool reduceSubstitution(std::vector<std::pair<AstArgument*, AstArgument*>>& sub) {
     // Type-Checking functions
-    auto isConstant = [&](AstArgument* arg) { return (dynamic_cast<AstConstant*>(arg)); };
-    auto isRecord = [&](AstArgument* arg) { return (dynamic_cast<AstRecordInit*>(arg)); };
+    auto isConstant = [&](AstArgument* arg) { return dynamic_cast<AstConstant*>(arg) != nullptr; };
+    auto isRecord = [&](AstArgument* arg) { return dynamic_cast<AstRecordInit*>(arg) != nullptr; };
 
     // Keep trying to reduce the substitutions until we reach a fixed point.
     // Note that at this point no underscores ('_') or counters ('$') should appear.
@@ -610,7 +610,7 @@ NullableVector<AstArgument*> getInlinedArgument(AstProgram& program, const AstAr
                 }
             }
         }
-    } else if (dynamic_cast<const AstFunctor*>(arg)) {
+    } else if (dynamic_cast<const AstFunctor*>(arg) != nullptr) {
         if (const auto* functor = dynamic_cast<const AstIntrinsicFunctor*>(arg)) {
             for (size_t i = 0; i < functor->getArity(); i++) {
                 // TODO (azreika): use unique pointers

--- a/src/InterpreterGenerator.h
+++ b/src/InterpreterGenerator.h
@@ -487,7 +487,7 @@ public:
     NodePtr visitNode(const RamNode& node) override {
         std::cerr << "Unsupported node type: " << typeid(node).name() << "\n";
         assert(false && "Unsupported Node Type!");
-        return 0;
+        return nullptr;
     }
 
 public:
@@ -606,9 +606,9 @@ private:
      * This function assume the operation does requires a view.
      */
     const RamRelation& getRelationRefForView(const RamNode* node) {
-        if (const RamAbstractExistenceCheck* exist = dynamic_cast<const RamAbstractExistenceCheck*>(node)) {
+        if (const auto* exist = dynamic_cast<const RamAbstractExistenceCheck*>(node)) {
             return exist->getRelation();
-        } else if (const RamIndexOperation* index = dynamic_cast<const RamIndexOperation*>(node)) {
+        } else if (const auto* index = dynamic_cast<const RamIndexOperation*>(node)) {
             return index->getRelation();
         }
         assert(false && "The RamNode does not require a view.");

--- a/src/InterpreterIndex.h
+++ b/src/InterpreterIndex.h
@@ -150,7 +150,7 @@ public:
 
     template <std::size_t Arity>
     ram::Tuple<RamDomain, Arity> encode(const ram::Tuple<RamDomain, Arity>& entry) const {
-        ram::Tuple<RamDomain, Arity> res;
+        ram::Tuple<RamDomain, Arity> res{};
         for (std::size_t i = 0; i < Arity; ++i) {
             res[i] = entry[order[i]];
         }
@@ -159,7 +159,7 @@ public:
 
     template <std::size_t Arity>
     ram::Tuple<RamDomain, Arity> decode(const ram::Tuple<RamDomain, Arity>& entry) const {
-        ram::Tuple<RamDomain, Arity> res;
+        ram::Tuple<RamDomain, Arity> res{};
         for (std::size_t i = 0; i < Arity; ++i) {
             res[order[i]] = entry[i];
         }

--- a/src/InterpreterIndex.h
+++ b/src/InterpreterIndex.h
@@ -133,8 +133,8 @@ class Order {
     std::vector<int> order;
 
 public:
-    template <typename... Positions>
-    Order(Positions... pos) : order{pos...} {
+    Order() = default;
+    Order(std::vector<int> pos) : order(std::move(pos)) {
         assert(valid());
     }
 

--- a/src/InterpreterRelation.cpp
+++ b/src/InterpreterRelation.cpp
@@ -15,17 +15,19 @@
  ***********************************************************************/
 
 #include "InterpreterRelation.h"
+
 #include "BTree.h"
 #include "Brie.h"
 #include "EquivalenceRelation.h"
 #include "Util.h"
+#include <utility>
 
 namespace souffle {
 
-InterpreterRelation::InterpreterRelation(std::size_t arity, std::size_t numberOfHeights,
-        const std::string& name, const std::vector<std::string>& attributeTypes,
-        const MinIndexSelection& orderSet, IndexFactory factory)
-        : relName(name), arity(arity), numberOfHeights(numberOfHeights), attributeTypes(attributeTypes) {
+InterpreterRelation::InterpreterRelation(std::size_t arity, std::size_t numberOfHeights, std::string name,
+        std::vector<std::string> attributeTypes, const MinIndexSelection& orderSet, IndexFactory factory)
+        : relName(std::move(name)), arity(arity), numberOfHeights(numberOfHeights),
+          attributeTypes(std::move(attributeTypes)) {
     for (auto order : orderSet.getAllOrders()) {
         // Expand the order to a total order
         std::set<int> set;

--- a/src/InterpreterRelation.h
+++ b/src/InterpreterRelation.h
@@ -28,8 +28,8 @@ public:
     /**
      * Creates a relation, build all necessary indexes.
      */
-    InterpreterRelation(std::size_t arity, std::size_t numberOfHeights, const std::string& name,
-            const std::vector<std::string>& attributeTypes, const MinIndexSelection& orderSet,
+    InterpreterRelation(std::size_t arity, std::size_t numberOfHeights, std::string name,
+            std::vector<std::string> attributeTypes, const MinIndexSelection& orderSet,
             IndexFactory factory = &createBTreeIndex);
 
     InterpreterRelation(InterpreterRelation& other) = delete;

--- a/src/LambdaBTree.h
+++ b/src/LambdaBTree.h
@@ -146,7 +146,9 @@ public:
                 cur_lease = cur->lock.start_read();
 
                 // check validity of root pointer
-                if (this->root_lock.end_read(root_lease)) break;
+                if (this->root_lock.end_read(root_lease)) {
+                    break;
+                }
 
             } while (true);
         }
@@ -284,7 +286,9 @@ public:
                         parent->lock.start_write();
                         while (true) {
                             // check whether parent is correct
-                            if (parent == priv->parent) break;
+                            if (parent == priv->parent) {
+                                break;
+                            }
                             // switch parent
                             parent->lock.abort_write();
                             parent = priv->parent;
@@ -299,7 +303,9 @@ public:
                     parents.push_back(parent);
 
                     // stop at "sphere of influence"
-                    if (!parent || !parent->isFull()) break;
+                    if (!parent || !parent->isFull()) {
+                        break;
+                    }
 
                     // go one step higher
                     priv = parent;

--- a/src/MagicSet.cpp
+++ b/src/MagicSet.cpp
@@ -160,11 +160,11 @@ bool isBindingConstraint(AstArgument* lhs, AstArgument* rhs, std::set<std::strin
     std::string rhs_name = getString(rhs);
 
     // only want to check variables we have not bound yet
-    if (dynamic_cast<AstVariable*>(lhs) && (boundArgs.find(lhs_name) == boundArgs.end())) {
+    if ((dynamic_cast<AstVariable*>(lhs) != nullptr) && (boundArgs.find(lhs_name) == boundArgs.end())) {
         // return true if the rhs is a bound variable or a constant
-        if (dynamic_cast<AstVariable*>(rhs) && (boundArgs.find(rhs_name) != boundArgs.end())) {
+        if ((dynamic_cast<AstVariable*>(rhs) != nullptr) && (boundArgs.find(rhs_name) != boundArgs.end())) {
             return true;
-        } else if (dynamic_cast<AstConstant*>(rhs)) {
+        } else if (dynamic_cast<AstConstant*>(rhs) != nullptr) {
             return true;
         }
     }
@@ -1185,7 +1185,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
             // set the name of each IDB pred in the clause to be the adorned version
             int atomsSeen = 0;
             for (AstLiteral* lit : newClause->getBodyLiterals()) {
-                if (dynamic_cast<AstAtom*>(lit)) {
+                if (dynamic_cast<AstAtom*>(lit) != nullptr) {
                     auto* bodyAtom = dynamic_cast<AstAtom*>(lit);
                     AstRelationIdentifier atomName = bodyAtom->getName();
                     // note that all atoms in the original clause were adorned,
@@ -1214,7 +1214,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
                 AstLiteral* currentLiteral = body[i];
 
                 // only care about atoms in the body
-                if (dynamic_cast<AstAtom*>(currentLiteral)) {
+                if (dynamic_cast<AstAtom*>(currentLiteral) != nullptr) {
                     auto* atom = dynamic_cast<AstAtom*>(currentLiteral);
                     AstRelationIdentifier atomName = atom->getName();
 

--- a/src/MagicSet.cpp
+++ b/src/MagicSet.cpp
@@ -41,7 +41,7 @@ class SymbolTable;
 // checks whether the adorned version of two predicates is equal
 bool isEqualAdornment(const AstRelationIdentifier& pred1, const std::string& adorn1,
         const AstRelationIdentifier& pred2, const std::string& adorn2) {
-    return ((pred1 == pred2) && (adorn1.compare(adorn2) == 0));
+    return ((pred1 == pred2) && (adorn1 == adorn2));
 }
 
 // checks whether an element is contained within a set
@@ -63,7 +63,7 @@ bool contains(std::set<AdornedPredicate> adornedPredicates, const AstRelationIde
 
 // checks whether a string begins with a given string
 bool hasPrefix(const std::string& str, const std::string& prefix) {
-    if (str.substr(0, prefix.size()).compare(prefix) == 0) {
+    if (str.substr(0, prefix.size()) == prefix) {
         return true;
     }
     return false;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,37 +11,37 @@ bin_PROGRAMS = souffle souffle-profile
 nodist_souffle_profile_SOURCES = $(BUILT_SOURCES)
 
 souffle_profile_sources = \
-                          ProfileDatabase.h                 \
-                          json11.h                          \
-                          profile/Cell.h                    \
-                          profile/CellInterface.h           \
-                          profile/Cli.h                     \
-                          profile/DataComparator.h          \
-                          profile/Iteration.h               \
-                          profile/OutputProcessor.h         \
-                          profile/ProgramRun.h              \
-                          profile/Reader.h                  \
-                          profile/Relation.h                \
-                          profile/Row.h                     \
-                          profile/Rule.h                    \
-                          profile/StringUtils.h             \
-                          profile/Table.h                   \
-                          profile/Tui.h                     \
-                          profile/UserInputReader.h         \
-                          profile/htmlCssChartist.h         \
-                          profile/htmlJsChartistMin.h       \
-                          profile/htmlJsMain.h              \
-                          profile/htmlJsUtil.h              \
-                          profile/htmlCssStyle.h            \
-                          profile/htmlJsChartistPlugin.h    \
-                          profile/htmlJsTableSort.h         \
-                          profile/htmlMain.h                \
-                          profile/HtmlGenerator.h
+        ProfileDatabase.h                         \
+        json11.h                                  \
+        profile/Cell.h                            \
+        profile/CellInterface.h                   \
+        profile/Cli.h                             \
+        profile/DataComparator.h                  \
+        profile/Iteration.h                       \
+        profile/OutputProcessor.h                 \
+        profile/ProgramRun.h                      \
+        profile/Reader.h                          \
+        profile/Relation.h                        \
+        profile/Row.h                             \
+        profile/Rule.h                            \
+        profile/StringUtils.h                     \
+        profile/Table.h                           \
+        profile/Tui.h                             \
+        profile/UserInputReader.h                 \
+        profile/htmlCssChartist.h                 \
+        profile/htmlJsChartistMin.h               \
+        profile/htmlJsMain.h                      \
+        profile/htmlJsUtil.h                      \
+        profile/htmlCssStyle.h                    \
+        profile/htmlJsChartistPlugin.h            \
+        profile/htmlJsTableSort.h                 \
+        profile/htmlMain.h                        \
+        profile/HtmlGenerator.h
 
 souffle_swig_sources = \
-                    swig/SwigInterface.h                 \
-                    swig/SwigInterface.cpp               \
-                    swig/SwigInterface.i                    
+        swig/SwigInterface.h                      \
+        swig/SwigInterface.cpp                    \
+        swig/SwigInterface.i
 
 DIR := ${CURDIR}
 
@@ -58,101 +58,101 @@ endif
 
 
 souffle_sources = \
-              AstAnalysis.h                             \
-              AstArgument.cpp       AstArgument.h       \
-              AstAttribute.h                            \
-              AstClause.cpp         AstClause.h         \
-              AstComponent.h                            \
-              AstComponentChecker.cpp                   \
-              AstComponentChecker.h                     \
-              AstConstraintAnalysis.h                   \
-              AstFunctorDeclaration.h                   \
-              AstGroundAnalysis.cpp AstGroundAnalysis.h \
-              AstIO.h                                   \
-              AstIOTypeAnalysis.cpp AstIOTypeAnalysis.h \
-              AstLiteral.h                              \
-              AstNode.h                                 \
-              AstParserUtils.cpp    AstParserUtils.h    \
-              AstPragma.cpp         AstPragma.h         \
-              AstProgram.cpp        AstProgram.h        \
-              AstProfileUse.cpp     AstProfileUse.h     \
-              AstRelation.h                             \
-              AstRelationIdentifier.h                   \
-              AstSemanticChecker.cpp                    \
-              AstSemanticChecker.h                      \
-              AstTransformer.cpp    AstTransformer.h    \
-              AstTransforms.cpp     AstTransforms.h     \
-              AstTranslationUnit.h  ErrorReport.h       \
-              AstTranslator.cpp     AstTranslator.h     \
-              AstType.h                                 \
-              AstTypeAnalysis.cpp   AstTypeAnalysis.h   \
-              AstTypeEnvironmentAnalysis.cpp            \
-              AstTypeEnvironmentAnalysis.h              \
-              AstTypes.h                                \
-              AstUtils.cpp          AstUtils.h          \
-              AstVisitor.h                              \
-              BinaryConstraintOps.h                     \
-              ComponentModel.cpp    ComponentModel.h    \
-              Constraints.h                             \
-              DebugReport.cpp       DebugReport.h       \
-              EventProcessor.h                          \
-              FunctorOps.h                              \
-              Global.cpp            Global.h            \
-              GraphUtils.h                              \
-              IODirectives.h                            \
-              IOSystem.h                                \
-              RamIndexAnalysis.cpp  RamIndexAnalysis.h  \
-              InlineRelationsTransformer.cpp            \
-              LogStatement.h                            \
-	      InterpreterIndex.h            InterpreterIndex.cpp	\
-	      InterpreterRelation.h         InterpreterRelation.cpp     \
-	      MagicSet.cpp          MagicSet.h          \
-              MinimiseProgramTransformer.cpp            \
-              ParserDriver.cpp      ParserDriver.h      \
-              PrecedenceGraph.cpp   PrecedenceGraph.h   \
-              ProfileEvent.h                            \
-              ProvenanceTransformer.cpp                 \
-              RamAnalysis.h                             \
-	      InterpreterContext.h                      \
-	      InterpreterEngine.cpp InterpreterEngine.h \
-	      InterpreterGenerator.h		        \
-	      InterpreterIndex.h                        \
-	      InterpreterNode.h				\
-	      InterpreterProgInterface.h                \
-	      InterpreterPreamble.h			\
-	      InterpreterRecords.h         InterpreterRecords.cpp     \
-              RamComplexityAnalysis.cpp  RamComplexityAnalysis.h  \
-              RamLevelAnalysis.cpp  RamLevelAnalysis.h  \
-              RamCondition.h                            \
-              RamNode.h                                 \
-              RamOperation.h                            \
-              RamProgram.h                              \
-              RamRelation.h                             \
-              RamStatement.h                            \
-              RamTransformer.cpp    RamTransformer.h    \
-              RamTransforms.cpp     RamTransforms.h     \
-              RamTranslationUnit.h                      \
-              RamExpression.h                           \
-              RamUtils.h                                \
-              RamVisitor.h                              \
-              ReadStream.h                              \
-              ReadStreamCSV.h                           \
-              RelationRepresentation.h                  \
-              ReorderLiteralsTransformer.cpp            \
-              ResolveAliasesTransformer.cpp             \
-              SignalHandler.h                           \
-              SrcLocation.cpp    SrcLocation.h          \
-              Synthesiser.cpp       Synthesiser.h       \
-              SynthesiserRelation.cpp                   \
-              SynthesiserRelation.h                     \
-              TypeSystem.cpp        TypeSystem.h        \
-              WriteStream.h                             \
-              WriteStreamCSV.h                          \
-              parser.cc             parser.hh           \
-              scanner.cc            stack.hh            \
-              $(sqlite_sources)                         \
-              $(libz_sources)                           \
-              $(souffle_profile_sources)
+        AstAnalysis.h                             \
+        AstArgument.cpp       AstArgument.h       \
+        AstAttribute.h                            \
+        AstClause.cpp         AstClause.h         \
+        AstComponent.h                            \
+        AstComponentChecker.cpp                   \
+        AstComponentChecker.h                     \
+        AstConstraintAnalysis.h                   \
+        AstFunctorDeclaration.h                   \
+        AstGroundAnalysis.cpp AstGroundAnalysis.h \
+        AstIO.h                                   \
+        AstIOTypeAnalysis.cpp AstIOTypeAnalysis.h \
+        AstLiteral.h                              \
+        AstNode.h                                 \
+        AstParserUtils.cpp    AstParserUtils.h    \
+        AstPragma.cpp         AstPragma.h         \
+        AstProgram.cpp        AstProgram.h        \
+        AstProfileUse.cpp     AstProfileUse.h     \
+        AstRelation.h                             \
+        AstRelationIdentifier.h                   \
+        AstSemanticChecker.cpp                    \
+        AstSemanticChecker.h                      \
+        AstTransformer.cpp    AstTransformer.h    \
+        AstTransforms.cpp     AstTransforms.h     \
+        AstTranslationUnit.h  ErrorReport.h       \
+        AstTranslator.cpp     AstTranslator.h     \
+        AstType.h                                 \
+        AstTypeAnalysis.cpp   AstTypeAnalysis.h   \
+        AstTypeEnvironmentAnalysis.cpp            \
+        AstTypeEnvironmentAnalysis.h              \
+        AstTypes.h                                \
+        AstUtils.cpp          AstUtils.h          \
+        AstVisitor.h                              \
+        BinaryConstraintOps.h                     \
+        ComponentModel.cpp    ComponentModel.h    \
+        Constraints.h                             \
+        DebugReport.cpp       DebugReport.h       \
+        EventProcessor.h                          \
+        FunctorOps.h                              \
+        Global.cpp            Global.h            \
+        GraphUtils.h                              \
+        IODirectives.h                            \
+        IOSystem.h                                \
+        RamIndexAnalysis.cpp  RamIndexAnalysis.h  \
+        InlineRelationsTransformer.cpp            \
+        LogStatement.h                            \
+        InterpreterIndex.h            InterpreterIndex.cpp	\
+        InterpreterRelation.h         InterpreterRelation.cpp     \
+        MagicSet.cpp          MagicSet.h          \
+        MinimiseProgramTransformer.cpp            \
+        ParserDriver.cpp      ParserDriver.h      \
+        PrecedenceGraph.cpp   PrecedenceGraph.h   \
+        ProfileEvent.h                            \
+        ProvenanceTransformer.cpp                 \
+        RamAnalysis.h                             \
+        InterpreterContext.h                      \
+        InterpreterEngine.cpp InterpreterEngine.h \
+        InterpreterGenerator.h                    \
+        InterpreterIndex.h                        \
+        InterpreterNode.h		          \
+        InterpreterProgInterface.h                \
+        InterpreterPreamble.h			  \
+        InterpreterRecords.h         InterpreterRecords.cpp     \
+        RamComplexityAnalysis.cpp  RamComplexityAnalysis.h  \
+        RamLevelAnalysis.cpp  RamLevelAnalysis.h  \
+        RamCondition.h                            \
+        RamNode.h                                 \
+        RamOperation.h                            \
+        RamProgram.h                              \
+        RamRelation.h                             \
+        RamStatement.h                            \
+        RamTransformer.cpp    RamTransformer.h    \
+        RamTransforms.cpp     RamTransforms.h     \
+        RamTranslationUnit.h                      \
+        RamExpression.h                           \
+        RamUtils.h                                \
+        RamVisitor.h                              \
+        ReadStream.h                              \
+        ReadStreamCSV.h                           \
+        RelationRepresentation.h                  \
+        ReorderLiteralsTransformer.cpp            \
+        ResolveAliasesTransformer.cpp             \
+        SignalHandler.h                           \
+        SrcLocation.cpp    SrcLocation.h          \
+        Synthesiser.cpp       Synthesiser.h       \
+        SynthesiserRelation.cpp                   \
+        SynthesiserRelation.h                     \
+        TypeSystem.cpp        TypeSystem.h        \
+        WriteStream.h                             \
+        WriteStreamCSV.h                          \
+        parser.cc             parser.hh           \
+        scanner.cc            stack.hh            \
+        $(sqlite_sources)                         \
+        $(libz_sources)                           \
+        $(souffle_profile_sources)
 
 # -- build souffle as a library so it can be reused in testing
 noinst_LTLIBRARIES = libsouffle.la
@@ -173,44 +173,44 @@ EXTRA_DIST = parser.yy scanner.ll  test/test.h
 soufflepublicdir = $(includedir)/souffle
 
 soufflepublic_HEADERS = \
-						CompiledOptions.h       \
-						BinaryConstraintOps.h   \
-                        Brie.h                  \
-                        BTree.h                 \
-                        CompiledIndexUtils.h    \
-                        CompiledRecord.h        \
-                        CompiledRelation.h      \
-                        CompiledSouffle.h       \
-                        CompiledTuple.h         \
-                        EventProcessor.h        \
-                        Explain.h               \
-                        ExplainProvenance.h     \
-                        ExplainProvenanceImpl.h \
-                        ExplainTree.h           \
-                        EquivalenceRelation.h 	\
-                        IODirectives.h          \
-                        IOSystem.h              \
-                        IterUtils.h             \
-                        LambdaBTree.h           \
-                        Logger.h                \
-                        ParallelUtils.h         \
-                        PiggyList.h             \
-                        ProfileDatabase.h       \
-                        ProfileEvent.h          \
-                        RamTypes.h              \
-                        ReadStream.h            \
-                        ReadStreamCSV.h         \
-                        SignalHandler.h         \
-                        SouffleInterface.h      \
-                        SymbolTable.h           \
-                        Table.h                 \
-                        UnionFind.h             \
-                        Util.h                  \
-                        WriteStream.h           \
-                        WriteStreamCSV.h        \
-                        json11.h                \
-                        $(libz_sources)         \
-                        $(sqlite_sources)
+        CompiledOptions.h                         \
+        BinaryConstraintOps.h                     \
+        Brie.h                                    \
+        BTree.h                                   \
+        CompiledIndexUtils.h                      \
+        CompiledRecord.h                          \
+        CompiledRelation.h                        \
+        CompiledSouffle.h                         \
+        CompiledTuple.h                           \
+        EventProcessor.h                          \
+        Explain.h                                 \
+        ExplainProvenance.h                       \
+        ExplainProvenanceImpl.h                   \
+        ExplainTree.h                             \
+        EquivalenceRelation.h                     \
+        IODirectives.h                            \
+        IOSystem.h                                \
+        IterUtils.h                               \
+        LambdaBTree.h                             \
+        Logger.h                                  \
+        ParallelUtils.h                           \
+        PiggyList.h                               \
+        ProfileDatabase.h                         \
+        ProfileEvent.h                            \
+        RamTypes.h                                \
+        ReadStream.h                              \
+        ReadStreamCSV.h                           \
+        SignalHandler.h                           \
+        SouffleInterface.h                        \
+        SymbolTable.h                             \
+        Table.h                                   \
+        UnionFind.h                               \
+        Util.h                                    \
+        WriteStream.h                             \
+        WriteStreamCSV.h                          \
+        json11.h                                  \
+        $(libz_sources)                           \
+        $(sqlite_sources)
 
 souffleprofiledir = $(soufflepublicdir)/profile
 

--- a/src/MinimiseProgramTransformer.cpp
+++ b/src/MinimiseProgramTransformer.cpp
@@ -106,7 +106,7 @@ std::vector<std::vector<unsigned int>> extractPermutations(
         possibilities.erase(possibilities.begin());
         todoStack.push(possibilities);
 
-        if (seen[nextNum]) {
+        if (seen[nextNum] != 0u) {
             // number already seen in this permutation
             continue;
         } else {

--- a/src/ParallelUtils.h
+++ b/src/ParallelUtils.h
@@ -121,7 +121,7 @@ public:
         }
         Lease(const Lease& other) = delete;
         ~Lease() {
-            if (mux) {
+            if (mux != nullptr) {
                 mux->unlock();
             }
         }

--- a/src/ParserDriver.cpp
+++ b/src/ParserDriver.cpp
@@ -55,7 +55,6 @@ std::unique_ptr<AstTranslationUnit> ParserDriver::parse(const std::string& filen
     yyset_in(in, scanner);
 
     yy::parser parser(*this, scanner);
-    parser.set_debug_level(trace_parsing);
     parser.parse();
 
     yylex_destroy(scanner);
@@ -76,7 +75,6 @@ std::unique_ptr<AstTranslationUnit> ParserDriver::parse(const std::string& code,
     yylex_init_extra(&data, &scanner);
     yy_scan_string(code.c_str(), scanner);
     yy::parser parser(*this, scanner);
-    parser.set_debug_level(trace_parsing);
     parser.parse();
 
     yylex_destroy(scanner);

--- a/src/ParserDriver.h
+++ b/src/ParserDriver.h
@@ -77,8 +77,6 @@ public:
     static std::unique_ptr<AstTranslationUnit> parseTranslationUnit(const std::string& code,
             SymbolTable& symbolTable, ErrorReport& errorReport, DebugReport& debugReport);
 
-    bool trace_parsing = false;
-
     void error(const SrcLocation& loc, const std::string& msg);
     void error(const std::string& msg);
 };

--- a/src/PiggyList.h
+++ b/src/PiggyList.h
@@ -299,10 +299,10 @@ public:
     const size_t BLOCKSIZE = (1ul << BLOCKBITS);
 
     // number of inserted
-    std::atomic<size_t> num_containers;
+    std::atomic<size_t> num_containers = 0;
     size_t allocsize = BLOCKSIZE;
-    std::atomic<size_t> container_size;
-    std::atomic<size_t> m_size;
+    std::atomic<size_t> container_size = 0;
+    std::atomic<size_t> m_size = 0;
 
     // > 2^64 elements can be stored (default initialise to nullptrs)
     static constexpr size_t max_conts = 64;

--- a/src/PrecedenceGraph.cpp
+++ b/src/PrecedenceGraph.cpp
@@ -57,14 +57,14 @@ void PrecedenceGraph::print(std::ostream& os) const {
     os << "digraph {\n";
     /* Print node of dependence graph */
     for (const AstRelation* rel : backingGraph.vertices()) {
-        if (rel) {
+        if (rel != nullptr) {
             os << "\t\"" << rel->getName() << "\" [label = \"" << rel->getName() << "\"];\n";
         }
     }
     for (const AstRelation* rel : backingGraph.vertices()) {
-        if (rel) {
+        if (rel != nullptr) {
             for (const AstRelation* adjRel : backingGraph.successors(rel)) {
-                if (adjRel) {
+                if (adjRel != nullptr) {
                     os << "\t\"" << rel->getName() << "\" -> \"" << adjRel->getName() << "\";\n";
                 }
             }
@@ -99,7 +99,7 @@ void RedundantRelations::run(const AstTranslationUnit& translationUnit) {
         /* Find all predecessors of u and add them to the worklist
             if they are not in the set notRedundant */
         for (const AstRelation* predecessor : precedenceGraph->graph().predecessors(u)) {
-            if (!notRedundant.count(predecessor)) {
+            if (notRedundant.count(predecessor) == 0u) {
                 work.insert(predecessor);
             }
         }
@@ -108,7 +108,7 @@ void RedundantRelations::run(const AstTranslationUnit& translationUnit) {
     /* All remaining relations are redundant. */
     redundantRelations.clear();
     for (const AstRelation* r : relations) {
-        if (!notRedundant.count(r)) {
+        if (notRedundant.count(r) == 0u) {
             redundantRelations.insert(r);
         }
     }
@@ -156,7 +156,7 @@ bool RecursiveClauses::computeIsRecursive(
         worklist.pop_back();
 
         // skip null pointers (errors in the input code)
-        if (!cur) {
+        if (cur == nullptr) {
             continue;
         }
 

--- a/src/PrecedenceGraph.h
+++ b/src/PrecedenceGraph.h
@@ -93,7 +93,7 @@ public:
     void print(std::ostream& os) const override;
 
     bool recursive(const AstClause* clause) const {
-        return recursiveClauses.count(clause);
+        return recursiveClauses.count(clause) != 0u;
     }
 
 private:
@@ -281,7 +281,7 @@ public:
         const std::set<const AstRelation*>& sccRelations = sccToRelation.at(scc);
         if (sccRelations.size() == 1) {
             const AstRelation* singleRelation = *sccRelations.begin();
-            if (!precedenceGraph->graph().predecessors(singleRelation).count(singleRelation)) {
+            if (precedenceGraph->graph().predecessors(singleRelation).count(singleRelation) == 0u) {
                 return false;
             }
         }

--- a/src/PrecedenceGraph.h
+++ b/src/PrecedenceGraph.h
@@ -159,7 +159,9 @@ public:
         const auto scc = relationToScc.at(relation);
         for (const auto& successor : precedenceGraph->graph().successors(relation)) {
             const auto successorScc = relationToScc.at(successor);
-            if (successorScc != scc) successorSccs.insert(successorScc);
+            if (successorScc != scc) {
+                successorSccs.insert(successorScc);
+            }
         }
         return successorSccs;
     }
@@ -170,7 +172,9 @@ public:
         const auto scc = relationToScc.at(relation);
         for (const auto& predecessor : precedenceGraph->graph().predecessors(relation)) {
             const auto predecessorScc = relationToScc.at(predecessor);
-            if (predecessorScc != scc) predecessorSccs.insert(predecessorScc);
+            if (predecessorScc != scc) {
+                predecessorSccs.insert(predecessorScc);
+            }
         }
         return predecessorSccs;
     }

--- a/src/ProvenanceTransformer.cpp
+++ b/src/ProvenanceTransformer.cpp
@@ -352,8 +352,9 @@ bool ProvenanceTransformer::transformSubtreeHeights(AstTranslationUnit& translat
             // if fact, level number is 0
             if (clause->isFact()) {
                 clause->getHead()->addArgument(std::make_unique<AstNumberConstant>(0));
-                for (size_t i = 0; i < relation->numberOfHeightParameters(); i++)
+                for (size_t i = 0; i < relation->numberOfHeightParameters(); i++) {
                     clause->getHead()->addArgument(std::make_unique<AstNumberConstant>(0));
+                }
             } else {
                 std::vector<AstArgument*> bodyLevels;
 

--- a/src/ProvenanceTransformer.cpp
+++ b/src/ProvenanceTransformer.cpp
@@ -139,11 +139,11 @@ std::unique_ptr<AstRelation> makeInfoRelation(
                 std::string atomDescription = relName;
 
                 for (auto& arg : atom->getArguments()) {
-                    if (dynamic_cast<AstVariable*>(arg)) {
+                    if (dynamic_cast<AstVariable*>(arg) != nullptr) {
                         std::stringstream argDescription;
                         arg->print(argDescription);
                         atomDescription.append("," + argDescription.str());
-                    } else if (dynamic_cast<AstAggregator*>(arg)) {
+                    } else if (dynamic_cast<AstAggregator*>(arg) != nullptr) {
                         atomDescription.append(",agg_" + std::to_string(aggregateNumber++));
                     }
                 }
@@ -163,7 +163,7 @@ std::unique_ptr<AstRelation> makeInfoRelation(
                 std::stringstream argDescription;
                 var->print(argDescription);
                 constraintDescription.append("," + argDescription.str());
-            } else if (dynamic_cast<AstAggregator*>(con->getLHS())) {
+            } else if (dynamic_cast<AstAggregator*>(con->getLHS()) != nullptr) {
                 constraintDescription.append(",agg_" + std::to_string(aggregateNumber++));
             }
 
@@ -171,7 +171,7 @@ std::unique_ptr<AstRelation> makeInfoRelation(
                 std::stringstream argDescription;
                 var->print(argDescription);
                 constraintDescription.append("," + argDescription.str());
-            } else if (dynamic_cast<AstAggregator*>(con->getRHS())) {
+            } else if (dynamic_cast<AstAggregator*>(con->getRHS()) != nullptr) {
                 constraintDescription.append(",agg_" + std::to_string(aggregateNumber++));
             }
 

--- a/src/RamIndexAnalysis.cpp
+++ b/src/RamIndexAnalysis.cpp
@@ -318,7 +318,7 @@ void RamIndexAnalysis::print(std::ostream& os) const {
         for (auto& cols : indexes.getSearches()) {
             os << "\t\t";
             for (uint32_t i = 0; i < rel.getArity(); i++) {
-                if ((1UL << i) & cols) {
+                if (((1UL << i) & cols) != 0u) {
                     os << rel.getArg(i) << " ";
                 }
             }

--- a/src/RamIndexAnalysis.h
+++ b/src/RamIndexAnalysis.h
@@ -242,7 +242,7 @@ protected:
     static size_t card(SearchSignature cols) {
         size_t sz = 0, idx = 1;
         for (size_t i = 0; i < sizeof(SearchSignature) * 8; i++) {
-            if (idx & cols) {
+            if ((idx & cols) != 0u) {
                 sz++;
             }
             idx *= 2;
@@ -278,7 +278,7 @@ protected:
         while (mask < delta) {
             mask = SearchSignature(1 << (pos));
             SearchSignature result = (delta) & (mask);
-            if (result) {
+            if (result != 0u) {
                 ids.push_back(pos);
             }
             pos++;

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -579,7 +579,7 @@ public:
         for (size_t i = 0; i < queryPattern.size(); ++i) {
             resQueryPattern[i] = std::unique_ptr<RamExpression>(queryPattern[i]->clone());
         }
-        RamIndexChoice* res = new RamIndexChoice(std::unique_ptr<RamRelationReference>(relationRef->clone()),
+        auto* res = new RamIndexChoice(std::unique_ptr<RamRelationReference>(relationRef->clone()),
                 getTupleId(), std::unique_ptr<RamCondition>(condition->clone()), std::move(resQueryPattern),
                 std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
         return res;
@@ -630,9 +630,8 @@ public:
         for (size_t i = 0; i < queryPattern.size(); ++i) {
             resQueryPattern[i] = std::unique_ptr<RamExpression>(queryPattern[i]->clone());
         }
-        RamParallelIndexChoice* res = new RamParallelIndexChoice(
-                std::unique_ptr<RamRelationReference>(relationRef->clone()), getTupleId(),
-                std::unique_ptr<RamCondition>(condition->clone()), std::move(resQueryPattern),
+        auto* res = new RamParallelIndexChoice(std::unique_ptr<RamRelationReference>(relationRef->clone()),
+                getTupleId(), std::unique_ptr<RamCondition>(condition->clone()), std::move(resQueryPattern),
                 std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
         return res;
     }
@@ -654,7 +653,7 @@ public:
             std::unique_ptr<RamCondition> condition)
             : function(fun), expression(std::move(expression)), condition(std::move(condition)) {}
 
-    virtual ~RamAbstractAggregate() {}
+    virtual ~RamAbstractAggregate() = default;
 
     /** @brief Get condition */
     const RamCondition& getCondition() const {

--- a/src/ResolveAliasesTransformer.cpp
+++ b/src/ResolveAliasesTransformer.cpp
@@ -202,10 +202,10 @@ std::unique_ptr<AstClause> ResolveAliasesTransformer::resolveAliases(const AstCl
     // -- utilities --
 
     // tests whether something is a variable
-    auto isVar = [&](const AstArgument& arg) { return dynamic_cast<const AstVariable*>(&arg); };
+    auto isVar = [&](const AstArgument& arg) { return dynamic_cast<const AstVariable*>(&arg) != nullptr; };
 
     // tests whether something is a record
-    auto isRec = [&](const AstArgument& arg) { return dynamic_cast<const AstRecordInit*>(&arg); };
+    auto isRec = [&](const AstArgument& arg) { return dynamic_cast<const AstRecordInit*>(&arg) != nullptr; };
 
     // tests whether a value `a` occurs in a term `b`
     auto occurs = [](const AstArgument& a, const AstArgument& b) {

--- a/src/SrcLocation.cpp
+++ b/src/SrcLocation.cpp
@@ -43,7 +43,7 @@ std::string SrcLocation::extloc() const {
 
             // Offset column to account for C preprocessor having reduced
             // consecutive non-leading whitespace chars to a single space.
-            if (std::isspace(c)) {
+            if (std::isspace(c) != 0) {
                 if (afterFirstNonSpace && prevWhitespace && offsetColumn >= lineLen) {
                     offsetColumn++;
                 }

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1661,8 +1661,9 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
     // produce external definitions for user-defined functors
     std::map<std::string, std::string> functors;
     visitDepthFirst(prog, [&](const RamUserDefinedOperator& op) {
-        if (functors.find(op.getName()) == functors.end())
+        if (functors.find(op.getName()) == functors.end()) {
             functors.insert(std::make_pair(op.getName(), op.getType()));
+        }
         withSharedLibrary = true;
     });
     os << "extern \"C\" {\n";
@@ -1765,7 +1766,9 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
         os << "  size_t freqs[" << numFreq << "]{};\n";
         size_t numRead = 0;
         for (auto rel : prog.getRelations()) {
-            if (!rel->isTemp()) numRead++;
+            if (!rel->isTemp()) {
+                numRead++;
+            }
         }
         os << "  size_t reads[" << numRead << "]{};\n";
     }
@@ -1901,7 +1904,9 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
         // Store count of relations
         size_t relationCount = 0;
         for (auto rel : prog.getRelations()) {
-            if (rel->getName()[0] != '@') ++relationCount;
+            if (rel->getName()[0] != '@') {
+                ++relationCount;
+            }
         }
         // Store configuration
         os << R"_(ProfileEventSingleton::instance().makeConfigRecord("relationCount", std::to_string()_"

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -83,14 +83,14 @@ const std::string Synthesiser::convertRamIdent(const std::string& name) {
     // strip leading numbers
     unsigned int i;
     for (i = 0; i < name.length(); ++i) {
-        if (isalnum(name.at(i)) || name.at(i) == '_') {
+        if ((isalnum(name.at(i)) != 0) || name.at(i) == '_') {
             break;
         }
     }
     std::string id;
     for (auto ch : std::to_string(identifiers.size() + 1) + '_' + name.substr(i)) {
         // alphanumeric characters are allowed
-        if (isalnum(ch)) {
+        if (isalnum(ch) != 0) {
             id += ch;
         }
         // all other characters are replaced by an underscore, except when
@@ -136,7 +136,7 @@ std::string Synthesiser::toIndex(SearchSignature key) {
     tmp << "<";
     int i = 0;
     while (key != 0) {
-        if (key % 2) {
+        if ((key % 2) != 0u) {
             tmp << i;
             if (key > 1) {
                 tmp << ",";
@@ -1815,7 +1815,7 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
             std::string tupleType = "std::array<const char *," + std::to_string(arity) + ">{{";
             std::string tupleName = "std::array<const char *," + std::to_string(arity) + ">{{";
 
-            if (rel->getArity()) {
+            if (rel->getArity() != 0u) {
                 tupleType += "\"" + rel->getArgTypeQualifier(0) + "\"";
                 for (int i = 1; i < arity; i++) {
                     tupleType += ",\"" + rel->getArgTypeQualifier(i) + "\"";

--- a/src/SynthesiserRelation.cpp
+++ b/src/SynthesiserRelation.cpp
@@ -366,7 +366,7 @@ void SynthesiserDirectRelation::generateTypeStruct(std::ostream& out) {
         // count size of search pattern
         size_t indSize = 0;
         for (size_t column = 0; column < arity; column++) {
-            if ((search >> column) & 1) {
+            if (((search >> column) & 1) != 0) {
                 indSize++;
             }
         }
@@ -383,7 +383,7 @@ void SynthesiserDirectRelation::generateTypeStruct(std::ostream& out) {
             // check which indices to pad out
             for (size_t column = 0; column < arity; column++) {
                 // if bit number column is set
-                if (!((search >> column) & 1)) {
+                if (((search >> column) & 1) == 0) {
                     out << "low[" << column << "] = MIN_RAM_DOMAIN;\n";
                     out << "high[" << column << "] = MAX_RAM_DOMAIN;\n";
                 }
@@ -672,7 +672,7 @@ void SynthesiserIndirectRelation::generateTypeStruct(std::ostream& out) {
         // count size of search pattern
         size_t indSize = 0;
         for (size_t column = 0; column < arity; column++) {
-            if ((search >> column) & 1) {
+            if (((search >> column) & 1) != 0) {
                 indSize++;
             }
         }
@@ -688,7 +688,7 @@ void SynthesiserIndirectRelation::generateTypeStruct(std::ostream& out) {
             // check which indices to pad out
             for (size_t column = 0; column < arity; column++) {
                 // if bit number column is set
-                if (!((search >> column) & 1)) {
+                if (((search >> column) & 1) == 0) {
                     out << "low[" << column << "] = MIN_RAM_DOMAIN;\n";
                     out << "high[" << column << "] = MAX_RAM_DOMAIN;\n";
                 }
@@ -982,7 +982,7 @@ void SynthesiserBrieRelation::generateTypeStruct(std::ostream& out) {
         // compute size of sub-index
         size_t indSize = 0;
         for (size_t i = 0; i < arity; i++) {
-            if ((search >> i) & 1) {
+            if (((search >> i) & 1) != 0) {
                 indSize++;
             }
         }
@@ -1216,7 +1216,7 @@ void SynthesiserEqrelRelation::generateTypeStruct(std::ostream& out) {
         // compute size of sub-index
         size_t indSize = 0;
         for (size_t column = 0; column < 2; column++) {
-            if ((i >> column) & 1) {
+            if (((i >> column) & 1) != 0) {
                 indSize++;
             }
         }

--- a/src/SynthesiserRelation.cpp
+++ b/src/SynthesiserRelation.cpp
@@ -315,8 +315,9 @@ void SynthesiserDirectRelation::generateTypeStruct(std::ostream& out) {
 
     out << "void insertAll(" << getTypeName() << "& other) {\n";
     for (size_t i = 0; i < numIndexes; i++) {
-        if (provenanceIndexNumbers.find(i) == provenanceIndexNumbers.end())
+        if (provenanceIndexNumbers.find(i) == provenanceIndexNumbers.end()) {
             out << "ind_" << i << ".insertAll(other.ind_" << i << ");\n";
+        }
     }
     out << "}\n";  // end of insertAll(relationType& other)
 

--- a/src/TypeSystem.cpp
+++ b/src/TypeSystem.cpp
@@ -324,7 +324,7 @@ bool isSymbolType(const TypeSet& s) {
 }
 
 bool isRecordType(const Type& type) {
-    return dynamic_cast<const RecordType*>(&type);
+    return dynamic_cast<const RecordType*>(&type) != nullptr;
 }
 
 bool isRecordType(const TypeSet& s) {

--- a/src/TypeSystem.h
+++ b/src/TypeSystem.h
@@ -73,7 +73,7 @@ public:
     }
 
     friend std::ostream& operator<<(std::ostream& out, const Type* t) {
-        if (!t) {
+        if (t == nullptr) {
             return out << "-null-";
         }
         return t->print(out), out;

--- a/src/UnionFind.h
+++ b/src/UnionFind.h
@@ -178,9 +178,13 @@ public:
             }
             // join the trees together
             // perhaps we can optimise the use of compare_exchange_strong here, as we're in a pessimistic loop
-            if (!updateRoot(x, xrank, y, yrank)) continue;
+            if (!updateRoot(x, xrank, y, yrank)) {
+                continue;
+            }
             // make sure that the ranks are orderable
-            if (xrank == yrank) updateRoot(y, yrank, y, yrank + 1);
+            if (xrank == yrank) {
+                updateRoot(y, yrank, y, yrank + 1);
+            }
             break;
         }
     }
@@ -230,12 +234,13 @@ public:
 template <typename StorePair>
 struct EqrelMapComparator {
     int operator()(const StorePair& a, const StorePair& b) {
-        if (a.first < b.first)
+        if (a.first < b.first) {
             return -1;
-        else if (b.first < a.first)
+        } else if (b.first < a.first) {
             return 1;
-        else
+        } else {
             return 0;
+        }
     }
 
     bool less(const StorePair& a, const StorePair& b) {

--- a/src/Util.h
+++ b/src/Util.h
@@ -125,8 +125,8 @@ inline bool isNumber(const char* str) {
         return false;
     }
 
-    while (*str) {
-        if (!isdigit(*str)) {
+    while (*str != 0) {
+        if (isdigit(*str) == 0) {
             return false;
         }
         str++;
@@ -1049,7 +1049,7 @@ inline bool existDir(const std::string& name) {
  * Check whether a given file exists and it is an executable
  */
 inline bool isExecutable(const std::string& name) {
-    return existFile(name) && !access(name.c_str(), X_OK);
+    return existFile(name) && (access(name.c_str(), X_OK) == 0);
 }
 
 /**
@@ -1057,7 +1057,7 @@ inline bool isExecutable(const std::string& name) {
  */
 inline std::string which(const std::string& name) {
     char buf[PATH_MAX];
-    if (::realpath(name.c_str(), buf) && isExecutable(buf)) {
+    if ((::realpath(name.c_str(), buf) != nullptr) && isExecutable(buf)) {
         return buf;
     }
     const char* syspath = ::getenv("PATH");
@@ -1069,7 +1069,7 @@ inline std::string which(const std::string& name) {
     std::string sub;
     while (std::getline(sstr, sub, ':')) {
         std::string path = sub + "/" + name;
-        if (isExecutable(path) && realpath(path.c_str(), buf)) {
+        if (isExecutable(path) && (realpath(path.c_str(), buf) != nullptr)) {
             return buf;
         }
     }
@@ -1257,7 +1257,7 @@ inline std::string stringify(const std::string& input) {
 /** Valid C++ identifier, note that this does not ensure the uniqueness of identifiers returned. */
 inline std::string identifier(std::string id) {
     for (size_t i = 0; i < id.length(); i++) {
-        if ((!isalpha(id[i]) && i == 0) || (!isalnum(id[i]) && id[i] != '_')) {
+        if (((isalpha(id[i]) == 0) && i == 0) || ((isalnum(id[i]) == 0) && id[i] != '_')) {
             id[i] = '_';
         }
     }
@@ -1480,7 +1480,7 @@ public:
  * disabled;
  */
 inline bool isHintsProfilingEnabled() {
-    return std::getenv("SOUFFLE_PROFILE_HINTS");
+    return std::getenv("SOUFFLE_PROFILE_HINTS") != nullptr;
 }
 
 /**

--- a/src/Util.h
+++ b/src/Util.h
@@ -304,7 +304,9 @@ struct range {
     std::vector<range> partition(int np = 100) {
         // obtain the size
         int n = 0;
-        for (auto i = a; i != b; ++i) n++;
+        for (auto i = a; i != b; ++i) {
+            n++;
+        }
 
         // split it up
         auto s = n / np;
@@ -1112,9 +1114,13 @@ inline std::string absPath(const std::string& path) {
  */
 inline std::string pathJoin(const std::string& first, const std::string& second) {
     unsigned firstPos = static_cast<unsigned>(first.size()) - 1;
-    while (first.at(firstPos) == '/') firstPos--;
+    while (first.at(firstPos) == '/') {
+        firstPos--;
+    }
     unsigned secondPos = 0;
-    while (second.at(secondPos) == '/') secondPos++;
+    while (second.at(secondPos) == '/') {
+        secondPos++;
+    }
     return first.substr(0, firstPos + 1) + '/' + second.substr(secondPos);
 }
 
@@ -1164,10 +1170,14 @@ inline std::string simpleName(const std::string& path) {
     std::string name = baseName(path);
     const size_t lastDot = name.find_last_of('.');
     // file has no extension
-    if (lastDot == std::string::npos) return name;
+    if (lastDot == std::string::npos) {
+        return name;
+    }
     const size_t lastSlash = name.find_last_of('/');
     // last slash occurs after last dot, so no extension
-    if (lastSlash != std::string::npos && lastSlash > lastDot) return name;
+    if (lastSlash != std::string::npos && lastSlash > lastDot) {
+        return name;
+    }
     // last dot after last slash, or no slash
     return name.substr(0, lastDot);
 }
@@ -1179,10 +1189,14 @@ inline std::string fileExtension(const std::string& path) {
     std::string name = path;
     const size_t lastDot = name.find_last_of('.');
     // file has no extension
-    if (lastDot == std::string::npos) return std::string();
+    if (lastDot == std::string::npos) {
+        return std::string();
+    }
     const size_t lastSlash = name.find_last_of('/');
     // last slash occurs after last dot, so no extension
-    if (lastSlash != std::string::npos && lastSlash > lastDot) return std::string();
+    if (lastSlash != std::string::npos && lastSlash > lastDot) {
+        return std::string();
+    }
     // last dot after last slash, or no slash
     return name.substr(lastDot + 1);
 }
@@ -1293,12 +1307,16 @@ public:
     void access(const T& val) {
         // test whether it is contained
         for (std::size_t i = 0; i < size; i++) {
-            if (entries[i] != val) continue;
+            if (entries[i] != val) {
+                continue;
+            }
 
             // -- move this one to the front --
 
             // if it is the first, nothing to handle
-            if (i == first) return;
+            if (i == first) {
+                return;
+            }
 
             // if this is the last, just first and last need to change
             if (i == last) {
@@ -1361,7 +1379,9 @@ template <typename T, unsigned size>
 std::ostream& operator<<(std::ostream& out, const LRUCache<T, size>& cache) {
     bool first = true;
     cache.forEachInOrder([&](const T& val) {
-        if (!first) out << ",";
+        if (!first) {
+            out << ",";
+        }
         first = false;
         out << val;
         return false;
@@ -1479,11 +1499,15 @@ public:
               misses((active) ? other.getMisses() : 0) {}
 
     void addHit() {
-        if (active) hits.fetch_add(1, std::memory_order_relaxed);
+        if (active) {
+            hits.fetch_add(1, std::memory_order_relaxed);
+        }
     }
 
     void addMiss() {
-        if (active) misses.fetch_add(1, std::memory_order_relaxed);
+        if (active) {
+            misses.fetch_add(1, std::memory_order_relaxed);
+        }
     }
 
     std::size_t getHits() const {

--- a/src/gzfstream.h
+++ b/src/gzfstream.h
@@ -41,15 +41,15 @@ public:
         if (is_open()) {
             return nullptr;
         }
-        if (!(mode ^ std::ios::in ^ std::ios::out)) {
+        if ((mode ^ std::ios::in ^ std::ios::out) == 0) {
             return nullptr;
         }
 
         this->mode = mode;
-        std::string gzmode(mode & std::ios::in ? "rb" : "wb");
+        std::string gzmode((mode & std::ios::in) != 0 ? "rb" : "wb");
         fileHandle = gzopen(filename.c_str(), gzmode.c_str());
 
-        if (!fileHandle) {
+        if (fileHandle == nullptr) {
             return nullptr;
         }
         isOpen = true;
@@ -82,7 +82,7 @@ public:
 
 protected:
     int_type overflow(int c = EOF) override {
-        if (!(mode & std::ios::out) || !isOpen) {
+        if (((mode & std::ios::out) == 0) || !isOpen) {
             return EOF;
         }
 
@@ -100,10 +100,10 @@ protected:
     }
 
     int_type underflow() override {
-        if (!(mode & std::ios::in) || !isOpen) {
+        if (((mode & std::ios::in) == 0) || !isOpen) {
             return EOF;
         }
-        if (gptr() && (gptr() < egptr())) {
+        if ((gptr() != nullptr) && (gptr() < egptr())) {
             return traits_type::to_int_type(*gptr());
         }
 
@@ -124,7 +124,7 @@ protected:
     }
 
     int sync() override {
-        if (pptr() && pptr() > pbase()) {
+        if ((pptr() != nullptr) && pptr() > pbase()) {
             int toWrite = pptr() - pbase();
             if (gzwrite(fileHandle, pbase(), toWrite) != toWrite) {
                 return -1;
@@ -162,7 +162,7 @@ public:
     ~gzfstream() override = default;
 
     void open(const std::string& filename, std::ios_base::openmode mode) {
-        if (!buf.open(filename, mode)) {
+        if (buf.open(filename, mode) == nullptr) {
             clear(rdstate() | std::ios::badbit);
         }
     }
@@ -173,7 +173,7 @@ public:
 
     void close() {
         if (buf.is_open()) {
-            if (!buf.close()) {
+            if (buf.close() == nullptr) {
                 clear(rdstate() | std::ios::badbit);
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ void executeBinary(const std::string& binaryFilename) {
                 ldPath += library + ':';
             }
             ldPath.back() = ' ';
-            setenv("LD_LIBRARY_PATH", ldPath.c_str(), true);
+            setenv("LD_LIBRARY_PATH", ldPath.c_str(), 1);
         }
 
         exitCode = system(binaryFilename.c_str());

--- a/src/profile/OutputProcessor.h
+++ b/src/profile/OutputProcessor.h
@@ -277,7 +277,7 @@ Table inline OutputProcessor::getVersions(std::string strRel, std::string strRul
 
     std::shared_ptr<Relation> rel;
     for (auto& current : relationMap) {
-        if (current.second->getId().compare(strRel) == 0) {
+        if (current.second->getId() == strRel) {
             rel = current.second;
             break;
         }
@@ -290,7 +290,7 @@ Table inline OutputProcessor::getVersions(std::string strRel, std::string strRul
     for (auto& iter : rel->getIterations()) {
         for (auto& current : iter->getRules()) {
             std::shared_ptr<Rule> rule = current.second;
-            if (rule->getId().compare(strRul) == 0) {
+            if (rule->getId() == strRul) {
                 std::string strTemp =
                         rule->getName() + rule->getLocator() + std::to_string(rule->getVersion());
 
@@ -346,7 +346,7 @@ Table inline OutputProcessor::getVersionAtoms(std::string strRel, std::string sr
     std::shared_ptr<Relation> rel;
 
     for (auto& current : relationMap) {
-        if (current.second->getId().compare(strRel) == 0) {
+        if (current.second->getId() == strRel) {
             rel = current.second;
             break;
         }
@@ -358,7 +358,7 @@ Table inline OutputProcessor::getVersionAtoms(std::string strRel, std::string sr
     for (auto& iter : rel->getIterations()) {
         for (auto& current : iter->getRules()) {
             std::shared_ptr<Rule> rule = current.second;
-            if (rule->getLocator().compare(srcLocator) == 0 && rule->getVersion() == version) {
+            if (rule->getLocator() == srcLocator && rule->getVersion() == version) {
                 for (auto& atom : rule->getAtoms()) {
                     Row row(4);
                     row[0] = std::make_shared<Cell<std::string>>(atom.rule);

--- a/src/profile/Relation.h
+++ b/src/profile/Relation.h
@@ -59,7 +59,7 @@ public:
     std::string createRecID(std::string name) {
         for (auto& iter : iterations) {
             for (auto& rul : iter->getRules()) {
-                if (rul.second->getName().compare(name) == 0) {
+                if (rul.second->getName() == name) {
                     return rul.second->getId();
                 }
             }

--- a/src/profile/Tui.h
+++ b/src/profile/Tui.h
@@ -130,9 +130,9 @@ public:
             std::cout << "\x1b[27A";
             top();
             std::cout << "\x1b[B> ";
-        } else if (c[0].compare("top") == 0) {
+        } else if (c[0] == "top") {
             top();
-        } else if (c[0].compare("rel") == 0) {
+        } else if (c[0] == "rel") {
             if (c.size() == 2) {
                 relRul(c[1]);
             } else if (c.size() == 1) {
@@ -140,12 +140,12 @@ public:
             } else {
                 std::cout << "Invalid parameters to rel command.\n";
             }
-        } else if (c[0].compare("rul") == 0) {
+        } else if (c[0] == "rul") {
             if (c.size() > 1) {
-                if (c.size() == 3 && c[1].compare("id") == 0) {
+                if (c.size() == 3 && c[1] == "id") {
                     std::printf("%7s%2s%s\n\n", "ID", "", "NAME");
                     id(c[2]);
-                } else if (c.size() == 2 && c[1].compare("id") == 0) {
+                } else if (c.size() == 2 && c[1] == "id") {
                     id("0");
                 } else if (c.size() == 2) {
                     verRul(c[1]);
@@ -155,19 +155,19 @@ public:
             } else {
                 rul(resultLimit);
             }
-        } else if (c[0].compare("graph") == 0) {
+        } else if (c[0] == "graph") {
             if (c.size() == 3 && c[1].find(".") == std::string::npos) {
                 iterRel(c[1], c[2]);
             } else if (c.size() == 3 && c[1].at(0) == 'C') {
                 iterRul(c[1], c[2]);
-            } else if (c.size() == 4 && c[1].compare("ver") == 0 && c[2].at(0) == 'C') {
+            } else if (c.size() == 4 && c[1] == "ver" && c[2].at(0) == 'C') {
                 verGraph(c[2], c[3]);
             } else {
                 std::cout << "Invalid parameters to graph command.\n";
             }
-        } else if (c[0].compare("memory") == 0) {
+        } else if (c[0] == "memory") {
             memoryUsage();
-        } else if (c[0].compare("usage") == 0) {
+        } else if (c[0] == "usage") {
             if (c.size() > 1) {
                 if (c[1][0] == 'R') {
                     usageRelation(c[1]);
@@ -177,9 +177,9 @@ public:
             } else {
                 usage();
             }
-        } else if (c[0].compare("help") == 0) {
+        } else if (c[0] == "help") {
             help();
-        } else if (c[0].compare("limit") == 0) {
+        } else if (c[0] == "limit") {
             if (c.size() == 1) {
                 setResultLimit(20000);
             } else {
@@ -189,7 +189,7 @@ public:
                     std::cout << "Invalid parameters to limit command.\n";
                 }
             }
-        } else if (c[0].compare("configuration") == 0) {
+        } else if (c[0] == "configuration") {
             configuration();
         } else {
             std::cout << "Unknown command. Use \"help\" for a list of commands.\n";
@@ -1108,14 +1108,14 @@ public:
         ruleTable.sort(6);
         std::vector<std::vector<std::string>> table = Tools::formatTable(ruleTable, precision);
 
-        if (col.compare("0") == 0) {
+        if (col == "0") {
             std::printf("%7s%2s%s\n\n", "ID", "", "NAME");
             for (auto& row : table) {
                 std::printf("%7s%2s%s\n", row[6].c_str(), "", row[5].c_str());
             }
         } else {
             for (auto& row : table) {
-                if (row[6].compare(col) == 0) {
+                if (row[6] == col) {
                     std::printf("%7s%2s%s\n", row[6].c_str(), "", row[5].c_str());
                 }
             }
@@ -1134,7 +1134,7 @@ public:
         std::string name = "";
         for (auto& row : formattedRelationTable) {
             // Test for relation name or relation id
-            if (row[5].compare(str) == 0 || row[6].compare(str) == 0) {
+            if (row[5] == str || row[6] == str) {
                 std::printf("%8s%8s%8s%8s%8s %s\n", row[0].c_str(), row[1].c_str(), row[2].c_str(),
                         row[4].c_str(), row[6].c_str(), row[5].c_str());
                 name = row[5];
@@ -1143,7 +1143,7 @@ public:
         }
         std::cout << " ---------------------------------------------------------\n";
         for (auto& row : formattedRuleTable) {
-            if (row[7].compare(name) == 0) {
+            if (row[7] == name) {
                 std::printf("%8s%8s%8s%8s%8s %s\n", row[0].c_str(), row[1].c_str(), row[2].c_str(),
                         row[4].c_str(), row[6].c_str(), row[7].c_str());
             }
@@ -1155,7 +1155,7 @@ public:
         }
         std::cout << "\nSrc locator: " << src << "\n\n";
         for (auto& row : formattedRuleTable) {
-            if (row[7].compare(name) == 0) {
+            if (row[7] == name) {
                 std::printf("%7s%2s%s\n", row[6].c_str(), "", row[5].c_str());
             }
         }
@@ -1181,7 +1181,7 @@ public:
         std::string srcLocator;
         // Check that the rule exists, and print it out if so.
         for (auto& row : formattedRuleTable) {
-            if (row[6].compare(str) == 0) {
+            if (row[6] == str) {
                 std::cout << row[5] << std::endl;
                 found = true;
                 ruleName = row[5];
@@ -1206,7 +1206,7 @@ public:
         std::cout << "  ----- Rule Versions Table -----\n";
         std::printf("%8s%8s%8s%16s%6s\n\n", "TOT_T", "NREC_T", "REC_T", "TUPLES", "VER");
         for (auto& row : formattedRuleTable) {
-            if (row[6].compare(str) == 0) {
+            if (row[6] == str) {
                 std::printf("%8s%8s%8s%16s%6s\n", row[0].c_str(), row[1].c_str(), row[2].c_str(),
                         row[4].c_str(), "");
             }
@@ -1235,24 +1235,24 @@ public:
         std::vector<std::vector<std::string>> table = Tools::formatTable(relationTable, -1);
         std::vector<std::shared_ptr<Iteration>> iter;
         for (auto& row : table) {
-            if (row[6].compare(c) == 0) {
+            if (row[6] == c) {
                 std::printf("%4s%2s%s\n\n", row[6].c_str(), "", row[5].c_str());
                 iter = run->getRelation(row[5])->getIterations();
-                if (col.compare("tot_t") == 0) {
+                if (col == "tot_t") {
                     std::vector<std::chrono::microseconds> list;
                     for (auto& i : iter) {
                         list.emplace_back(i->getRuntime());
                     }
                     std::printf("%4s   %s\n\n", "NO", "RUNTIME");
                     graphByTime(list);
-                } else if (col.compare("copy_t") == 0) {
+                } else if (col == "copy_t") {
                     std::vector<std::chrono::microseconds> list;
                     for (auto& i : iter) {
                         list.emplace_back(i->getCopytime());
                     }
                     std::printf("%4s   %s\n\n", "NO", "COPYTIME");
                     graphByTime(list);
-                } else if (col.compare("tuples") == 0) {
+                } else if (col == "tuples") {
                     std::vector<size_t> list;
                     for (auto& i : iter) {
                         list.emplace_back(i->size());
@@ -1264,25 +1264,25 @@ public:
             }
         }
         for (auto& row : table) {
-            if (row[5].compare(c) == 0) {
+            if (row[5] == c) {
                 std::printf("%4s%2s%s\n\n", row[6].c_str(), "", row[5].c_str());
                 const std::shared_ptr<ProgramRun>& run = out.getProgramRun();
                 iter = run->getRelation(row[5])->getIterations();
-                if (col.compare("tot_t") == 0) {
+                if (col == "tot_t") {
                     std::vector<std::chrono::microseconds> list;
                     for (auto& i : iter) {
                         list.emplace_back(i->getRuntime());
                     }
                     std::printf("%4s   %s\n\n", "NO", "RUNTIME");
                     graphByTime(list);
-                } else if (col.compare("copy_t") == 0) {
+                } else if (col == "copy_t") {
                     std::vector<std::chrono::microseconds> list;
                     for (auto& i : iter) {
                         list.emplace_back(i->getCopytime());
                     }
                     std::printf("%4s   %s\n\n", "NO", "COPYTIME");
                     graphByTime(list);
-                } else if (col.compare("tuples") == 0) {
+                } else if (col == "tuples") {
                     std::vector<size_t> list;
                     for (auto& i : iter) {
                         list.emplace_back(i->size());
@@ -1299,17 +1299,17 @@ public:
         std::vector<std::vector<std::string>> table = Tools::formatTable(ruleTable, precision);
         std::vector<std::shared_ptr<Iteration>> iter;
         for (auto& row : table) {
-            if (row[6].compare(c) == 0) {
+            if (row[6] == c) {
                 std::printf("%6s%2s%s\n\n", row[6].c_str(), "", row[5].c_str());
                 const std::shared_ptr<ProgramRun>& run = out.getProgramRun();
                 iter = run->getRelation(row[7])->getIterations();
-                if (col.compare("tot_t") == 0) {
+                if (col == "tot_t") {
                     std::vector<std::chrono::microseconds> list;
                     for (auto& i : iter) {
                         bool add = false;
                         std::chrono::microseconds totalTime{};
                         for (auto& rul : i->getRules()) {
-                            if (rul.second->getId().compare(c) == 0) {
+                            if (rul.second->getId() == c) {
                                 totalTime += rul.second->getRuntime();
                                 add = true;
                             }
@@ -1320,13 +1320,13 @@ public:
                     }
                     std::printf("%4s   %s\n\n", "NO", "RUNTIME");
                     graphByTime(list);
-                } else if (col.compare("tuples") == 0) {
+                } else if (col == "tuples") {
                     std::vector<size_t> list;
                     for (auto& i : iter) {
                         bool add = false;
                         size_t totalSize = 0L;
                         for (auto& rul : i->getRules()) {
-                            if (rul.second->getId().compare(c) == 0) {
+                            if (rul.second->getId() == c) {
                                 totalSize += rul.second->size();
                                 add = true;
                             }
@@ -1355,21 +1355,21 @@ public:
         Table versionTable = out.getVersions(strRel, c);
         std::printf("%6s%2s%s\n\n", (*versionTable.rows[0])[6]->toString(0).c_str(), "",
                 (*versionTable.rows[0])[5]->toString(0).c_str());
-        if (col.compare("tot_t") == 0) {
+        if (col == "tot_t") {
             std::vector<std::chrono::microseconds> list;
             for (auto& row : versionTable.rows) {
                 list.emplace_back((*row)[0]->getTimeVal());
             }
             std::printf("%4s   %s\n\n", "NO", "RUNTIME");
             graphByTime(list);
-        } else if (col.compare("copy_t") == 0) {
+        } else if (col == "copy_t") {
             std::vector<std::chrono::microseconds> list;
             for (auto& row : versionTable.rows) {
                 list.emplace_back((*row)[3]->getTimeVal());
             }
             std::printf("%4s   %s\n\n", "NO", "COPYTIME");
             graphByTime(list);
-        } else if (col.compare("tuples") == 0) {
+        } else if (col == "tuples") {
             std::vector<size_t> list;
             for (auto& row : versionTable.rows) {
                 list.emplace_back((*row)[4]->getLongVal());

--- a/src/profile/UserInputReader.h
+++ b/src/profile/UserInputReader.h
@@ -56,16 +56,24 @@ public:
     void readchar() {
         char buf = 0;
         struct termios old = {};
-        if (tcgetattr(0, &old) < 0) perror("tcsetattr()");
+        if (tcgetattr(0, &old) < 0) {
+            perror("tcsetattr()");
+        }
         old.c_lflag &= ~ICANON;
         old.c_lflag &= ~ECHO;
         old.c_cc[VMIN] = 1;
         old.c_cc[VTIME] = 0;
-        if (tcsetattr(0, TCSANOW, &old) < 0) perror("tcsetattr ICANON");
-        if (::read(0, &buf, 1) < 0) perror("read()");
+        if (tcsetattr(0, TCSANOW, &old) < 0) {
+            perror("tcsetattr ICANON");
+        }
+        if (::read(0, &buf, 1) < 0) {
+            perror("read()");
+        }
         old.c_lflag |= ICANON;
         old.c_lflag |= ECHO;
-        if (tcsetattr(0, TCSADRAIN, &old) < 0) perror("tcsetattr ~ICANON");
+        if (tcsetattr(0, TCSADRAIN, &old) < 0) {
+            perror("tcsetattr ~ICANON");
+        }
 
         current_char = buf;
     }

--- a/src/profile/UserInputReader.h
+++ b/src/profile/UserInputReader.h
@@ -202,7 +202,7 @@ public:
     void addHistory(std::string hist) {
         if (history.size() > 0) {
             // only add to history if the last command wasn't the same
-            if (hist.compare(history.at(history.size() - 1)) == 0) {
+            if (hist == history.at(history.size() - 1)) {
                 return;
             }
         }

--- a/src/swig/SwigInterface.cpp
+++ b/src/swig/SwigInterface.cpp
@@ -21,6 +21,6 @@
  */
 SWIGSouffleProgram* newInstance(const std::string& name) {
     souffle::SouffleProgram* prog = souffle::ProgramFactory::newInstance(name);
-    SWIGSouffleProgram* p = new SWIGSouffleProgram(prog);
+    auto* p = new SWIGSouffleProgram(prog);
     return p;
 }

--- a/src/test/binary_relation_test.cpp
+++ b/src/test/binary_relation_test.cpp
@@ -492,8 +492,8 @@ TEST(EqRelTest, IterPartition) {
     EXPECT_TRUE(chunks.size() > 0);
 
     for (auto chunk : chunks) {
-        for (auto x = chunk.begin(); x != chunk.end(); ++x) {
-            values.push_back(std::make_pair((*x)[0], (*x)[1]));
+        for (auto x : chunk) {
+            values.push_back(std::make_pair(x[0], x[1]));
         }
     }
 
@@ -511,8 +511,8 @@ TEST(EqRelTest, IterPartition) {
 
     chunks = br.partition(400);
     for (auto chunk : chunks) {
-        for (auto x = chunk.begin(); x != chunk.end(); ++x) {
-            values.push_back(std::make_pair((*x)[0], (*x)[1]));
+        for (auto x : chunk) {
+            values.push_back(std::make_pair(x[0], x[1]));
         }
     }
 

--- a/src/test/binary_relation_test.cpp
+++ b/src/test/binary_relation_test.cpp
@@ -104,7 +104,7 @@ TEST(EqRelTest, Duplicates) {
     EXPECT_FALSE(br.contains(1, 1));
 
     // check iteration of duplicate is fine
-    ram::Tuple<RamDomain, 2> tup;
+    ram::Tuple<RamDomain, 2> tup{};
     tup[0] = 0;
     tup[1] = 0;
     auto x = br.begin();

--- a/src/test/brie_test.cpp
+++ b/src/test/brie_test.cpp
@@ -262,8 +262,8 @@ TEST(SparseArray, Merge) {
     m1.addAll(m2);
 
     std::vector<std::pair<int, int>> data;
-    for (auto it = m1.begin(); it != m1.end(); ++it) {
-        data.push_back(*it);
+    for (const auto& it : m1) {
+        data.push_back(it);
     }
     EXPECT_EQ("[(100,1),(500,2)]", toString(data));
 }

--- a/src/test/btree_set_test.cpp
+++ b/src/test/btree_set_test.cpp
@@ -520,8 +520,8 @@ TEST(BTreeSet, ChunkSplit) {
     //        EXPECT_EQ(20, chunks.size());
 
     for (const auto& cur : chunks) {
-        for (auto i = cur.begin(); i != cur.end(); ++i) {
-            std::cout << *i << ", ";
+        for (int i : cur) {
+            std::cout << i << ", ";
         }
         std::cout << "\n";
     }

--- a/tests/interface/get_symboltabletype/driver.cpp
+++ b/tests/interface/get_symboltabletype/driver.cpp
@@ -35,7 +35,9 @@ void error(std::string txt) {
  */
 int main(int argc, char** argv) {
     // check number of arguments
-    if (argc != 2) error("wrong number of arguments!");
+    if (argc != 2) {
+        error("wrong number of arguments!");
+    }
 
     // create instance of program "get_symboltabletype"
     if (SouffleProgram* prog = ProgramFactory::newInstance("get_symboltabletype")) {

--- a/tests/interface/load_print/driver.cpp
+++ b/tests/interface/load_print/driver.cpp
@@ -34,7 +34,9 @@ void error(std::string txt) {
  */
 int main(int argc, char** argv) {
     // check number of arguments
-    if (argc != 2) error("wrong number of arguments!");
+    if (argc != 2) {
+        error("wrong number of arguments!");
+    }
 
     // create instance of program "load_print"
     if (SouffleProgram* prog = ProgramFactory::newInstance("load_print")) {

--- a/tests/interface/repeat_analysis/driver.cpp
+++ b/tests/interface/repeat_analysis/driver.cpp
@@ -43,7 +43,7 @@ void printSource2sink(SouffleProgram* prog){
  */
 int main(int argc, char** argv){
     SouffleProgram* prog = ProgramFactory::newInstance("repeat_analysis");
-    if (!prog) {
+    if (prog == nullptr) {
         error("failed to create souffle program");
     }
     //load the facts

--- a/tests/interface/repeat_analysis/driver.cpp
+++ b/tests/interface/repeat_analysis/driver.cpp
@@ -43,8 +43,9 @@ void printSource2sink(SouffleProgram* prog){
  */
 int main(int argc, char** argv){
     SouffleProgram* prog = ProgramFactory::newInstance("repeat_analysis");
-    if(!prog)
+    if (!prog) {
         error("failed to create souffle program");
+    }
     //load the facts
     prog->loadAll("./facts");
     //run the program

--- a/tests/interface/signal_error/driver.cpp
+++ b/tests/interface/signal_error/driver.cpp
@@ -17,9 +17,9 @@
 
 #include "souffle/SouffleInterface.h"
 #include <array>
+#include <csignal>
 #include <string>
 #include <vector>
-#include <signal.h>
 
 using namespace souffle;
 

--- a/tests/interface/tuple_insertion_diff_element_type/driver.cpp
+++ b/tests/interface/tuple_insertion_diff_element_type/driver.cpp
@@ -16,10 +16,10 @@
 
 #include "souffle/SouffleInterface.h"
 #include <array>
+#include <csignal>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <iostream>
-#include <signal.h>
 
 using namespace souffle;
 

--- a/tests/interface/tuple_insertion_diff_relation/driver.cpp
+++ b/tests/interface/tuple_insertion_diff_relation/driver.cpp
@@ -16,10 +16,10 @@
 
 #include "souffle/SouffleInterface.h"
 #include <array>
+#include <csignal>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <iostream>
-#include <signal.h>
 
 using namespace souffle;
 


### PR DESCRIPTION
Six changes applied:
* Initialise all variables (bar one Brie iterator value which objects)
* nullptr comparisons are explicit
* size comparisons explicit
* stop assigning booleans to ints
* Use braces around control flow (with the exception of single line returns)
* Use `==` instead of `string.compare(other) == 0`