### PR TITLE
Add Domain size to version info

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,7 +201,9 @@ int main(int argc, char** argv) {
 
         /* for the version option, if given print the version text then exit */
         if (Global::config().has("version")) {
-            std::cout << "Souffle: " << PACKAGE_VERSION << "" << std::endl;
+            std::cout << "Souffle: " << PACKAGE_VERSION;
+            std::cout << "(" << RAM_DOMAIN_SIZE << "bit Domains)";
+            std::cout << std::endl;
             std::cout << "Copyright (c) 2016-19 The Souffle Developers." << std::endl;
             std::cout << "Copyright (c) 2013-16 Oracle and/or its affiliates." << std::endl;
             return 0;


### PR DESCRIPTION
If a 64bit version of souffle is needed for your project it can be hard to tell if that is what you have. This PR adds Domain size information to the version info.

(Note that domain size is already available to the datalog via the macro of RAM_DOMAIN_SIZE.)