### PR TITLE
Add basic unit tests for Ast prints

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -43,9 +43,9 @@ IndentCaseLabels: true
 IndentWidth:     4
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: "CASE|CASE_NO_CAST|SECTION_START|SECTIONS_START|PARALLEL_START|TESTASTPRINTSTART"
+MacroBlockEnd: "ESAC|SECTION_END|SECTIONS_END|PARALLEL_END|TESTASTPRINTEND"
 MaxEmptyLinesToKeep: 1
-MacroBlockBegin: "CASE|CASE_NO_CAST|SECTION_START|SECTIONS_START|PARALLEL_START"
-MacroBlockEnd: "ESAC|SECTION_END|SECTIONS_END|PARALLEL_END"
 NamespaceIndentation: None
 ObjCBlockIndentWidth: 4
 ObjCSpaceAfterProperty: false

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -323,6 +323,12 @@ test_constraints_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/tes
 test_constraints_test_SOURCES = test/constraints_test.cpp
 test_constraints_test_LDADD = libsouffle.la
 
+# ast print test
+check_PROGRAMS += test/ast_print_test
+test_ast_print_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test
+test_ast_print_test_SOURCES = test/ast_print_test.cpp
+test_ast_print_test_LDADD = libsouffle.la
+
 # ast program test
 check_PROGRAMS += test/ast_program_test
 test_ast_program_test_CXXFLAGS = $(souffle_CPPFLAGS) -I @abs_top_srcdir@/src/test

--- a/src/test/ast_print_test.cpp
+++ b/src/test/ast_print_test.cpp
@@ -1,0 +1,160 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file ast_print_test.cpp
+ *
+ * Tests souffle's AST program.
+ *
+ ***********************************************************************/
+
+#include "AstArgument.h"
+#include "AstLiteral.h"
+#include "AstProgram.h"
+#include "AstTranslationUnit.h"
+#include "ParserDriver.h"
+#include "SymbolTable.h"
+#include "test.h"
+
+namespace souffle::test {
+
+inline std::unique_ptr<AstTranslationUnit> makeATU(std::string program = ".decl A,B,C(x:number)") {
+    SymbolTable sym;
+    ErrorReport e;
+    DebugReport d;
+    return ParserDriver::parseTranslationUnit(program, sym, e, d);
+}
+
+inline std::unique_ptr<AstTranslationUnit> makePrintedATU(std::unique_ptr<AstTranslationUnit>& tu) {
+    std::stringstream ss;
+    tu->getProgram()->print(ss);
+    return makeATU(ss.str());
+}
+
+inline std::unique_ptr<AstClause> makeClauseA(std::unique_ptr<AstArgument> headArgument) {
+    auto headAtom = std::make_unique<AstAtom>("A");
+    headAtom->addArgument(std::move(headArgument));
+    auto clause = std::make_unique<AstClause>();
+    clause->setHead(std::move(headAtom));
+    return clause;
+}
+
+TEST(AstPrint, NilConstant) {
+    auto testArgument = std::make_unique<AstNilConstant>();
+
+    auto tu1 = makeATU();
+    tu1->getProgram()->appendClause(makeClauseA(std::move(testArgument)));
+    auto tu2 = makePrintedATU(tu1);
+    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+}
+
+TEST(AstPrint, NumberConstant) {
+    auto testArgument = std::make_unique<AstNumberConstant>(2);
+
+    auto tu1 = makeATU();
+    tu1->getProgram()->appendClause(makeClauseA(std::move(testArgument)));
+    auto tu2 = makePrintedATU(tu1);
+    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+}
+
+TEST(AstPrint, StringConstant) {
+    SymbolTable sym;
+    ErrorReport e;
+    DebugReport d;
+    auto testArgument = std::make_unique<AstStringConstant>(sym, "test string");
+
+    auto tu1 = ParserDriver::parseTranslationUnit(".decl A,B,C(x:number)", sym, e, d);
+    tu1->getProgram()->appendClause(makeClauseA(std::move(testArgument)));
+    auto tu2 = makePrintedATU(tu1);
+    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+}
+
+TEST(AstPrint, Variable) {
+    auto testArgument = std::make_unique<AstVariable>("testVar");
+
+    auto tu1 = makeATU();
+    tu1->getProgram()->appendClause(makeClauseA(std::move(testArgument)));
+    auto tu2 = makePrintedATU(tu1);
+    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+}
+
+TEST(AstPrint, UnnamedVariable) {
+    auto testArgument = std::make_unique<AstUnnamedVariable>();
+
+    auto tu1 = makeATU();
+    tu1->getProgram()->appendClause(makeClauseA(std::move(testArgument)));
+    auto tu2 = makePrintedATU(tu1);
+    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+}
+
+TEST(AstPrint, Counter) {
+    auto testArgument = std::make_unique<AstCounter>();
+
+    auto tu1 = makeATU();
+    tu1->getProgram()->appendClause(makeClauseA(std::move(testArgument)));
+    auto tu2 = makePrintedATU(tu1);
+    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+}
+
+TEST(AstPrint, AggregatorMin) {
+    auto atom = std::make_unique<AstAtom>("B");
+    atom->addArgument(std::make_unique<AstVariable>("x"));
+    auto min = std::make_unique<AstAggregator>(AstAggregator::min);
+    min->setTargetExpression(std::make_unique<AstVariable>("x"));
+    min->addBodyLiteral(std::move(atom));
+
+    auto tu1 = makeATU();
+    auto* prog1 = tu1->getProgram();
+    prog1->appendClause(makeClauseA(std::move(min)));
+    auto tu2 = makePrintedATU(tu1);
+    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+}
+
+TEST(AstPrint, AggregatorMax) {
+    auto atom = std::make_unique<AstAtom>("B");
+    atom->addArgument(std::make_unique<AstVariable>("x"));
+    auto max = std::make_unique<AstAggregator>(AstAggregator::max);
+    max->setTargetExpression(std::make_unique<AstVariable>("x"));
+    max->addBodyLiteral(std::move(atom));
+
+    auto tu1 = makeATU();
+    auto* prog1 = tu1->getProgram();
+    prog1->appendClause(makeClauseA(std::move(max)));
+    auto tu2 = makePrintedATU(tu1);
+    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+}
+
+TEST(AstPrint, AggregatorCount) {
+    auto atom = std::make_unique<AstAtom>("B");
+    atom->addArgument(std::make_unique<AstVariable>("x"));
+    auto count = std::make_unique<AstAggregator>(AstAggregator::count);
+    count->addBodyLiteral(std::move(atom));
+
+    auto tu1 = makeATU();
+    auto* prog1 = tu1->getProgram();
+    prog1->appendClause(makeClauseA(std::move(count)));
+    auto tu2 = makePrintedATU(tu1);
+    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+}
+
+TEST(AstPrint, AggregatorSum) {
+    auto atom = std::make_unique<AstAtom>("B");
+    atom->addArgument(std::make_unique<AstVariable>("x"));
+    auto sum = std::make_unique<AstAggregator>(AstAggregator::sum);
+    sum->setTargetExpression(std::make_unique<AstVariable>("x"));
+    sum->addBodyLiteral(std::move(atom));
+
+    auto tu1 = makeATU();
+    auto* prog1 = tu1->getProgram();
+    prog1->appendClause(makeClauseA(std::move(sum)));
+    auto tu2 = makePrintedATU(tu1);
+    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+}
+
+}  // end namespace souffle::test


### PR DESCRIPTION
An initial set of unit tests for the Ast node print methods.

For each test an AST of a datalog program is generated, printed, the output re-parsed into a new AST, then the two AST programs compared.