### PR TITLE
Fixed literal hierarchy

### DIFF
--- a/src/AstAbstract.h
+++ b/src/AstAbstract.h
@@ -20,24 +20,29 @@
 
 namespace souffle {
 
-/**
- * Intermediate representation of atoms, binary relations,
- * and negated atoms in the body and head of a clause.
- */
 class AstAtom;
 
+/**
+ * Literal
+ */
 class AstLiteral : public AstNode {
 public:
-    /** Obtains the atom referenced by this literal - if any */
-    /* TODO (b-scholz): revisit the following methods */
-    virtual const AstAtom* getAtom() const = 0;
-
-    /** Creates a clone of this AST sub-structure */
     AstLiteral* clone() const override = 0;
 };
 
 /**
- * Intermediate representation of an argument
+ * Atom Literal
+ */
+class AstAtomLiteral : public AstLiteral {
+public:
+    /** get atom */
+    virtual const AstAtom* getAtom() const = 0;
+
+    AstLiteral* clone() const override = 0;
+};
+
+/**
+ * Argument
  */
 class AstArgument : public AstNode {
 public:

--- a/src/AstAbstract.h
+++ b/src/AstAbstract.h
@@ -23,7 +23,7 @@ namespace souffle {
 class AstAtom;
 
 /**
- * Literal 
+ * Literal
  * e.g. atoms, binary relations, and negated atoms
  * in the body and head of a clause.
  */

--- a/src/AstAbstract.h
+++ b/src/AstAbstract.h
@@ -23,7 +23,9 @@ namespace souffle {
 class AstAtom;
 
 /**
- * Literal
+ * Literal 
+ * e.g. atoms, binary relations, and negated atoms
+ * in the body and head of a clause.
  */
 class AstLiteral : public AstNode {
 public:

--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -445,8 +445,8 @@ static bool hasUnnamedVariable(const AstLiteral* lit) {
 void AstSemanticChecker::checkLiteral(
         ErrorReport& report, const AstProgram& program, const AstLiteral& literal) {
     // check potential nested atom
-    if (auto* atom = literal.getAtom()) {
-        checkAtom(report, program, *atom);
+    if (const auto* atomLiteral = dynamic_cast<const AstAtomLiteral*>(&literal)) {
+        checkAtom(report, program, *atomLiteral->getAtom());
     }
 
     if (const auto* constraint = dynamic_cast<const AstBinaryConstraint*>(&literal)) {

--- a/src/InlineRelationsTransformer.cpp
+++ b/src/InlineRelationsTransformer.cpp
@@ -795,7 +795,7 @@ NullableVector<std::vector<AstLiteral*>> getInlinedLiteral(AstProgram& program, 
                 }
             }
         }
-    } else if (AstNegation* neg = dynamic_cast<AstNegation*>(lit)) {
+    } else if (auto neg = dynamic_cast<AstNegation*>(lit)) {
         // For negations, check the corresponding atom
         AstAtom* atom = neg->getAtom();
         NullableVector<std::vector<AstLiteral*>> atomVersions = getInlinedLiteral(program, atom);

--- a/src/InlineRelationsTransformer.cpp
+++ b/src/InlineRelationsTransformer.cpp
@@ -795,7 +795,7 @@ NullableVector<std::vector<AstLiteral*>> getInlinedLiteral(AstProgram& program, 
                 }
             }
         }
-    } else if (auto* neg = dynamic_cast<AstNegation*>(lit)) {
+    } else if (AstNegation* neg = dynamic_cast<AstNegation*>(lit)) {
         // For negations, check the corresponding atom
         AstAtom* atom = neg->getAtom();
         NullableVector<std::vector<AstLiteral*>> atomVersions = getInlinedLiteral(program, atom);

--- a/src/MagicSet.h
+++ b/src/MagicSet.h
@@ -104,20 +104,15 @@ public:
         out << arg.clause->getHead()->getName() << "{" << arg.headAdornment << "} :- ";
 
         std::vector<AstLiteral*> bodyLiterals = arg.clause->getBodyLiterals();
-        for (AstLiteral* lit : bodyLiterals) {
-            if (dynamic_cast<AstAtom*>(lit) == nullptr) {
-                const AstAtom* corresAtom = lit->getAtom();
-                if (corresAtom != nullptr) {
-                    if (firstadded) {
-                        firstadded = false;
-                        out << corresAtom->getName() << "{_}";
-                    } else {
-                        out << ", " << corresAtom->getName() << "{_}";
-                    }
+        for (AstLiteral* literal : bodyLiterals) {
+            if (AstAtom* corresAtom = dynamic_cast<AstAtom*>(literal)) {
+                if (firstadded) {
+                    firstadded = false;
+                    out << corresAtom->getName() << "{_}";
                 } else {
-                    continue;
+                    out << ", " << corresAtom->getName() << "{_}";
                 }
-            } else {
+            } else if (AstAtomLiteral* lit = dynamic_cast<AstAtomLiteral*>(literal)) {
                 if (firstadded) {
                     firstadded = false;
                     out << lit->getAtom()->getName() << "{" << arg.bodyAdornment[currpos] << "}";

--- a/src/MinimiseProgramTransformer.cpp
+++ b/src/MinimiseProgramTransformer.cpp
@@ -149,10 +149,22 @@ bool isValidMove(const AstClause* left, size_t leftIdx, const AstClause* right, 
 
     // both must hence be body atoms
     int leftBodyAtomIdx = leftIdx - 1;
-    const AstAtom* leftAtom = left->getBodyLiteral(leftBodyAtomIdx)->getAtom();
+    const AstAtomLiteral* leftAtomLiteral =
+            dynamic_cast<const AstAtomLiteral*>(left->getBodyLiteral(leftBodyAtomIdx));
+    const AstAtom* leftAtom = nullptr;
+    if (leftAtomLiteral != nullptr) {
+        leftAtom = leftAtomLiteral->getAtom();
+    }
+    assert(leftAtom != nullptr);
 
     int rightBodyAtomIdx = rightIdx - 1;
-    const AstAtom* rightAtom = right->getBodyLiteral(rightBodyAtomIdx)->getAtom();
+    const AstAtomLiteral* rightAtomLiteral =
+            dynamic_cast<const AstAtomLiteral*>(right->getBodyLiteral(rightBodyAtomIdx));
+    const AstAtom* rightAtom = nullptr;
+    if (rightAtomLiteral != nullptr) {
+        rightAtom = rightAtomLiteral->getAtom();
+    }
+    assert(rightAtom != nullptr);
 
     return leftAtom->getName() == rightAtom->getName();
 }
@@ -210,8 +222,11 @@ bool isValidPermutation(
     bool validMapping = true;
     for (size_t i = 0; i < leftAtoms.size() && validMapping; i++) {
         // match arguments
-        std::vector<AstArgument*> leftArgs = leftAtoms[i]->getAtom()->getArguments();
-        std::vector<AstArgument*> rightArgs = rightAtoms[i]->getAtom()->getArguments();
+
+        std::vector<AstArgument*> leftArgs =
+                dynamic_cast<AstAtomLiteral*>(leftAtoms[i])->getAtom()->getArguments();
+        std::vector<AstArgument*> rightArgs =
+                dynamic_cast<AstAtomLiteral*>(rightAtoms[i])->getAtom()->getArguments();
 
         for (size_t j = 0; j < leftArgs.size(); j++) {
             AstArgument* leftArg = leftArgs[j];

--- a/src/MinimiseProgramTransformer.cpp
+++ b/src/MinimiseProgramTransformer.cpp
@@ -149,22 +149,11 @@ bool isValidMove(const AstClause* left, size_t leftIdx, const AstClause* right, 
 
     // both must hence be body atoms
     int leftBodyAtomIdx = leftIdx - 1;
-    const AstAtomLiteral* leftAtomLiteral =
-            dynamic_cast<const AstAtomLiteral*>(left->getBodyLiteral(leftBodyAtomIdx));
-    const AstAtom* leftAtom = nullptr;
-    if (leftAtomLiteral != nullptr) {
-        leftAtom = leftAtomLiteral->getAtom();
-    }
-    assert(leftAtom != nullptr);
+    const AstAtom* leftAtom = dynamic_cast<AstAtomLiteral*>(left->getBodyLiteral(leftBodyAtomIdx))->getAtom();
 
     int rightBodyAtomIdx = rightIdx - 1;
-    const AstAtomLiteral* rightAtomLiteral =
-            dynamic_cast<const AstAtomLiteral*>(right->getBodyLiteral(rightBodyAtomIdx));
-    const AstAtom* rightAtom = nullptr;
-    if (rightAtomLiteral != nullptr) {
-        rightAtom = rightAtomLiteral->getAtom();
-    }
-    assert(rightAtom != nullptr);
+    const AstAtom* rightAtom =
+            dynamic_cast<AstAtomLiteral*>(right->getBodyLiteral(rightBodyAtomIdx))->getAtom();
 
     return leftAtom->getName() == rightAtom->getName();
 }
@@ -222,7 +211,6 @@ bool isValidPermutation(
     bool validMapping = true;
     for (size_t i = 0; i < leftAtoms.size() && validMapping; i++) {
         // match arguments
-
         std::vector<AstArgument*> leftArgs =
                 dynamic_cast<AstAtomLiteral*>(leftAtoms[i])->getAtom()->getArguments();
         std::vector<AstArgument*> rightArgs =

--- a/src/ProvenanceTransformer.cpp
+++ b/src/ProvenanceTransformer.cpp
@@ -130,7 +130,11 @@ std::unique_ptr<AstRelation> makeInfoRelation(
     // visit all body literals and add to info clause head
     for (size_t i = 0; i < originalClause.getBodyLiterals().size(); i++) {
         auto lit = originalClause.getBodyLiterals()[i];
-        const AstAtom* atom = dynamic_cast<AstAtomLiteral *>(lit)->getAtom();
+        const AstAtomLiteral* atomLit = dynamic_cast<AstAtomLiteral*>(lit);
+        const AstAtom* atom = nullptr;
+        if (atomLit != nullptr) {
+            atom = atomLit->getAtom();
+        }
 
         // add an attribute for atoms and binary constraints
         if (atom != nullptr || dynamic_cast<AstBinaryConstraint*>(lit) != nullptr) {

--- a/src/ProvenanceTransformer.cpp
+++ b/src/ProvenanceTransformer.cpp
@@ -130,41 +130,43 @@ std::unique_ptr<AstRelation> makeInfoRelation(
     // visit all body literals and add to info clause head
     for (size_t i = 0; i < originalClause.getBodyLiterals().size(); i++) {
         auto lit = originalClause.getBodyLiterals()[i];
-        const AstAtom* atom = lit->getAtom();
+        if (const AstAtomLiteral* atomLiteral = dynamic_cast<const AstAtomLiteral*>(lit)) {
+            const AstAtom* atom = atomLiteral->getAtom();
 
-        // add an attribute for atoms and binary constraints
-        if (atom != nullptr || dynamic_cast<AstBinaryConstraint*>(lit) != nullptr) {
-            infoRelation->addAttribute(std::make_unique<AstAttribute>(
-                    std::string("rel_") + std::to_string(i), AstTypeIdentifier("symbol")));
-        }
-
-        if (atom != nullptr) {
-            std::string relName = identifierToString(atom->getName());
-
-            // for an atom, add its name and variables (converting aggregates to variables)
-            if (dynamic_cast<AstAtom*>(lit) != nullptr) {
-                std::string atomDescription = relName;
-
-                for (auto& arg : atom->getArguments()) {
-                    atomDescription.append("," + getArgInfo(arg));
-                }
-
-                infoClauseHead->addArgument(std::make_unique<AstStringConstant>(
-                        translationUnit.getSymbolTable(), atomDescription));
-                // for a negation, add a marker with the relation name
-            } else if (dynamic_cast<AstNegation*>(lit) != nullptr) {
-                infoClauseHead->addArgument(std::make_unique<AstStringConstant>(
-                        translationUnit.getSymbolTable(), ("!" + relName)));
+            // add an attribute for atoms and binary constraints
+            if (atom != nullptr || dynamic_cast<AstBinaryConstraint*>(lit) != nullptr) {
+                infoRelation->addAttribute(std::make_unique<AstAttribute>(
+                        std::string("rel_") + std::to_string(i), AstTypeIdentifier("symbol")));
             }
-            // for a constraint, add the constraint symbol and LHS and RHS
-        } else if (auto con = dynamic_cast<AstBinaryConstraint*>(lit)) {
-            std::string constraintDescription = toBinaryConstraintSymbol(con->getOperator());
 
-            constraintDescription.append("," + getArgInfo(con->getLHS()));
-            constraintDescription.append("," + getArgInfo(con->getRHS()));
+            if (atom != nullptr) {
+                std::string relName = identifierToString(atom->getName());
 
-            infoClauseHead->addArgument(std::make_unique<AstStringConstant>(
-                    translationUnit.getSymbolTable(), constraintDescription));
+                // for an atom, add its name and variables (converting aggregates to variables)
+                if (dynamic_cast<AstAtom*>(lit) != nullptr) {
+                    std::string atomDescription = relName;
+
+                    for (auto& arg : atom->getArguments()) {
+                        atomDescription.append("," + getArgInfo(arg));
+                    }
+
+                    infoClauseHead->addArgument(std::make_unique<AstStringConstant>(
+                            translationUnit.getSymbolTable(), atomDescription));
+                    // for a negation, add a marker with the relation name
+                } else if (dynamic_cast<AstNegation*>(lit) != nullptr) {
+                    infoClauseHead->addArgument(std::make_unique<AstStringConstant>(
+                            translationUnit.getSymbolTable(), ("!" + relName)));
+                }
+                // for a constraint, add the constraint symbol and LHS and RHS
+            } else if (auto con = dynamic_cast<AstBinaryConstraint*>(lit)) {
+                std::string constraintDescription = toBinaryConstraintSymbol(con->getOperator());
+
+                constraintDescription.append("," + getArgInfo(con->getLHS()));
+                constraintDescription.append("," + getArgInfo(con->getRHS()));
+
+                infoClauseHead->addArgument(std::make_unique<AstStringConstant>(
+                        translationUnit.getSymbolTable(), constraintDescription));
+            }
         }
     }
 


### PR DESCRIPTION
Method getAtom() was present in classes such as AstConstraint without having an Atom/Predicate available. The change introduces a new sub-class AstAtomLiteral introducing getAtom() with the guarantee that getAtom() does not return a null-pointer for AstAtomLiteral. 

This is a fix for issue #1255.