### PR TITLE
Move transformers to their own cpp/h files

### DIFF
--- a/src/AstComponentChecker.cpp
+++ b/src/AstComponentChecker.cpp
@@ -21,7 +21,7 @@
 #include "AstRelationIdentifier.h"
 #include "AstTranslationUnit.h"
 #include "AstType.h"
-#include "ComponentModel.h"
+#include "ComponentLookupAnalysis.h"
 #include "ErrorReport.h"
 #include "SrcLocation.h"
 #include "Util.h"

--- a/src/AstPragma.h
+++ b/src/AstPragma.h
@@ -30,18 +30,14 @@ namespace souffle {
  */
 class AstPragma : public AstNode {
 public:
-    AstPragma() = default;
-
-    AstPragma(std::string k, std::string v) : key(std::move(k)), value(std::move(v)) {}
+    AstPragma(std::string key, std::string value) : key(std::move(key)), value(std::move(value)) {}
 
     void print(std::ostream& os) const override {
         os << ".pragma " << key << " " << value << "\n";
     }
 
     AstPragma* clone() const override {
-        auto res = new AstPragma();
-        res->key = key;
-        res->value = value;
+        auto res = new AstPragma(key, value);
         res->setSrcLoc(getSrcLoc());
         return res;
     }

--- a/src/AstPragma.h
+++ b/src/AstPragma.h
@@ -17,16 +17,12 @@
 #pragma once
 
 #include "AstNode.h"
-#include "AstTransformer.h"
 #include <cassert>
 #include <ostream>
 #include <string>
 #include <utility>
-#include <vector>
 
 namespace souffle {
-
-class AstTranslationUnit;
 
 /**
  * @class AstPragma
@@ -68,17 +64,6 @@ protected:
 
     /** Value */
     std::string value;
-};
-
-/** TODO (b-scholz): this should not be here */
-class AstPragmaChecker : public AstTransformer {
-public:
-    std::string getName() const override {
-        return "AstPragmaChecker";
-    }
-
-private:
-    bool transform(AstTranslationUnit&) override;
 };
 
 }  // end of namespace souffle

--- a/src/AstPragmaChecker.cpp
+++ b/src/AstPragmaChecker.cpp
@@ -8,12 +8,13 @@
 
 /************************************************************************
  *
- * @file AstPragma.cpp
+ * @file AstPragmaChecker.cpp
  *
- * Define the class AstPragma to update global options based on parameter.
+ * Defines a transformer that applies pragmas found in parsed input.
  *
  ***********************************************************************/
 
+#include "AstPragmaChecker.h"
 #include "AstPragma.h"
 #include "AstProgram.h"
 #include "AstTranslationUnit.h"
@@ -26,24 +27,7 @@ bool AstPragmaChecker::transform(AstTranslationUnit& translationUnit) {
     bool changed = false;
     AstProgram* program = translationUnit.getProgram();
 
-    // Take in pragma options from the command line
-    if (Global::config().has("pragma")) {
-        std::vector<std::string> configOptions = splitString(Global::config().get("pragma"), ';');
-        for (const std::string& option : configOptions) {
-            size_t splitPoint = option.find(':');
-
-            std::string optionName = option.substr(0, splitPoint);
-            std::string optionValue =
-                    (splitPoint == std::string::npos) ? "" : option.substr(splitPoint + 1, option.length());
-
-            if (!Global::config().has(optionName)) {
-                changed = true;
-                Global::config().set(optionName, optionValue);
-            }
-        }
-    }
-
-    // Take in pragma options from the datalog file itself
+    // Take in pragma options from the datalog file
     visitDepthFirst(*program, [&](const AstPragma& pragma) {
         std::pair<std::string, std::string> kvp = pragma.getkvp();
 

--- a/src/AstPragmaChecker.h
+++ b/src/AstPragmaChecker.h
@@ -1,0 +1,33 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2017, The Souffle Developers. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file AstPragmaChecker.h
+ *
+ * Defines a transformer that applies pragmas found in parsed input.
+ *
+ ***********************************************************************/
+
+#pragma once
+
+#include "AstTransformer.h"
+
+namespace souffle {
+
+class AstPragmaChecker : public AstTransformer {
+public:
+    std::string getName() const override {
+        return "AstPragmaChecker";
+    }
+
+private:
+    bool transform(AstTranslationUnit&) override;
+};
+
+}  // end of namespace souffle

--- a/src/AstTransforms.h
+++ b/src/AstTransforms.h
@@ -19,7 +19,7 @@
 #include "AstArgument.h"
 #include "AstTransformer.h"
 #include "AstTranslationUnit.h"
-#include "DebugReport.h"
+#include "DebugReporter.h"
 #include "Util.h"
 #include <functional>
 #include <memory>

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -1634,8 +1634,7 @@ std::unique_ptr<RamTranslationUnit> AstTranslator::translateUnit(AstTranslationU
                     "(" + std::to_string(std::chrono::duration<double>(ram_end - ram_start).count()) + "s)";
             std::stringstream ramProgStr;
             ramProgStr << *ramProg;
-            debugReport.addSection(DebugReporter::getCodeSection(
-                    "ram-program", "RAM Program " + runtimeStr, ramProgStr.str()));
+            debugReport.addSection("ram-program", "RAM Program " + runtimeStr, ramProgStr.str());
         }
     }
     return std::make_unique<RamTranslationUnit>(std::move(ramProg), symTab, errReport, debugReport);

--- a/src/ComponentInstantiationTransformer.h
+++ b/src/ComponentInstantiationTransformer.h
@@ -1,0 +1,34 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file ComponentInstantiationTransformer.h
+ *
+ ***********************************************************************/
+
+#pragma once
+
+#include "AstTransformer.h"
+#include <string>
+
+namespace souffle {
+
+class AstComponent;
+
+class ComponentInstantiationTransformer : public AstTransformer {
+public:
+    std::string getName() const override {
+        return "ComponentInstantiationTransformer";
+    }
+
+private:
+    bool transform(AstTranslationUnit& translationUnit) override;
+};
+
+}  // end of namespace souffle

--- a/src/ComponentLookupAnalysis.cpp
+++ b/src/ComponentLookupAnalysis.cpp
@@ -1,0 +1,78 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file ComponentLookupAnalysis.cpp
+ *
+ * Implements the component lookup
+ *
+ ***********************************************************************/
+
+#include "ComponentLookupAnalysis.h"
+#include "AstComponent.h"
+#include "AstProgram.h"
+#include "AstTranslationUnit.h"
+#include "AstVisitor.h"
+#include "Util.h"
+
+namespace souffle {
+
+void ComponentLookup::run(const AstTranslationUnit& translationUnit) {
+    const AstProgram* program = translationUnit.getProgram();
+    for (AstComponent* component : program->getComponents()) {
+        globalScopeComponents.insert(component);
+        enclosingComponent[component] = nullptr;
+    }
+    visitDepthFirst(*program, [&](const AstComponent& cur) {
+        nestedComponents[&cur];
+        for (AstComponent* nestedComponent : cur.getComponents()) {
+            nestedComponents[&cur].insert(nestedComponent);
+            enclosingComponent[nestedComponent] = &cur;
+        }
+    });
+}
+
+const AstComponent* ComponentLookup::getComponent(
+        const AstComponent* scope, const std::string& name, const TypeBinding& activeBinding) const {
+    // forward according to binding (we do not do this recursively on purpose)
+    AstTypeIdentifier boundName = activeBinding.find(name);
+    if (boundName.empty()) {
+        // compName is not bound to anything => just just compName
+        boundName = name;
+    }
+
+    // search nested scopes bottom up
+    const AstComponent* searchScope = scope;
+    while (searchScope != nullptr) {
+        for (const AstComponent* cur : searchScope->getComponents()) {
+            if (cur->getComponentType()->getName() == toString(boundName)) {
+                return cur;
+            }
+        }
+        auto found = enclosingComponent.find(searchScope);
+        if (found != enclosingComponent.end()) {
+            searchScope = found->second;
+        } else {
+            searchScope = nullptr;
+            break;
+        }
+    }
+
+    // check global scope
+    for (const AstComponent* cur : globalScopeComponents) {
+        if (cur->getComponentType()->getName() == toString(boundName)) {
+            return cur;
+        }
+    }
+
+    // no such component in scope
+    return nullptr;
+}
+
+}  // end namespace souffle

--- a/src/ComponentLookupAnalysis.h
+++ b/src/ComponentLookupAnalysis.h
@@ -8,14 +8,13 @@
 
 /************************************************************************
  *
- * @file ComponentModel.h
+ * @file ComponentLookupAnalysis.h
  *
  ***********************************************************************/
 
 #pragma once
 
 #include "AstAnalysis.h"
-#include "AstTransformer.h"
 #include "AstType.h"
 #include <cstddef>
 #include <map>
@@ -26,7 +25,6 @@
 namespace souffle {
 
 class AstComponent;
-class AstTranslationUnit;
 
 /**
  * Class that encapsulates std::map of types binding that comes from .init c = Comp<MyType>
@@ -96,16 +94,6 @@ private:
     std::map<const AstComponent*, std::set<const AstComponent*>> nestedComponents;
     // component definition enclosing a component definition
     std::map<const AstComponent*, const AstComponent*> enclosingComponent;
-};
-
-class ComponentInstantiationTransformer : public AstTransformer {
-public:
-    std::string getName() const override {
-        return "ComponentInstantiationTransformer";
-    }
-
-private:
-    bool transform(AstTranslationUnit& translationUnit) override;
 };
 
 }  // end of namespace souffle

--- a/src/DebugReport.cpp
+++ b/src/DebugReport.cpp
@@ -15,57 +15,11 @@
  ***********************************************************************/
 
 #include "DebugReport.h"
-#include "AstTranslationUnit.h"
-#include "AstTypeAnalysis.h"
-#include "AstTypeEnvironmentAnalysis.h"
-#include "PrecedenceGraph.h"
-#include <chrono>
-#include <cstdio>
 #include <ostream>
-#include <sstream>
 #include <utility>
+#include <vector>
 
 namespace souffle {
-
-static std::string toBase64(const std::string& data) {
-    static const std::vector<char> table = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
-            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
-            'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y',
-            'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
-    std::string result;
-    std::string tmp = data;
-    unsigned int padding = 0;
-    if (data.size() % 3 == 2) {
-        padding = 1;
-    } else if (data.size() % 3 == 1) {
-        padding = 2;
-    }
-
-    for (unsigned int i = 0; i < padding; i++) {
-        tmp.push_back(0);
-    }
-    for (unsigned int i = 0; i < tmp.size(); i += 3) {
-        auto c1 = static_cast<unsigned char>(tmp[i]);
-        auto c2 = static_cast<unsigned char>(tmp[i + 1]);
-        auto c3 = static_cast<unsigned char>(tmp[i + 2]);
-        unsigned char index1 = c1 >> 2;
-        unsigned char index2 = ((c1 & 0x03) << 4) | (c2 >> 4);
-        unsigned char index3 = ((c2 & 0x0F) << 2) | (c3 >> 6);
-        unsigned char index4 = c3 & 0x3F;
-
-        result.push_back(table[index1]);
-        result.push_back(table[index2]);
-        result.push_back(table[index3]);
-        result.push_back(table[index4]);
-    }
-    if (padding == 1) {
-        result[result.size() - 1] = '=';
-    } else if (padding == 2) {
-        result[result.size() - 1] = '=';
-        result[result.size() - 2] = '=';
-    }
-    return result;
-}
 
 void DebugReportSection::printIndex(std::ostream& out) const {
     out << "<a href=\"#" << id << "\">" << title << "</a>\n";
@@ -148,109 +102,6 @@ void DebugReport::print(std::ostream& out) const {
     out << "<a href='#'>(return to top)</a>\n";
     out << "</body>\n";
     out << "</html>\n";
-}
-
-DebugReportSection DebugReporter::getCodeSection(const std::string& id, std::string title, std::string code) {
-    std::stringstream codeHTML;
-    std::string escapedCode = std::move(code);
-    while (true) {
-        size_t i = escapedCode.find("<");
-        if (i == std::string::npos) {
-            break;
-        }
-        escapedCode.replace(i, 1, "&lt;");
-    }
-    codeHTML << "<pre>" << escapedCode << "</pre>\n";
-    return DebugReportSection(id, std::move(title), {}, codeHTML.str());
-}
-
-DebugReportSection DebugReporter::getDotGraphSection(
-        const std::string& id, std::string title, const std::string& dotSpec) {
-    std::string tempFileName = tempFile();
-    {
-        std::ofstream dotFile(tempFileName);
-        dotFile << dotSpec;
-    }
-
-    std::string cmd = "dot -Tsvg < " + tempFileName;
-    FILE* in = popen(cmd.c_str(), "r");
-    std::stringstream data;
-    while (in != nullptr) {
-        char c = fgetc(in);
-        if (feof(in) != 0) {
-            break;
-        }
-        data << c;
-    }
-    pclose(in);
-    remove(tempFileName.c_str());
-
-    std::stringstream graphHTML;
-    if (data.str().find("<svg") != std::string::npos) {
-        graphHTML << "<img alt='graph image' src='data:image/svg+xml;base64," << toBase64(data.str())
-                  << "'><br/>\n";
-    } else {
-        graphHTML << "<p>(error: unable to generate dot graph image)</p>";
-    }
-    graphHTML << "<a href=\"javascript:toggleVisibility('" << id << "-source"
-              << "')\">(show dot source)</a>\n";
-    graphHTML << "<div id='" << id << "-source"
-              << "' style='display:none'>\n";
-    graphHTML << "<pre>" << dotSpec << "</pre>\n";
-    graphHTML << "</div>\n";
-    return DebugReportSection(id, std::move(title), {}, graphHTML.str());
-}
-
-bool DebugReporter::transform(AstTranslationUnit& translationUnit) {
-    auto start = std::chrono::high_resolution_clock::now();
-    bool changed = applySubtransformer(translationUnit, wrappedTransformer.get());
-    auto end = std::chrono::high_resolution_clock::now();
-    std::string runtimeStr = "(" + std::to_string(std::chrono::duration<double>(end - start).count()) + "s)";
-    if (changed) {
-        generateDebugReport(translationUnit, wrappedTransformer->getName(),
-                "After " + wrappedTransformer->getName() + " " + runtimeStr);
-    } else {
-        translationUnit.getDebugReport().addSection(DebugReportSection(wrappedTransformer->getName(),
-                "After " + wrappedTransformer->getName() + " " + runtimeStr + " (unchanged)", {}, ""));
-    }
-    return changed;
-}
-
-void DebugReporter::generateDebugReport(
-        AstTranslationUnit& translationUnit, const std::string& id, std::string title) {
-    std::stringstream datalogSpec;
-    translationUnit.getProgram()->print(datalogSpec);
-
-    DebugReportSection datalogSection = getCodeSection(id + "-dl", "Datalog", datalogSpec.str());
-
-    std::stringstream typeAnalysis;
-    translationUnit.getAnalysis<TypeAnalysis>()->print(typeAnalysis);
-    DebugReportSection typeAnalysisSection = getCodeSection(id + "-ta", "Type Analysis", typeAnalysis.str());
-
-    std::stringstream typeEnvironmentAnalysis;
-    translationUnit.getAnalysis<TypeEnvironmentAnalysis>()->print(typeEnvironmentAnalysis);
-    DebugReportSection typeEnvironmentAnalysisSection =
-            getCodeSection(id + "-tea", "Type Environment Analysis", typeEnvironmentAnalysis.str());
-
-    std::stringstream precGraphDot;
-    translationUnit.getAnalysis<PrecedenceGraph>()->print(precGraphDot);
-    DebugReportSection precedenceGraphSection =
-            getDotGraphSection(id + "-prec-graph", "Precedence Graph", precGraphDot.str());
-
-    std::stringstream sccGraphDot;
-    translationUnit.getAnalysis<SCCGraph>()->print(sccGraphDot);
-    DebugReportSection sccGraphSection =
-            getDotGraphSection(id + "-scc-graph", "SCC Graph", sccGraphDot.str());
-
-    std::stringstream topsortSCCGraph;
-    translationUnit.getAnalysis<TopologicallySortedSCCGraph>()->print(topsortSCCGraph);
-    DebugReportSection topsortSCCGraphSection =
-            getCodeSection(id + "-topsort-scc-graph", "SCC Topological Sort Order", topsortSCCGraph.str());
-
-    translationUnit.getDebugReport().addSection(DebugReportSection(id, std::move(title),
-            {datalogSection, typeAnalysisSection, typeEnvironmentAnalysisSection, precedenceGraphSection,
-                    sccGraphSection, topsortSCCGraphSection},
-            ""));
 }
 
 }  // end of namespace souffle

--- a/src/DebugReporter.cpp
+++ b/src/DebugReporter.cpp
@@ -1,0 +1,158 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file DebugReporter.cpp
+ *
+ * Defines class for adapting other transformers to produce debug output
+ *
+ ***********************************************************************/
+
+#include "DebugReporter.h"
+#include "AstTranslationUnit.h"
+#include "AstTypeAnalysis.h"
+#include "AstTypeEnvironmentAnalysis.h"
+#include "DebugReport.h"
+#include "PrecedenceGraph.h"
+#include <chrono>
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <utility>
+
+namespace souffle {
+
+static std::string toBase64(const std::string& data) {
+    static const std::vector<char> table = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+            'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y',
+            'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
+    std::string result;
+    std::string tmp = data;
+    unsigned int padding = 0;
+    if (data.size() % 3 == 2) {
+        padding = 1;
+    } else if (data.size() % 3 == 1) {
+        padding = 2;
+    }
+
+    for (unsigned int i = 0; i < padding; i++) {
+        tmp.push_back(0);
+    }
+    for (unsigned int i = 0; i < tmp.size(); i += 3) {
+        auto c1 = static_cast<unsigned char>(tmp[i]);
+        auto c2 = static_cast<unsigned char>(tmp[i + 1]);
+        auto c3 = static_cast<unsigned char>(tmp[i + 2]);
+        unsigned char index1 = c1 >> 2;
+        unsigned char index2 = ((c1 & 0x03) << 4) | (c2 >> 4);
+        unsigned char index3 = ((c2 & 0x0F) << 2) | (c3 >> 6);
+        unsigned char index4 = c3 & 0x3F;
+
+        result.push_back(table[index1]);
+        result.push_back(table[index2]);
+        result.push_back(table[index3]);
+        result.push_back(table[index4]);
+    }
+    if (padding == 1) {
+        result[result.size() - 1] = '=';
+    } else if (padding == 2) {
+        result[result.size() - 1] = '=';
+        result[result.size() - 2] = '=';
+    }
+    return result;
+}
+
+DebugReportSection DebugReporter::getDotGraphSection(
+        const std::string& id, std::string title, const std::string& dotSpec) {
+    std::string tempFileName = tempFile();
+    {
+        std::ofstream dotFile(tempFileName);
+        dotFile << dotSpec;
+    }
+
+    std::string cmd = "dot -Tsvg < " + tempFileName;
+    FILE* in = popen(cmd.c_str(), "r");
+    std::stringstream data;
+    while (in != nullptr) {
+        char c = fgetc(in);
+        if (feof(in) != 0) {
+            break;
+        }
+        data << c;
+    }
+    pclose(in);
+    remove(tempFileName.c_str());
+
+    std::stringstream graphHTML;
+    if (data.str().find("<svg") != std::string::npos) {
+        graphHTML << "<img alt='graph image' src='data:image/svg+xml;base64," << toBase64(data.str())
+                  << "'><br/>\n";
+    } else {
+        graphHTML << "<p>(error: unable to generate dot graph image)</p>";
+    }
+    graphHTML << "<a href=\"javascript:toggleVisibility('" << id << "-source"
+              << "')\">(show dot source)</a>\n";
+    graphHTML << "<div id='" << id << "-source"
+              << "' style='display:none'>\n";
+    graphHTML << "<pre>" << dotSpec << "</pre>\n";
+    graphHTML << "</div>\n";
+    return DebugReportSection(id, std::move(title), {}, graphHTML.str());
+}
+
+bool DebugReporter::transform(AstTranslationUnit& translationUnit) {
+    auto start = std::chrono::high_resolution_clock::now();
+    bool changed = applySubtransformer(translationUnit, wrappedTransformer.get());
+    auto end = std::chrono::high_resolution_clock::now();
+    std::string runtimeStr = "(" + std::to_string(std::chrono::duration<double>(end - start).count()) + "s)";
+    if (changed) {
+        generateDebugReport(translationUnit, wrappedTransformer->getName(),
+                "After " + wrappedTransformer->getName() + " " + runtimeStr);
+    } else {
+        translationUnit.getDebugReport().addSection(DebugReportSection(wrappedTransformer->getName(),
+                "After " + wrappedTransformer->getName() + " " + runtimeStr + " (unchanged)", {}, ""));
+    }
+    return changed;
+}
+
+void DebugReporter::generateDebugReport(
+        AstTranslationUnit& translationUnit, const std::string& id, std::string title) {
+    std::stringstream datalogSpec;
+    translationUnit.getProgram()->print(datalogSpec);
+
+    DebugReportSection datalogSection(id + "-dl", "Datalog", datalogSpec.str());
+
+    std::stringstream typeAnalysis;
+    translationUnit.getAnalysis<TypeAnalysis>()->print(typeAnalysis);
+    DebugReportSection typeAnalysisSection(id + "-ta", "Type Analysis", typeAnalysis.str());
+
+    std::stringstream typeEnvironmentAnalysis;
+    translationUnit.getAnalysis<TypeEnvironmentAnalysis>()->print(typeEnvironmentAnalysis);
+    DebugReportSection typeEnvironmentAnalysisSection(
+            id + "-tea", "Type Environment Analysis", typeEnvironmentAnalysis.str());
+
+    std::stringstream precGraphDot;
+    translationUnit.getAnalysis<PrecedenceGraph>()->print(precGraphDot);
+    DebugReportSection precedenceGraphSection(id + "-prec-graph", "Precedence Graph", precGraphDot.str());
+
+    std::stringstream sccGraphDot;
+    translationUnit.getAnalysis<SCCGraph>()->print(sccGraphDot);
+    DebugReportSection sccGraphSection(id + "-scc-graph", "SCC Graph", sccGraphDot.str());
+
+    std::stringstream topsortSCCGraph;
+    translationUnit.getAnalysis<TopologicallySortedSCCGraph>()->print(topsortSCCGraph);
+    DebugReportSection topsortSCCGraphSection(
+            id + "-topsort-scc-graph", "SCC Topological Sort Order", topsortSCCGraph.str());
+
+    translationUnit.getDebugReport().addSection(DebugReportSection(id, std::move(title),
+            {datalogSection, typeAnalysisSection, typeEnvironmentAnalysisSection, precedenceGraphSection,
+                    sccGraphSection, topsortSCCGraphSection},
+            ""));
+}
+
+}  // end of namespace souffle

--- a/src/DebugReporter.h
+++ b/src/DebugReporter.h
@@ -1,0 +1,83 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file DebugReporter.h
+ *
+ * Defines an adaptor transformer to capture debug output from other transformers
+ *
+ ***********************************************************************/
+#pragma once
+
+#include "AstTransformer.h"
+#include "DebugReport.h"
+
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+
+namespace souffle {
+
+class AstTranslationUnit;
+
+/**
+ * Transformation pass which wraps another transformation pass and generates
+ * a debug report section for the stage after applying the wrapped transformer,
+ * and adds it to the translation unit's debug report.
+ */
+class DebugReporter : public MetaTransformer {
+public:
+    DebugReporter(std::unique_ptr<AstTransformer> wrappedTransformer)
+            : wrappedTransformer(std::move(wrappedTransformer)) {}
+
+    void setDebugReport() override {}
+
+    void setVerbosity(bool verbose) override {
+        this->verbose = verbose;
+        if (auto* mt = dynamic_cast<MetaTransformer*>(wrappedTransformer.get())) {
+            mt->setVerbosity(verbose);
+        }
+    }
+
+    void disableTransformers(const std::set<std::string>& transforms) override {
+        if (auto* mt = dynamic_cast<MetaTransformer*>(wrappedTransformer.get())) {
+            mt->disableTransformers(transforms);
+        } else if (transforms.find(wrappedTransformer->getName()) != transforms.end()) {
+            wrappedTransformer = std::unique_ptr<AstTransformer>(new NullTransformer());
+        }
+    }
+
+    std::string getName() const override {
+        return "DebugReporter";
+    }
+
+    /**
+     * Generate a debug report section for the current state of the given translation unit
+     * with the given id and title, and add the section to the translation unit's debug report.
+     * @param translationUnit translation unit to generate and add debug report section
+     * @param id the unique id of the generated section
+     * @param title the text to display as the heading of the section
+     */
+    static void generateDebugReport(
+            AstTranslationUnit& translationUnit, const std::string& id, std::string title);
+
+    /**
+     * Generated a debug report section for a dot graph specification, with the given id and title.
+     */
+    static DebugReportSection getDotGraphSection(
+            const std::string& id, std::string title, const std::string& dotSpec);
+
+private:
+    std::unique_ptr<AstTransformer> wrappedTransformer;
+
+    bool transform(AstTranslationUnit& translationUnit) override;
+};
+
+}  // end of namespace souffle

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,7 +94,10 @@ souffle_sources = \
         AstUtils.cpp          AstUtils.h          \
         AstVisitor.h                              \
         BinaryConstraintOps.h                     \
-        ComponentModel.cpp    ComponentModel.h    \
+        ComponentInstantiationTransformer.cpp     \
+        ComponentInstantiationTransformer.h       \
+        ComponentLookupAnalysis.cpp               \
+        ComponentLookupAnalysis.h                 \
         Constraints.h                             \
         DebugReport.cpp       DebugReport.h       \
         DebugReporter.cpp     DebugReporter.h     \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -97,6 +97,7 @@ souffle_sources = \
         ComponentModel.cpp    ComponentModel.h    \
         Constraints.h                             \
         DebugReport.cpp       DebugReport.h       \
+        DebugReporter.cpp     DebugReporter.h     \
         EventProcessor.h                          \
         FunctorOps.h                              \
         Global.cpp            Global.h            \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,7 +75,8 @@ souffle_sources = \
         AstLiteral.h                              \
         AstNode.h                                 \
         AstParserUtils.cpp    AstParserUtils.h    \
-        AstPragma.cpp         AstPragma.h         \
+        AstPragma.h                               \
+        AstPragmaChecker.cpp  AstPragmaChecker.h  \
         AstProgram.h                              \
         AstProfileUse.cpp     AstProfileUse.h     \
         AstRelation.h                             \

--- a/src/RamTransformer.cpp
+++ b/src/RamTransformer.cpp
@@ -15,6 +15,7 @@
  ***********************************************************************/
 
 #include "RamTransformer.h"
+#include "DebugReport.h"
 #include "RamTranslationUnit.h"
 
 #include <algorithm>
@@ -38,8 +39,8 @@ bool RamTransformer::apply(RamTranslationUnit& translationUnit) {
                 std::stringstream ramAnalysisStr;
                 analysis->print(ramAnalysisStr);
                 if (!ramAnalysisStr.str().empty()) {
-                    translationUnit.getDebugReport().addSection(DebugReporter::getCodeSection(
-                            getName(), "RAM Analysis " + analysis->getName(), ramAnalysisStr.str()));
+                    translationUnit.getDebugReport().addSection(
+                            getName(), "RAM Analysis " + analysis->getName(), ramAnalysisStr.str());
                 }
             }
         }
@@ -50,11 +51,11 @@ bool RamTransformer::apply(RamTranslationUnit& translationUnit) {
         std::stringstream ramProgStr;
         ramProgStr << translationUnit.getProgram();
         translationUnit.getDebugReport().addSection(
-                DebugReporter::getCodeSection(getName(), "RAM Program after " + getName(), ramProgStr.str()));
+                getName(), "RAM Program after " + getName(), ramProgStr.str());
 
     } else {
         translationUnit.getDebugReport().addSection(
-                DebugReportSection(getName(), "After " + getName() + " " + " (unchanged)", {}, ""));
+                getName(), "After " + getName() + " " + " (unchanged)", "");
     }
 
     /* Abort evaluation of the program if errors were encountered */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "AstTypeAnalysis.h"
 #include "ComponentModel.h"
 #include "DebugReport.h"
+#include "DebugReporter.h"
 #include "ErrorReport.h"
 #include "Explain.h"
 #include "Global.h"
@@ -210,7 +211,6 @@ int main(int argc, char** argv) {
                                                   : option.substr(splitPoint + 1, option.length());
 
                 if (!Global::config().has(optionName)) {
-                    changed = true;
                     Global::config().set(optionName, optionValue);
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
  ***********************************************************************/
 
 #include "AstComponentChecker.h"
-#include "AstPragma.h"
+#include "AstPragmaChecker.h"
 #include "AstSemanticChecker.h"
 #include "AstTransforms.h"
 #include "AstTranslationUnit.h"
@@ -197,6 +197,24 @@ int main(int argc, char** argv) {
         Global::config().processArgs(argc, argv, header.str(), footer.str(), options);
 
         // ------ command line arguments -------------
+
+        // Take in pragma options from the command line
+        if (Global::config().has("pragma")) {
+            std::vector<std::string> configOptions = splitString(Global::config().get("pragma"), ';');
+            for (const std::string& option : configOptions) {
+                size_t splitPoint = option.find(':');
+
+                std::string optionName = option.substr(0, splitPoint);
+                std::string optionValue = (splitPoint == std::string::npos)
+                                                  ? ""
+                                                  : option.substr(splitPoint + 1, option.length());
+
+                if (!Global::config().has(optionName)) {
+                    changed = true;
+                    Global::config().set(optionName, optionValue);
+                }
+            }
+        }
 
         /* for the version option, if given print the version text then exit */
         if (Global::config().has("version")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@
 #include "AstTranslationUnit.h"
 #include "AstTranslator.h"
 #include "AstTypeAnalysis.h"
-#include "ComponentModel.h"
+#include "ComponentInstantiationTransformer.h"
 #include "DebugReport.h"
 #include "DebugReporter.h"
 #include "ErrorReport.h"


### PR DESCRIPTION
Move transformers out of non-transformer files

AstPragmaChecker also contained a non-transformer check of souffle parameters which has been moved to main.cpp

DebugReport/DebugReporter were a little confused. As well as moving, the transformer responsibilities has been shuffled a bit so that the transformer is not responsible for non-transformer duties.

ComponentModel contained an AstAnalysis which has been moved to an Analysis file name.