### PR TITLE
Added equal_targets for std::map & fix AstProgram / AstExecutionPlan

### DIFF
--- a/src/AstClause.h
+++ b/src/AstClause.h
@@ -125,20 +125,7 @@ protected:
     bool equal(const AstNode& node) const override {
         assert(nullptr != dynamic_cast<const AstExecutionPlan*>(&node));
         const auto& other = static_cast<const AstExecutionPlan&>(node);
-        if (plans.size() != other.plans.size()) {
-            return false;
-        }
-        auto iter = plans.begin();
-        auto otherIter = other.plans.begin();
-        for (; iter != plans.end(); ++iter, ++otherIter) {
-            if (iter->first != otherIter->first) {
-                return false;
-            }
-            if (*iter->second != *otherIter->second) {
-                return false;
-            }
-        }
-        return true;
+        return equal_targets(plans, other.plans);
     }
 
 private:

--- a/src/AstProgram.h
+++ b/src/AstProgram.h
@@ -359,41 +359,22 @@ protected:
         assert(nullptr != dynamic_cast<const AstProgram*>(&node));
         const auto& other = static_cast<const AstProgram&>(node);
 
-        // check list sizes
-        if (types.size() != other.types.size()) {
+        if (!equal_targets(pragmaDirectives, other.pragmaDirectives)) {
             return false;
         }
-        if (relations.size() != other.relations.size()) {
-            return false;
-        }
-
-        // check types
-        for (const auto& cur : types) {
-            auto pos = other.types.find(cur.first);
-            if (pos == other.types.end()) {
-                return false;
-            }
-            if (*cur.second != *pos->second) {
-                return false;
-            }
-        }
-
-        // check relations
-        for (const auto& cur : relations) {
-            auto pos = other.relations.find(cur.first);
-            if (pos == other.relations.end()) {
-                return false;
-            }
-            if (*cur.second != *pos->second) {
-                return false;
-            }
-        }
-
-        // check components
         if (!equal_targets(components, other.components)) {
             return false;
         }
         if (!equal_targets(instantiations, other.instantiations)) {
+            return false;
+        }
+        if (!equal_targets(functors, other.functors)) {
+            return false;
+        }
+        if (!equal_targets(types, other.types)) {
+            return false;
+        }
+        if (!equal_targets(relations, other.relations)) {
             return false;
         }
         if (!equal_targets(clauses, other.clauses)) {
@@ -408,8 +389,6 @@ protected:
         if (!equal_targets(stores, other.stores)) {
             return false;
         }
-
-        // no different found => programs are equal
         return true;
     }
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -430,36 +430,35 @@ bool equal(const std::vector<T>& a, const std::vector<T>& b, const Comp& comp = 
             return false;
         }
     }
-
-    // all the same
     return true;
 }
 
 /**
- * A function testing whether two vector of pointers are referencing to equivalent
- * targets.
+ * A function testing whether two maps are equal.
  */
-template <typename T>
-bool equal_targets(const std::vector<T*>& a, const std::vector<T*>& b) {
-    return equal(a, b, comp_deref<T*>());
-}
+template <typename T1, typename T2, typename Comp = std::equal_to<T2>>
+bool equal(const std::map<T1, T2>& a, const std::map<T1, T2>& b, const Comp& comp = Comp()) {
+    // check reference
+    if (&a == &b) {
+        return true;
+    }
 
-/**
- * A function testing whether two vector of pointers are referencing to equivalent
- * targets.
- */
-template <typename T>
-bool equal_targets(const std::vector<std::unique_ptr<T>>& a, const std::vector<std::unique_ptr<T>>& b) {
-    return equal(a, b, comp_deref<std::unique_ptr<T>>());
-}
+    // check size
+    if (a.size() != a.size()) {
+        return false;
+    }
 
-/**
- * A function testing whether two vector of pointers are referencing to equivalent
- * targets.
- */
-template <typename T>
-bool equal_targets(const std::vector<std::shared_ptr<T>>& a, const std::vector<std::shared_ptr<T>>& b) {
-    return equal(a, b, comp_deref<std::shared_ptr<T>>());
+    // check contents
+    auto itB = b.begin();
+    for (auto itA = a.begin(); itA != a.end(); ++itA, ++itB) {
+        if (itA->first != itB->first) {
+            return false;
+        }
+        if (!comp(itA->second, itB->second)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 /**
@@ -492,6 +491,33 @@ bool equal(const std::set<T>& a, const std::set<T>& b, const Comp& comp = Comp()
 }
 
 /**
+ * A function testing whether two vector of pointers are referencing to equivalent
+ * targets.
+ */
+template <typename T>
+bool equal_targets(const std::vector<T*>& a, const std::vector<T*>& b) {
+    return equal(a, b, comp_deref<T*>());
+}
+
+/**
+ * A function testing whether two vector of unique pointers are referencing to equivalent
+ * targets.
+ */
+template <typename T>
+bool equal_targets(const std::vector<std::unique_ptr<T>>& a, const std::vector<std::unique_ptr<T>>& b) {
+    return equal(a, b, comp_deref<std::unique_ptr<T>>());
+}
+
+/**
+ * A function testing whether two maps of unique pointers are referencing to equivalent
+ * targets.
+ */
+template <typename T1, typename T2>
+bool equal_targets(const std::map<T1, std::unique_ptr<T2>>& a, const std::map<T1, std::unique_ptr<T2>>& b) {
+    return equal(a, b, comp_deref<std::unique_ptr<T2>>());
+}
+
+/**
  * A function testing whether two set of pointers are referencing to equivalent
  * targets.
  */
@@ -507,15 +533,6 @@ bool equal_targets(const std::set<T*>& a, const std::set<T*>& b) {
 template <typename T>
 bool equal_targets(const std::set<std::unique_ptr<T>>& a, const std::set<std::unique_ptr<T>>& b) {
     return equal(a, b, comp_deref<std::unique_ptr<T>>());
-}
-
-/**
- * A function testing whether two set of pointers are referencing to equivalent
- * targets.
- */
-template <typename T>
-bool equal_targets(const std::set<std::shared_ptr<T>>& a, const std::set<std::shared_ptr<T>>& b) {
-    return equal(a, b, comp_deref<std::shared_ptr<T>>());
 }
 
 /**


### PR DESCRIPTION
AstProgram has an incomplete equal() implementation and an equal_target utility for std::map<T1,T2> was missing. The new equal code replaces repetitive code in AstProgram and in AstExecutionPlan.

This is related to issue #1255.