### PR TITLE
Refactoring of AstIO

### DIFF
--- a/src/AstIO.h
+++ b/src/AstIO.h
@@ -36,13 +36,13 @@ public:
     void print(std::ostream& os) const override {
         os << name;
         if (!kvps.empty()) {
-           os << "(" << join(kvps, ",") << ")"; 
+            os << "(" << join(kvps, ",") << ")";
         }
     }
 
     /** relation name of I/O-directive */
     const AstRelationIdentifier& getName() const {
-        return name; 
+        return name;
     }
 
     /** set relation name of I/O-directive */

--- a/src/AstIO.h
+++ b/src/AstIO.h
@@ -68,25 +68,6 @@ public:
         return res;
     }
 
-    std::string unescape(const std::string& inputString) const {
-        std::string unescaped = unescape(inputString, "\\\"", "\"");
-        unescaped = unescape(unescaped, "\\t", "\t");
-        unescaped = unescape(unescaped, "\\r", "\r");
-        unescaped = unescape(unescaped, "\\n", "\n");
-        return unescaped;
-    }
-
-    std::string unescape(
-            const std::string& inputString, const std::string& needle, const std::string& replacement) const {
-        std::string result = inputString;
-        size_t pos = 0;
-        while ((pos = result.find(needle, pos)) != std::string::npos) {
-            result = result.replace(pos, needle.length(), replacement);
-            pos += replacement.length();
-        }
-        return result;
-    }
-
 protected:
     bool equal(const AstNode& node) const override {
         assert(nullptr != dynamic_cast<const AstIO*>(&node));

--- a/src/AstIO.h
+++ b/src/AstIO.h
@@ -36,7 +36,9 @@ public:
     void print(std::ostream& os) const override {
         os << name;
         if (!kvps.empty()) {
-            os << "(" << join(kvps, ",") << ")";
+            os << "(" << join(kvps, ",", [](std::ostream& out, const auto& arg) {
+                out << arg.first << "=\"" << arg.second << "\"";
+            }) << ")";
         }
     }
 

--- a/src/AstIO.h
+++ b/src/AstIO.h
@@ -30,67 +30,39 @@ namespace souffle {
  */
 class AstIO : public AstNode {
 public:
-    AstIO(const AstIO& io) : names(io.names), kvps(io.kvps) {}
+    AstIO(const AstIO& io) : name(io.name), kvps(io.kvps) {}
     AstIO() = default;
+
     void print(std::ostream& os) const override {
-        bool first = true;
-        for (auto& relationName : getNames()) {
-            if (first) {
-                first = false;
-            } else {
-                os << ',';
-            }
-            os << relationName;
+        os << name;
+        if (!kvps.empty()) {
+           os << "(" << join(kvps, ",") << ")"; 
         }
-        if (kvps.empty()) {
-            return;
-        }
-        os << "(";
-        first = true;
-        for (auto& pair : kvps) {
-            if (first) {
-                first = false;
-            } else {
-                os << ',';
-            }
-            os << pair.first << "=\"" << pair.second << "\"";
-        }
-        os << ')';
     }
 
-    /** Return the name of this kvp map */
+    /** relation name of I/O-directive */
     const AstRelationIdentifier& getName() const {
-        return *names.begin();
+        return name; 
     }
 
-    /** Return the names of this kvp map */
-    const std::set<AstRelationIdentifier>& getNames() const {
-        return names;
-    }
-
-    /** Set kvp map name */
-    void addName(const AstRelationIdentifier& name) {
-        names.insert(name);
-    }
-    /** Set kvp map name */
+    /** set relation name of I/O-directive */
     void setName(const AstRelationIdentifier& name) {
-        names.clear();
-        names.insert(name);
+        this->name = name;
     }
 
-    /** Add kvp */
+    /** add key-value pair */
     void addKVP(const std::string& key, const std::string& value) {
         kvps[key] = unescape(value);
     }
 
-    /** Get IO directive map */
+    /** get I/O-directive map */
     const std::map<std::string, std::string>& getIODirectiveMap() const {
         return kvps;
     }
 
     AstIO* clone() const override {
         auto res = new AstIO();
-        res->names = names;
+        res->name = name;
         res->kvps = kvps;
         res->setSrcLoc(getSrcLoc());
         return res;
@@ -119,13 +91,13 @@ protected:
     bool equal(const AstNode& node) const override {
         assert(nullptr != dynamic_cast<const AstIO*>(&node));
         const auto& other = static_cast<const AstIO&>(node);
-        return other.names == names && other.kvps == kvps;
+        return other.name == name && other.kvps == kvps;
     }
 
-    /** Name of the kvp */
-    std::set<AstRelationIdentifier> names;
+    /** relation name of I/O directive */
+    AstRelationIdentifier name;
 
-    /** kvp map */
+    /** key-value pair map */
     std::map<std::string, std::string> kvps;
 };
 
@@ -147,7 +119,7 @@ public:
 
     AstStore* clone() const override {
         auto res = new AstStore();
-        res->names = names;
+        res->name = name;
         res->kvps = kvps;
         res->setSrcLoc(getSrcLoc());
         return res;
@@ -172,7 +144,7 @@ public:
 
     AstLoad* clone() const override {
         auto res = new AstLoad();
-        res->names = names;
+        res->name = name;
         res->kvps = kvps;
         res->setSrcLoc(getSrcLoc());
         return res;
@@ -199,7 +171,7 @@ public:
 
     AstPrintSize* clone() const override {
         auto res = new AstPrintSize();
-        res->names = names;
+        res->name = name;
         res->kvps = kvps;
         res->setSrcLoc(getSrcLoc());
         return res;

--- a/src/AstIOTypeAnalysis.cpp
+++ b/src/AstIOTypeAnalysis.cpp
@@ -24,39 +24,24 @@ namespace souffle {
 
 void IOType::run(const AstTranslationUnit& translationUnit) {
     visitDepthFirst(*translationUnit.getProgram(), [&](const AstLoad& directive) {
-        if (directive.getNames().empty()) {
-            return;
-        }
-
         auto* relation = translationUnit.getProgram()->getRelation(directive.getName());
         if (relation == nullptr) {
             return;
         }
-
         inputRelations.insert(relation);
     });
     visitDepthFirst(*translationUnit.getProgram(), [&](const AstStore& directive) {
-        if (directive.getNames().empty()) {
-            return;
-        }
-
         auto* relation = translationUnit.getProgram()->getRelation(directive.getName());
         if (relation == nullptr) {
             return;
         }
-
         outputRelations.insert(relation);
     });
     visitDepthFirst(*translationUnit.getProgram(), [&](const AstPrintSize& directive) {
-        if (directive.getNames().empty()) {
-            return;
-        }
-
         auto* relation = translationUnit.getProgram()->getRelation(directive.getName());
         if (relation == nullptr) {
             return;
         }
-
         printSizeRelations.insert(relation);
     });
 }

--- a/src/MagicSet.cpp
+++ b/src/MagicSet.cpp
@@ -1144,7 +1144,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
                     IODirectives inputDirectives;  // to more easily work with the directive
                     auto* newDirective = new AstLoad();
                     inputDirectives.setRelationName(newRelName.getNames()[0]);
-                    newDirective->addName(newRelName);
+                    newDirective->setName(newRelName);
                     visitDepthFirst(*program, [&](const AstLoad& current) {
                         if (current.getName() == originalName) {
                             for (const auto& currentPair : current.getIODirectiveMap()) {

--- a/src/Util.h
+++ b/src/Util.h
@@ -1191,6 +1191,25 @@ inline std::string identifier(std::string id) {
     return id;
 }
 
+/** string operation for I/O directives */
+std::string unescape(const std::string& inputString) const {
+    std::string unescaped = unescape(inputString, "\\\"", "\"");
+    unescaped = unescape(unescaped, "\\t", "\t");
+    unescaped = unescape(unescaped, "\\r", "\r");
+    unescaped = unescape(unescaped, "\\n", "\n");
+    return unescaped;
+}
+
+std::string unescape(
+        const std::string& inputString, const std::string& needle, const std::string& replacement) const {
+    std::string result = inputString;
+    size_t pos = 0;
+    while ((pos = result.find(needle, pos)) != std::string::npos) {
+        result = result.replace(pos, needle.length(), replacement);
+        pos += replacement.length();
+    }
+    return result;
+}
 // -------------------------------------------------------------------------------
 //                              Hint / Cache
 // -------------------------------------------------------------------------------

--- a/src/Util.h
+++ b/src/Util.h
@@ -1192,16 +1192,8 @@ inline std::string identifier(std::string id) {
 }
 
 /** string operation for I/O directives */
-std::string unescape(const std::string& inputString) const {
-    std::string unescaped = unescape(inputString, "\\\"", "\"");
-    unescaped = unescape(unescaped, "\\t", "\t");
-    unescaped = unescape(unescaped, "\\r", "\r");
-    unescaped = unescape(unescaped, "\\n", "\n");
-    return unescaped;
-}
-
-std::string unescape(
-        const std::string& inputString, const std::string& needle, const std::string& replacement) const {
+inline std::string unescape(
+        const std::string& inputString, const std::string& needle, const std::string& replacement) {
     std::string result = inputString;
     size_t pos = 0;
     while ((pos = result.find(needle, pos)) != std::string::npos) {
@@ -1210,6 +1202,15 @@ std::string unescape(
     }
     return result;
 }
+
+inline std::string unescape(const std::string& inputString) {
+    std::string unescaped = unescape(inputString, "\\\"", "\"");
+    unescaped = unescape(unescaped, "\\t", "\t");
+    unescaped = unescape(unescaped, "\\r", "\r");
+    unescaped = unescape(unescaped, "\\n", "\n");
+    return unescaped;
+}
+
 // -------------------------------------------------------------------------------
 //                              Hint / Cache
 // -------------------------------------------------------------------------------

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -281,19 +281,19 @@ unit
         for (auto* cur : $relation_decl) {
             if ((cur->getQualifier() & INPUT_RELATION) != 0) {
                 auto load = std::make_unique<AstLoad>();
-                load->addName(cur->getName());
+                load->setName(cur->getName());
                 load->setSrcLoc(cur->getSrcLoc());
                 driver.addLoad(std::move(load));
             }
             if ((cur->getQualifier() & OUTPUT_RELATION) != 0) {
                 auto store = std::make_unique<AstStore>();
-                store->addName(cur->getName());
+                store->setName(cur->getName());
                 store->setSrcLoc(cur->getSrcLoc());
                 driver.addStore(std::move(store));
             }
             if ((cur->getQualifier() & PRINTSIZE_RELATION) != 0) {
                 auto printSize = std::make_unique<AstPrintSize>();
-                printSize->addName(cur->getName());
+                printSize->setName(cur->getName());
                 printSize->setSrcLoc(cur->getSrcLoc());
                 driver.addStore(std::move(printSize));
             }
@@ -1434,19 +1434,19 @@ component_body
         for (auto* rel : $relation_decl) {
             if ((rel->getQualifier() & INPUT_RELATION) != 0) {
                 auto load = std::make_unique<AstLoad>();
-                load->addName(rel->getName());
+                load->setName(rel->getName());
                 load->setSrcLoc(rel->getSrcLoc());
                 driver.addLoad(std::move(load));
             }
             if ((rel->getQualifier() & OUTPUT_RELATION) != 0) {
                 auto store = std::make_unique<AstStore>();
-                store->addName(rel->getName());
+                store->setName(rel->getName());
                 store->setSrcLoc(rel->getSrcLoc());
                 driver.addStore(std::move(store));
             }
             if ((rel->getQualifier() & PRINTSIZE_RELATION) != 0) {
                 auto printSize = std::make_unique<AstPrintSize>();
-                printSize->addName(rel->getName());
+                printSize->setName(rel->getName());
                 printSize->setSrcLoc(rel->getSrcLoc());
                 driver.addStore(std::move(printSize));
             }


### PR DESCRIPTION
- There was an issue that a set of relation names was used but we have only a single relation name per I/O directive. 
- The printing was clumsy
- Pushed unescape to Util.h