### PR TITLE
Small improvements to `-g` mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -593,8 +593,7 @@ int main(int argc, char** argv) {
             std::string sourceFilename = baseFilename + ".cpp";
 
             bool withSharedLibrary;
-            const bool emitToStdOut =
-                    Global::config().has("generate") && Global::config().get("generate") == "-";
+            const bool emitToStdOut = Global::config().has("generate", "-");
             if (emitToStdOut)
                 synthesiser->generateCode(std::cout, baseIdentifier, withSharedLibrary);
             else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -597,7 +597,7 @@ int main(int argc, char** argv) {
             if (emitToStdOut)
                 synthesiser->generateCode(std::cout, baseIdentifier, withSharedLibrary);
             else {
-                std::ofstream os{baseFilename + ".cpp"};
+                std::ofstream os{sourceFilename};
                 synthesiser->generateCode(os, baseIdentifier, withSharedLibrary);
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -593,11 +593,12 @@ int main(int argc, char** argv) {
             std::string sourceFilename = baseFilename + ".cpp";
 
             bool withSharedLibrary;
-            const bool emitToStdOut = Global::config().has("generate") && Global::config().get("generate") == "-";
+            const bool emitToStdOut =
+                    Global::config().has("generate") && Global::config().get("generate") == "-";
             if (emitToStdOut)
                 synthesiser->generateCode(std::cout, baseIdentifier, withSharedLibrary);
             else {
-                std::ofstream os { baseFilename + ".cpp" };
+                std::ofstream os{baseFilename + ".cpp"};
                 synthesiser->generateCode(os, baseIdentifier, withSharedLibrary);
             }
 


### PR DESCRIPTION
1) `-g` now matches `-D`: handles `-` as stdout.
2) `-g` no longer depends on `souffle-compile`.