### PR TITLE
Fix Inline bug / accessing invalid vector

### DIFF
--- a/src/InlineRelationsTransformer.cpp
+++ b/src/InlineRelationsTransformer.cpp
@@ -836,9 +836,11 @@ NullableVector<std::vector<AstLiteral*>> getInlinedLiteral(AstProgram& program, 
                 addedBodyLiterals = formNegatedLiterals(program, atom);
             }
         }
-        for (const auto& curVec : atomVersions.getVector()) {
-            for (auto* cur : curVec) {
-                delete cur;
+        if (atomVersions.isValid()) {
+            for (const auto& curVec : atomVersions.getVector()) {
+                for (auto* cur : curVec) {
+                    delete cur;
+                }
             }
         }
     } else if (auto* constraint = dynamic_cast<AstBinaryConstraint*>(lit)) {


### PR DESCRIPTION
In a large codebase, an assertion about an invalid state is triggered. This fix checks the state of the vector first before iterating over its elements. 