### PR TITLE
Refactoring AST

### DIFF
--- a/src/AstAbstract.h
+++ b/src/AstAbstract.h
@@ -33,6 +33,14 @@ public:
 };
 
 /**
+ * Logical constraint
+ */
+class AstConstraint : public AstLiteral {
+public:
+    AstConstraint* clone() const override = 0;
+};
+
+/**
  * Argument
  */
 class AstArgument : public AstNode {

--- a/src/AstLiteral.h
+++ b/src/AstLiteral.h
@@ -81,17 +81,7 @@ public:
 
     void print(std::ostream& os) const override {
         os << getQualifiedName() << "(";
-
-        for (size_t i = 0; i < arguments.size(); ++i) {
-            if (i != 0) {
-                os << ",";
-            }
-            if (arguments[i] != nullptr) {
-                arguments[i]->print(os);
-            } else {
-                os << "_";
-            }
-        }
+        os << join(arguments, ",", print_deref<std::unique_ptr<AstArgument>>());
         os << ")";
     }
 
@@ -222,17 +212,6 @@ protected:
 };
 
 /**
- * Subclass of Literal that represents a logical constraint
- */
-class AstConstraint : public AstLiteral {
-public:
-    /** Negates the constraint */
-    virtual void negate() = 0;
-
-    AstConstraint* clone() const override = 0;
-};
-
-/**
  * Subclass of Constraint that represents a constant 'true'
  * or 'false' value.
  *
@@ -246,8 +225,8 @@ public:
         return truthValue;
     }
 
-    void negate() override {
-        truthValue = !truthValue;
+    void set(bool value) {
+        truthValue = value;
     }
 
     void print(std::ostream& os) const override {
@@ -303,11 +282,6 @@ public:
     /** Update the binary operator */
     void setOperator(BinaryConstraintOp op) {
         operation = op;
-    }
-
-    /** Negates the constraint */
-    void negate() override {
-        setOperator(souffle::negatedConstraintOp(operation));
     }
 
     /** Check whether constraint is a numeric constraint */

--- a/src/AstParserUtils.cpp
+++ b/src/AstParserUtils.cpp
@@ -17,6 +17,7 @@
 #include "AstParserUtils.h"
 #include "AstClause.h"
 #include "AstNode.h"
+#include "AstUtils.h"
 #include "Util.h"
 #include <memory>
 #include <ostream>
@@ -92,7 +93,7 @@ std::vector<AstClause*> RuleBody::toClauseBodies() const {
                     base = new AstNegation(std::unique_ptr<AstAtom>(atom));
                     base->setSrcLoc(atom->getSrcLoc());
                 } else if (auto* cstr = dynamic_cast<AstConstraint*>(base)) {
-                    cstr->negate();
+                    negateConstraint(cstr);
                 }
             }
 

--- a/src/AstProgram.h
+++ b/src/AstProgram.h
@@ -49,55 +49,29 @@ class AstIO;
 class AstProgram : public AstNode {
 public:
     void print(std::ostream& os) const override {
-        for (const auto& cur : types) {
-            os << *cur << "\n";
+        if (!pragmaDirectives.empty()) {
+            os << join(pragmaDirectives, "\n\n", print_deref<std::unique_ptr<AstPragma>>()) << "\n";
         }
         if (!components.empty()) {
-            for (const auto& cur : components) {
-                os << *cur << "\n";
-            }
+            os << join(components, "\n", print_deref<std::unique_ptr<AstComponent>>()) << "\n";
         }
         if (!instantiations.empty()) {
-            os << "\n";
-            for (const auto& cur : instantiations) {
-                os << *cur << "\n";
-            }
+            os << join(instantiations, "\n", print_deref<std::unique_ptr<AstComponentInit>>()) << "\n";
         }
-
-        for (const auto& f : functors) {
-            os << "\n\n// -- " << f->getName() << " --\n";
-            f->print(os);
-            os << "\n";
+        if (!types.empty()) {
+            os << join(types, "\n", print_deref<std::unique_ptr<AstType>>()) << "\n";
         }
-
-        // print declared relations and their corresponding clauses
-        std::set<AstQualifiedName> declaredRelations;
-        for (const auto& rel : relations) {
-            declaredRelations.insert(rel->getQualifiedName());
-            os << "\n\n// -- " << rel->getQualifiedName() << " --\n";
-            os << *rel << "\n\n";
-            for (const auto& clause : clauses) {
-                if (clause->getHead()->getQualifiedName() == rel->getQualifiedName()) {
-                    os << *clause << "\n\n";
-                }
-            }
+        if (!functors.empty()) {
+            os << join(functors, "\n", print_deref<std::unique_ptr<AstFunctorDeclaration>>()) << "\n";
         }
-
-        // print clauses without a corresponding relation declaration
-        for (const auto& clause : clauses) {
-            if (!contains(declaredRelations, clause->getHead()->getQualifiedName())) {
-                os << *clause << "\n\n";
-            }
+        if (!relations.empty()) {
+            os << join(relations, "\n", print_deref<std::unique_ptr<AstRelation>>()) << "\n";
         }
-
+        if (!clauses.empty()) {
+            os << join(clauses, "\n\n", print_deref<std::unique_ptr<AstClause>>()) << "\n";
+        }
         if (!ios.empty()) {
             os << join(ios, "\n\n", print_deref<std::unique_ptr<AstIO>>()) << "\n";
-        }
-
-        if (!pragmaDirectives.empty()) {
-            for (const auto& cur : pragmaDirectives) {
-                os << *cur << "\n";
-            }
         }
     }
 

--- a/src/AstUtils.cpp
+++ b/src/AstUtils.cpp
@@ -226,7 +226,7 @@ void negateConstraint(AstConstraint* constraint) {
     } else if (auto* cstr = dynamic_cast<AstBinaryConstraint*>(constraint)) {
         cstr->setOperator(souffle::negatedConstraintOp(cstr->getOperator()));
     } else {
-        assert("Unknown ast-constraint type");
+        assert(false && "Unknown ast-constraint type");
     }
 }
 

--- a/src/AstUtils.cpp
+++ b/src/AstUtils.cpp
@@ -218,4 +218,16 @@ AstClause* reorderAtoms(const AstClause* clause, const std::vector<unsigned int>
 
     return newClause;
 }
+
+void negateConstraint(AstConstraint* constraint) {
+    assert(nullptr != dynamic_cast<AstConstraint*>(constraint) && "not a constraint object");
+    if (auto* bcstr = dynamic_cast<AstBooleanConstraint*>(constraint)) {
+        bcstr->set(!bcstr->isTrue());
+    } else if (auto* cstr = dynamic_cast<AstBinaryConstraint*>(constraint)) {
+        cstr->setOperator(souffle::negatedConstraintOp(cstr->getOperator()));
+    } else {
+        assert("Unknown ast-constraint type");
+    }
+}
+
 }  // end of namespace souffle

--- a/src/AstUtils.h
+++ b/src/AstUtils.h
@@ -25,6 +25,7 @@ namespace souffle {
 // some forward declarations
 class AstAtom;
 class AstClause;
+class AstConstraint;
 class AstFunctorDeclaration;
 class AstLiteral;
 class AstNode;
@@ -218,4 +219,12 @@ AstClause* cloneHead(const AstClause* clause);
  * @param newOrder new order of atoms; atoms[i] = atoms[newOrder[i]]
  */
 AstClause* reorderAtoms(const AstClause* clause, const std::vector<unsigned int>& newOrder);
+
+/**
+ * Negate an ast constraint
+ *
+ * @param constraint constraint that will be negated
+ */
+void negateConstraint(AstConstraint* constraint);
+
 }  // end of namespace souffle

--- a/src/InlineRelationsTransformer.cpp
+++ b/src/InlineRelationsTransformer.cpp
@@ -344,7 +344,7 @@ AstLiteral* negateLiteral(AstLiteral* lit) {
         return atom;
     } else if (auto* cons = dynamic_cast<AstConstraint*>(lit)) {
         AstConstraint* newCons = cons->clone();
-        newCons->negate();
+        negateConstraint(newCons);
         return newCons;
     } else {
         assert(false && "Unsupported literal type!");


### PR DESCRIPTION
Related to issue #1255.

 - Negate() method was pushed out of the AstConstraint class and put into AstUtils. 
 - Refactored print method for AstProgram
