### PR TITLE
Fix `int` overflow in `RamIndexAnalysis::getSearchSignature`

### DIFF
--- a/src/RamIndexAnalysis.cpp
+++ b/src/RamIndexAnalysis.cpp
@@ -349,7 +349,7 @@ SearchSignature searchSignature(Iter const& bgn, Iter const& end) {
     size_t i = 0;
     for (auto cur = bgn; cur != end; ++cur, ++i) {
         if (!isRamUndefValue(*cur)) {
-            keys |= SearchSignature(i) << i;
+            keys |= SearchSignature(1) << i;
         }
     }
     return keys;
@@ -372,7 +372,7 @@ SearchSignature RamIndexAnalysis::getSearchSignature(
 
     // values.size() - auxiliaryArity because we discard the height annotations
     auto const numSig = values.size() - auxiliaryArity;
-    return searchSignature(values.begin(), values.end() + numSig);
+    return searchSignature(values.begin(), values.begin() + numSig);
 }
 
 SearchSignature RamIndexAnalysis::getSearchSignature(const RamExistenceCheck* existCheck) const {

--- a/src/RamIndexAnalysis.cpp
+++ b/src/RamIndexAnalysis.cpp
@@ -346,11 +346,10 @@ SearchSignature searchSignature(Iter const& bgn, Iter const& end) {
     SearchSignature keys = 0;
     assert(std::distance(bgn, end) <= MAX_SEARCH_KEYS && "too many patterns for index signature");
 
-    for (auto cur = bgn; cur != end; ++cur) {
-        keys <<= 1;
-
+    size_t i = 0;
+    for (auto cur = bgn; cur != end; ++cur, ++i) {
         if (!isRamUndefValue(*cur)) {
-            keys |= 1;
+            keys |= SearchSignature(i) << i;
         }
     }
     return keys;

--- a/src/RamIndexAnalysis.cpp
+++ b/src/RamIndexAnalysis.cpp
@@ -347,11 +347,11 @@ SearchSignature searchSignature(Iter const& bgn, Iter const& end) {
     assert(std::distance(bgn, end) <= MAX_SEARCH_KEYS && "too many patterns for index signature");
 
     for (auto cur = bgn; cur != end; ++cur) {
+        keys <<= 1;
+
         if (!isRamUndefValue(*cur)) {
             keys |= 1;
         }
-
-        keys <<= 1;
     }
     return keys;
 }
@@ -381,7 +381,7 @@ SearchSignature RamIndexAnalysis::getSearchSignature(const RamExistenceCheck* ex
 }
 
 SearchSignature RamIndexAnalysis::getSearchSignature(const RamRelation* ramRel) const {
-    assert(ramRel->getArity() < MAX_SEARCH_KEYS && "relation is too big to fit in search key");
+    assert(ramRel->getArity() <= MAX_SEARCH_KEYS && "relation is too big to fit in search key");
     return (SearchSignature(1) << ramRel->getArity()) - 1;
 }
 


### PR DESCRIPTION
What it says on the tin.