### PR TITLE
GCC-9 `-Wextra` clean + tests cpps

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 dnl Do not set default CFLAGS and CXXFLAGS
 ENV_CXXFLAGS="$CXXFLAGS"
-CXXFLAGS=" -Wall "
+CXXFLAGS=" -Wall -Wextra "
 
 # Disable provenance
 AC_ARG_ENABLE(

--- a/src/ExplainTree.h
+++ b/src/ExplainTree.h
@@ -42,8 +42,8 @@ public:
 
     // write into screen buffer at a specific location
     void write(uint32_t x, uint32_t y, const std::string& s) {
-        assert(x >= 0 && x < width && "wrong x dimension");
-        assert(y >= 0 && y < height && "wrong y dimension");
+        assert(x < width && "wrong x dimension");
+        assert(y < height && "wrong y dimension");
         assert(x + s.length() <= width && "string too long");
         for (size_t i = 0; i < s.length(); i++) {
             buffer[y * width + x + i] = s[i];

--- a/src/MinimiseProgramTransformer.cpp
+++ b/src/MinimiseProgramTransformer.cpp
@@ -134,11 +134,6 @@ std::vector<std::vector<unsigned int>> extractPermutations(
  * NOTE: index 0 refers to the head atom, index 1 to the first body atom, and so on.
  */
 bool isValidMove(const AstClause* left, size_t leftIdx, const AstClause* right, size_t rightIdx) {
-    // invalid indices
-    if (leftIdx < 0 || rightIdx < 0) {
-        return false;
-    }
-
     // handle the case where one of the indices refers to the head
     if (leftIdx == 0 && rightIdx == 0) {
         const AstAtom* leftHead = left->getHead();

--- a/src/SynthesiserRelation.cpp
+++ b/src/SynthesiserRelation.cpp
@@ -192,7 +192,7 @@ void SynthesiserDirectRelation::computeIndices() {
         masterIndex = 0;
     }
 
-    assert(masterIndex >= 0 && masterIndex < inds.size());
+    assert(masterIndex < inds.size());
 
     computedIndices = inds;
 }

--- a/src/test/brie_test.cpp
+++ b/src/test/brie_test.cpp
@@ -317,11 +317,11 @@ TEST(SparseArray, LowerBound) {
 }
 
 TEST(SparseArray, LowerBound2) {
-    for (int m = 0; m < 256; ++m) {
-        SparseArray<int> a;
-        std::set<int> r;
+    for (uint32_t m = 0; m < 256; ++m) {
+        SparseArray<uint32_t> a;
+        std::set<uint32_t> r;
 
-        for (int i = 0; i < 8; i++) {
+        for (uint32_t i = 0; i < 8; i++) {
             if (!(m & (1 << i))) {
                 continue;
             }
@@ -329,7 +329,7 @@ TEST(SparseArray, LowerBound2) {
             r.insert(i * 100);
         }
 
-        for (int i = 0; i < 10; i++) {
+        for (uint32_t i = 0; i < 10; i++) {
             auto a_res = a.lowerBound(i * 100);
             auto r_res = r.lower_bound(i * 100);
 
@@ -397,11 +397,11 @@ TEST(SparseArray, UpperBound) {
 }
 
 TEST(SparseArray, UpperBound2) {
-    for (int m = 0; m < 256; ++m) {
-        SparseArray<int> a;
-        std::set<int> r;
+    for (uint32_t m = 0; m < 256; ++m) {
+        SparseArray<uint32_t> a;
+        std::set<uint32_t> r;
 
-        for (int i = 0; i < 8; i++) {
+        for (uint32_t i = 0; i < 8; i++) {
             if (!(m & (1 << i))) {
                 continue;
             }
@@ -409,7 +409,7 @@ TEST(SparseArray, UpperBound2) {
             r.insert(i * 100);
         }
 
-        for (int i = 0; i < 10; i++) {
+        for (uint32_t i = 0; i < 10; i++) {
             auto a_res = a.upperBound(i * 100);
             auto r_res = r.upper_bound(i * 100);
 

--- a/src/test/eqrel_datastructure_test.cpp
+++ b/src/test/eqrel_datastructure_test.cpp
@@ -535,7 +535,7 @@ TEST(LambdaBTreeTest, Insert) {
     // now lets insert something that already exists (the anterior is all that matters)
     TestPair alreadyExistsPair = {55, 12313123};
     EXPECT_EQ(t.insert(alreadyExistsPair,
-                      [&](TestPair& tp) {
+                      [&](TestPair&) {
                           EXPECT_TRUE(false &&
                                       "newly inserted function called for an element that already exists!");
                           // some dummy value

--- a/src/test/eqrel_datastructure_test.cpp
+++ b/src/test/eqrel_datastructure_test.cpp
@@ -241,7 +241,7 @@ TEST(PiggyTest, ParallelAppend) {
     EXPECT_EQ(verifier.size(), N);
     // check every element within the inserted range exists
     for (size_t e : verifier) {
-        EXPECT_TRUE(e >= 0 && e < N);
+        EXPECT_TRUE(e < N);
     }
 }
 

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -112,7 +112,7 @@ public:
      * Same as check() except in case of a condition that evaluates to false, the method
      * aborts the test.
      */
-    std::ostream& fatal(bool condition, const std::string& txt, const std::string& loc) {
+    std::ostream& fatal(bool condition, const std::string& /* txt */, const std::string& /* loc */) {
         if (!condition) {
             std::cerr << "Tests failed.\n";
             exit(99);
@@ -208,7 +208,7 @@ public:
 /**
  * Main program of a unit test
  */
-int main(int argc, char** argv) {
+int main(int /* argc */, char** /* argv */) {
     // add all groups to a set
     std::set<std::string> groups;
     for (TestCase* p = base; p != nullptr; p = p->nextTestCase()) {

--- a/src/test/util_test.cpp
+++ b/src/test/util_test.cpp
@@ -61,7 +61,7 @@ TEST(Util, printMap) {
 }
 
 TEST(Util, LambdaTraits) {
-    auto lambda = [](int x) -> bool { return true; };
+    auto lambda = [](int) -> bool { return true; };
 
     EXPECT_EQ(typeid(bool).name(), typeid(lambda_traits<decltype(lambda)>::result_type).name());
     EXPECT_EQ(typeid(int).name(), typeid(lambda_traits<decltype(lambda)>::arg0_type).name());


### PR DESCRIPTION
Test files weren't included in previous warning-cleanup PRs since I was using a custom CMakeLists.txt which didn't include them.