### PR TITLE
Fix clang compilation

### DIFF
--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1253,8 +1253,8 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             // if it is total we use the contains function
             if (isa->isTotalSignature(&exists)) {
                 out << relName << "->"
-                    << "contains(Tuple<RamDomain," << arity << ">{{" << join(exists.getValues(), ",", rec)
-                    << "}}," << ctxName << ")" << after;
+                    << "contains(Tuple<RamDomain," << arity << ">{{ramBitCast("
+                    << join(exists.getValues(), "),ramBitCast(", rec) << ")}}," << ctxName << ")" << after;
                 PRINT_END_COMMENT(out);
                 return;
             }


### PR DESCRIPTION
Newer versions of clang disagree with our synthesised code now, e.g., tests/semantic/type_system5 produces this error
```
error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'int'
in initializer list [-Wc++11-narrowing]
... Tuple<RamDomain,1>{{(env0[0]) + (RamUnsigned(1))}} ...
```

This PR is to wrap synthesised initialiser list elements with a cast so the result is valid.
```
... Tuple<RamDomain,1>{{(env0[0]) + (RamUnsigned(1))}} ...
```
becomes
```
... Tuple<RamDomain, 1>{{ramBitCast((env0[0]) + (RamUnsigned(1)))}} ...
```
Note that we're still adding a RamDomain to a RamUnsigned, so there may be more to do.