### PR TITLE
Fixing verbose flag for RAM transformers and fixing debug report

### DIFF
--- a/src/RamTranslationUnit.h
+++ b/src/RamTranslationUnit.h
@@ -49,13 +49,23 @@ public:
     /** @brief templated method to compute/retrieve an analysis for a translation unit */
     template <class Analysis>
     Analysis* getAnalysis() const {
+        static const bool debug = Global::config().has("debug-report");
         std::string name = Analysis::name;
         auto it = analyses.find(name);
         if (it == analyses.end()) {
             // analysis does not exist yet, create instance and run it.
             auto analysis = std::make_unique<Analysis>(Analysis::name);
             analysis->run(*this);
-            // Check it hasn't been created by someone else, and insert if not
+            // output analysis in debug report
+            if (debug) {
+                std::stringstream ramAnalysisStr;
+                ramAnalysisStr << *analysis;
+                if (!ramAnalysisStr.str().empty()) {
+                    debugReport.addSection(
+                            analysis->getName(), "RAM Analysis " + analysis->getName(), ramAnalysisStr.str());
+                }
+            }
+            // check it hasn't been created by someone else, and insert if not
             it = analyses.find(name);
             if (it == analyses.end()) {
                 analyses[name] = std::move(analysis);


### PR DESCRIPTION
This is related to issue #1255.

 - RAM Transformers did not report on runtime and whether they changed the RAM program with the verbose flag enabled. This PR fixes that issue. 

 - The output of RAM analysis to the debug report is moved to getAnalysis()
