### PR TITLE
DRAFT: polymorphic aggregates + `mean` aggregate

### DIFF
--- a/src/AggregateOp.h
+++ b/src/AggregateOp.h
@@ -24,6 +24,7 @@ enum class AggregateOp {
     min,
     count,
     sum,
+    mean,
 };
 
 }  // namespace souffle

--- a/src/AstArgument.h
+++ b/src/AstArgument.h
@@ -509,6 +509,16 @@ public:
         return expression.get();
     }
 
+    /** Sets/caches the target expression's type */
+    void setTargetExpressionType(TypeAttribute type) {
+        expressionType = type;
+    }
+
+    /** Get target expression's type, if cached/computed */
+    std::optional<TypeAttribute> getTargetExpressionType() const {
+        return expressionType;
+    }
+
     /** Get body literals */
     std::vector<AstLiteral*> getBodyLiterals() const {
         return toPtrVector(body);
@@ -537,10 +547,9 @@ public:
 
     AstAggregator* clone() const override {
         auto res = new AstAggregator(fun);
-        res->expression = (expression) ? std::unique_ptr<AstArgument>(expression->clone()) : nullptr;
-        for (const auto& cur : body) {
-            res->body.emplace_back(cur->clone());
-        }
+        res->body = souffle::clone(body);
+        res->expression = souffle::clone(expression);
+        res->expressionType = expressionType;
         res->setSrcLoc(getSrcLoc());
         return res;
     }
@@ -588,7 +597,8 @@ protected:
     bool equal(const AstNode& node) const override {
         assert(nullptr != dynamic_cast<const AstAggregator*>(&node));
         const auto& other = static_cast<const AstAggregator&>(node);
-        return fun == other.fun && equal_ptr(expression, other.expression) && equal_targets(body, other.body);
+        return fun == other.fun && equal_ptr(expression, other.expression) &&
+               expressionType == other.expressionType && equal_targets(body, other.body);
     }
 
 private:
@@ -597,6 +607,9 @@ private:
 
     /** Aggregation expression */
     std::unique_ptr<AstArgument> expression;
+
+    /** Aggregation expression type */
+    std::optional<TypeAttribute> expressionType;
 
     /** Body literal of sub-query */
     std::vector<std::unique_ptr<AstLiteral>> body;

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -808,11 +808,12 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
             aggCondition = std::make_unique<RamTrue>();
         }
 
+        assert(cur->getTargetExpressionType() && "need type info regarding agg expr");
+
         // add Ram-Aggregation layer
-        std::unique_ptr<RamAggregate> aggregate =
-                std::make_unique<RamAggregate>(std::move(op), cur->getOperator(),
-                        translator.translateRelation(atom), std::move(expr), std::move(aggCondition), level);
-        op = std::move(aggregate);
+        op = std::make_unique<RamAggregate>(std::move(op), cur->getOperator(),
+                translator.translateRelation(atom), std::move(expr), *cur->getTargetExpressionType(),
+                std::move(aggCondition), level);
     }
 
     // build operation bottom-up

--- a/src/InterpreterEngine.cpp
+++ b/src/InterpreterEngine.cpp
@@ -1285,15 +1285,14 @@ bool InterpreterEngine::executeAggregate(InterpreterContext& ctxt, const Aggrega
             exit(EXIT_FAILURE);                                   \
     } }();
 #define FOLD_NUMERIC(op_num)                                      \
-    ([&]() { switch (agg.getExpressionType()) {                   \
+    [&]() { switch (agg.getExpressionType()) {                    \
         case TypeAttribute::Signed  : FOLDL(RamSigned  , op_num); \
         case TypeAttribute::Unsigned: FOLDL(RamUnsigned, op_num); \
         case TypeAttribute::Float   : FOLDL(RamFloat   , op_num); \
         default:                                                  \
             assert(false && "non-numeric type found");            \
             exit(EXIT_FAILURE);                                   \
-            return std::make_pair<size_t, RamDomain>(0, 0);       \
-    } })();
+    } }();
     // clang-format on
 
     switch (agg.getFunction()) {

--- a/src/InterpreterEngine.cpp
+++ b/src/InterpreterEngine.cpp
@@ -1322,7 +1322,10 @@ bool InterpreterEngine::executeAggregate(InterpreterContext& ctxt, const Aggrega
         case AggregateOp::mean: {
             auto result = FOLD_NUMERIC([](auto a, auto b) { return a + b; });
 
-            if (result.first != 0 && agg.getFunction() == AggregateOp::mean) {
+            if (agg.getFunction() == AggregateOp::mean) {
+                // fail the `mean` aggregate if there isn't at least one match
+                if (result.first == 0) return false;
+
                 switch (agg.getExpressionType()) {
                     case TypeAttribute::Signed:
                         result.second =
@@ -1342,6 +1345,7 @@ bool InterpreterEngine::executeAggregate(InterpreterContext& ctxt, const Aggrega
                 }
             }
 
+            // `sum` has historically succeeded w/ zero when there are no matches
             return runNested(result.second);
         }
     }

--- a/src/InterpreterEngine.h
+++ b/src/InterpreterEngine.h
@@ -75,6 +75,10 @@ private:
     RamTranslationUnit& getTranslationUnit();
     /** @brief Execute the program */
     RamDomain execute(const InterpreterNode*, InterpreterContext&);
+    /** @brief Executes an aggregation */
+    template <typename Aggregate>
+    bool executeAggregate(InterpreterContext&, const Aggregate&, const InterpreterNode& filter,
+            const InterpreterNode& expr, const InterpreterNode& nested_op, Stream);
     /** @brief Return method handler */
     void* getMethodHandle(const std::string& method);
     /** @brief Load DLL */

--- a/src/RamTransforms.cpp
+++ b/src/RamTransforms.cpp
@@ -320,10 +320,9 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteAggregate(const RamAg
         std::unique_ptr<RamCondition> condition = constructPattern(
                 queryPattern, indexable, toConjunctionList(&agg->getCondition()), identifier);
         if (indexable) {
-            return std::make_unique<RamIndexAggregate>(
-                    std::unique_ptr<RamOperation>(agg->getOperation().clone()), agg->getFunction(),
-                    std::make_unique<RamRelationReference>(&rel),
-                    std::unique_ptr<RamExpression>(agg->getExpression().clone()), std::move(condition),
+            return std::make_unique<RamIndexAggregate>(souffle::clone(&agg->getOperation()),
+                    agg->getFunction(), std::make_unique<RamRelationReference>(&rel),
+                    souffle::clone(&agg->getExpression()), agg->getExpressionType(), std::move(condition),
                     std::move(queryPattern), agg->getTupleId());
         }
     }

--- a/src/TypeSystem.h
+++ b/src/TypeSystem.h
@@ -429,9 +429,32 @@ public:
         types.swap(env.types);
     }
 
+    TypeSet const& getNumericTypes() const {
+        if (numericTypes.empty()) {
+            numericTypes.insert(getNumberType());
+            numericTypes.insert(getUnsignedType());
+            numericTypes.insert(getFloatType());
+        }
+
+        return numericTypes;
+    }
+
+    TypeSet const& getOrderedTypes() const {
+        if (orderedTypes.empty()) {
+            orderedTypes = getNumericTypes();
+            orderedTypes.insert(getSymbolType());
+        }
+
+        return orderedTypes;
+    }
+
 private:
     /** The list of covered types */
     std::map<AstQualifiedName, Type*> types;
+
+    // `mutable` as these are lazy-init'd and once init'd immutable
+    mutable TypeSet numericTypes;
+    mutable TypeSet orderedTypes;
 
     /** Register types created by one of the factory functions */
     void addType(Type& type);
@@ -463,7 +486,8 @@ bool eqTypeTypeAttribute(const TypeAttribute ramType, const T& type) {
         case TypeAttribute::Record:
             return isRecordType(type);
     }
-    return false;
+    assert(false && "unhandled `TypeAttribute`");
+    exit(EXIT_FAILURE);
 }
 
 /**
@@ -495,6 +519,11 @@ TypeAttribute getTypeAttribute(const T& type) {
 template <typename T>  // T = Type or T = Typeset
 inline bool isNumericType(const T& type) {
     return isFloatType(type) || isNumberType(type) || isUnsignedType(type);
+}
+
+template <typename T>  // T = Type or T = Typeset
+inline bool isOrderableType(const T& type) {
+    return isNumericType(type) || isSymbolType(type);
 }
 
 /**

--- a/src/Util.h
+++ b/src/Util.h
@@ -432,6 +432,30 @@ range<Iter> make_range(const Iter& a, const Iter& b) {
 }
 
 // -------------------------------------------------------------------------------
+//                             Cloning Utilities
+// -------------------------------------------------------------------------------
+
+template <typename A>
+std::unique_ptr<A> clone(const A* node) {
+    return node ? std::unique_ptr<A>(node->clone()) : nullptr;
+}
+
+template <typename A>
+std::unique_ptr<A> clone(const std::unique_ptr<A>& node) {
+    return node ? std::unique_ptr<A>(node->clone()) : nullptr;
+}
+
+template <typename A>
+std::vector<std::unique_ptr<A>> clone(const std::vector<std::unique_ptr<A>>& xs) {
+    std::vector<std::unique_ptr<A>> ys;
+    ys.reserve(xs.size());
+    for (auto&& x : xs) {
+        ys.emplace_back(clone(x));
+    }
+    return ys;
+}
+
+// -------------------------------------------------------------------------------
 //                             Equality Utilities
 // -------------------------------------------------------------------------------
 

--- a/src/scanner.ll
+++ b/src/scanner.ll
@@ -96,6 +96,7 @@
 "ftoi"                                { return yy::parser::make_FTOI(yylloc); }
 "ftou"                                { return yy::parser::make_FTOU(yylloc); }
 "match"                               { return yy::parser::make_TMATCH(yylloc); }
+"mean"                                { return yy::parser::make_MEAN(yylloc); }
 "cat"                                 { return yy::parser::make_CAT(yylloc); }
 "ord"                                 { return yy::parser::make_ORD(yylloc); }
 "strlen"                              { return yy::parser::make_STRLEN(yylloc); }


### PR DESCRIPTION
**Superseded by #1366**
I'll leave this open until #1366 lands in `master`.

Features:
`min`, `max`: Now polymorphic across all orderable types.
`sum`: Polymorphic for numeric types.
`mean`: New aggregate. Produces a `float` result regardless of expr's type.

Fixes:
`min`/`max` no longer incorrectly fail to match if the minimum/maximum of an agg set happens to be `INT_MAX`/`INT_MIN` (respectively).

To Do:
Synth is not yet implemented.
Tests are missing.