### PR TITLE
Fix source location display for included files

### DIFF
--- a/src/MagicSet.cpp
+++ b/src/MagicSet.cpp
@@ -178,7 +178,7 @@ SrcLocation nextSrcLoc(SrcLocation orig) {
     pos += 1;
 
     SrcLocation newLoc;
-    newLoc.filename = orig.filename + " [MAGIC_FILE]";
+    newLoc.filenames.back() = orig.filenames.back() + " [MAGIC_FILE]";
     newLoc.start.line = pos;
     newLoc.end.line = pos;
     newLoc.start.column = 0;

--- a/src/MagicSet.cpp
+++ b/src/MagicSet.cpp
@@ -178,7 +178,12 @@ SrcLocation nextSrcLoc(SrcLocation orig) {
     pos += 1;
 
     SrcLocation newLoc;
-    newLoc.filenames.back() = orig.filenames.back() + " [MAGIC_FILE]";
+    newLoc.filenames = orig.filenames;
+    if (orig.filenames.empty()) {
+        newLoc.filenames.emplace_back("[MAGIC_FILE]");
+    } else {
+        newLoc.filenames.back() = orig.filenames.back() + "[MAGIC_FILE]";
+    }
     newLoc.start.line = pos;
     newLoc.end.line = pos;
     newLoc.start.column = 0;

--- a/src/SrcLocation.cpp
+++ b/src/SrcLocation.cpp
@@ -24,7 +24,29 @@
 
 namespace souffle {
 
+std::string getCurrentFilename(const std::vector<std::string>& filenames) {
+    if (filenames.empty()) {
+        return "";
+    }
+
+    std::string path = ".";
+    for (std::string filename : filenames) {
+        if (!filename.empty() && filename[0] == '/') {
+            path = dirName(filename);
+        } else if (existFile(path + "/" + filename)) {
+            path = dirName(path + "/" + filename);
+        } else if (existFile(filename)) {
+            path = dirName(filename);
+        } else {
+            path = ".";
+        }
+    }
+
+    return path + "/" + baseName(filenames.back());
+}
+
 std::string SrcLocation::extloc() const {
+    std::string filename = getCurrentFilename(filenames);
     std::ifstream in(filename);
     std::stringstream s;
     if (in.is_open()) {
@@ -62,9 +84,12 @@ std::string SrcLocation::extloc() const {
         }
         in.close();
     } else {
-        s << "unknown source location.";
+        s << filename << ":" << start.line << ":" << start.column;
     }
     return s.str();
 }
 
+void SrcLocation::print(std::ostream& out) const {
+    out << getCurrentFilename(filenames) << " [" << start << "-" << end << "]";
+}
 }  // end of namespace souffle

--- a/src/SrcLocation.h
+++ b/src/SrcLocation.h
@@ -18,6 +18,7 @@
 
 #include <ostream>
 #include <string>
+#include <vector>
 
 namespace souffle {
 
@@ -53,7 +54,7 @@ public:
     };
 
     /** The file referred to */
-    std::string filename;
+    std::vector<std::string> filenames;
 
     /** The start location */
     Point start = {};
@@ -63,10 +64,10 @@ public:
 
     /** A comparison for source locations */
     bool operator<(const SrcLocation& other) const {
-        if (filename < other.filename) {
+        if (filenames.back() < other.filenames.back()) {
             return true;
         }
-        if (filename > other.filename) {
+        if (filenames.back() > other.filenames.back()) {
             return false;
         }
         if (start < other.start) {
@@ -81,12 +82,25 @@ public:
         return false;
     }
 
+    void setFilename(std::string filename) {
+        if (filenames.empty()) {
+            filenames.emplace_back(filename);
+            return;
+        }
+        if (filenames.back() == filename) {
+            return;
+        }
+        if (filenames.size() > 1 && filenames.at(filenames.size() - 2) == filename) {
+            filenames.pop_back();
+            return;
+        }
+        filenames.emplace_back(filename);
+    }
+
     /** An extended string describing this location in a end-user friendly way */
     std::string extloc() const;
 
-    void print(std::ostream& out) const {
-        out << filename << " [" << start << "-" << end << "]";
-    }
+    void print(std::ostream& out) const;
 
     /** Enables ranges to be printed */
     friend std::ostream& operator<<(std::ostream& out, const SrcLocation& range) {

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -60,11 +60,11 @@
         if (N) {                                                \
             (Cur).start         = YYRHSLOC(Rhs, 1).start;       \
             (Cur).end           = YYRHSLOC(Rhs, N).end;         \
-            (Cur).filename      = YYRHSLOC(Rhs, N).filename;    \
+            (Cur).filenames     = YYRHSLOC(Rhs, N).filenames;   \
         } else {                                                \
             (Cur).start         = YYRHSLOC(Rhs, 0).end;         \
             (Cur).end           = YYRHSLOC(Rhs, 0).end;         \
-            (Cur).filename      = YYRHSLOC(Rhs, 0).filename;    \
+            (Cur).filenames     = YYRHSLOC(Rhs, 0).filenames;   \
         }                                                       \
     } while (0)
 }

--- a/src/scanner.ll
+++ b/src/scanner.ll
@@ -56,7 +56,7 @@
     yylloc.start = SrcLocation::Point({ yylineno, yycolumn }); \
     yycolumn += yyleng;             \
     yylloc.end   = SrcLocation::Point({ yylineno, yycolumn }); \
-    yylloc.filename = yyfilename;   \
+    yylloc.setFilename(yyfilename); \
 }
 
 %}


### PR DESCRIPTION
Fixes #1369 

The stored filename from a `#include` may not include the full path. This PR changes SrcLocation to keep a stack of filenames instead of a single filename, and determine most recent path from the previous filenames.