### PR TITLE
TRIVIAL: added `souffle-test` helper script

### DIFF
--- a/src/souffle-test
+++ b/src/souffle-test
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# helper for running souffle against a specific test case
+
+GIVEN=$1
+shift
+
+TEST_ROOT=${GIVEN%%/}${GIVEN:+/}
+TEST_FACT=$(echo $TEST_ROOT)facts
+TEST_FILE=$(echo $TEST_ROOT)$(basename $GIVEN)
+TEST_SRC=$TEST_FILE.dl
+TEST_OUT=$TEST_FILE.out
+TEST_ERR=$TEST_FILE.err
+
+set -e
+echo $(dirname $0)/souffle $TEST_SRC -D $TEST_ROOT -F $TEST_FACT $@
+$(dirname $0)/souffle $TEST_SRC -D $TEST_ROOT -F $TEST_FACT $@ 1> $TEST_OUT 2> $TEST_ERR


### PR DESCRIPTION
`souffle-test` is a tiny helper script for running a specific test cases in the test suite. It `echo`s out the command, executes it, and updates the expected `out` and `err`. I've found it handy for quickly testing specific test cases and getting the command argument for launch the debugger.

Usage: `./src/souffle-test tests/semantic/agg_checks`

There may be an easy way to do this using the main test driver, but if so I didn't stumble across it in half an hour or so of googling. (I've never used autotools before, sorry.)