### PR TITLE
Update pre-commit hook

### DIFF
--- a/utilities/git/hooks/pre-commit.sh
+++ b/utilities/git/hooks/pre-commit.sh
@@ -14,7 +14,28 @@ then
    exit 1
 fi
 
-clang-format \
-    -i \
-    -style=file \
-    $(git diff --cached --name-only *.cpp *.h)
+# Some of the git tools can set this variable, which can cause problems
+# https://magit.vc/manual/magit/My-Git-hooks-work-on-the-command_002dline-but-not-inside-Magit.html
+unset GIT_LITERAL_PATHSPECS
+
+#Change the delimiter used by 'for' so we can handle spaces in names
+IFS=$'\n'
+for FILE in $(git diff --cached --name-only "*.cpp" "*.h")
+do
+    # Store the current version in case it has been modified
+    TMPFILE="$(mktemp)"
+    cp "$FILE" "$TMPFILE"
+    # Temporarily remove modified versions, if they exist
+    git checkout -q "$FILE"
+    # Format
+    clang-format -i -style=file "$FILE"
+    # Add the formatted file
+    git add "$FILE"
+    # Restore the old, possibly modified version
+    mv "$TMPFILE" "$FILE"
+    # Format the uncached version to keep it in sync with the cached
+    clang-format -i -style=file "$FILE"
+done
+
+# Don't commit if there are no changes to commit
+test "$(git diff --cached)" != ""


### PR DESCRIPTION
I've had problems with the pre-commit hook not formatting the header files. This is a fix attempt. 

- Format both `.cpp` and `.h` files.
- Do not fail when there are no `.cpp`/`.h` files modified. 