### PR TITLE
Ram Refactoring

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -1005,7 +1005,7 @@ std::unique_ptr<RamStatement> AstTranslator::translateNonRecursiveRelation(
         const std::string logSizeStatement = LogStatement::nNonrecursiveRelation(relationName, srcLocation);
 
         // add timer if we did any work
-        if (res.size() > 0) {
+        if (!res.empty()) {
             const std::string logTimerStatement =
                     LogStatement::tNonrecursiveRelation(relationName, srcLocation);
             std::unique_ptr<RamStatement> newStmt =

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -71,6 +71,14 @@ using json11::Json;
 class ErrorReport;
 class SymbolTable;
 
+/** append statement to a list of statements */
+inline void appendStmt(
+        std::vector<std::unique_ptr<RamStatement>>& stmtList, std::unique_ptr<RamStatement> stmt) {
+    if (stmt) {
+        stmtList.push_back(std::move(stmt));
+    }
+}
+
 std::unique_ptr<RamTupleElement> AstTranslator::makeRamTupleElement(const Location& loc) {
     return std::make_unique<RamTupleElement>(loc.identifier, loc.element);
 }
@@ -931,22 +939,6 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
     }
 }
 
-/* utility for appending statements */
-void AstTranslator::appendStmt(std::unique_ptr<RamStatement>& stmtList, std::unique_ptr<RamStatement> stmt) {
-    if (stmt) {
-        if (stmtList) {
-            RamSequence* stmtSeq;
-            if ((stmtSeq = dynamic_cast<RamSequence*>(stmtList.get())) != nullptr) {
-                stmtSeq->add(std::move(stmt));
-            } else {
-                stmtList = std::make_unique<RamSequence>(std::move(stmtList), std::move(stmt));
-            }
-        } else {
-            stmtList = std::move(stmt);
-        }
-    }
-}
-
 std::unique_ptr<RamExpression> AstTranslator::translateConstant(AstConstant const& c) {
     auto const rawConstant = getConstantRamRepresentation(c);
 
@@ -968,7 +960,7 @@ std::unique_ptr<RamExpression> AstTranslator::translateConstant(AstConstant cons
 std::unique_ptr<RamStatement> AstTranslator::translateNonRecursiveRelation(
         const AstRelation& rel, const RecursiveClauses* recursiveClauses) {
     /* start with an empty sequence */
-    std::unique_ptr<RamStatement> res;
+    std::vector<std::unique_ptr<RamStatement>> res;
 
     // the ram table reference
     std::unique_ptr<RamRelationReference> rrel = translateRelation(&rel);
@@ -992,8 +984,8 @@ std::unique_ptr<RamStatement> AstTranslator::translateNonRecursiveRelation(
                     LogStatement::tNonrecursiveRule(relationName, srcLocation, clauseText);
             const std::string logSizeStatement =
                     LogStatement::nNonrecursiveRule(relationName, srcLocation, clauseText);
-            rule = std::make_unique<RamSequence>(std::make_unique<RamLogRelationTimer>(std::move(rule),
-                    logTimerStatement, std::unique_ptr<RamRelationReference>(rrel->clone())));
+            rule = std::make_unique<RamLogRelationTimer>(
+                    std::move(rule), logTimerStatement, std::unique_ptr<RamRelationReference>(rrel->clone()));
         }
 
         // add debug info
@@ -1013,11 +1005,14 @@ std::unique_ptr<RamStatement> AstTranslator::translateNonRecursiveRelation(
         const std::string logSizeStatement = LogStatement::nNonrecursiveRelation(relationName, srcLocation);
 
         // add timer if we did any work
-        if (res) {
+        if (res.size() > 0) {
             const std::string logTimerStatement =
                     LogStatement::tNonrecursiveRelation(relationName, srcLocation);
-            res = std::make_unique<RamLogRelationTimer>(
-                    std::move(res), logTimerStatement, std::unique_ptr<RamRelationReference>(rrel->clone()));
+            std::unique_ptr<RamStatement> newStmt =
+                    std::make_unique<RamLogRelationTimer>(std::make_unique<RamSequence>(std::move(res)),
+                            logTimerStatement, std::unique_ptr<RamRelationReference>(rrel->clone()));
+            res.clear();
+            appendStmt(res, std::move(newStmt));
         } else {
             // add table size printer
             appendStmt(res, std::make_unique<RamLogSize>(
@@ -1026,7 +1021,7 @@ std::unique_ptr<RamStatement> AstTranslator::translateNonRecursiveRelation(
     }
 
     // done
-    return res;
+    return std::make_unique<RamSequence>(std::move(res));
 }
 
 /**
@@ -1066,9 +1061,9 @@ void AstTranslator::nameUnnamedVariables(AstClause* clause) {
 std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
         const std::set<const AstRelation*>& scc, const RecursiveClauses* recursiveClauses) {
     // initialize sections
-    std::unique_ptr<RamStatement> preamble;
-    std::unique_ptr<RamSequence> updateTable(new RamSequence());
-    std::unique_ptr<RamStatement> postamble;
+    std::vector<std::unique_ptr<RamStatement>> preamble;
+    std::vector<std::unique_ptr<RamStatement>> updateTable;
+    std::vector<std::unique_ptr<RamStatement>> postamble;
 
     auto genMerge = [](const RamRelationReference* dest,
                             const RamRelationReference* src) -> std::unique_ptr<RamStatement> {
@@ -1088,10 +1083,12 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
                         std::make_unique<RamProject>(
                                 std::unique_ptr<RamRelationReference>(dest->clone()), std::move(values))));
         if (dest->get()->getRepresentation() == RelationRepresentation::EQREL) {
-            stmt = std::make_unique<RamSequence>(
-                    std::make_unique<RamExtend>(std::unique_ptr<RamRelationReference>(dest->clone()),
-                            std::unique_ptr<RamRelationReference>(src->clone())),
-                    std::move(stmt));
+            std::vector<std::unique_ptr<RamStatement>> stmts;
+            appendStmt(
+                    stmts, std::make_unique<RamExtend>(std::unique_ptr<RamRelationReference>(dest->clone()),
+                                   std::unique_ptr<RamRelationReference>(src->clone())));
+            appendStmt(stmts, std::move(stmt));
+            stmt = std::make_unique<RamSequence>(std::move(stmts));
         }
         return stmt;
     };
@@ -1101,26 +1098,27 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
     /* Compute non-recursive clauses for relations in scc and push
        the results in their delta tables. */
     for (const AstRelation* rel : scc) {
-        std::unique_ptr<RamStatement> updateRelTable;
+        std::vector<std::unique_ptr<RamStatement>> updateRelTable;
 
         /* create update statements for fixpoint (even iteration) */
+        appendStmt(updateRelTable, genMerge(translateRelation(rel).get(), translateNewRelation(rel).get()));
         appendStmt(updateRelTable,
-                std::make_unique<RamSequence>(
-                        genMerge(translateRelation(rel).get(), translateNewRelation(rel).get()),
-                        std::make_unique<RamSwap>(translateDeltaRelation(rel), translateNewRelation(rel)),
-                        std::make_unique<RamClear>(translateNewRelation(rel))));
+                std::make_unique<RamSwap>(translateDeltaRelation(rel), translateNewRelation(rel)));
+        appendStmt(updateRelTable, std::make_unique<RamClear>(translateNewRelation(rel)));
 
         /* measure update time for each relation */
         if (Global::config().has("profile")) {
-            updateRelTable = std::make_unique<RamLogRelationTimer>(std::move(updateRelTable),
+            std::unique_ptr<RamStatement> profileStmt = std::make_unique<RamLogRelationTimer>(
+                    std::make_unique<RamSequence>(std::move(updateRelTable)),
                     LogStatement::cRecursiveRelation(toString(rel->getQualifiedName()), rel->getSrcLoc()),
                     translateNewRelation(rel));
+            updateRelTable.clear();
+            appendStmt(updateRelTable, std::move(profileStmt));
         }
 
         /* drop temporary tables after recursion */
-        appendStmt(postamble,
-                std::make_unique<RamSequence>(std::make_unique<RamClear>(translateDeltaRelation(rel)),
-                        std::make_unique<RamClear>(translateNewRelation(rel))));
+        appendStmt(postamble, std::make_unique<RamClear>(translateDeltaRelation(rel)));
+        appendStmt(postamble, std::make_unique<RamClear>(translateNewRelation(rel)));
 
         /* Generate code for non-recursive part of relation */
         appendStmt(preamble, translateNonRecursiveRelation(*rel, recursiveClauses));
@@ -1129,12 +1127,12 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
         appendStmt(preamble, genMerge(translateDeltaRelation(rel).get(), translateRelation(rel).get()));
 
         /* Add update operations of relations to parallel statements */
-        updateTable->add(std::move(updateRelTable));
+        appendStmt(updateTable, std::make_unique<RamSequence>(std::move(updateRelTable)));
     }
 
     // --- build main loop ---
 
-    std::unique_ptr<RamParallel> loopSeq(new RamParallel());
+    std::vector<std::unique_ptr<RamStatement>> loopSeq;
 
     // create a utility to check SCC membership
     auto isInSameSCC = [&](const AstRelation* rel) {
@@ -1143,7 +1141,7 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
 
     /* Compute temp for the current tables */
     for (const AstRelation* rel : scc) {
-        std::unique_ptr<RamStatement> loopRelSeq;
+        std::vector<std::unique_ptr<RamStatement>> loopRelSeq;
 
         /* Find clauses for relation rel */
         for (const auto& cl : getClauses(*program, *rel)) {
@@ -1205,8 +1203,8 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
                             LogStatement::tRecursiveRule(relationName, version, srcLocation, clauseText);
                     const std::string logSizeStatement =
                             LogStatement::nRecursiveRule(relationName, version, srcLocation, clauseText);
-                    rule = std::make_unique<RamSequence>(std::make_unique<RamLogRelationTimer>(
-                            std::move(rule), logTimerStatement, translateNewRelation(rel)));
+                    rule = std::make_unique<RamLogRelationTimer>(
+                            std::move(rule), logTimerStatement, translateNewRelation(rel));
                 }
 
                 // add debug info
@@ -1233,7 +1231,7 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
         }
 
         // if there was no rule, continue
-        if (loopRelSeq == nullptr) {
+        if (loopRelSeq.size() == 0) {
             continue;
         }
 
@@ -1243,13 +1241,17 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
             const SrcLocation& srcLocation = rel->getSrcLoc();
             const std::string logTimerStatement = LogStatement::tRecursiveRelation(relationName, srcLocation);
             const std::string logSizeStatement = LogStatement::nRecursiveRelation(relationName, srcLocation);
-            loopRelSeq = std::make_unique<RamLogRelationTimer>(
-                    std::move(loopRelSeq), logTimerStatement, translateNewRelation(rel));
+            std::unique_ptr<RamStatement> newStmt = std::make_unique<RamLogRelationTimer>(
+                    std::make_unique<RamSequence>(std::move(loopRelSeq)), logTimerStatement,
+                    translateNewRelation(rel));
+            loopRelSeq.clear();
+            appendStmt(loopRelSeq, std::move(newStmt));
         }
 
         /* add rule computations of a relation to parallel statement */
-        loopSeq->add(std::move(loopRelSeq));
+        appendStmt(loopSeq, std::make_unique<RamSequence>(std::move(loopRelSeq)));
     }
+    std::unique_ptr<RamParallel> loop = std::make_unique<RamParallel>(std::move(loopSeq));
 
     /* construct exit conditions for odd and even iteration */
     auto addCondition = [](std::unique_ptr<RamCondition>& cond, std::unique_ptr<RamCondition> clause) {
@@ -1263,19 +1265,22 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
     }
 
     /* construct fixpoint loop  */
-    std::unique_ptr<RamStatement> res;
-    if (preamble != nullptr) {
-        appendStmt(res, std::move(preamble));
+    std::vector<std::unique_ptr<RamStatement>> res;
+    if (preamble.size() > 0) {
+        appendStmt(res, std::make_unique<RamSequence>(std::move(preamble)));
     }
-    if (!loopSeq->getStatements().empty() && exitCond && updateTable) {
-        appendStmt(res, std::make_unique<RamLoop>(std::move(loopSeq),
-                                std::make_unique<RamExit>(std::move(exitCond)), std::move(updateTable)));
+    if (!loop->getStatements().empty() && exitCond && updateTable.size() > 0) {
+        std::vector<std::unique_ptr<RamStatement>> loopBody;
+        appendStmt(loopBody, std::move(loop));
+        appendStmt(loopBody, std::make_unique<RamExit>(std::move(exitCond)));
+        appendStmt(loopBody, std::make_unique<RamSequence>(std::move(updateTable)));
+        appendStmt(res, std::make_unique<RamLoop>(std::make_unique<RamSequence>(std::move(loopBody))));
     }
-    if (postamble != nullptr) {
-        appendStmt(res, std::move(postamble));
+    if (postamble.size() > 0) {
+        appendStmt(res, std::make_unique<RamSequence>(std::move(postamble)));
     }
-    if (res != nullptr) {
-        return res;
+    if (res.size() > 0) {
+        return std::make_unique<RamSequence>(std::move(res));
     }
 
     assert(false && "Not Implemented");
@@ -1432,7 +1437,7 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
 
     // the structure of this subroutine is a sequence where each nested statement is a search in each
     // relation
-    std::unique_ptr<RamStatement> searchSequence;
+    std::vector<std::unique_ptr<RamStatement>> searchSequence;
 
     // make a copy so that when we mutate clause, pointers to objects in newClause are not affected
     auto newClause = std::unique_ptr<AstClause>(clauseReplacedAggregates->clone());
@@ -1516,7 +1521,7 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
         litNumber++;
     }
 
-    return searchSequence;
+    return std::make_unique<RamSequence>(std::move(searchSequence));
 }
 
 /** translates the given datalog program into an equivalent RAM program  */
@@ -1540,14 +1545,15 @@ void AstTranslator::translateProgram(const AstTranslationUnit& translationUnit) 
     auxArityAnalysis = translationUnit.getAnalysis<AuxiliaryArity>();
 
     // start with an empty sequence of ram statements
-    std::unique_ptr<RamStatement> res = std::make_unique<RamSequence>();
+    std::vector<std::unique_ptr<RamStatement>> res;
 
     // handle the case of an empty SCC graph
     if (sccGraph.getNumberOfSCCs() == 0) return;
 
     // a function to load relations
-    const auto& makeRamLoad = [&](std::unique_ptr<RamStatement>& current, const AstRelation* relation,
-                                      const std::string& inputDirectory, const std::string& fileExtension) {
+    const auto& makeRamLoad = [&](std::vector<std::unique_ptr<RamStatement>>& current,
+                                      const AstRelation* relation, const std::string& inputDirectory,
+                                      const std::string& fileExtension) {
         for (auto directives :
                 getInputDirectives(relation, Global::config().get(inputDirectory), fileExtension)) {
             std::unique_ptr<RamStatement> statement = std::make_unique<RamIO>(
@@ -1563,8 +1569,9 @@ void AstTranslator::translateProgram(const AstTranslationUnit& translationUnit) 
     };
 
     // a function to store relations
-    const auto& makeRamStore = [&](std::unique_ptr<RamStatement>& current, const AstRelation* relation,
-                                       const std::string& outputDirectory, const std::string& fileExtension) {
+    const auto& makeRamStore = [&](std::vector<std::unique_ptr<RamStatement>>& current,
+                                       const AstRelation* relation, const std::string& outputDirectory,
+                                       const std::string& fileExtension) {
         for (auto directives :
                 getOutputDirectives(relation, Global::config().get(outputDirectory), fileExtension)) {
             std::unique_ptr<RamStatement> statement = std::make_unique<RamIO>(
@@ -1580,7 +1587,8 @@ void AstTranslator::translateProgram(const AstTranslationUnit& translationUnit) 
     };
 
     // a function to drop relations
-    const auto& makeRamClear = [&](std::unique_ptr<RamStatement>& current, const AstRelation* relation) {
+    const auto& makeRamClear = [&](std::vector<std::unique_ptr<RamStatement>>& current,
+                                       const AstRelation* relation) {
         appendStmt(current, std::make_unique<RamClear>(translateRelation(relation)));
     };
 
@@ -1621,7 +1629,7 @@ void AstTranslator::translateProgram(const AstTranslationUnit& translationUnit) 
     // iterate over each SCC according to the topological order
     for (const auto& scc : sccOrder.order()) {
         // make a new ram statement for the current SCC
-        std::unique_ptr<RamStatement> current;
+        std::vector<std::unique_ptr<RamStatement>> current;
 
         // find out if the current SCC is recursive
         const auto& isRecursive = sccGraph.isRecursive(scc);
@@ -1660,17 +1668,20 @@ void AstTranslator::translateProgram(const AstTranslationUnit& translationUnit) 
             }
         }
 
-        appendStmt(res, std::move(current));
+        appendStmt(res, std::make_unique<RamSequence>(std::move(current)));
         indexOfScc++;
     }
 
     // add main timer if profiling
-    if (res && Global::config().has("profile")) {
-        res = std::make_unique<RamLogTimer>(std::move(res), LogStatement::runtime());
+    if (res.size() > 0 && Global::config().has("profile")) {
+        std::unique_ptr<RamStatement> newStmt = std::make_unique<RamLogTimer>(
+                std::make_unique<RamSequence>(std::move(res)), LogStatement::runtime());
+        res.clear();
+        appendStmt(res, std::move(newStmt));
     }
 
     // done for main prog
-    ramMain = std::move(res);
+    ramMain = std::make_unique<RamSequence>(std::move(res));
 
     // add subroutines for each clause
     if (Global::config().has("provenance")) {

--- a/src/AstTranslator.h
+++ b/src/AstTranslator.h
@@ -293,9 +293,6 @@ private:
      */
     void nameUnnamedVariables(AstClause* clause);
 
-    /** append statement to a list of statements */
-    void appendStmt(std::unique_ptr<RamStatement>& stmtList, std::unique_ptr<RamStatement> stmt);
-
     /** converts the given relation identifier into a relation name */
     std::string getRelationName(const AstQualifiedName& id) {
         return toString(join(id.getQualifiers(), "."));

--- a/src/RamNode.h
+++ b/src/RamNode.h
@@ -149,11 +149,6 @@ public:
     }
 
     /**
-     * @brief Print RAM node
-     */
-    virtual void print(std::ostream& out = std::cout) const = 0;
-
-    /**
      * Print RAM on a stream
      */
     friend std::ostream& operator<<(std::ostream& out, const RamNode& node) {
@@ -162,6 +157,11 @@ public:
     }
 
 protected:
+    /**
+     * @brief Print RAM node
+     */
+    virtual void print(std::ostream& out = std::cout) const = 0;
+
     /**
      * @brief Equality check for two RAM nodes.
      * Default action is that nothing needs to be checked.

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -296,6 +296,7 @@ public:
         }
     }
 
+protected:
     /** @brief Helper method for printing */
     void printIndex(std::ostream& os) const {
         const auto& attrib = getRelation().getAttributeNames();
@@ -315,7 +316,6 @@ public:
         }
     }
 
-protected:
     bool equal(const RamNode& node) const override {
         const auto& other = static_cast<const RamIndexOperation&>(node);
         return RamRelationOperation::equal(other) && equal_targets(queryPattern, other.queryPattern);
@@ -837,7 +837,7 @@ public:
 
 protected:
     bool equal(const RamNode& node) const override {
-        const auto& other = static_cast<const RamAggregate&>(node);
+        const auto& other = static_cast<const RamIndexAggregate&>(node);
         return RamIndexOperation::equal(other) && RamAbstractAggregate::equal(other);
     }
 };

--- a/src/RamProgram.h
+++ b/src/RamProgram.h
@@ -68,24 +68,6 @@ public:
         return children;
     }
 
-    void print(std::ostream& out) const override {
-        out << "PROGRAM" << std::endl;
-        out << " DECLARATION" << std::endl;
-        for (const auto& rel : relations) {
-            out << "  " << *rel << std::endl;
-        }
-        out << " END DECLARATION" << std::endl;
-        for (const auto& sub : subroutines) {
-            out << " SUBROUTINE " << sub.first << std::endl;
-            sub.second->print(out, 2);
-            out << " END SUBROUTINE" << std::endl;
-        }
-        out << " BEGIN MAIN" << std::endl;
-        main->print(out, 2);
-        out << " END MAIN" << std::endl;
-        out << "END PROGRAM" << std::endl;
-    }
-
     /** @brief Get main program */
     RamStatement& getMain() const {
         return *main;
@@ -144,17 +126,29 @@ public:
     }
 
 protected:
+    void print(std::ostream& out) const override {
+        out << "PROGRAM" << std::endl;
+        out << " DECLARATION" << std::endl;
+        for (const auto& rel : relations) {
+            out << "  " << *rel << std::endl;
+        }
+        out << " END DECLARATION" << std::endl;
+        for (const auto& sub : subroutines) {
+            out << " SUBROUTINE " << sub.first << std::endl;
+            sub.second->print(out, 2);
+            out << " END SUBROUTINE" << std::endl;
+        }
+        out << " BEGIN MAIN" << std::endl;
+        main->print(out, 2);
+        out << " END MAIN" << std::endl;
+        out << "END PROGRAM" << std::endl;
+    }
+
     bool equal(const RamNode& node) const override {
         const auto& other = static_cast<const RamProgram&>(node);
-        if (relations.size() != other.relations.size() || subroutines.size() != other.subroutines.size()) {
-            return false;
-        }
-        for (auto& sub : subroutines) {
-            if (other.getSubroutine(sub.first) != getSubroutine(sub.first)) {
-                return false;
-            }
-        }
-        return getMain() == other.getMain() && equal_targets(relations, other.relations);
+
+        return equal_targets(relations, other.relations) && equal_ptr(main, other.main) &&
+               equal_targets(subroutines, other.subroutines);
     }
 
 protected:

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -1,5 +1,4 @@
 /*
-               ietMain() == other.getMain() && equal_targets(relations, other.relations);
  * Souffle - A Datalog Compiler
  * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved
  * Licensed under the Universal Permissive License v 1.0 as shown at:

--- a/src/RamRelation.h
+++ b/src/RamRelation.h
@@ -1,4 +1,5 @@
 /*
+               ietMain() == other.getMain() && equal_targets(relations, other.relations);
  * Souffle - A Datalog Compiler
  * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved
  * Licensed under the Universal Permissive License v 1.0 as shown at:
@@ -18,6 +19,7 @@
 #include "RamNode.h"
 #include "RamTypes.h"
 #include "RelationTag.h"
+#include "Util.h"
 
 #include <string>
 #include <utility>
@@ -90,6 +92,11 @@ public:
         return name < other.name;
     }
 
+    RamRelation* clone() const override {
+        return new RamRelation(name, arity, auxiliaryArity, attributeNames, attributeTypes, representation);
+    }
+
+protected:
     void print(std::ostream& out) const override {
         out << name;
         if (arity > 0) {
@@ -108,16 +115,12 @@ public:
         }
     }
 
-    RamRelation* clone() const override {
-        return new RamRelation(name, arity, auxiliaryArity, attributeNames, attributeTypes, representation);
-    }
-
-protected:
     bool equal(const RamNode& node) const override {
         assert(nullptr != dynamic_cast<const RamRelation*>(&node));
         const auto& other = static_cast<const RamRelation&>(node);
-        return name == other.name && arity == other.arity && attributeNames == other.attributeNames &&
-               attributeTypes == other.attributeTypes && representation == other.representation;
+        return representation == other.representation && name == other.name && arity == other.arity &&
+               auxiliaryArity == other.auxiliaryArity && attributeNames == other.attributeNames &&
+               attributeTypes == other.attributeTypes;
     }
 
 protected:
@@ -155,19 +158,18 @@ public:
         return relation;
     }
 
-    void print(std::ostream& out) const override {
-        out << relation->getName();
-    }
-
     RamRelationReference* clone() const override {
         return new RamRelationReference(relation);
     }
 
 protected:
+    void print(std::ostream& out) const override {
+        out << relation->getName();
+    }
+
     bool equal(const RamNode& node) const override {
-        assert(nullptr != dynamic_cast<const RamRelationReference*>(&node));
         const auto& other = static_cast<const RamRelationReference&>(node);
-        return relation == other.relation;
+        return equal_ptr(relation, other.relation);
     }
 
 protected:

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -469,12 +469,6 @@ public:
         assert(body != nullptr && "Loop body is a null-pointer");
     }
 
-#if 0
-    template <typename... Stmts>
-    RamLoop(std::unique_ptr<RamStatement> f, std::unique_ptr<RamStatement> s, std::unique_ptr<Stmts>... rest)
-            : body(std::make_unique<RamSequence>(std::move(f), std::move(s), std::move(rest)...)) {}
-#endif
-
     /** @brief Get loop body */
     const RamStatement& getBody() const {
         return *body;

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -388,8 +388,8 @@ public:
             : RamListStatement(std::move(statements)) {}
     RamSequence() : RamListStatement() {}
     template <typename... Stmts>
-    RamSequence(std::unique_ptr<RamStatement> f, std::unique_ptr<Stmts>... rest)
-            : RamListStatement(std::move(f), std::move(rest)...) {}
+    RamSequence(std::unique_ptr<RamStatement> first, std::unique_ptr<Stmts>... rest)
+            : RamListStatement(std::move(first), std::move(rest)...) {}
 
     RamSequence* clone() const override {
         auto* res = new RamSequence();
@@ -429,8 +429,8 @@ public:
             : RamListStatement(std::move(statements)) {}
     RamParallel() : RamListStatement() {}
     template <typename... Stmts>
-    RamParallel(std::unique_ptr<RamStatement> f, std::unique_ptr<Stmts>... rest)
-            : RamListStatement(std::move(f), std::move(rest)...) {}
+    RamParallel(std::unique_ptr<RamStatement> first, std::unique_ptr<Stmts>... rest)
+            : RamListStatement(std::move(first), std::move(rest)...) {}
 
     RamParallel* clone() const override {
         auto* res = new RamParallel();

--- a/src/RamStatement.h
+++ b/src/RamStatement.h
@@ -124,7 +124,6 @@ protected:
         return RamRelationStatement::equal(other) && directives == other.directives;
     }
 
-protected:
     /** IO directives */
     std::map<std::string, std::string> directives;
 };
@@ -340,11 +339,11 @@ public:
 
     template <typename... Stmts>
     RamListStatement(std::unique_ptr<Stmts>&&... stmts) {
-         std::unique_ptr<RamStatement> tmp[] = {std::move(stmts)...};
-         for (auto& cur : tmp) {
-             assert(cur.get() != nullptr && "statement is a null-pointer");
-             statements.emplace_back(std::move(cur));
-         }
+        std::unique_ptr<RamStatement> tmp[] = {std::move(stmts)...};
+        for (auto& cur : tmp) {
+            assert(cur.get() != nullptr && "statement is a null-pointer");
+            statements.emplace_back(std::move(cur));
+        }
     }
 
     /** @brief Get statements */
@@ -498,7 +497,7 @@ protected:
         return equal_ptr(body, other.body);
     }
 
-    /** Body of loop */
+    /** loop body */
     std::unique_ptr<RamStatement> body;
 };
 
@@ -752,7 +751,6 @@ protected:
         return RamRelationStatement::equal(other) && message == other.message;
     }
 
-protected:
     /** logging message */
     std::string message;
 };

--- a/src/test/ram_statement_equal_clone_test.cpp
+++ b/src/test/ram_statement_equal_clone_test.cpp
@@ -208,7 +208,6 @@ TEST(RamParallel, CloneAndEquals) {
      * END PARALLEL
      * */
 
-    RamParallel a;
     std::vector<std::unique_ptr<RamExpression>> a_expressions;
     a_expressions.emplace_back(new RamTupleElement(0, 0));
     a_expressions.emplace_back(new RamTupleElement(0, 2));
@@ -221,9 +220,8 @@ TEST(RamParallel, CloneAndEquals) {
     auto a_scan =
             std::make_unique<RamScan>(std::make_unique<RamRelationReference>(&A), 0, std::move(a_cond), "");
     auto a_query = std::make_unique<RamQuery>(std::move(a_scan));
-    a.add(std::move(a_query));
+    RamParallel a(std::move(a_query));
 
-    RamParallel b;
     std::vector<std::unique_ptr<RamExpression>> b_expressions;
     b_expressions.emplace_back(new RamTupleElement(0, 0));
     b_expressions.emplace_back(new RamTupleElement(0, 2));
@@ -236,7 +234,7 @@ TEST(RamParallel, CloneAndEquals) {
     auto b_scan =
             std::make_unique<RamScan>(std::make_unique<RamRelationReference>(&A), 0, std::move(b_cond), "");
     auto b_query = std::make_unique<RamQuery>(std::move(b_scan));
-    b.add(std::move(b_query));
+    RamParallel b(std::move(b_query));
 
     EXPECT_EQ(a, b);
     EXPECT_NE(&a, &b);


### PR DESCRIPTION
This fixes some aspects of if issue #961.

 - Equal methods forgot a state variable in RamRelation.
 - Equal methods used sometimes pointers instead of references
 - Changed equal() methods to access directly state variables rather via getters
 - Changed equal() methods to use equal_ptr() for pointer states so that in case of null-pointers no crashes are happening. 
 - The generic print methods were pushed into the protected section; indented printing will be done in a subsequent PR. 
 - A state-changing method add() was removed from RamListStatement
 - AstTranslator was adjusted for the above changes (TODO: needs a major refactoring urgently)