### PR TITLE
Ast Refactoring

### DIFF
--- a/src/AstArgument.h
+++ b/src/AstArgument.h
@@ -65,7 +65,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstVariable*>(&node));
         const auto& other = static_cast<const AstVariable&>(node);
         return name == other.name;
     }
@@ -126,7 +125,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstConstant*>(&node));
         const auto& other = static_cast<const AstConstant&>(node);
         return constant == other.constant;
     }
@@ -188,7 +186,6 @@ public:
 
 protected:
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstNumericConstant*>(&node));
         const auto& other = static_cast<const AstNumericConstant&>(node);
         return AstConstant::equal(node) && type == other.type;
     }
@@ -246,7 +243,6 @@ public:
 
 protected:
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstTerm*>(&node));
         const auto& other = static_cast<const AstTerm&>(node);
         return equal_targets(args, other.args);
     }
@@ -333,7 +329,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstIntrinsicFunctor*>(&node));
         const auto& other = static_cast<const AstIntrinsicFunctor&>(node);
         return function == other.function && AstFunctor::equal(node);
     }
@@ -396,7 +391,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstUserDefinedFunctor*>(&node));
         const auto& other = static_cast<const AstUserDefinedFunctor&>(node);
         return name == other.name && AstFunctor::equal(node);
     }
@@ -473,7 +467,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstTypeCast*>(&node));
         const auto& other = static_cast<const AstTypeCast&>(node);
         return type == other.type && equal_ptr(value, other.value);
     }
@@ -585,7 +578,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstAggregator*>(&node));
         const auto& other = static_cast<const AstAggregator&>(node);
         return fun == other.fun && equal_ptr(targetExpression, other.targetExpression) &&
                equal_targets(body, other.body);
@@ -626,7 +618,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstSubroutineArgument*>(&node));
         const auto& other = static_cast<const AstSubroutineArgument&>(node);
         return index == other.index;
     }

--- a/src/AstAttribute.h
+++ b/src/AstAttribute.h
@@ -65,7 +65,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstAttribute*>(&node));
         const auto& other = static_cast<const AstAttribute&>(node);
         return name == other.name && typeName == other.typeName;
     }

--- a/src/AstClause.h
+++ b/src/AstClause.h
@@ -59,7 +59,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstExecutionOrder*>(&node));
         const auto& other = static_cast<const AstExecutionOrder&>(node);
         return order == other.order;
     }
@@ -122,7 +121,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstExecutionPlan*>(&node));
         const auto& other = static_cast<const AstExecutionPlan&>(node);
         return equal_targets(plans, other.plans);
     }
@@ -223,7 +221,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstClause*>(&node));
         const auto& other = static_cast<const AstClause&>(node);
         return equal_ptr(head, other.head) && equal_targets(bodyLiterals, other.bodyLiterals) &&
                equal_ptr(plan, other.plan);

--- a/src/AstComponent.h
+++ b/src/AstComponent.h
@@ -78,7 +78,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstComponentType*>(&node));
         const auto& other = static_cast<const AstComponentType&>(node);
         return name == other.name && typeParams == other.typeParams;
     }
@@ -139,7 +138,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstComponentInit*>(&node));
         const auto& other = static_cast<const AstComponentInit&>(node);
         return instanceName == other.instanceName && *componentType == *other.componentType;
     }
@@ -373,7 +371,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstComponent*>(&node));
         const auto& other = static_cast<const AstComponent&>(node);
 
         if (equal_ptr(componentType, other.componentType)) {

--- a/src/AstFunctorDeclaration.h
+++ b/src/AstFunctorDeclaration.h
@@ -89,7 +89,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstFunctorDeclaration*>(&node));
         const auto& other = static_cast<const AstFunctorDeclaration&>(node);
         return name == other.name && argsTypes == other.argsTypes && returnType == other.returnType;
     }

--- a/src/AstIO.h
+++ b/src/AstIO.h
@@ -113,7 +113,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstIO*>(&node));
         const auto& other = static_cast<const AstIO&>(node);
         return other.type == type && other.name == name && other.directives == directives;
     }

--- a/src/AstLiteral.h
+++ b/src/AstLiteral.h
@@ -110,7 +110,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstAtom*>(&node));
         const auto& other = static_cast<const AstAtom&>(node);
         return name == other.name && equal_targets(arguments, other.arguments);
     }

--- a/src/AstNode.h
+++ b/src/AstNode.h
@@ -64,7 +64,6 @@ public:
             return equal(other);
         }
         return false;
-        // return this == &other || (typeid(*this) == typeid(other) && equal(other));
     }
 
     /** Inequality check for two AST nodes */

--- a/src/AstPragma.h
+++ b/src/AstPragma.h
@@ -49,7 +49,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstPragma*>(&node));
         const auto& other = static_cast<const AstPragma&>(node);
         return other.key == key && other.value == value;
     }

--- a/src/AstProgram.h
+++ b/src/AstProgram.h
@@ -242,9 +242,7 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstProgram*>(&node));
         const auto& other = static_cast<const AstProgram&>(node);
-
         if (!equal_targets(pragmaDirectives, other.pragmaDirectives)) {
             return false;
         }

--- a/src/AstRelation.h
+++ b/src/AstRelation.h
@@ -48,7 +48,7 @@ class AstRelation : public AstNode {
 public:
     AstRelation() = default;
 
-    /** Return the name of the relation */
+    /** get qualified relation name */
     const AstQualifiedName& getQualifiedName() const {
         return name;
     }
@@ -69,12 +69,12 @@ public:
         return attributes.size();
     }
 
-    /** Obtains a list of the contained attributes */
+    /** Get relation attributes */
     std::vector<AstAttribute*> getAttributes() const {
         return toPtrVector(attributes);
     }
 
-    /** Return qualifiers associated with this relation */
+    /** Get relation qualifiers */
     const std::set<RelationQualifier>& getQualifiers() const {
         return qualifiers;
     }
@@ -89,15 +89,17 @@ public:
         qualifiers.erase(q);
     }
 
-    /** Get representation for this relation */
+    /** Get relation representation */
     RelationRepresentation getRepresentation() const {
         return representation;
     }
 
+    /** Set relation representation */
     void setRepresentation(RelationRepresentation representation) {
         this->representation = representation;
     }
 
+    /** check for a relation qualifier */
     bool hasQualifier(RelationQualifier q) const {
         return qualifiers.find(q) != qualifiers.end();
     }
@@ -163,6 +165,10 @@ protected:
     RelationRepresentation representation{RelationRepresentation::DEFAULT};
 };
 
+/**
+ * Lexicographical order for AstRelation
+ * using the qualified name as an ordering criteria.
+ */
 struct AstNameComparison {
     bool operator()(const AstRelation* x, const AstRelation* y) const {
         if (x != nullptr && y != nullptr) {

--- a/src/AstRelation.h
+++ b/src/AstRelation.h
@@ -146,7 +146,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstRelation*>(&node));
         const auto& other = static_cast<const AstRelation&>(node);
         return name == other.name && equal_targets(attributes, other.attributes);
     }

--- a/src/AstType.h
+++ b/src/AstType.h
@@ -94,7 +94,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstSubsetType*>(&node));
         const auto& other = static_cast<const AstSubsetType&>(node);
         return getQualifiedName() == other.getQualifiedName() && type == other.type;
     }
@@ -141,7 +140,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstUnionType*>(&node));
         const auto& other = static_cast<const AstUnionType&>(node);
         return getQualifiedName() == other.getQualifiedName() && types == other.types;
     }
@@ -209,7 +207,6 @@ protected:
     }
 
     bool equal(const AstNode& node) const override {
-        assert(nullptr != dynamic_cast<const AstRecordType*>(&node));
         const auto& other = static_cast<const AstRecordType&>(node);
         return getQualifiedName() == other.getQualifiedName() && fields == other.fields;
     }


### PR DESCRIPTION
The equal checks had unnecessary type assertion checks that are checked in the ==operator in AstNode. 

This is a fix for #1255.