### PR TITLE
Wrong includes for index-utils and misplaced namespace.

### DIFF
--- a/src/Brie.h
+++ b/src/Brie.h
@@ -1843,7 +1843,7 @@ public:
     /**
      * The type of the stored entries / tuples.
      */
-    using entry_type = typename ram::Tuple<RamDomain, Dim>;
+    using entry_type = typename souffle::Tuple<RamDomain, Dim>;
 
     // -- operation wrappers --
 
@@ -2295,7 +2295,7 @@ class Trie : public detail::TrieBase<Dim, Trie<Dim>> {
     store_type store;
 
 public:
-    using entry_type = typename ram::Tuple<RamDomain, Dim>;
+    using entry_type = typename souffle::Tuple<RamDomain, Dim>;
     using element_type = entry_type;
 
     // ---------------------------------------------------------------------
@@ -2826,10 +2826,10 @@ class Trie<0u> : public detail::TrieBase<0u, Trie<0u>> {
 
     using base = typename detail::TrieBase<0u, Trie<0u>>;
 
-    using entry_type = typename ram::Tuple<RamDomain, 0>;
+    using entry_type = typename souffle::Tuple<RamDomain, 0>;
 
     // the singleton instance of the 0-ary tuple
-    static const ram::Tuple<RamDomain, 0> instance;
+    static const Tuple<RamDomain, 0> instance;
 
     // a flag determining whether this trie is empty or contains the singleton instance
     bool present = false;

--- a/src/CompiledIndexUtils.h
+++ b/src/CompiledIndexUtils.h
@@ -17,12 +17,7 @@
 
 #pragma once
 
-#include "BTree.h"
-#include "Brie.h"
 #include "CompiledTuple.h"
-#include "EquivalenceRelation.h"
-#include "IterUtils.h"
-#include "RamTypes.h"
 #include "Util.h"
 #include <cassert>
 #include <iterator>
@@ -32,8 +27,6 @@
 #include <vector>
 
 namespace souffle {
-
-namespace ram {
 
 /**
  * A namespace enclosing template-meta-programming utilities for handling
@@ -281,7 +274,5 @@ struct get_full_index<0> {
 };
 
 }  // namespace index_utils
-
-}  // end namespace ram
 
 }  // end namespace souffle

--- a/src/CompiledSouffle.h
+++ b/src/CompiledSouffle.h
@@ -19,7 +19,9 @@
 #include "souffle/Brie.h"
 #include "souffle/CompiledIndexUtils.h"
 #include "souffle/CompiledTuple.h"
+#include "souffle/EquivalenceRelation.h"
 #include "souffle/IOSystem.h"
+#include "souffle/IterUtils.h"
 #include "souffle/ParallelUtils.h"
 #include "souffle/RWOperation.h"
 #include "souffle/RamTypes.h"
@@ -166,7 +168,7 @@ private:
 
 public:
     t_nullaries() = default;
-    using t_tuple = ram::Tuple<RamDomain, 0>;
+    using t_tuple = Tuple<RamDomain, 0>;
     struct context {};
     context createContext() {
         return context();
@@ -238,18 +240,18 @@ public:
 template <int Arity>
 class t_info {
 private:
-    std::vector<ram::Tuple<RamDomain, Arity>> data;
+    std::vector<Tuple<RamDomain, Arity>> data;
     Lock insert_lock;
 
 public:
     t_info() = default;
-    using t_tuple = ram::Tuple<RamDomain, Arity>;
+    using t_tuple = Tuple<RamDomain, Arity>;
     struct context {};
     context createContext() {
         return context();
     }
-    class iterator : public std::iterator<std::forward_iterator_tag, ram::Tuple<RamDomain, Arity>> {
-        typename std::vector<ram::Tuple<RamDomain, Arity>>::const_iterator it;
+    class iterator : public std::iterator<std::forward_iterator_tag, Tuple<RamDomain, Arity>> {
+        typename std::vector<Tuple<RamDomain, Arity>>::const_iterator it;
 
     public:
         iterator(const typename std::vector<t_tuple>::const_iterator& o) : it(o) {}

--- a/src/CompiledTuple.h
+++ b/src/CompiledTuple.h
@@ -21,8 +21,6 @@
 
 namespace souffle {
 
-namespace ram {
-
 /**
  * The type of object stored within relations representing the actual
  * tuple value. Each tuple consists of a constant number of components.
@@ -164,7 +162,6 @@ struct Tuple<Domain, 0> {
     }
 };
 #endif  // _MSC_VER
-}  // end namespace ram
 }  // end of namespace souffle
 
 // -- add hashing support --
@@ -172,8 +169,8 @@ struct Tuple<Domain, 0> {
 namespace std {
 
 template <typename Domain, std::size_t arity>
-struct hash<souffle::ram::Tuple<Domain, arity>> {
-    size_t operator()(const souffle::ram::Tuple<Domain, arity>& value) const {
+struct hash<souffle::Tuple<Domain, arity>> {
+    size_t operator()(const souffle::Tuple<Domain, arity>& value) const {
         std::hash<Domain> hash;
         size_t res = 0;
         for (unsigned i = 0; i < arity; i++) {

--- a/src/InterpreterIndex.cpp
+++ b/src/InterpreterIndex.cpp
@@ -15,7 +15,9 @@
  ***********************************************************************/
 
 #include "InterpreterIndex.h"
+#include "Brie.h"
 #include "CompiledIndexUtils.h"
+#include "EquivalenceRelation.h"
 #include "Util.h"
 #include <atomic>
 
@@ -560,11 +562,11 @@ private:
 
 // The comparator to be used for B-tree nodes.
 template <std::size_t Arity>
-using comparator = typename ram::index_utils::get_full_index<Arity>::type::comparator;
+using comparator = typename index_utils::get_full_index<Arity>::type::comparator;
 
 // Node type
 template <std::size_t Arity>
-using t_tuple = typename ram::Tuple<RamDomain, Arity>;
+using t_tuple = typename souffle::Tuple<RamDomain, Arity>;
 
 // Updater for Provenance
 template <std::size_t Arity>

--- a/src/InterpreterIndex.h
+++ b/src/InterpreterIndex.h
@@ -78,14 +78,14 @@ public:
      * a tuple into a reference.
      */
     template <std::size_t Arity>
-    TupleRef(const ram::Tuple<RamDomain, Arity>& tuple) : TupleRef(&tuple[0], Arity) {}
+    TupleRef(const Tuple<RamDomain, Arity>& tuple) : TupleRef(&tuple[0], Arity) {}
 
     TupleRef(const DynTuple& tuple) : TupleRef(&tuple[0], tuple.size()) {}
 
     template <std::size_t Arity>
-    const ram::Tuple<RamDomain, Arity>& asTuple() const {
+    const Tuple<RamDomain, Arity>& asTuple() const {
         assert(arity == Arity);
-        return *reinterpret_cast<const ram::Tuple<RamDomain, Arity>*>(base);
+        return *reinterpret_cast<const Tuple<RamDomain, Arity>*>(base);
     }
 
     /**
@@ -149,8 +149,8 @@ public:
     bool valid() const;
 
     template <std::size_t Arity>
-    ram::Tuple<RamDomain, Arity> encode(const ram::Tuple<RamDomain, Arity>& entry) const {
-        ram::Tuple<RamDomain, Arity> res{};
+    Tuple<RamDomain, Arity> encode(const Tuple<RamDomain, Arity>& entry) const {
+        Tuple<RamDomain, Arity> res{};
         for (std::size_t i = 0; i < Arity; ++i) {
             res[i] = entry[order[i]];
         }
@@ -158,8 +158,8 @@ public:
     }
 
     template <std::size_t Arity>
-    ram::Tuple<RamDomain, Arity> decode(const ram::Tuple<RamDomain, Arity>& entry) const {
-        ram::Tuple<RamDomain, Arity> res{};
+    Tuple<RamDomain, Arity> decode(const Tuple<RamDomain, Arity>& entry) const {
+        Tuple<RamDomain, Arity> res{};
         for (std::size_t i = 0; i < Arity; ++i) {
             res[order[i]] = entry[i];
         }

--- a/src/RecordTable.h
+++ b/src/RecordTable.h
@@ -140,7 +140,7 @@ private:
 
 /** @brief helper to convert tuple to record reference for the synthesiser */
 template <std::size_t Arity>
-inline RamDomain pack(RecordTable& recordTab, ram::Tuple<RamDomain, Arity> tuple) {
+inline RamDomain pack(RecordTable& recordTab, Tuple<RamDomain, Arity> tuple) {
     return recordTab.pack(static_cast<RamDomain*>(tuple.data), Arity);
 }
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -821,10 +821,10 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             auto identifier = aggregate.getTupleId();
 
             // aggregate tuple storing the result of aggregate
-            std::string tuple_type = "ram::Tuple<RamDomain," + toString(arity) + ">";
+            std::string tuple_type = "Tuple<RamDomain," + toString(arity) + ">";
 
             // declare environment variable
-            out << "ram::Tuple<RamDomain,1> env" << identifier << ";\n";
+            out << "Tuple<RamDomain,1> env" << identifier << ";\n";
 
             // get range to aggregate
             auto keys = isa->getSearchSignature(&aggregate);
@@ -993,7 +993,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             auto identifier = aggregate.getTupleId();
 
             // declare environment variable
-            out << "ram::Tuple<RamDomain,1> env" << identifier << ";\n";
+            out << "Tuple<RamDomain,1> env" << identifier << ";\n";
 
             // special case: counting number elements over an unrestricted predicate
             if (aggregate.getFunction() == AggregateOp::COUNT && isRamTrue(&aggregate.getCondition())) {
@@ -1681,7 +1681,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             PRINT_BEGIN_COMMENT(out);
 
             out << "pack(recordTable,"
-                << "ram::Tuple<RamDomain," << pack.getArguments().size() << ">";
+                << "Tuple<RamDomain," << pack.getArguments().size() << ">";
             if (pack.getArguments().size() == 0) {
                 out << "{{}}";
             } else {
@@ -1817,7 +1817,6 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
     os << "}\n";
     os << "\n";
     os << "namespace souffle {\n";
-    os << "using namespace ram;\n";
     os << "static const RamDomain RAM_BIT_SHIFT_MASK = RAM_DOMAIN_SIZE - 1;\n";
 
     // synthesise data-structures for relations

--- a/src/SynthesiserRelation.cpp
+++ b/src/SynthesiserRelation.cpp
@@ -1077,7 +1077,7 @@ void SynthesiserEqrelRelation::generateTypeStruct(std::ostream& out) {
     out << "struct " << getTypeName() << " {\n";
 
     // eqrel is only for binary relations
-    out << "using t_tuple = ram::Tuple<RamDomain, 2>;\n";
+    out << "using t_tuple = Tuple<RamDomain, 2>;\n";
     out << "using t_ind_" << masterIndex << " = EquivalenceRelation<t_tuple>;\n";
     out << "t_ind_" << masterIndex << " ind_" << masterIndex << ";\n";
 

--- a/src/test/binary_relation_test.cpp
+++ b/src/test/binary_relation_test.cpp
@@ -37,10 +37,10 @@ namespace test {
 
 TEST(EqRelTest, Scoping) {
     // simply test that namespaces were setup correctly
-    souffle::EquivalenceRelation<souffle::ram::Tuple<RamDomain, 2>> br;
+    souffle::EquivalenceRelation<souffle::Tuple<RamDomain, 2>> br;
 }
 
-using EqRel = souffle::EquivalenceRelation<ram::Tuple<RamDomain, 2>>;
+using EqRel = souffle::EquivalenceRelation<Tuple<RamDomain, 2>>;
 
 TEST(EqRelTest, Basic) {
     EqRel br;
@@ -104,7 +104,7 @@ TEST(EqRelTest, Duplicates) {
     EXPECT_FALSE(br.contains(1, 1));
 
     // check iteration of duplicate is fine
-    ram::Tuple<RamDomain, 2> tup{};
+    Tuple<RamDomain, 2> tup{};
     tup[0] = 0;
     tup[1] = 0;
     auto x = br.begin();

--- a/src/test/brie_test.cpp
+++ b/src/test/brie_test.cpp
@@ -781,7 +781,7 @@ RamDomain rand(RamDomain max) {
 }  // namespace
 
 TEST(Trie, IteratorStress_1D) {
-    using tuple = typename ram::Tuple<RamDomain, 1>;
+    using tuple = typename souffle::Tuple<RamDomain, 1>;
 
     const int N = 10000;
 
@@ -807,7 +807,7 @@ TEST(Trie, IteratorStress_1D) {
 }
 
 TEST(Trie, IteratorStress_2D) {
-    using tuple = typename ram::Tuple<RamDomain, 2>;
+    using tuple = typename souffle::Tuple<RamDomain, 2>;
 
     const int N = 10000;
 
@@ -835,7 +835,7 @@ TEST(Trie, IteratorStress_2D) {
 }
 
 TEST(Trie, IteratorStress_3D) {
-    using tuple = typename ram::Tuple<RamDomain, 3>;
+    using tuple = typename souffle::Tuple<RamDomain, 3>;
 
     const int N = 10000;
 
@@ -864,7 +864,7 @@ TEST(Trie, IteratorStress_3D) {
 }
 
 TEST(Trie, IteratorStress_4D) {
-    using tuple = typename ram::Tuple<RamDomain, 4>;
+    using tuple = typename souffle::Tuple<RamDomain, 4>;
 
     const int N = 10000;
 
@@ -1279,7 +1279,7 @@ TEST(Trie, BoundaryTest_3D_Stress) {
 }
 
 TEST(Trie, RangeQuery) {
-    using tuple = typename ram::Tuple<RamDomain, 3>;
+    using tuple = typename souffle::Tuple<RamDomain, 3>;
 
     Trie<3> set;
 
@@ -1307,7 +1307,7 @@ TEST(Trie, RangeQuery) {
 }
 
 TEST(Trie, RangeQuery_0D) {
-    using tuple = typename ram::Tuple<RamDomain, 0>;
+    using tuple = typename souffle::Tuple<RamDomain, 0>;
 
     Trie<0> set;
 
@@ -1319,7 +1319,7 @@ TEST(Trie, RangeQuery_0D) {
 }
 
 TEST(Trie, RangeQuery_1D) {
-    using tuple = typename ram::Tuple<RamDomain, 1>;
+    using tuple = typename souffle::Tuple<RamDomain, 1>;
 
     Trie<1> set;
 
@@ -1340,7 +1340,7 @@ TEST(Trie, RangeQuery_1D) {
 }
 
 TEST(Trie, RangeQuery_2D) {
-    using tuple = typename ram::Tuple<RamDomain, 2>;
+    using tuple = typename souffle::Tuple<RamDomain, 2>;
 
     Trie<2> set;
 
@@ -1370,7 +1370,7 @@ TEST(Trie, RangeQuery_2D) {
 }
 
 TEST(Trie, RangeQuery_3D) {
-    using tuple = typename ram::Tuple<RamDomain, 3>;
+    using tuple = typename souffle::Tuple<RamDomain, 3>;
 
     Trie<3> set;
 
@@ -1412,7 +1412,7 @@ TEST(Trie, RangeQuery_3D) {
 }
 
 TEST(Trie, RangeQueryStress) {
-    using tuple = typename ram::Tuple<RamDomain, 3>;
+    using tuple = typename souffle::Tuple<RamDomain, 3>;
 
     Trie<3> set;
 

--- a/src/test/record_table_test.cpp
+++ b/src/test/record_table_test.cpp
@@ -27,7 +27,7 @@ namespace souffle::test {
 
 TEST(Pack, Tuple) {
     RecordTable recordTable;
-    const ram::Tuple<RamDomain, 3> tuple = {{1, 2, 3}};
+    const Tuple<RamDomain, 3> tuple = {{1, 2, 3}};
 
     RamDomain ref = pack(recordTable, tuple);
 
@@ -43,7 +43,7 @@ TEST(Pack, Tuple) {
 // unpack and test for equality
 TEST(PackUnpack, Tuple) {
     constexpr size_t tupleSize = 3;
-    using tupleType = ram::Tuple<RamDomain, tupleSize>;
+    using tupleType = Tuple<RamDomain, tupleSize>;
 
     RecordTable recordTable;
 


### PR DESCRIPTION
Some unnecessary includes in the index-utils file and there is a misnomer/misplaced namespace in the runtime called "ram".