### PR TITLE
Functor library fixes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,7 @@ void executeBinary(const std::string& binaryFilename) {
         }
         ldPath.back() = ' ';
         setenv("LD_LIBRARY_PATH", ldPath.c_str(), 1);
+        setenv("DYLD_LIBRARY_PATH", ldPath.c_str(), 1);
     }
 
     int exitCode = system(binaryFilename.c_str());

--- a/tests/interface/functors/Makefile.am
+++ b/tests/interface/functors/Makefile.am
@@ -4,6 +4,6 @@
 # - https://opensource.org/licenses/UPL
 # - <souffle root>/licenses/SOUFFLE-UPL.txt
 
-lib_LTLIBRARIES = libfunctors.la
+check_LTLIBRARIES = libfunctors.la
 libfunctors_la_SOURCES = functors.cpp
-libfunctors_la_LDFLAGS = -avoid-version
+libfunctors_la_LDFLAGS = -avoid-version -shared -rpath /tmp


### PR DESCRIPTION
Currently there are two bugs with related roots:
* On OSX we pass LD_LIBRARY_PATH when compiling, but should be using DYLD_LIBRARY_PATH. This PR adds the latter path.
* A fix for functor library testing on OSX has led to the inclusion in installed/distributed souffle of a test library. This PR also fixes that.

The fix for installation of the test library is a little hacky, but I have found no other way to generate a dynamic library without also installing it.