### PR TITLE
Assume 2's complement when compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 dnl Do not set default CFLAGS and CXXFLAGS
 ENV_CXXFLAGS="$CXXFLAGS"
-CXXFLAGS=""
+CXXFLAGS=" -fwrapv "
 
 # Disable provenance
 AC_ARG_ENABLE(


### PR DESCRIPTION
Related to #1344 - Adds -fwrapv to interpreted and synthesised souffle, which tells the compiler to assume 2's complement representation for ints. Our code currently assumes this anyway, so this is a reasonable flag to be using.