### PR TITLE
Fix mem corruption in `btree::base` dtor

### DIFF
--- a/src/BTree.h
+++ b/src/BTree.h
@@ -331,6 +331,8 @@ protected:
          */
         base(bool inner) : parent(nullptr), numElements(0), position(0), inner(inner) {}
 
+        virtual ~base() {}
+
         bool isLeaf() const {
             return !inner;
         }

--- a/src/BTree.h
+++ b/src/BTree.h
@@ -331,7 +331,7 @@ protected:
          */
         base(bool inner) : parent(nullptr), numElements(0), position(0), inner(inner) {}
 
-        virtual ~base() {}
+        virtual ~base() = default;
 
         bool isLeaf() const {
             return !inner;
@@ -377,13 +377,6 @@ protected:
 
         // a simple constructor
         node(bool inner) : base(inner) {}
-
-        // a destructor cleaning up nodes
-        ~node() {
-            if (this->inner) {
-                asInnerNode().cleanup();
-            }
-        }
 
         /**
          * A deep-copy operation creating a clone of this node.
@@ -1068,8 +1061,8 @@ protected:
         // a simple default constructor initializing member fields
         inner_node() : node(true) {}
 
-        // a destruction operation clearing up child nodes recursively
-        void cleanup() {
+        // clear up child nodes recursively
+        ~inner_node() override {
             for (unsigned i = 0; i <= this->numElements; ++i) {
                 delete children[i];
             }


### PR DESCRIPTION
`btree::base` (or at least `btree::node`) needs a virtual dtor as it is `delete`d via pointer in `btree::clear`. 

This was picked up by asan whilst running the test suite. Perhaps ASAN/UBSAN should be enabled globally when running the test suite?