### PR TITLE
Formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,7 @@ AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: true
-AllowShortLoopsOnASingleLine: true
+AllowShortLoopsOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true

--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,7 @@ AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: false

--- a/src/AggregateOp.h
+++ b/src/AggregateOp.h
@@ -41,26 +41,21 @@ enum class AggregateOp {
 
 inline std::ostream& operator<<(std::ostream& os, AggregateOp op) {
     switch (op) {
-        case AggregateOp::COUNT:
-            return os << "count";
+        case AggregateOp::COUNT: return os << "count";
 
-        case AggregateOp::MEAN:
-            return os << "mean";
+        case AggregateOp::MEAN: return os << "mean";
 
         case AggregateOp::MAX:
         case AggregateOp::UMAX:
-        case AggregateOp::FMAX:
-            return os << "max";
+        case AggregateOp::FMAX: return os << "max";
 
         case AggregateOp::MIN:
         case AggregateOp::UMIN:
-        case AggregateOp::FMIN:
-            return os << "min";
+        case AggregateOp::FMIN: return os << "min";
 
         case AggregateOp::SUM:
         case AggregateOp::USUM:
-        case AggregateOp::FSUM:
-            return os << "sum";
+        case AggregateOp::FSUM: return os << "sum";
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -69,8 +64,7 @@ inline std::ostream& operator<<(std::ostream& os, AggregateOp op) {
 // `[min, max]` # of arguments for each function
 inline std::pair<uint8_t, uint8_t> aggregateArity(AggregateOp op) {
     switch (op) {
-        case AggregateOp::COUNT:
-            return {0, 0};
+        case AggregateOp::COUNT: return {0, 0};
 
         case AggregateOp::FMAX:
         case AggregateOp::FMIN:
@@ -81,8 +75,7 @@ inline std::pair<uint8_t, uint8_t> aggregateArity(AggregateOp op) {
         case AggregateOp::SUM:
         case AggregateOp::UMAX:
         case AggregateOp::UMIN:
-        case AggregateOp::USUM:
-            return {1, 1};
+        case AggregateOp::USUM: return {1, 1};
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -96,19 +89,16 @@ inline TypeAttribute getTypeAttributeAggregate(const AggregateOp op) {
         case AggregateOp::COUNT:
         case AggregateOp::MAX:
         case AggregateOp::MIN:
-        case AggregateOp::SUM:
-            return TypeAttribute::Signed;
+        case AggregateOp::SUM: return TypeAttribute::Signed;
 
         case AggregateOp::MEAN:
         case AggregateOp::FMAX:
         case AggregateOp::FMIN:
-        case AggregateOp::FSUM:
-            return TypeAttribute::Float;
+        case AggregateOp::FSUM: return TypeAttribute::Float;
 
         case AggregateOp::UMAX:
         case AggregateOp::UMIN:
-        case AggregateOp::USUM:
-            return TypeAttribute::Unsigned;
+        case AggregateOp::USUM: return TypeAttribute::Unsigned;
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -118,15 +108,12 @@ inline bool isOverloadedAggregator(const AggregateOp op) {
     switch (op) {
         case AggregateOp::MAX:
         case AggregateOp::MIN:
-        case AggregateOp::SUM:
-            return true;
+        case AggregateOp::SUM: return true;
 
         case AggregateOp::MEAN:
-        case AggregateOp::COUNT:
-            return false;
+        case AggregateOp::COUNT: return false;
 
-        default:
-            fatal("likely mistaken use of overloaded aggregator op");
+        default: fatal("likely mistaken use of overloaded aggregator op");
     }
 }
 

--- a/src/AstArgument.h
+++ b/src/AstArgument.h
@@ -269,7 +269,9 @@ private:
     static VecOwn<AstArgument> asVec(Operands... ops) {
         Own<AstArgument> ary[] = {std::move(ops)...};
         VecOwn<AstArgument> xs;
-        for (auto&& x : ary) xs.push_back(std::move(x));
+        for (auto&& x : ary) {
+            xs.push_back(std::move(x));
+        }
         return xs;
     }
 };

--- a/src/AstFunctorDeclaration.h
+++ b/src/AstFunctorDeclaration.h
@@ -67,16 +67,11 @@ protected:
     void print(std::ostream& out) const override {
         auto convert = [&](TypeAttribute type) {
             switch (type) {
-                case TypeAttribute::Signed:
-                    return "number";
-                case TypeAttribute::Symbol:
-                    return "symbol";
-                case TypeAttribute::Float:
-                    return "float";
-                case TypeAttribute::Unsigned:
-                    return "unsigned";
-                case TypeAttribute::Record:
-                    fatal("unhandled `TypeAttribute`");
+                case TypeAttribute::Signed: return "number";
+                case TypeAttribute::Symbol: return "symbol";
+                case TypeAttribute::Float: return "float";
+                case TypeAttribute::Unsigned: return "unsigned";
+                case TypeAttribute::Record: fatal("unhandled `TypeAttribute`");
             }
 
             UNREACHABLE_BAD_CASE_ANALYSIS

--- a/src/AstIO.h
+++ b/src/AstIO.h
@@ -29,12 +29,9 @@ enum class AstIoType { input, output, printsize };
 // FIXME: I'm going crazy defining these. There has to be a library that does this boilerplate for us.
 inline std::ostream& operator<<(std::ostream& os, AstIoType e) {
     switch (e) {
-        case AstIoType::input:
-            return os << "input";
-        case AstIoType::output:
-            return os << "output";
-        case AstIoType::printsize:
-            return os << "printsize";
+        case AstIoType::input: return os << "input";
+        case AstIoType::output: return os << "output";
+        case AstIoType::printsize: return os << "printsize";
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS

--- a/src/AstIOTypeAnalysis.cpp
+++ b/src/AstIOTypeAnalysis.cpp
@@ -30,12 +30,8 @@ void IOType::run(const AstTranslationUnit& translationUnit) {
             return;
         }
         switch (io.getType()) {
-            case AstIoType::input:
-                inputRelations.insert(relation);
-                break;
-            case AstIoType::output:
-                outputRelations.insert(relation);
-                break;
+            case AstIoType::input: inputRelations.insert(relation); break;
+            case AstIoType::output: outputRelations.insert(relation); break;
             case AstIoType::printsize:
                 printSizeRelations.insert(relation);
                 outputRelations.insert(relation);

--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -301,8 +301,7 @@ AstSemanticCheckerImpl::AstSemanticCheckerImpl(AstTranslationUnit& tu) : tu(tu) 
                 case TypeAttribute::Symbol:
                     report.addError("Non-symbolic use for symbolic functor", fun.getSrcLoc());
                     break;
-                case TypeAttribute::Record:
-                    fatal("Invalid return type");
+                case TypeAttribute::Record: fatal("Invalid return type");
             }
         }
 
@@ -329,8 +328,7 @@ AstSemanticCheckerImpl::AstSemanticCheckerImpl(AstTranslationUnit& tu) : tu(tu) 
                     case TypeAttribute::Float:
                         report.addError("Non-float argument for functor", arg->getSrcLoc());
                         break;
-                    case TypeAttribute::Record:
-                        fatal("Invalid argument type");
+                    case TypeAttribute::Record: fatal("Invalid argument type");
                 }
             }
             ++i;
@@ -361,21 +359,11 @@ AstSemanticCheckerImpl::AstSemanticCheckerImpl(AstTranslationUnit& tu) : tu(tu) 
                     ss << "Constraint requires an operand of type "
                        << join(opRamTypes, " or ", [&](auto& out, auto& ramTy) {
                               switch (ramTy) {
-                                  case TypeAttribute::Signed:
-                                      out << "`number`";
-                                      break;
-                                  case TypeAttribute::Symbol:
-                                      out << "`symbol`";
-                                      break;
-                                  case TypeAttribute::Unsigned:
-                                      out << "`unsigned`";
-                                      break;
-                                  case TypeAttribute::Float:
-                                      out << "`float`";
-                                      break;
-                                  case TypeAttribute::Record:
-                                      out << "a record";
-                                      break;
+                                  case TypeAttribute::Signed: out << "`number`"; break;
+                                  case TypeAttribute::Symbol: out << "`symbol`"; break;
+                                  case TypeAttribute::Unsigned: out << "`unsigned`"; break;
+                                  case TypeAttribute::Float: out << "`float`"; break;
+                                  case TypeAttribute::Record: out << "a record"; break;
                               }
                           });
                     report.addError(ss.str(), side.getSrcLoc());
@@ -844,20 +832,11 @@ void AstSemanticCheckerImpl::checkUnionType(const AstUnionType& type) {
             std::stringstream errorMessage;
             auto toPrimitiveTypeName = [](std::ostream& out, TypeAttribute type) {
                 switch (type) {
-                    case TypeAttribute::Signed:
-                        out << "number";
-                        break;
-                    case TypeAttribute::Unsigned:
-                        out << "unsigned";
-                        break;
-                    case TypeAttribute::Float:
-                        out << "float";
-                        break;
-                    case TypeAttribute::Symbol:
-                        out << "symbol";
-                        break;
-                    case TypeAttribute::Record:
-                        fatal("Invalid type");
+                    case TypeAttribute::Signed: out << "number"; break;
+                    case TypeAttribute::Unsigned: out << "unsigned"; break;
+                    case TypeAttribute::Float: out << "float"; break;
+                    case TypeAttribute::Symbol: out << "symbol"; break;
+                    case TypeAttribute::Record: fatal("Invalid type");
                 }
             };
             errorMessage << "Union type " << name << " is defined over {"

--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -136,8 +136,12 @@ AstSemanticCheckerImpl::AstSemanticCheckerImpl(AstTranslationUnit& tu) : tu(tu) 
     }
 
     // check rules
-    for (auto* rel : program.getRelations()) checkRelation(*rel);
-    for (auto* clause : program.getClauses()) checkClause(*clause);
+    for (auto* rel : program.getRelations()) {
+        checkRelation(*rel);
+    }
+    for (auto* clause : program.getClauses()) {
+        checkClause(*clause);
+    }
 
     checkNamespaces();
     checkIO();

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -865,16 +865,11 @@ std::unique_ptr<RamStatement> AstTranslator::ClauseTranslator::translateClause(
 
             auto func_op = [&]() -> RamNestedIntrinsicOp {
                 switch (func->getFunction()) {
-                    case FunctorOp::RANGE:
-                        return RamNestedIntrinsicOp::RANGE;
-                    case FunctorOp::URANGE:
-                        return RamNestedIntrinsicOp::URANGE;
-                    case FunctorOp::FRANGE:
-                        return RamNestedIntrinsicOp::FRANGE;
+                    case FunctorOp::RANGE: return RamNestedIntrinsicOp::RANGE;
+                    case FunctorOp::URANGE: return RamNestedIntrinsicOp::URANGE;
+                    case FunctorOp::FRANGE: return RamNestedIntrinsicOp::FRANGE;
 
-                    default:
-                        assert(isFunctorMultiResult(func->getFunction()));
-                        abort();
+                    default: assert(isFunctorMultiResult(func->getFunction())); abort();
                 }
             };
 
@@ -967,12 +962,9 @@ std::unique_ptr<RamExpression> AstTranslator::translateConstant(AstConstant cons
 
     if (auto* const c_num = dynamic_cast<const AstNumericConstant*>(&c)) {
         switch (*c_num->getType()) {
-            case AstNumericConstant::Type::Int:
-                return std::make_unique<RamSignedConstant>(rawConstant);
-            case AstNumericConstant::Type::Uint:
-                return std::make_unique<RamUnsignedConstant>(rawConstant);
-            case AstNumericConstant::Type::Float:
-                return std::make_unique<RamFloatConstant>(rawConstant);
+            case AstNumericConstant::Type::Int: return std::make_unique<RamSignedConstant>(rawConstant);
+            case AstNumericConstant::Type::Uint: return std::make_unique<RamUnsignedConstant>(rawConstant);
+            case AstNumericConstant::Type::Float: return std::make_unique<RamFloatConstant>(rawConstant);
         }
     }
 

--- a/src/AstTranslator.h
+++ b/src/AstTranslator.h
@@ -409,8 +409,7 @@ private:
                     return RamSignedFromString(numConstant->getConstant(), nullptr, 0);
                 case AstNumericConstant::Type::Uint:
                     return RamUnsignedFromString(numConstant->getConstant(), nullptr, 0);
-                case AstNumericConstant::Type::Float:
-                    return RamFloatFromString(numConstant->getConstant());
+                case AstNumericConstant::Type::Float: return RamFloatFromString(numConstant->getConstant());
             }
         }
 

--- a/src/AstType.h
+++ b/src/AstType.h
@@ -77,20 +77,11 @@ protected:
     void print(std::ostream& os) const override {
         os << ".type " << getQualifiedName() << " <: ";
         switch (type) {
-            case TypeAttribute::Signed:
-                os << "number";
-                break;
-            case TypeAttribute::Unsigned:
-                os << "unsigned";
-                break;
-            case TypeAttribute::Float:
-                os << "float";
-                break;
-            case TypeAttribute::Symbol:
-                os << "symbol";
-                break;
-            case TypeAttribute::Record:
-                fatal("Invalid type");
+            case TypeAttribute::Signed: os << "number"; break;
+            case TypeAttribute::Unsigned: os << "unsigned"; break;
+            case TypeAttribute::Float: os << "float"; break;
+            case TypeAttribute::Symbol: os << "symbol"; break;
+            case TypeAttribute::Record: fatal("Invalid type");
         }
     }
 

--- a/src/AstTypeEnvironmentAnalysis.cpp
+++ b/src/AstTypeEnvironmentAnalysis.cpp
@@ -105,8 +105,7 @@ Graph<AstQualifiedName> TypeEnvironmentAnalysis::createTypeDependencyGraph(
                 case TypeAttribute::Symbol:
                     typeDependencyGraph.insert(type->getQualifiedName(), "symbol");
                     break;
-                case TypeAttribute::Record:
-                    fatal("invalid type");
+                case TypeAttribute::Record: fatal("invalid type");
             }
         } else if (dynamic_cast<const AstRecordType*>(astType) != nullptr) {
             // do nothing

--- a/src/BinaryConstraintOps.h
+++ b/src/BinaryConstraintOps.h
@@ -68,10 +68,8 @@ inline std::ostream& operator<<(std::ostream& os, BinaryConstraintOp x) {
 inline bool isEqConstraint(const BinaryConstraintOp constraintOp) {
     switch (constraintOp) {
         case BinaryConstraintOp::EQ:
-        case BinaryConstraintOp::FEQ:
-            return true;
-        default:
-            break;
+        case BinaryConstraintOp::FEQ: return true;
+        default: break;
     }
     return false;
 }
@@ -82,10 +80,8 @@ inline bool isIneqConstraint(const BinaryConstraintOp constraintOp) {
         case BinaryConstraintOp::LT:
         case BinaryConstraintOp::GT:
         case BinaryConstraintOp::LE:
-        case BinaryConstraintOp::GE:
-            return true;
-        default:
-            break;
+        case BinaryConstraintOp::GE: return true;
+        default: break;
     }
     return false;
 }
@@ -117,10 +113,8 @@ inline bool isOverloaded(const BinaryConstraintOp constraintOp) {
         case BinaryConstraintOp::LT:
         case BinaryConstraintOp::LE:
         case BinaryConstraintOp::GT:
-        case BinaryConstraintOp::GE:
-            return true;
-        default:
-            break;
+        case BinaryConstraintOp::GE: return true;
+        default: break;
     }
     return false;
 }
@@ -163,8 +157,7 @@ inline BinaryConstraintOp convertOverloadedConstraint(
         COMPARE_CONSTRAINT(GT)
         COMPARE_CONSTRAINT(GE)
 
-        default:
-            fatal("invalid constraint conversion: constraint = %s", constraintOp);
+        default: fatal("invalid constraint conversion: constraint = %s", constraintOp);
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -180,59 +173,35 @@ inline BinaryConstraintOp convertOverloadedConstraint(
  */
 inline BinaryConstraintOp negatedConstraintOp(const BinaryConstraintOp op) {
     switch (op) {
-        case BinaryConstraintOp::EQ:
-            return BinaryConstraintOp::NE;
-        case BinaryConstraintOp::FEQ:
-            return BinaryConstraintOp::FNE;
-        case BinaryConstraintOp::NE:
-            return BinaryConstraintOp::EQ;
-        case BinaryConstraintOp::FNE:
-            return BinaryConstraintOp::FEQ;
+        case BinaryConstraintOp::EQ: return BinaryConstraintOp::NE;
+        case BinaryConstraintOp::FEQ: return BinaryConstraintOp::FNE;
+        case BinaryConstraintOp::NE: return BinaryConstraintOp::EQ;
+        case BinaryConstraintOp::FNE: return BinaryConstraintOp::FEQ;
 
-        case BinaryConstraintOp::LT:
-            return BinaryConstraintOp::GE;
-        case BinaryConstraintOp::ULT:
-            return BinaryConstraintOp::UGE;
-        case BinaryConstraintOp::FLT:
-            return BinaryConstraintOp::FGE;
-        case BinaryConstraintOp::SLT:
-            return BinaryConstraintOp::SGE;
+        case BinaryConstraintOp::LT: return BinaryConstraintOp::GE;
+        case BinaryConstraintOp::ULT: return BinaryConstraintOp::UGE;
+        case BinaryConstraintOp::FLT: return BinaryConstraintOp::FGE;
+        case BinaryConstraintOp::SLT: return BinaryConstraintOp::SGE;
 
-        case BinaryConstraintOp::LE:
-            return BinaryConstraintOp::GT;
-        case BinaryConstraintOp::ULE:
-            return BinaryConstraintOp::UGT;
-        case BinaryConstraintOp::FLE:
-            return BinaryConstraintOp::FGT;
-        case BinaryConstraintOp::SLE:
-            return BinaryConstraintOp::SGT;
+        case BinaryConstraintOp::LE: return BinaryConstraintOp::GT;
+        case BinaryConstraintOp::ULE: return BinaryConstraintOp::UGT;
+        case BinaryConstraintOp::FLE: return BinaryConstraintOp::FGT;
+        case BinaryConstraintOp::SLE: return BinaryConstraintOp::SGT;
 
-        case BinaryConstraintOp::GE:
-            return BinaryConstraintOp::LT;
-        case BinaryConstraintOp::UGE:
-            return BinaryConstraintOp::ULT;
-        case BinaryConstraintOp::FGE:
-            return BinaryConstraintOp::FLT;
-        case BinaryConstraintOp::SGE:
-            return BinaryConstraintOp::SLT;
+        case BinaryConstraintOp::GE: return BinaryConstraintOp::LT;
+        case BinaryConstraintOp::UGE: return BinaryConstraintOp::ULT;
+        case BinaryConstraintOp::FGE: return BinaryConstraintOp::FLT;
+        case BinaryConstraintOp::SGE: return BinaryConstraintOp::SLT;
 
-        case BinaryConstraintOp::GT:
-            return BinaryConstraintOp::LE;
-        case BinaryConstraintOp::UGT:
-            return BinaryConstraintOp::ULE;
-        case BinaryConstraintOp::FGT:
-            return BinaryConstraintOp::FLE;
-        case BinaryConstraintOp::SGT:
-            return BinaryConstraintOp::SLE;
+        case BinaryConstraintOp::GT: return BinaryConstraintOp::LE;
+        case BinaryConstraintOp::UGT: return BinaryConstraintOp::ULE;
+        case BinaryConstraintOp::FGT: return BinaryConstraintOp::FLE;
+        case BinaryConstraintOp::SGT: return BinaryConstraintOp::SLE;
 
-        case BinaryConstraintOp::MATCH:
-            return BinaryConstraintOp::NOT_MATCH;
-        case BinaryConstraintOp::NOT_MATCH:
-            return BinaryConstraintOp::MATCH;
-        case BinaryConstraintOp::CONTAINS:
-            return BinaryConstraintOp::NOT_CONTAINS;
-        case BinaryConstraintOp::NOT_CONTAINS:
-            return BinaryConstraintOp::CONTAINS;
+        case BinaryConstraintOp::MATCH: return BinaryConstraintOp::NOT_MATCH;
+        case BinaryConstraintOp::NOT_MATCH: return BinaryConstraintOp::MATCH;
+        case BinaryConstraintOp::CONTAINS: return BinaryConstraintOp::NOT_CONTAINS;
+        case BinaryConstraintOp::NOT_CONTAINS: return BinaryConstraintOp::CONTAINS;
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -244,39 +213,29 @@ inline BinaryConstraintOp negatedConstraintOp(const BinaryConstraintOp op) {
 inline char const* toBinaryConstraintSymbol(const BinaryConstraintOp op) {
     switch (op) {
         case BinaryConstraintOp::FEQ:
-        case BinaryConstraintOp::EQ:
-            return "=";
+        case BinaryConstraintOp::EQ: return "=";
         case BinaryConstraintOp::FNE:
-        case BinaryConstraintOp::NE:
-            return "!=";
+        case BinaryConstraintOp::NE: return "!=";
         case BinaryConstraintOp::SLT:
         case BinaryConstraintOp::ULT:
         case BinaryConstraintOp::FLT:
-        case BinaryConstraintOp::LT:
-            return "<";
+        case BinaryConstraintOp::LT: return "<";
         case BinaryConstraintOp::SLE:
         case BinaryConstraintOp::ULE:
         case BinaryConstraintOp::FLE:
-        case BinaryConstraintOp::LE:
-            return "<=";
+        case BinaryConstraintOp::LE: return "<=";
         case BinaryConstraintOp::SGT:
         case BinaryConstraintOp::UGT:
         case BinaryConstraintOp::FGT:
-        case BinaryConstraintOp::GT:
-            return ">";
+        case BinaryConstraintOp::GT: return ">";
         case BinaryConstraintOp::SGE:
         case BinaryConstraintOp::UGE:
         case BinaryConstraintOp::FGE:
-        case BinaryConstraintOp::GE:
-            return ">=";
-        case BinaryConstraintOp::MATCH:
-            return "match";
-        case BinaryConstraintOp::CONTAINS:
-            return "contains";
-        case BinaryConstraintOp::NOT_MATCH:
-            return "not_match";
-        case BinaryConstraintOp::NOT_CONTAINS:
-            return "not_contains";
+        case BinaryConstraintOp::GE: return ">=";
+        case BinaryConstraintOp::MATCH: return "match";
+        case BinaryConstraintOp::CONTAINS: return "contains";
+        case BinaryConstraintOp::NOT_MATCH: return "not_match";
+        case BinaryConstraintOp::NOT_CONTAINS: return "not_contains";
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -325,14 +284,12 @@ inline bool isOrderedBinaryConstraintOp(const BinaryConstraintOp op) {
         case BinaryConstraintOp::SLT:
         case BinaryConstraintOp::SLE:
         case BinaryConstraintOp::SGE:
-        case BinaryConstraintOp::SGT:
-            return true;
+        case BinaryConstraintOp::SGT: return true;
 
         case BinaryConstraintOp::MATCH:
         case BinaryConstraintOp::NOT_MATCH:
         case BinaryConstraintOp::CONTAINS:
-        case BinaryConstraintOp::NOT_CONTAINS:
-            return false;
+        case BinaryConstraintOp::NOT_CONTAINS: return false;
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -366,8 +323,7 @@ inline std::vector<TypeAttribute> getBinaryConstraintTypes(const BinaryConstrain
         case BinaryConstraintOp::MATCH:
         case BinaryConstraintOp::NOT_MATCH:
         case BinaryConstraintOp::CONTAINS:
-        case BinaryConstraintOp::NOT_CONTAINS:
-            return {TypeAttribute::Symbol};
+        case BinaryConstraintOp::NOT_CONTAINS: return {TypeAttribute::Symbol};
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS

--- a/src/CompiledOptions.h
+++ b/src/CompiledOptions.h
@@ -187,9 +187,7 @@ public:
                     std::cerr << "\nWarning: OpenMP was not enabled in compilation\n\n";
 #endif
                     break;
-                default:
-                    printHelpPage(exec_name);
-                    return false;
+                default: printHelpPage(exec_name); return false;
             }
         }
 

--- a/src/EvaluatorUtils.h
+++ b/src/EvaluatorUtils.h
@@ -26,10 +26,15 @@ template <typename A, typename F /* Tuple<RamDomain,1> -> void */>
 void runRange(A from, A to, A step, F&& go) {
 #define GO(x) go(Tuple<RamDomain, 1>{ramBitCast(x)})
     if (0 < step) {
-        for (auto x = from; x < to; x += step) GO(x);
+        for (auto x = from; x < to; x += step) {
+            GO(x);
+        }
     } else if (step < 0) {
-        for (auto x = from; to < x; x += step) GO(x);
-    } else if (from != to) {  // `step = 0` edge case, only if non-empty range
+        for (auto x = from; to < x; x += step) {
+            GO(x);
+        }
+    } else if (from != to) {
+        // `step = 0` edge case, only if non-empty range
         GO(from);
     }
 #undef GO

--- a/src/ExplainProvenance.h
+++ b/src/ExplainProvenance.h
@@ -226,36 +226,25 @@ protected:
 
     std::string valueShow(const char type, const RamDomain value) const {
         switch (type) {
-            case 'i':
-                return format("%d", ramBitCast<RamSigned>(value));
-            case 'u':
-                return format("%d", ramBitCast<RamUnsigned>(value));
-            case 'f':
-                return format("%f", ramBitCast<RamFloat>(value));
-            case 's':
-                return format("\"%s\"", symTable.resolve(value));
-            case 'r':
-                return format("record #%d", value);
-            default:
-                fatal("unhandled type attr code");
+            case 'i': return format("%d", ramBitCast<RamSigned>(value));
+            case 'u': return format("%d", ramBitCast<RamUnsigned>(value));
+            case 'f': return format("%f", ramBitCast<RamFloat>(value));
+            case 's': return format("\"%s\"", symTable.resolve(value));
+            case 'r': return format("record #%d", value);
+            default: fatal("unhandled type attr code");
         }
     }
 
     RamDomain valueRead(const char type, const std::string& value) const {
         switch (type) {
-            case 'i':
-                return ramBitCast(RamSignedFromString(value));
-            case 'u':
-                return ramBitCast(RamUnsignedFromString(value));
-            case 'f':
-                return ramBitCast(RamFloatFromString(value));
+            case 'i': return ramBitCast(RamSignedFromString(value));
+            case 'u': return ramBitCast(RamUnsignedFromString(value));
+            case 'f': return ramBitCast(RamFloatFromString(value));
             case 's':
                 assert(2 <= value.size() && value[0] == '"' && value.back() == '"');
                 return symTable.lookup(value.substr(1, value.size() - 2));
-            case 'r':
-                fatal("not implemented");
-            default:
-                fatal("unhandled type attr code");
+            case 'r': fatal("not implemented");
+            default: fatal("unhandled type attr code");
         }
     }
 };

--- a/src/ExplainProvenanceImpl.h
+++ b/src/ExplainProvenanceImpl.h
@@ -700,8 +700,7 @@ public:
                         }
                         rd = ramBitCast(RamUnsignedFromString(rel.second[j]));
                         break;
-                    default:
-                        continue;
+                    default: continue;
                 }
 
                 constConstraints.push_back(std::make_pair(std::make_pair(idx, j), rd));
@@ -867,20 +866,11 @@ private:
 
                     solution << var.second.getSymbol() << " = ";
                     switch (var.second.getType()) {
-                        case 'i':
-                            solution << ramBitCast<RamSigned>(raw);
-                            break;
-                        case 'f':
-                            solution << ramBitCast<RamFloat>(raw);
-                            break;
-                        case 'u':
-                            solution << ramBitCast<RamUnsigned>(raw);
-                            break;
-                        case 's':
-                            solution << prog.getSymbolTable().resolve(raw);
-                            break;
-                        default:
-                            fatal("invalid type: `%c`", var.second.getType());
+                        case 'i': solution << ramBitCast<RamSigned>(raw); break;
+                        case 'f': solution << ramBitCast<RamFloat>(raw); break;
+                        case 'u': solution << ramBitCast<RamUnsigned>(raw); break;
+                        case 's': solution << prog.getSymbolTable().resolve(raw); break;
+                        default: fatal("invalid type: `%c`", var.second.getType());
                     }
 
                     auto sep = ++c < nameToEquivalence.size() ? ", " : " ";

--- a/src/FunctorOps.h
+++ b/src/FunctorOps.h
@@ -106,11 +106,9 @@ inline bool isFunctorMultiResult(FunctorOp op) {
     switch (op) {
         case FunctorOp::RANGE:
         case FunctorOp::URANGE:
-        case FunctorOp::FRANGE:
-            return true;
+        case FunctorOp::FRANGE: return true;
 
-        default:
-            return false;
+        default: return false;
     }
 }
 
@@ -135,8 +133,7 @@ inline bool isValidFunctorOpArity(const FunctorOp op, const size_t arity) {
         case FunctorOp::ITOF:
         case FunctorOp::FTOI:
         case FunctorOp::UTOF:
-        case FunctorOp::FTOU:
-            return arity == 1;
+        case FunctorOp::FTOU: return arity == 1;
 
         /** Binary Functor Operators */
         case FunctorOp::ADD:
@@ -171,17 +168,14 @@ inline bool isValidFunctorOpArity(const FunctorOp op, const size_t arity) {
         case FunctorOp::FSUB:
         case FunctorOp::FMUL:
         case FunctorOp::FDIV:
-        case FunctorOp::FEXP:
-            return arity == 2;
+        case FunctorOp::FEXP: return arity == 2;
 
         case FunctorOp::RANGE:
         case FunctorOp::URANGE:
-        case FunctorOp::FRANGE:
-            return 2 <= arity && arity < 4;
+        case FunctorOp::FRANGE: return 2 <= arity && arity < 4;
 
         /** Ternary Functor Operators */
-        case FunctorOp::SUBSTR:
-            return arity == 3;
+        case FunctorOp::SUBSTR: return arity == 3;
 
         /** Non-fixed */
         case FunctorOp::MAX:
@@ -192,8 +186,7 @@ inline bool isValidFunctorOpArity(const FunctorOp op, const size_t arity) {
         case FunctorOp::FMIN:
         case FunctorOp::SMAX:
         case FunctorOp::SMIN:
-        case FunctorOp::CAT:
-            return arity >= 2;
+        case FunctorOp::CAT: return arity >= 2;
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -205,107 +198,75 @@ inline bool isValidFunctorOpArity(const FunctorOp op, const size_t arity) {
 inline char const* getSymbolForFunctorOp(const FunctorOp op) {
     switch (op) {
         /** Unary Functor Operators */
-        case FunctorOp::ITOF:
-            return "itof";
-        case FunctorOp::ITOU:
-            return "itou";
-        case FunctorOp::UTOF:
-            return "utof";
-        case FunctorOp::UTOI:
-            return "utoi";
-        case FunctorOp::FTOI:
-            return "ftoi";
-        case FunctorOp::FTOU:
-            return "ftou";
-        case FunctorOp::ORD:
-            return "ord";
-        case FunctorOp::STRLEN:
-            return "strlen";
+        case FunctorOp::ITOF: return "itof";
+        case FunctorOp::ITOU: return "itou";
+        case FunctorOp::UTOF: return "utof";
+        case FunctorOp::UTOI: return "utoi";
+        case FunctorOp::FTOI: return "ftoi";
+        case FunctorOp::FTOU: return "ftou";
+        case FunctorOp::ORD: return "ord";
+        case FunctorOp::STRLEN: return "strlen";
         case FunctorOp::NEG:
-        case FunctorOp::FNEG:
-            return "-";
+        case FunctorOp::FNEG: return "-";
         case FunctorOp::BNOT:
-        case FunctorOp::UBNOT:
-            return "bnot";
+        case FunctorOp::UBNOT: return "bnot";
         case FunctorOp::LNOT:
-        case FunctorOp::ULNOT:
-            return "lnot";
-        case FunctorOp::TONUMBER:
-            return "to_number";
-        case FunctorOp::TOSTRING:
-            return "to_string";
+        case FunctorOp::ULNOT: return "lnot";
+        case FunctorOp::TONUMBER: return "to_number";
+        case FunctorOp::TOSTRING: return "to_string";
 
         /** Binary Functor Operators */
         case FunctorOp::ADD:
         case FunctorOp::FADD:
-        case FunctorOp::UADD:
-            return "+";
+        case FunctorOp::UADD: return "+";
         case FunctorOp::SUB:
         case FunctorOp::USUB:
-        case FunctorOp::FSUB:
-            return "-";
+        case FunctorOp::FSUB: return "-";
         case FunctorOp::MUL:
         case FunctorOp::UMUL:
-        case FunctorOp::FMUL:
-            return "*";
+        case FunctorOp::FMUL: return "*";
         case FunctorOp::DIV:
         case FunctorOp::UDIV:
-        case FunctorOp::FDIV:
-            return "/";
+        case FunctorOp::FDIV: return "/";
         case FunctorOp::EXP:
         case FunctorOp::FEXP:
-        case FunctorOp::UEXP:
-            return "^";
+        case FunctorOp::UEXP: return "^";
         case FunctorOp::MOD:
-        case FunctorOp::UMOD:
-            return "%";
+        case FunctorOp::UMOD: return "%";
         case FunctorOp::BAND:
-        case FunctorOp::UBAND:
-            return "band";
+        case FunctorOp::UBAND: return "band";
         case FunctorOp::BOR:
-        case FunctorOp::UBOR:
-            return "bor";
+        case FunctorOp::UBOR: return "bor";
         case FunctorOp::BXOR:
-        case FunctorOp::UBXOR:
-            return "bxor";
+        case FunctorOp::UBXOR: return "bxor";
         case FunctorOp::BSHIFT_L:
-        case FunctorOp::UBSHIFT_L:
-            return "bshl";
+        case FunctorOp::UBSHIFT_L: return "bshl";
         case FunctorOp::BSHIFT_R:
-        case FunctorOp::UBSHIFT_R:
-            return "bshr";
+        case FunctorOp::UBSHIFT_R: return "bshr";
         case FunctorOp::BSHIFT_R_UNSIGNED:
-        case FunctorOp::UBSHIFT_R_UNSIGNED:
-            return "bshru";
+        case FunctorOp::UBSHIFT_R_UNSIGNED: return "bshru";
         case FunctorOp::LAND:
-        case FunctorOp::ULAND:
-            return "land";
+        case FunctorOp::ULAND: return "land";
         case FunctorOp::LOR:
-        case FunctorOp::ULOR:
-            return "lor";
+        case FunctorOp::ULOR: return "lor";
 
         case FunctorOp::RANGE:
         case FunctorOp::URANGE:
-        case FunctorOp::FRANGE:
-            return "range";
+        case FunctorOp::FRANGE: return "range";
 
         /* N-ary Functor Operators */
         case FunctorOp::MAX:
         case FunctorOp::UMAX:
         case FunctorOp::FMAX:
-        case FunctorOp::SMAX:
-            return "max";
+        case FunctorOp::SMAX: return "max";
         case FunctorOp::MIN:
         case FunctorOp::UMIN:
         case FunctorOp::FMIN:
-        case FunctorOp::SMIN:
-            return "min";
-        case FunctorOp::CAT:
-            return "cat";
+        case FunctorOp::SMIN: return "min";
+        case FunctorOp::CAT: return "cat";
 
         /** Ternary Functor Operators */
-        case FunctorOp::SUBSTR:
-            return "substr";
+        case FunctorOp::SUBSTR: return "substr";
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -344,8 +305,7 @@ inline TypeAttribute functorReturnType(const FunctorOp op) {
         case FunctorOp::MAX:
         case FunctorOp::MIN:
         case FunctorOp::FTOI:
-        case FunctorOp::UTOI:
-            return TypeAttribute::Signed;
+        case FunctorOp::UTOI: return TypeAttribute::Signed;
         case FunctorOp::UBNOT:
         case FunctorOp::ITOU:
         case FunctorOp::FTOU:
@@ -366,8 +326,7 @@ inline TypeAttribute functorReturnType(const FunctorOp op) {
         case FunctorOp::UBSHIFT_R:
         case FunctorOp::UBSHIFT_R_UNSIGNED:
         case FunctorOp::ULAND:
-        case FunctorOp::ULOR:
-            return TypeAttribute::Unsigned;
+        case FunctorOp::ULOR: return TypeAttribute::Unsigned;
         case FunctorOp::FMAX:
         case FunctorOp::FMIN:
         case FunctorOp::FNEG:
@@ -378,14 +337,12 @@ inline TypeAttribute functorReturnType(const FunctorOp op) {
         case FunctorOp::FMUL:
         case FunctorOp::FDIV:
         case FunctorOp::FEXP:
-        case FunctorOp::FRANGE:
-            return TypeAttribute::Float;
+        case FunctorOp::FRANGE: return TypeAttribute::Float;
         case FunctorOp::SMAX:
         case FunctorOp::SMIN:
         case FunctorOp::TOSTRING:
         case FunctorOp::CAT:
-        case FunctorOp::SUBSTR:
-            return TypeAttribute::Symbol;
+        case FunctorOp::SUBSTR: return TypeAttribute::Symbol;
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -409,9 +366,7 @@ inline TypeAttribute functorOpArgType(const size_t arg, const FunctorOp op) {
             return TypeAttribute::Signed;
         case FunctorOp::FNEG:
         case FunctorOp::FTOI:
-        case FunctorOp::FTOU:
-            assert(arg == 0 && "unary functor out of bound");
-            return TypeAttribute::Float;
+        case FunctorOp::FTOU: assert(arg == 0 && "unary functor out of bound"); return TypeAttribute::Float;
         case FunctorOp::STRLEN:
         case FunctorOp::TONUMBER:
             assert(arg == 0 && "unary functor out of bound");
@@ -435,9 +390,7 @@ inline TypeAttribute functorOpArgType(const size_t arg, const FunctorOp op) {
         case FunctorOp::BSHIFT_R:
         case FunctorOp::BSHIFT_R_UNSIGNED:
         case FunctorOp::LAND:
-        case FunctorOp::LOR:
-            assert(arg < 2 && "binary functor out of bound");
-            return TypeAttribute::Signed;
+        case FunctorOp::LOR: assert(arg < 2 && "binary functor out of bound"); return TypeAttribute::Signed;
         case FunctorOp::UADD:
         case FunctorOp::USUB:
         case FunctorOp::UMUL:
@@ -458,9 +411,7 @@ inline TypeAttribute functorOpArgType(const size_t arg, const FunctorOp op) {
         case FunctorOp::FSUB:
         case FunctorOp::FMUL:
         case FunctorOp::FDIV:
-        case FunctorOp::FEXP:
-            assert(arg < 2 && "binary functor out of bound");
-            return TypeAttribute::Float;
+        case FunctorOp::FEXP: assert(arg < 2 && "binary functor out of bound"); return TypeAttribute::Float;
         case FunctorOp::SUBSTR:
             assert(arg < 3 && "ternary functor out of bound");
             if (arg == 0) {
@@ -469,25 +420,18 @@ inline TypeAttribute functorOpArgType(const size_t arg, const FunctorOp op) {
                 return TypeAttribute::Signed;  // In the future: Change to unsigned
             }
         case FunctorOp::MAX:
-        case FunctorOp::MIN:
-            return TypeAttribute::Signed;
+        case FunctorOp::MIN: return TypeAttribute::Signed;
         case FunctorOp::UMAX:
-        case FunctorOp::UMIN:
-            return TypeAttribute::Unsigned;
+        case FunctorOp::UMIN: return TypeAttribute::Unsigned;
         case FunctorOp::FMAX:
-        case FunctorOp::FMIN:
-            return TypeAttribute::Float;
+        case FunctorOp::FMIN: return TypeAttribute::Float;
         case FunctorOp::SMAX:
         case FunctorOp::SMIN:
-        case FunctorOp::CAT:
-            return TypeAttribute::Symbol;
+        case FunctorOp::CAT: return TypeAttribute::Symbol;
 
-        case FunctorOp::RANGE:
-            return TypeAttribute::Signed;
-        case FunctorOp::URANGE:
-            return TypeAttribute::Unsigned;
-        case FunctorOp::FRANGE:
-            return TypeAttribute::Float;
+        case FunctorOp::RANGE: return TypeAttribute::Signed;
+        case FunctorOp::URANGE: return TypeAttribute::Unsigned;
+        case FunctorOp::FRANGE: return TypeAttribute::Float;
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -518,11 +462,9 @@ inline bool isOverloadedFunctor(const FunctorOp functor) {
         case FunctorOp::MOD:
         case FunctorOp::MAX:
         case FunctorOp::MIN:
-        case FunctorOp::RANGE:
-            return true;
+        case FunctorOp::RANGE: return true;
 
-        default:
-            return false;
+        default: return false;
     }
 }
 
@@ -558,8 +500,7 @@ inline FunctorOp convertOverloadedFunctor(const FunctorOp functor, const TypeAtt
     } break;
 
     switch (functor) {
-        default:
-            fatal("functor is not overloaded");
+        default: fatal("functor is not overloaded");
 
         case FunctorOp::NEG: {
             OVERLOAD_SIGNED(NEG);
@@ -642,10 +583,8 @@ inline bool isInfixFunctorOp(const FunctorOp op) {
         case FunctorOp::LOR:
         case FunctorOp::ULOR:
         case FunctorOp::MOD:
-        case FunctorOp::UMOD:
-            return true;
-        default:
-            return false;
+        case FunctorOp::UMOD: return true;
+        default: return false;
     }
 }
 

--- a/src/FunctorOps.h
+++ b/src/FunctorOps.h
@@ -305,7 +305,9 @@ inline TypeAttribute functorReturnType(const FunctorOp op) {
         case FunctorOp::MAX:
         case FunctorOp::MIN:
         case FunctorOp::FTOI:
-        case FunctorOp::UTOI: return TypeAttribute::Signed;
+        case FunctorOp::UTOI: {
+            return TypeAttribute::Signed;
+        }
         case FunctorOp::UBNOT:
         case FunctorOp::ITOU:
         case FunctorOp::FTOU:
@@ -326,7 +328,9 @@ inline TypeAttribute functorReturnType(const FunctorOp op) {
         case FunctorOp::UBSHIFT_R:
         case FunctorOp::UBSHIFT_R_UNSIGNED:
         case FunctorOp::ULAND:
-        case FunctorOp::ULOR: return TypeAttribute::Unsigned;
+        case FunctorOp::ULOR: {
+            return TypeAttribute::Unsigned;
+        }
         case FunctorOp::FMAX:
         case FunctorOp::FMIN:
         case FunctorOp::FNEG:
@@ -337,12 +341,16 @@ inline TypeAttribute functorReturnType(const FunctorOp op) {
         case FunctorOp::FMUL:
         case FunctorOp::FDIV:
         case FunctorOp::FEXP:
-        case FunctorOp::FRANGE: return TypeAttribute::Float;
+        case FunctorOp::FRANGE: {
+            return TypeAttribute::Float;
+        }
         case FunctorOp::SMAX:
         case FunctorOp::SMIN:
         case FunctorOp::TOSTRING:
         case FunctorOp::CAT:
-        case FunctorOp::SUBSTR: return TypeAttribute::Symbol;
+        case FunctorOp::SUBSTR: {
+            return TypeAttribute::Symbol;
+        }
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -354,29 +362,36 @@ inline TypeAttribute functorReturnType(const FunctorOp op) {
 inline TypeAttribute functorOpArgType(const size_t arg, const FunctorOp op) {
     switch (op) {
         // Special case
-        case FunctorOp::ORD:
+        case FunctorOp::ORD: {
             fatal("ord is a special function that returns a Ram Representation of the element");
+        }
         case FunctorOp::ITOF:
         case FunctorOp::ITOU:
         case FunctorOp::NEG:
         case FunctorOp::BNOT:
         case FunctorOp::LNOT:
-        case FunctorOp::TOSTRING:
+        case FunctorOp::TOSTRING: {
             assert(arg == 0 && "unary functor out of bound");
             return TypeAttribute::Signed;
+        }
         case FunctorOp::FNEG:
         case FunctorOp::FTOI:
-        case FunctorOp::FTOU: assert(arg == 0 && "unary functor out of bound"); return TypeAttribute::Float;
+        case FunctorOp::FTOU: {
+            assert(arg == 0 && "unary functor out of bound");
+            return TypeAttribute::Float;
+        }
         case FunctorOp::STRLEN:
-        case FunctorOp::TONUMBER:
+        case FunctorOp::TONUMBER: {
             assert(arg == 0 && "unary functor out of bound");
             return TypeAttribute::Symbol;
+        }
         case FunctorOp::UBNOT:
         case FunctorOp::ULNOT:
         case FunctorOp::UTOI:
-        case FunctorOp::UTOF:
+        case FunctorOp::UTOF: {
             assert(arg == 0 && "unary functor out of bound");
             return TypeAttribute::Unsigned;
+        }
         case FunctorOp::ADD:
         case FunctorOp::SUB:
         case FunctorOp::MUL:
@@ -390,7 +405,10 @@ inline TypeAttribute functorOpArgType(const size_t arg, const FunctorOp op) {
         case FunctorOp::BSHIFT_R:
         case FunctorOp::BSHIFT_R_UNSIGNED:
         case FunctorOp::LAND:
-        case FunctorOp::LOR: assert(arg < 2 && "binary functor out of bound"); return TypeAttribute::Signed;
+        case FunctorOp::LOR: {
+            assert(arg < 2 && "binary functor out of bound");
+            return TypeAttribute::Signed;
+        }
         case FunctorOp::UADD:
         case FunctorOp::USUB:
         case FunctorOp::UMUL:
@@ -404,30 +422,44 @@ inline TypeAttribute functorOpArgType(const size_t arg, const FunctorOp op) {
         case FunctorOp::UBSHIFT_R:
         case FunctorOp::UBSHIFT_R_UNSIGNED:
         case FunctorOp::ULAND:
-        case FunctorOp::ULOR:
+        case FunctorOp::ULOR: {
             assert(arg < 2 && "binary functor out of bound");
             return TypeAttribute::Unsigned;
+        }
         case FunctorOp::FADD:
         case FunctorOp::FSUB:
         case FunctorOp::FMUL:
         case FunctorOp::FDIV:
-        case FunctorOp::FEXP: assert(arg < 2 && "binary functor out of bound"); return TypeAttribute::Float;
-        case FunctorOp::SUBSTR:
+        case FunctorOp::FEXP: {
+            assert(arg < 2 && "binary functor out of bound");
+            return TypeAttribute::Float;
+        }
+        case FunctorOp::SUBSTR: {
             assert(arg < 3 && "ternary functor out of bound");
             if (arg == 0) {
                 return TypeAttribute::Symbol;
             } else {
-                return TypeAttribute::Signed;  // In the future: Change to unsigned
+                // In the future: Change to unsigned
+                return TypeAttribute::Signed;
             }
+        }
         case FunctorOp::MAX:
-        case FunctorOp::MIN: return TypeAttribute::Signed;
+        case FunctorOp::MIN: {
+            return TypeAttribute::Signed;
+        }
         case FunctorOp::UMAX:
-        case FunctorOp::UMIN: return TypeAttribute::Unsigned;
+        case FunctorOp::UMIN: {
+            return TypeAttribute::Unsigned;
+        }
         case FunctorOp::FMAX:
-        case FunctorOp::FMIN: return TypeAttribute::Float;
+        case FunctorOp::FMIN: {
+            return TypeAttribute::Float;
+        }
         case FunctorOp::SMAX:
         case FunctorOp::SMIN:
-        case FunctorOp::CAT: return TypeAttribute::Symbol;
+        case FunctorOp::CAT: {
+            return TypeAttribute::Symbol;
+        }
 
         case FunctorOp::RANGE: return TypeAttribute::Signed;
         case FunctorOp::URANGE: return TypeAttribute::Unsigned;
@@ -462,9 +494,13 @@ inline bool isOverloadedFunctor(const FunctorOp functor) {
         case FunctorOp::MOD:
         case FunctorOp::MAX:
         case FunctorOp::MIN:
-        case FunctorOp::RANGE: return true;
+        case FunctorOp::RANGE: {
+            return true;
+        }
 
-        default: return false;
+        default: {
+            return false;
+        }
     }
 }
 
@@ -583,8 +619,13 @@ inline bool isInfixFunctorOp(const FunctorOp op) {
         case FunctorOp::LOR:
         case FunctorOp::ULOR:
         case FunctorOp::MOD:
-        case FunctorOp::UMOD: return true;
-        default: return false;
+        case FunctorOp::UMOD: {
+            return true;
+        }
+
+        default: {
+            return false;
+        }
     }
 }
 

--- a/src/FunctorOps.h
+++ b/src/FunctorOps.h
@@ -498,9 +498,7 @@ inline bool isOverloadedFunctor(const FunctorOp functor) {
             return true;
         }
 
-        default: {
-            return false;
-        }
+        default: return false;
     }
 }
 
@@ -623,9 +621,7 @@ inline bool isInfixFunctorOp(const FunctorOp op) {
             return true;
         }
 
-        default: {
-            return false;
-        }
+        default: return false;
     }
 }
 

--- a/src/InlineRelationsTransformer.cpp
+++ b/src/InlineRelationsTransformer.cpp
@@ -600,28 +600,17 @@ NullableVector<AstArgument*> getInlinedArgument(AstProgram& program, const AstAr
                     // Utility lambda: get functor used to tie aggregators together.
                     auto aggregateToFunctor = [](AggregateOp op) {
                         switch (op) {
-                            case AggregateOp::MIN:
-                                return FunctorOp::MIN;
-                            case AggregateOp::FMIN:
-                                return FunctorOp::FMIN;
-                            case AggregateOp::UMIN:
-                                return FunctorOp::UMIN;
-                            case AggregateOp::MAX:
-                                return FunctorOp::MAX;
-                            case AggregateOp::FMAX:
-                                return FunctorOp::FMAX;
-                            case AggregateOp::UMAX:
-                                return FunctorOp::UMAX;
-                            case AggregateOp::SUM:
-                                return FunctorOp::ADD;
-                            case AggregateOp::FSUM:
-                                return FunctorOp::FADD;
-                            case AggregateOp::USUM:
-                                return FunctorOp::UADD;
-                            case AggregateOp::COUNT:
-                                return FunctorOp::ADD;
-                            case AggregateOp::MEAN:
-                                fatal("no translation");
+                            case AggregateOp::MIN: return FunctorOp::MIN;
+                            case AggregateOp::FMIN: return FunctorOp::FMIN;
+                            case AggregateOp::UMIN: return FunctorOp::UMIN;
+                            case AggregateOp::MAX: return FunctorOp::MAX;
+                            case AggregateOp::FMAX: return FunctorOp::FMAX;
+                            case AggregateOp::UMAX: return FunctorOp::UMAX;
+                            case AggregateOp::SUM: return FunctorOp::ADD;
+                            case AggregateOp::FSUM: return FunctorOp::FADD;
+                            case AggregateOp::USUM: return FunctorOp::UADD;
+                            case AggregateOp::COUNT: return FunctorOp::ADD;
+                            case AggregateOp::MEAN: fatal("no translation");
                         }
 
                         UNREACHABLE_BAD_CASE_ANALYSIS

--- a/src/InterpreterEngine.cpp
+++ b/src/InterpreterEngine.cpp
@@ -299,24 +299,20 @@ RamDomain InterpreterEngine::execute(const InterpreterNode* node, InterpreterCon
             const auto& args = cur.getArguments();
             switch (cur.getOperator()) {
                 /** Unary Functor Operators */
-                case FunctorOp::ORD:
-                    return execute(node->getChild(0), ctxt);
+                case FunctorOp::ORD: return execute(node->getChild(0), ctxt);
                 case FunctorOp::STRLEN:
                     return getSymbolTable().resolve(execute(node->getChild(0), ctxt)).size();
-                case FunctorOp::NEG:
-                    return -execute(node->getChild(0), ctxt);
+                case FunctorOp::NEG: return -execute(node->getChild(0), ctxt);
                 case FunctorOp::FNEG: {
                     RamDomain result = execute(node->getChild(0), ctxt);
                     return ramBitCast(-ramBitCast<RamFloat>(result));
                 }
-                case FunctorOp::BNOT:
-                    return ~execute(node->getChild(0), ctxt);
+                case FunctorOp::BNOT: return ~execute(node->getChild(0), ctxt);
                 case FunctorOp::UBNOT: {
                     RamDomain result = execute(node->getChild(0), ctxt);
                     return ramBitCast(~ramBitCast<RamUnsigned>(result));
                 }
-                case FunctorOp::LNOT:
-                    return !execute(node->getChild(0), ctxt);
+                case FunctorOp::LNOT: return !execute(node->getChild(0), ctxt);
 
                 case FunctorOp::ULNOT: {
                     RamDomain result = execute(node->getChild(0), ctxt);
@@ -489,12 +485,9 @@ RamDomain InterpreterEngine::execute(const InterpreterNode* node, InterpreterCon
             true
 
             switch (cur.getFunction()) {
-                case RamNestedIntrinsicOp::RANGE:
-                    return RUN_RANGE(RamSigned);
-                case RamNestedIntrinsicOp::URANGE:
-                    return RUN_RANGE(RamUnsigned);
-                case RamNestedIntrinsicOp::FRANGE:
-                    return RUN_RANGE(RamFloat);
+                case RamNestedIntrinsicOp::RANGE: return RUN_RANGE(RamSigned);
+                case RamNestedIntrinsicOp::URANGE: return RUN_RANGE(RamUnsigned);
+                case RamNestedIntrinsicOp::FRANGE: return RUN_RANGE(RamFloat);
             }
 
             { UNREACHABLE_BAD_CASE_ANALYSIS }
@@ -544,8 +537,7 @@ RamDomain InterpreterEngine::execute(const InterpreterNode* node, InterpreterCon
                         floatVal[i] = ramBitCast<RamFloat>(arg);
                         values[i] = &floatVal[i];
                         break;
-                    case TypeAttribute::Record:
-                        fatal("Record support is not implemented");
+                    case TypeAttribute::Record: fatal("Record support is not implemented");
                 }
             }
 
@@ -553,20 +545,11 @@ RamDomain InterpreterEngine::execute(const InterpreterNode* node, InterpreterCon
             auto codomain = &FFI_RamSigned;
             switch (cur.getReturnType()) {
                 // initialize for string value.
-                case TypeAttribute::Symbol:
-                    codomain = &FFI_Symbol;
-                    break;
-                case TypeAttribute::Signed:
-                    codomain = &FFI_RamSigned;
-                    break;
-                case TypeAttribute::Unsigned:
-                    codomain = &FFI_RamUnsigned;
-                    break;
-                case TypeAttribute::Float:
-                    codomain = &FFI_RamFloat;
-                    break;
-                case TypeAttribute::Record:
-                    fatal("Not implemented");
+                case TypeAttribute::Symbol: codomain = &FFI_Symbol; break;
+                case TypeAttribute::Signed: codomain = &FFI_RamSigned; break;
+                case TypeAttribute::Unsigned: codomain = &FFI_RamUnsigned; break;
+                case TypeAttribute::Float: codomain = &FFI_RamFloat; break;
+                case TypeAttribute::Record: fatal("Not implemented");
             }
 
             // Call the external function.
@@ -579,20 +562,13 @@ RamDomain InterpreterEngine::execute(const InterpreterNode* node, InterpreterCon
 
             RamDomain result;
             switch (cur.getReturnType()) {
-                case TypeAttribute::Signed:
-                    result = static_cast<RamDomain>(rc);
-                    break;
+                case TypeAttribute::Signed: result = static_cast<RamDomain>(rc); break;
                 case TypeAttribute::Symbol:
                     result = getSymbolTable().lookup(reinterpret_cast<const char*>(rc));
                     break;
-                case TypeAttribute::Unsigned:
-                    result = ramBitCast(static_cast<RamUnsigned>(rc));
-                    break;
-                case TypeAttribute::Float:
-                    result = ramBitCast(static_cast<RamFloat>(rc));
-                    break;
-                case TypeAttribute::Record:
-                    fatal("Not implemented");
+                case TypeAttribute::Unsigned: result = ramBitCast(static_cast<RamUnsigned>(rc)); break;
+                case TypeAttribute::Float: result = ramBitCast(static_cast<RamFloat>(rc)); break;
+                case TypeAttribute::Record: fatal("Not implemented");
             }
 
             return result;
@@ -1253,25 +1229,13 @@ RamDomain InterpreterEngine::executeAggregate(InterpreterContext& ctxt, const Ag
     std::pair<RamFloat, RamFloat> accumulateMean;
 
     switch (aggregate.getFunction()) {
-        case AggregateOp::MIN:
-            res = ramBitCast(MAX_RAM_SIGNED);
-            break;
-        case AggregateOp::UMIN:
-            res = ramBitCast(MAX_RAM_UNSIGNED);
-            break;
-        case AggregateOp::FMIN:
-            res = ramBitCast(MAX_RAM_FLOAT);
-            break;
+        case AggregateOp::MIN: res = ramBitCast(MAX_RAM_SIGNED); break;
+        case AggregateOp::UMIN: res = ramBitCast(MAX_RAM_UNSIGNED); break;
+        case AggregateOp::FMIN: res = ramBitCast(MAX_RAM_FLOAT); break;
 
-        case AggregateOp::MAX:
-            res = ramBitCast(MIN_RAM_SIGNED);
-            break;
-        case AggregateOp::UMAX:
-            res = ramBitCast(MIN_RAM_UNSIGNED);
-            break;
-        case AggregateOp::FMAX:
-            res = ramBitCast(MIN_RAM_FLOAT);
-            break;
+        case AggregateOp::MAX: res = ramBitCast(MIN_RAM_SIGNED); break;
+        case AggregateOp::UMAX: res = ramBitCast(MIN_RAM_UNSIGNED); break;
+        case AggregateOp::FMAX: res = ramBitCast(MIN_RAM_FLOAT); break;
 
         case AggregateOp::SUM:
             res = ramBitCast(static_cast<RamSigned>(0));
@@ -1317,9 +1281,7 @@ RamDomain InterpreterEngine::executeAggregate(InterpreterContext& ctxt, const Ag
         RamDomain val = execute(&expression, ctxt);
 
         switch (aggregate.getFunction()) {
-            case AggregateOp::MIN:
-                res = std::min(res, val);
-                break;
+            case AggregateOp::MIN: res = std::min(res, val); break;
             case AggregateOp::FMIN:
                 res = ramBitCast(std::min(ramBitCast<RamFloat>(res), ramBitCast<RamFloat>(val)));
                 break;
@@ -1327,9 +1289,7 @@ RamDomain InterpreterEngine::executeAggregate(InterpreterContext& ctxt, const Ag
                 res = ramBitCast(std::min(ramBitCast<RamUnsigned>(res), ramBitCast<RamUnsigned>(val)));
                 break;
 
-            case AggregateOp::MAX:
-                res = std::max(res, val);
-                break;
+            case AggregateOp::MAX: res = std::max(res, val); break;
             case AggregateOp::FMAX:
                 res = ramBitCast(std::max(ramBitCast<RamFloat>(res), ramBitCast<RamFloat>(val)));
                 break;
@@ -1337,9 +1297,7 @@ RamDomain InterpreterEngine::executeAggregate(InterpreterContext& ctxt, const Ag
                 res = ramBitCast(std::max(ramBitCast<RamUnsigned>(res), ramBitCast<RamUnsigned>(val)));
                 break;
 
-            case AggregateOp::SUM:
-                res += val;
-                break;
+            case AggregateOp::SUM: res += val; break;
             case AggregateOp::FSUM:
                 res = ramBitCast(ramBitCast<RamFloat>(res) + ramBitCast<RamFloat>(val));
                 break;
@@ -1352,8 +1310,7 @@ RamDomain InterpreterEngine::executeAggregate(InterpreterContext& ctxt, const Ag
                 accumulateMean.second++;
                 break;
 
-            case AggregateOp::COUNT:
-                fatal("This should never be executed");
+            case AggregateOp::COUNT: fatal("This should never be executed");
         }
     }
 

--- a/src/InterpreterIndex.cpp
+++ b/src/InterpreterIndex.cpp
@@ -624,32 +624,19 @@ public:
 
 std::unique_ptr<InterpreterIndex> createBTreeIndex(const Order& order) {
     switch (order.size()) {
-        case 0:
-            return std::make_unique<NullaryIndex>();
-        case 1:
-            return std::make_unique<BTreeIndex<1>>(order);
-        case 2:
-            return std::make_unique<BTreeIndex<2>>(order);
-        case 3:
-            return std::make_unique<BTreeIndex<3>>(order);
-        case 4:
-            return std::make_unique<BTreeIndex<4>>(order);
-        case 5:
-            return std::make_unique<BTreeIndex<5>>(order);
-        case 6:
-            return std::make_unique<BTreeIndex<6>>(order);
-        case 7:
-            return std::make_unique<BTreeIndex<7>>(order);
-        case 8:
-            return std::make_unique<BTreeIndex<8>>(order);
-        case 9:
-            return std::make_unique<BTreeIndex<9>>(order);
-        case 10:
-            return std::make_unique<BTreeIndex<10>>(order);
-        case 11:
-            return std::make_unique<BTreeIndex<11>>(order);
-        case 12:
-            return std::make_unique<BTreeIndex<12>>(order);
+        case 0: return std::make_unique<NullaryIndex>();
+        case 1: return std::make_unique<BTreeIndex<1>>(order);
+        case 2: return std::make_unique<BTreeIndex<2>>(order);
+        case 3: return std::make_unique<BTreeIndex<3>>(order);
+        case 4: return std::make_unique<BTreeIndex<4>>(order);
+        case 5: return std::make_unique<BTreeIndex<5>>(order);
+        case 6: return std::make_unique<BTreeIndex<6>>(order);
+        case 7: return std::make_unique<BTreeIndex<7>>(order);
+        case 8: return std::make_unique<BTreeIndex<8>>(order);
+        case 9: return std::make_unique<BTreeIndex<9>>(order);
+        case 10: return std::make_unique<BTreeIndex<10>>(order);
+        case 11: return std::make_unique<BTreeIndex<11>>(order);
+        case 12: return std::make_unique<BTreeIndex<12>>(order);
     }
 
     fatal("Requested arity not yet supported. Feel free to add it.");
@@ -658,34 +645,20 @@ std::unique_ptr<InterpreterIndex> createBTreeIndex(const Order& order) {
 std::unique_ptr<InterpreterIndex> createBTreeProvenanceIndex(const Order& order) {
     switch (order.size()) {
         case 0:
-        case 1:
-            fatal("Provenance relation with arity < 2.");
-        case 2:
-            return std::make_unique<BTreeProvenanceIndex<2>>(order);
-        case 3:
-            return std::make_unique<BTreeProvenanceIndex<3>>(order);
-        case 4:
-            return std::make_unique<BTreeProvenanceIndex<4>>(order);
-        case 5:
-            return std::make_unique<BTreeProvenanceIndex<5>>(order);
-        case 6:
-            return std::make_unique<BTreeProvenanceIndex<6>>(order);
-        case 7:
-            return std::make_unique<BTreeProvenanceIndex<7>>(order);
-        case 8:
-            return std::make_unique<BTreeProvenanceIndex<8>>(order);
-        case 9:
-            return std::make_unique<BTreeProvenanceIndex<9>>(order);
-        case 10:
-            return std::make_unique<BTreeProvenanceIndex<10>>(order);
-        case 11:
-            return std::make_unique<BTreeProvenanceIndex<11>>(order);
-        case 12:
-            return std::make_unique<BTreeProvenanceIndex<12>>(order);
-        case 13:
-            return std::make_unique<BTreeProvenanceIndex<13>>(order);
-        case 14:
-            return std::make_unique<BTreeProvenanceIndex<14>>(order);
+        case 1: fatal("Provenance relation with arity < 2.");
+        case 2: return std::make_unique<BTreeProvenanceIndex<2>>(order);
+        case 3: return std::make_unique<BTreeProvenanceIndex<3>>(order);
+        case 4: return std::make_unique<BTreeProvenanceIndex<4>>(order);
+        case 5: return std::make_unique<BTreeProvenanceIndex<5>>(order);
+        case 6: return std::make_unique<BTreeProvenanceIndex<6>>(order);
+        case 7: return std::make_unique<BTreeProvenanceIndex<7>>(order);
+        case 8: return std::make_unique<BTreeProvenanceIndex<8>>(order);
+        case 9: return std::make_unique<BTreeProvenanceIndex<9>>(order);
+        case 10: return std::make_unique<BTreeProvenanceIndex<10>>(order);
+        case 11: return std::make_unique<BTreeProvenanceIndex<11>>(order);
+        case 12: return std::make_unique<BTreeProvenanceIndex<12>>(order);
+        case 13: return std::make_unique<BTreeProvenanceIndex<13>>(order);
+        case 14: return std::make_unique<BTreeProvenanceIndex<14>>(order);
     }
 
     fatal("Requested arity not yet supported. Feel free to add it.");
@@ -693,32 +666,19 @@ std::unique_ptr<InterpreterIndex> createBTreeProvenanceIndex(const Order& order)
 
 std::unique_ptr<InterpreterIndex> createBrieIndex(const Order& order) {
     switch (order.size()) {
-        case 0:
-            return std::make_unique<NullaryIndex>();
-        case 1:
-            return std::make_unique<BrieIndex<1>>(order);
-        case 2:
-            return std::make_unique<BrieIndex<2>>(order);
-        case 3:
-            return std::make_unique<BrieIndex<3>>(order);
-        case 4:
-            return std::make_unique<BrieIndex<4>>(order);
-        case 5:
-            return std::make_unique<BrieIndex<5>>(order);
-        case 6:
-            return std::make_unique<BrieIndex<6>>(order);
-        case 7:
-            return std::make_unique<BrieIndex<7>>(order);
-        case 8:
-            return std::make_unique<BrieIndex<8>>(order);
-        case 9:
-            return std::make_unique<BrieIndex<9>>(order);
-        case 10:
-            return std::make_unique<BrieIndex<10>>(order);
-        case 11:
-            return std::make_unique<BrieIndex<11>>(order);
-        case 12:
-            return std::make_unique<BrieIndex<12>>(order);
+        case 0: return std::make_unique<NullaryIndex>();
+        case 1: return std::make_unique<BrieIndex<1>>(order);
+        case 2: return std::make_unique<BrieIndex<2>>(order);
+        case 3: return std::make_unique<BrieIndex<3>>(order);
+        case 4: return std::make_unique<BrieIndex<4>>(order);
+        case 5: return std::make_unique<BrieIndex<5>>(order);
+        case 6: return std::make_unique<BrieIndex<6>>(order);
+        case 7: return std::make_unique<BrieIndex<7>>(order);
+        case 8: return std::make_unique<BrieIndex<8>>(order);
+        case 9: return std::make_unique<BrieIndex<9>>(order);
+        case 10: return std::make_unique<BrieIndex<10>>(order);
+        case 11: return std::make_unique<BrieIndex<11>>(order);
+        case 12: return std::make_unique<BrieIndex<12>>(order);
     }
 
     fatal("Requested arity not yet supported. Feel free to add it.");

--- a/src/InterpreterProgInterface.h
+++ b/src/InterpreterProgInterface.h
@@ -128,9 +128,18 @@ protected:
                         tup << s;
                         break;
                     }
-                    case 'f': tup << ramBitCast<RamFloat>((*it)[i]); break;
-                    case 'u': tup << ramBitCast<RamUnsigned>((*it)[i]); break;
-                    default: tup << (*it)[i]; break;
+                    case 'f': {
+                        tup << ramBitCast<RamFloat>((*it)[i]);
+                        break;
+                    }
+                    case 'u': {
+                        tup << ramBitCast<RamUnsigned>((*it)[i]);
+                        break;
+                    }
+                    default: {
+                        tup << (*it)[i];
+                        break;
+                    }
                 }
             }
             tup.rewind();

--- a/src/InterpreterProgInterface.h
+++ b/src/InterpreterProgInterface.h
@@ -128,15 +128,9 @@ protected:
                         tup << s;
                         break;
                     }
-                    case 'f':
-                        tup << ramBitCast<RamFloat>((*it)[i]);
-                        break;
-                    case 'u':
-                        tup << ramBitCast<RamUnsigned>((*it)[i]);
-                        break;
-                    default:
-                        tup << (*it)[i];
-                        break;
+                    case 'f': tup << ramBitCast<RamFloat>((*it)[i]); break;
+                    case 'u': tup << ramBitCast<RamUnsigned>((*it)[i]); break;
+                    default: tup << (*it)[i]; break;
                 }
             }
             tup.rewind();

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -772,25 +772,15 @@ protected:
         switch (function) {
             case AggregateOp::MIN:
             case AggregateOp::FMIN:
-            case AggregateOp::UMIN:
-                os << "min ";
-                break;
+            case AggregateOp::UMIN: os << "min "; break;
             case AggregateOp::MAX:
             case AggregateOp::UMAX:
-            case AggregateOp::FMAX:
-                os << "max ";
-                break;
+            case AggregateOp::FMAX: os << "max "; break;
             case AggregateOp::SUM:
             case AggregateOp::FSUM:
-            case AggregateOp::USUM:
-                os << "sum ";
-                break;
-            case AggregateOp::COUNT:
-                os << "count ";
-                break;
-            case AggregateOp::MEAN:
-                os << "mean ";
-                break;
+            case AggregateOp::USUM: os << "sum "; break;
+            case AggregateOp::COUNT: os << "count "; break;
+            case AggregateOp::MEAN: os << "mean "; break;
         }
         if (function != AggregateOp::COUNT) {
             os << *expression << " ";
@@ -939,12 +929,9 @@ enum class RamNestedIntrinsicOp {
 
 inline std::ostream& operator<<(std::ostream& os, RamNestedIntrinsicOp e) {
     switch (e) {
-        case RamNestedIntrinsicOp::RANGE:
-            return os << "RANGE";
-        case RamNestedIntrinsicOp::URANGE:
-            return os << "URANGE";
-        case RamNestedIntrinsicOp::FRANGE:
-            return os << "FRANGE";
+        case RamNestedIntrinsicOp::RANGE: return os << "RANGE";
+        case RamNestedIntrinsicOp::URANGE: return os << "URANGE";
+        case RamNestedIntrinsicOp::FRANGE: return os << "FRANGE";
     }
     abort();
 }

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -974,7 +974,9 @@ public:
 
     std::vector<const RamNode*> getChildNodes() const override {
         auto res = RamTupleOperation::getChildNodes();
-        for (auto&& x : args) res.push_back(x.get());
+        for (auto&& x : args) {
+            res.push_back(x.get());
+        }
         return res;
     }
 
@@ -985,7 +987,9 @@ public:
 
     void apply(const RamNodeMapper& map) override {
         RamTupleOperation::apply(map);
-        for (auto&& x : args) x = map(std::move(x));
+        for (auto&& x : args) {
+            x = map(std::move(x));
+        }
     }
 
 protected:

--- a/src/ReadStream.h
+++ b/src/ReadStream.h
@@ -89,23 +89,16 @@ protected:
             }
             consumeWhiteSpace(source, pos);
             switch (recordType[0]) {
-                case 's':
-                    recordValues[i] = readStringInRecord(source, pos, &consumed);
-                    break;
-                case 'i':
-                    recordValues[i] = RamSignedFromString(source.substr(pos), &consumed);
-                    break;
+                case 's': recordValues[i] = readStringInRecord(source, pos, &consumed); break;
+                case 'i': recordValues[i] = RamSignedFromString(source.substr(pos), &consumed); break;
                 case 'u':
                     recordValues[i] = ramBitCast(RamUnsignedFromString(source.substr(pos), &consumed));
                     break;
                 case 'f':
                     recordValues[i] = ramBitCast(RamFloatFromString(source.substr(pos), &consumed));
                     break;
-                case 'r':
-                    recordValues[i] = readRecord(source, recordType, pos, &consumed);
-                    break;
-                default:
-                    fatal("Invalid type attribute");
+                case 'r': recordValues[i] = readRecord(source, recordType, pos, &consumed); break;
+                default: fatal("Invalid type attribute");
             }
             pos += consumed;
         }

--- a/src/ReadStream.h
+++ b/src/ReadStream.h
@@ -89,16 +89,29 @@ protected:
             }
             consumeWhiteSpace(source, pos);
             switch (recordType[0]) {
-                case 's': recordValues[i] = readStringInRecord(source, pos, &consumed); break;
-                case 'i': recordValues[i] = RamSignedFromString(source.substr(pos), &consumed); break;
-                case 'u':
+                case 's': {
+                    recordValues[i] = readStringInRecord(source, pos, &consumed);
+                    break;
+                }
+                case 'i': {
+                    recordValues[i] = RamSignedFromString(source.substr(pos), &consumed);
+                    break;
+                }
+                case 'u': {
                     recordValues[i] = ramBitCast(RamUnsignedFromString(source.substr(pos), &consumed));
                     break;
-                case 'f':
+                }
+                case 'f': {
                     recordValues[i] = ramBitCast(RamFloatFromString(source.substr(pos), &consumed));
                     break;
-                case 'r': recordValues[i] = readRecord(source, recordType, pos, &consumed); break;
-                default: fatal("Invalid type attribute");
+                }
+                case 'r': {
+                    recordValues[i] = readRecord(source, recordType, pos, &consumed);
+                    break;
+                }
+                default: {
+                    fatal("Invalid type attribute");
+                }
             }
             pos += consumed;
         }

--- a/src/ReadStream.h
+++ b/src/ReadStream.h
@@ -109,9 +109,7 @@ protected:
                     recordValues[i] = readRecord(source, recordType, pos, &consumed);
                     break;
                 }
-                default: {
-                    fatal("Invalid type attribute");
-                }
+                default: fatal("Invalid type attribute");
             }
             pos += consumed;
         }

--- a/src/ReadStreamCSV.h
+++ b/src/ReadStreamCSV.h
@@ -105,9 +105,7 @@ protected:
                         tuple[inputMap[column]] = ramBitCast(RamFloatFromString(element, &charactersRead));
                         break;
                     }
-                    default: {
-                        fatal("invalid type attribute: `%c`", ty[0]);
-                    }
+                    default: fatal("invalid type attribute: `%c`", ty[0]);
                 }
                 // Check if everything was read.
                 if (charactersRead != element.size()) {

--- a/src/ReadStreamCSV.h
+++ b/src/ReadStreamCSV.h
@@ -88,20 +88,15 @@ protected:
                         tuple[inputMap[column]] = symbolTable.unsafeLookup(element);
                         charactersRead = element.size();
                         break;
-                    case 'r':
-                        tuple[inputMap[column]] = readRecord(element, ty, 0, &charactersRead);
-                        break;
-                    case 'i':
-                        tuple[inputMap[column]] = RamSignedFromString(element, &charactersRead);
-                        break;
+                    case 'r': tuple[inputMap[column]] = readRecord(element, ty, 0, &charactersRead); break;
+                    case 'i': tuple[inputMap[column]] = RamSignedFromString(element, &charactersRead); break;
                     case 'u':
                         tuple[inputMap[column]] = ramBitCast(readRamUnsigned(element, charactersRead));
                         break;
                     case 'f':
                         tuple[inputMap[column]] = ramBitCast(RamFloatFromString(element, &charactersRead));
                         break;
-                    default:
-                        fatal("invalid type attribute: `%c`", ty[0]);
+                    default: fatal("invalid type attribute: `%c`", ty[0]);
                 }
                 // Check if everything was read.
                 if (charactersRead != element.size()) {

--- a/src/ReadStreamCSV.h
+++ b/src/ReadStreamCSV.h
@@ -84,19 +84,30 @@ protected:
             try {
                 auto&& ty = typeAttributes.at(inputMap[column]);
                 switch (ty[0]) {
-                    case 's':
+                    case 's': {
                         tuple[inputMap[column]] = symbolTable.unsafeLookup(element);
                         charactersRead = element.size();
                         break;
-                    case 'r': tuple[inputMap[column]] = readRecord(element, ty, 0, &charactersRead); break;
-                    case 'i': tuple[inputMap[column]] = RamSignedFromString(element, &charactersRead); break;
-                    case 'u':
+                    }
+                    case 'r': {
+                        tuple[inputMap[column]] = readRecord(element, ty, 0, &charactersRead);
+                        break;
+                    }
+                    case 'i': {
+                        tuple[inputMap[column]] = RamSignedFromString(element, &charactersRead);
+                        break;
+                    }
+                    case 'u': {
                         tuple[inputMap[column]] = ramBitCast(readRamUnsigned(element, charactersRead));
                         break;
-                    case 'f':
+                    }
+                    case 'f': {
                         tuple[inputMap[column]] = ramBitCast(RamFloatFromString(element, &charactersRead));
                         break;
-                    default: fatal("invalid type attribute: `%c`", ty[0]);
+                    }
+                    default: {
+                        fatal("invalid type attribute: `%c`", ty[0]);
+                    }
                 }
                 // Check if everything was read.
                 if (charactersRead != element.size()) {

--- a/src/ReadStreamSQLite.h
+++ b/src/ReadStreamSQLite.h
@@ -69,17 +69,12 @@ protected:
             try {
                 auto&& ty = typeAttributes.at(column);
                 switch (ty[0]) {
-                    case 's':
-                        tuple[column] = symbolTable.unsafeLookup(element);
-                        break;
+                    case 's': tuple[column] = symbolTable.unsafeLookup(element); break;
                     case 'i':
                     case 'u':
                     case 'f':
-                    case 'r':
-                        tuple[column] = RamSignedFromString(element);
-                        break;
-                    default:
-                        fatal("invalid type attribute: `%c`", ty[0]);
+                    case 'r': tuple[column] = RamSignedFromString(element); break;
+                    default: fatal("invalid type attribute: `%c`", ty[0]);
                 }
             } catch (...) {
                 std::stringstream errorMessage;

--- a/src/RelationTag.h
+++ b/src/RelationTag.h
@@ -59,10 +59,8 @@ inline bool isRelationRepresentationTag(const RelationTag& tag) {
     switch (tag) {
         case RelationTag::BRIE:
         case RelationTag::BTREE:
-        case RelationTag::EQREL:
-            return true;
-        default:
-            return false;
+        case RelationTag::EQREL: return true;
+        default: return false;
     }
 }
 
@@ -76,10 +74,8 @@ inline bool isRelationQualifierTag(const RelationTag& tag) {
         case RelationTag::PRINTSIZE:
         case RelationTag::OVERRIDABLE:
         case RelationTag::INLINE:
-        case RelationTag::SUPPRESSED:
-            return true;
-        default:
-            return false;
+        case RelationTag::SUPPRESSED: return true;
+        default: return false;
     }
 }
 
@@ -88,20 +84,13 @@ inline bool isRelationQualifierTag(const RelationTag& tag) {
  */
 inline RelationQualifier getRelationQualifierFromTag(const RelationTag& tag) {
     switch (tag) {
-        case RelationTag::INPUT:
-            return RelationQualifier::INPUT;
-        case RelationTag::OUTPUT:
-            return RelationQualifier::OUTPUT;
-        case RelationTag::PRINTSIZE:
-            return RelationQualifier::PRINTSIZE;
-        case RelationTag::OVERRIDABLE:
-            return RelationQualifier::OVERRIDABLE;
-        case RelationTag::INLINE:
-            return RelationQualifier::INLINE;
-        case RelationTag::SUPPRESSED:
-            return RelationQualifier::SUPPRESSED;
-        default:
-            fatal("invalid relation tag");
+        case RelationTag::INPUT: return RelationQualifier::INPUT;
+        case RelationTag::OUTPUT: return RelationQualifier::OUTPUT;
+        case RelationTag::PRINTSIZE: return RelationQualifier::PRINTSIZE;
+        case RelationTag::OVERRIDABLE: return RelationQualifier::OVERRIDABLE;
+        case RelationTag::INLINE: return RelationQualifier::INLINE;
+        case RelationTag::SUPPRESSED: return RelationQualifier::SUPPRESSED;
+        default: fatal("invalid relation tag");
     }
 }
 
@@ -110,14 +99,10 @@ inline RelationQualifier getRelationQualifierFromTag(const RelationTag& tag) {
  */
 inline RelationRepresentation getRelationRepresentationFromTag(const RelationTag& tag) {
     switch (tag) {
-        case RelationTag::BRIE:
-            return RelationRepresentation::BRIE;
-        case RelationTag::BTREE:
-            return RelationRepresentation::BTREE;
-        case RelationTag::EQREL:
-            return RelationRepresentation::EQREL;
-        default:
-            fatal("invalid relation tag");
+        case RelationTag::BRIE: return RelationRepresentation::BRIE;
+        case RelationTag::BTREE: return RelationRepresentation::BTREE;
+        case RelationTag::EQREL: return RelationRepresentation::EQREL;
+        default: fatal("invalid relation tag");
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -125,24 +110,15 @@ inline RelationRepresentation getRelationRepresentationFromTag(const RelationTag
 
 inline std::ostream& operator<<(std::ostream& os, RelationTag qualifier) {
     switch (qualifier) {
-        case RelationTag::INPUT:
-            return os << "input";
-        case RelationTag::OUTPUT:
-            return os << "output";
-        case RelationTag::PRINTSIZE:
-            return os << "printsize";
-        case RelationTag::OVERRIDABLE:
-            return os << "overridable";
-        case RelationTag::INLINE:
-            return os << "inline";
-        case RelationTag::SUPPRESSED:
-            return os << "suppressed";
-        case RelationTag::BRIE:
-            return os << "brie";
-        case RelationTag::BTREE:
-            return os << "btree";
-        case RelationTag::EQREL:
-            return os << "eqrel";
+        case RelationTag::INPUT: return os << "input";
+        case RelationTag::OUTPUT: return os << "output";
+        case RelationTag::PRINTSIZE: return os << "printsize";
+        case RelationTag::OVERRIDABLE: return os << "overridable";
+        case RelationTag::INLINE: return os << "inline";
+        case RelationTag::SUPPRESSED: return os << "suppressed";
+        case RelationTag::BRIE: return os << "brie";
+        case RelationTag::BTREE: return os << "btree";
+        case RelationTag::EQREL: return os << "eqrel";
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -150,18 +126,12 @@ inline std::ostream& operator<<(std::ostream& os, RelationTag qualifier) {
 
 inline std::ostream& operator<<(std::ostream& os, RelationQualifier qualifier) {
     switch (qualifier) {
-        case RelationQualifier::INPUT:
-            return os << "input";
-        case RelationQualifier::OUTPUT:
-            return os << "output";
-        case RelationQualifier::PRINTSIZE:
-            return os << "printsize";
-        case RelationQualifier::OVERRIDABLE:
-            return os << "overridable";
-        case RelationQualifier::INLINE:
-            return os << "inline";
-        case RelationQualifier::SUPPRESSED:
-            return os << "suppressed";
+        case RelationQualifier::INPUT: return os << "input";
+        case RelationQualifier::OUTPUT: return os << "output";
+        case RelationQualifier::PRINTSIZE: return os << "printsize";
+        case RelationQualifier::OVERRIDABLE: return os << "overridable";
+        case RelationQualifier::INLINE: return os << "inline";
+        case RelationQualifier::SUPPRESSED: return os << "suppressed";
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
@@ -169,16 +139,11 @@ inline std::ostream& operator<<(std::ostream& os, RelationQualifier qualifier) {
 
 inline std::ostream& operator<<(std::ostream& os, RelationRepresentation representation) {
     switch (representation) {
-        case RelationRepresentation::BTREE:
-            return os << "btree";
-        case RelationRepresentation::BRIE:
-            return os << "brie";
-        case RelationRepresentation::EQREL:
-            return os << "eqrel";
-        case RelationRepresentation::INFO:
-            return os << "info";
-        case RelationRepresentation::DEFAULT:
-            return os;
+        case RelationRepresentation::BTREE: return os << "btree";
+        case RelationRepresentation::BRIE: return os << "brie";
+        case RelationRepresentation::EQREL: return os << "eqrel";
+        case RelationRepresentation::INFO: return os << "info";
+        case RelationRepresentation::DEFAULT: return os;
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS

--- a/src/SignalHandler.h
+++ b/src/SignalHandler.h
@@ -152,18 +152,10 @@ private:
         const char* msg = instance()->msg;
         std::string error;
         switch (signal) {
-            case SIGINT:
-                error = "Interrupt";
-                break;
-            case SIGFPE:
-                error = "Floating-point arithmetic exception";
-                break;
-            case SIGSEGV:
-                error = "Segmentation violation";
-                break;
-            default:
-                error = "Unknown";
-                break;
+            case SIGINT: error = "Interrupt"; break;
+            case SIGFPE: error = "Floating-point arithmetic exception"; break;
+            case SIGSEGV: error = "Segmentation violation"; break;
+            default: error = "Unknown"; break;
         }
         if (msg != nullptr) {
             std::cerr << error << " signal in rule:\n" << msg << std::endl;

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -867,31 +867,17 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             // init result
             std::string init;
             switch (aggregate.getFunction()) {
-                case AggregateOp::MIN:
-                    init = "MAX_RAM_SIGNED";
-                    break;
-                case AggregateOp::FMIN:
-                    init = "MAX_RAM_FLOAT";
-                    break;
-                case AggregateOp::UMIN:
-                    init = "MAX_RAM_UNSIGNED";
-                    break;
-                case AggregateOp::MAX:
-                    init = "MIN_RAM_SIGNED";
-                    break;
-                case AggregateOp::FMAX:
-                    init = "MIN_RAM_FLOAT";
-                    break;
-                case AggregateOp::UMAX:
-                    init = "MIN_RAM_UNSIGNED";
-                    break;
+                case AggregateOp::MIN: init = "MAX_RAM_SIGNED"; break;
+                case AggregateOp::FMIN: init = "MAX_RAM_FLOAT"; break;
+                case AggregateOp::UMIN: init = "MAX_RAM_UNSIGNED"; break;
+                case AggregateOp::MAX: init = "MIN_RAM_SIGNED"; break;
+                case AggregateOp::FMAX: init = "MIN_RAM_FLOAT"; break;
+                case AggregateOp::UMAX: init = "MIN_RAM_UNSIGNED"; break;
                 case AggregateOp::COUNT:
                     init = "0";
                     out << "shouldRunNested = true;\n";
                     break;
-                case AggregateOp::MEAN:
-                    init = "0";
-                    break;
+                case AggregateOp::MEAN: init = "0"; break;
                 case AggregateOp::FSUM:
                 case AggregateOp::USUM:
                 case AggregateOp::SUM:
@@ -902,20 +888,12 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 
             std::string type;
             switch (getTypeAttributeAggregate(aggregate.getFunction())) {
-                case TypeAttribute::Signed:
-                    type = "RamSigned";
-                    break;
-                case TypeAttribute::Unsigned:
-                    type = "RamUnsigned";
-                    break;
-                case TypeAttribute::Float:
-                    type = "RamFloat";
-                    break;
+                case TypeAttribute::Signed: type = "RamSigned"; break;
+                case TypeAttribute::Unsigned: type = "RamUnsigned"; break;
+                case TypeAttribute::Float: type = "RamFloat"; break;
 
                 case TypeAttribute::Symbol:
-                case TypeAttribute::Record:
-                    type = "RamDomain";
-                    break;
+                case TypeAttribute::Record: type = "RamDomain"; break;
             }
             out << type << " res" << identifier << " = " << init << ";\n";
 
@@ -973,9 +951,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                     visit(aggregate.getExpression(), out);
                     out << "));\n";
                     break;
-                case AggregateOp::COUNT:
-                    out << "++res" << identifier << "\n;";
-                    break;
+                case AggregateOp::COUNT: out << "++res" << identifier << "\n;"; break;
                 case AggregateOp::FSUM:
                 case AggregateOp::USUM:
                 case AggregateOp::SUM:
@@ -1042,32 +1018,18 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             // init result
             std::string init;
             switch (aggregate.getFunction()) {
-                case AggregateOp::MIN:
-                    init = "MAX_RAM_SIGNED";
-                    break;
-                case AggregateOp::FMIN:
-                    init = "MAX_RAM_FLOAT";
-                    break;
-                case AggregateOp::UMIN:
-                    init = "MAX_RAM_UNSIGNED";
-                    break;
-                case AggregateOp::MAX:
-                    init = "MIN_RAM_SIGNED";
-                    break;
-                case AggregateOp::FMAX:
-                    init = "MIN_RAM_FLOAT";
-                    break;
-                case AggregateOp::UMAX:
-                    init = "MIN_RAM_UNSIGNED";
-                    break;
+                case AggregateOp::MIN: init = "MAX_RAM_SIGNED"; break;
+                case AggregateOp::FMIN: init = "MAX_RAM_FLOAT"; break;
+                case AggregateOp::UMIN: init = "MAX_RAM_UNSIGNED"; break;
+                case AggregateOp::MAX: init = "MIN_RAM_SIGNED"; break;
+                case AggregateOp::FMAX: init = "MIN_RAM_FLOAT"; break;
+                case AggregateOp::UMAX: init = "MIN_RAM_UNSIGNED"; break;
                 case AggregateOp::COUNT:
                     init = "0";
                     out << "shouldRunNested = true;\n";
                     break;
 
-                case AggregateOp::MEAN:
-                    init = "0";
-                    break;
+                case AggregateOp::MEAN: init = "0"; break;
 
                 case AggregateOp::FSUM:
                 case AggregateOp::USUM:
@@ -1079,20 +1041,12 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 
             char const* type;
             switch (getTypeAttributeAggregate(aggregate.getFunction())) {
-                case TypeAttribute::Signed:
-                    type = "RamSigned";
-                    break;
-                case TypeAttribute::Unsigned:
-                    type = "RamUnsigned";
-                    break;
-                case TypeAttribute::Float:
-                    type = "RamFloat";
-                    break;
+                case TypeAttribute::Signed: type = "RamSigned"; break;
+                case TypeAttribute::Unsigned: type = "RamUnsigned"; break;
+                case TypeAttribute::Float: type = "RamFloat"; break;
 
                 case TypeAttribute::Symbol:
-                case TypeAttribute::Record:
-                    type = "RamDomain";
-                    break;
+                case TypeAttribute::Record: type = "RamDomain"; break;
             }
             out << type << " res" << identifier << " = " << init << ";\n";
 
@@ -1128,9 +1082,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                     visit(aggregate.getExpression(), out);
                     out << "));\n";
                     break;
-                case AggregateOp::COUNT:
-                    out << "++res" << identifier << "\n;";
-                    break;
+                case AggregateOp::COUNT: out << "++res" << identifier << "\n;"; break;
                 case AggregateOp::FSUM:
                 case AggregateOp::USUM:
                 case AggregateOp::SUM:
@@ -1634,11 +1586,9 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                 NARY_OP_ORDERED(MIN, std::min)
                     // clang-format on
 
-                case FunctorOp::SMAX:
-                    MINMAX_SYMBOL(std::max)
+                case FunctorOp::SMAX: MINMAX_SYMBOL(std::max)
 
-                case FunctorOp::SMIN:
-                    MINMAX_SYMBOL(std::min)
+                case FunctorOp::SMIN: MINMAX_SYMBOL(std::min)
 
                 // strings
                 case FunctorOp::CAT: {
@@ -1697,12 +1647,9 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
             };
 
             switch (op.getFunction()) {
-                case RamNestedIntrinsicOp::RANGE:
-                    return emitRange("RamSigned");
-                case RamNestedIntrinsicOp::URANGE:
-                    return emitRange("RamUnsigned");
-                case RamNestedIntrinsicOp::FRANGE:
-                    return emitRange("RamFloat");
+                case RamNestedIntrinsicOp::RANGE: return emitRange("RamSigned");
+                case RamNestedIntrinsicOp::URANGE: return emitRange("RamUnsigned");
+                case RamNestedIntrinsicOp::FRANGE: return emitRange("RamFloat");
             }
 
             UNREACHABLE_BAD_CASE_ANALYSIS
@@ -1744,8 +1691,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                         visit(args[i], out);
                         out << ").c_str()";
                         break;
-                    case TypeAttribute::Record:
-                        fatal("unhandled type");
+                    case TypeAttribute::Record: fatal("unhandled type");
                 }
             }
             out << ")";
@@ -1858,16 +1804,11 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
 
         auto cppTypeDecl = [](TypeAttribute ty) -> char const* {
             switch (ty) {
-                case TypeAttribute::Signed:
-                    return "souffle::RamSigned";
-                case TypeAttribute::Unsigned:
-                    return "souffle::RamUnsigned";
-                case TypeAttribute::Float:
-                    return "souffle::RamFloat";
-                case TypeAttribute::Symbol:
-                    return "const char *";
-                case TypeAttribute::Record:
-                    fatal("records cannot be used by user-defined functors");
+                case TypeAttribute::Signed: return "souffle::RamSigned";
+                case TypeAttribute::Unsigned: return "souffle::RamUnsigned";
+                case TypeAttribute::Float: return "souffle::RamFloat";
+                case TypeAttribute::Symbol: return "const char *";
+                case TypeAttribute::Record: fatal("records cannot be used by user-defined functors");
             }
 
             UNREACHABLE_BAD_CASE_ANALYSIS

--- a/src/TypeSystem.cpp
+++ b/src/TypeSystem.cpp
@@ -228,21 +228,11 @@ std::string getTypeQualifier(const Type& type) {
             std::string str;
 
             switch (getTypeAttribute(type)) {
-                case TypeAttribute::Signed:
-                    str.append("i");
-                    break;
-                case TypeAttribute::Unsigned:
-                    str.append("u");
-                    break;
-                case TypeAttribute::Float:
-                    str.append("f");
-                    break;
-                case TypeAttribute::Symbol:
-                    str.append("s");
-                    break;
-                case TypeAttribute::Record:
-                    str.append("r");
-                    break;
+                case TypeAttribute::Signed: str.append("i"); break;
+                case TypeAttribute::Unsigned: str.append("u"); break;
+                case TypeAttribute::Float: str.append("f"); break;
+                case TypeAttribute::Symbol: str.append("s"); break;
+                case TypeAttribute::Record: str.append("r"); break;
             }
             str.append(":");
             str.append(toString(type.getName()));

--- a/src/TypeSystem.h
+++ b/src/TypeSystem.h
@@ -360,16 +360,11 @@ public:
 
     SubsetType& createSubsetType(const AstQualifiedName& name, TypeAttribute typeAttribute) {
         switch (typeAttribute) {
-            case TypeAttribute::Signed:
-                return createType<SubsetType>(name, getType("number"));
-            case TypeAttribute::Unsigned:
-                return createType<SubsetType>(name, getType("unsigned"));
-            case TypeAttribute::Float:
-                return createType<SubsetType>(name, getType("float"));
-            case TypeAttribute::Symbol:
-                return createType<SubsetType>(name, getType("symbol"));
-            case TypeAttribute::Record:
-                break;
+            case TypeAttribute::Signed: return createType<SubsetType>(name, getType("number"));
+            case TypeAttribute::Unsigned: return createType<SubsetType>(name, getType("unsigned"));
+            case TypeAttribute::Float: return createType<SubsetType>(name, getType("float"));
+            case TypeAttribute::Symbol: return createType<SubsetType>(name, getType("symbol"));
+            case TypeAttribute::Record: break;
         }
 
         fatal("Invalid type attribute");
@@ -384,16 +379,11 @@ public:
 
     const Type& getConstantType(TypeAttribute type) const {
         switch (type) {
-            case TypeAttribute::Signed:
-                return getType("numberConstant");
-            case TypeAttribute::Unsigned:
-                return getType("unsignedConstant");
-            case TypeAttribute::Float:
-                return getType("floatConstant");
-            case TypeAttribute::Symbol:
-                return getType("symbolConstant");
-            case TypeAttribute::Record:
-                break;
+            case TypeAttribute::Signed: return getType("numberConstant");
+            case TypeAttribute::Unsigned: return getType("unsignedConstant");
+            case TypeAttribute::Float: return getType("floatConstant");
+            case TypeAttribute::Symbol: return getType("symbolConstant");
+            case TypeAttribute::Record: break;
         }
 
         fatal("There is no constant record type");
@@ -458,16 +448,11 @@ std::string getTypeQualifier(const Type& type);
 template <typename T>  // T = Type or T = Typeset
 bool eqTypeTypeAttribute(const TypeAttribute ramType, const T& type) {
     switch (ramType) {
-        case TypeAttribute::Signed:
-            return isNumberType(type);
-        case TypeAttribute::Unsigned:
-            return isUnsignedType(type);
-        case TypeAttribute::Float:
-            return isFloatType(type);
-        case TypeAttribute::Symbol:
-            return isSymbolType(type);
-        case TypeAttribute::Record:
-            return isRecordType(type);
+        case TypeAttribute::Signed: return isNumberType(type);
+        case TypeAttribute::Unsigned: return isUnsignedType(type);
+        case TypeAttribute::Float: return isFloatType(type);
+        case TypeAttribute::Symbol: return isSymbolType(type);
+        case TypeAttribute::Record: return isRecordType(type);
     }
     fatal("unhandled `TypeAttribute`");
 }

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -13,16 +13,11 @@ namespace souffle {
 
 std::ostream& operator<<(std::ostream& os, TypeAttribute T) {
     switch (T) {
-        case TypeAttribute::Symbol:
-            return os << "TypeAttribute::Symbol";
-        case TypeAttribute::Signed:
-            return os << "TypeAttribute::Signed";
-        case TypeAttribute::Float:
-            return os << "TypeAttribute::Float";
-        case TypeAttribute::Unsigned:
-            return os << "TypeAttribute::Unsigned";
-        case TypeAttribute::Record:
-            return os << "TypeAttribute::Record";
+        case TypeAttribute::Symbol: return os << "TypeAttribute::Symbol";
+        case TypeAttribute::Signed: return os << "TypeAttribute::Signed";
+        case TypeAttribute::Float: return os << "TypeAttribute::Float";
+        case TypeAttribute::Unsigned: return os << "TypeAttribute::Unsigned";
+        case TypeAttribute::Record: return os << "TypeAttribute::Record";
     }
 
     fatal("unhandled `TypeAttribute`");
@@ -32,11 +27,9 @@ bool isNumericType(TypeAttribute ramType) {
     switch (ramType) {
         case TypeAttribute::Signed:
         case TypeAttribute::Unsigned:
-        case TypeAttribute::Float:
-            return true;
+        case TypeAttribute::Float: return true;
         case TypeAttribute::Symbol:
-        case TypeAttribute::Record:
-            return false;
+        case TypeAttribute::Record: return false;
     }
 
     fatal("unhandled `TypeAttribute`");

--- a/src/WriteStream.h
+++ b/src/WriteStream.h
@@ -102,23 +102,12 @@ protected:
             const RamDomain recordValue = tuplePtr[i];
 
             switch (recordType[0]) {
-                case 'i':
-                    destination << recordValue;
-                    break;
-                case 'f':
-                    destination << ramBitCast<RamFloat>(recordValue);
-                    break;
-                case 'u':
-                    destination << ramBitCast<RamUnsigned>(recordValue);
-                    break;
-                case 's':
-                    destination << symbolTable.unsafeResolve(recordValue);
-                    break;
-                case 'r':
-                    outputRecord(destination, recordValue, recordType);
-                    break;
-                default:
-                    fatal("Unsupported type attribute: `%c`", recordType[0]);
+                case 'i': destination << recordValue; break;
+                case 'f': destination << ramBitCast<RamFloat>(recordValue); break;
+                case 'u': destination << ramBitCast<RamUnsigned>(recordValue); break;
+                case 's': destination << symbolTable.unsafeResolve(recordValue); break;
+                case 'r': outputRecord(destination, recordValue, recordType); break;
+                default: fatal("Unsupported type attribute: `%c`", recordType[0]);
             }
         }
         destination << "]";

--- a/src/WriteStreamCSV.h
+++ b/src/WriteStreamCSV.h
@@ -53,23 +53,12 @@ protected:
 
     void writeNextTupleElement(std::ostream& destination, const std::string& type, RamDomain value) {
         switch (type[0]) {
-            case 's':
-                destination << symbolTable.unsafeResolve(value);
-                break;
-            case 'i':
-                destination << value;
-                break;
-            case 'u':
-                destination << ramBitCast<RamUnsigned>(value);
-                break;
-            case 'f':
-                destination << ramBitCast<RamFloat>(value);
-                break;
-            case 'r':
-                outputRecord(destination, value, type);
-                break;
-            default:
-                fatal("unsupported type attribute: `%c`", type[0]);
+            case 's': destination << symbolTable.unsafeResolve(value); break;
+            case 'i': destination << value; break;
+            case 'u': destination << ramBitCast<RamUnsigned>(value); break;
+            case 'f': destination << ramBitCast<RamFloat>(value); break;
+            case 'r': outputRecord(destination, value, type); break;
+            default: fatal("unsupported type attribute: `%c`", type[0]);
         }
     }
 };

--- a/src/WriteStreamSQLite.h
+++ b/src/WriteStreamSQLite.h
@@ -54,12 +54,8 @@ protected:
             RamDomain value = 0;  // Silence warning
 
             switch (typeAttributes.at(i)[0]) {
-                case 's':
-                    value = getSymbolTableID(tuple[i]);
-                    break;
-                default:
-                    value = tuple[i];
-                    break;
+                case 's': value = getSymbolTableID(tuple[i]); break;
+                default: value = tuple[i]; break;
             }
 
 #if RAM_DOMAIN_SIZE == 64

--- a/src/json11.h
+++ b/src/json11.h
@@ -673,7 +673,9 @@ struct JsonParser final {
      * Advance until the current character is non-whitespace.
      */
     void consume_whitespace() {
-        while (str[i] == ' ' || str[i] == '\r' || str[i] == '\n' || str[i] == '\t') i++;
+        while (str[i] == ' ' || str[i] == '\r' || str[i] == '\n' || str[i] == '\t') {
+            i++;
+        }
     }
 
     /* consume_comment()
@@ -864,10 +866,14 @@ struct JsonParser final {
         // Integer part
         if (str[i] == '0') {
             i++;
-            if (in_range(str[i], '0', '9')) return fail("leading 0s not permitted in numbers");
+            if (in_range(str[i], '0', '9')) {
+                return fail("leading 0s not permitted in numbers");
+            }
         } else if (in_range(str[i], '1', '9')) {
             i++;
-            while (in_range(str[i], '0', '9')) i++;
+            while (in_range(str[i], '0', '9')) {
+                i++;
+            }
         } else {
             return fail("invalid " + esc(str[i]) + " in number");
         }
@@ -880,20 +886,29 @@ struct JsonParser final {
         // Decimal part
         if (str[i] == '.') {
             i++;
-            if (!in_range(str[i], '0', '9')) return fail("at least one digit required in fractional part");
+            if (!in_range(str[i], '0', '9')) {
+                return fail("at least one digit required in fractional part");
+            }
 
-            while (in_range(str[i], '0', '9')) i++;
+            while (in_range(str[i], '0', '9')) {
+                i++;
+            }
         }
 
         // Exponent part
         if (str[i] == 'e' || str[i] == 'E') {
             i++;
 
-            if (str[i] == '+' || str[i] == '-') i++;
+            if (str[i] == '+' || str[i] == '-') {
+                i++;
+            }
 
-            if (!in_range(str[i], '0', '9')) return fail("at least one digit required in exponent");
-
-            while (in_range(str[i], '0', '9')) i++;
+            if (!in_range(str[i], '0', '9')) {
+                return fail("at least one digit required in exponent");
+            }
+            while (in_range(str[i], '0', '9')) {
+                i++;
+            }
         }
 
         return std::strtod(str.c_str() + start_pos, nullptr);

--- a/src/test/binary_relation_test.cpp
+++ b/src/test/binary_relation_test.cpp
@@ -96,10 +96,14 @@ TEST(EqRelTest, Clear) {
 TEST(EqRelTest, Duplicates) {
     EqRel br;
     // test inserting same pair
-    for (int i = 0; i < 10; ++i) br.insert(0, 0);
+    for (int i = 0; i < 10; ++i) {
+        br.insert(0, 0);
+    }
     EXPECT_EQ(br.size(), 1);
 
-    for (int i = 0; i < 10; ++i) EXPECT_TRUE(br.contains(0, 0));
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_TRUE(br.contains(0, 0));
+    }
     EXPECT_EQ(br.size(), 1);
     EXPECT_FALSE(br.contains(1, 1));
 
@@ -538,8 +542,10 @@ TEST(EqRelTest, ParallelScaling) {
     const int N = 100000;
     std::vector<int> data1;
     std::vector<int> data2;
-    for (int i = 0; i < N; ++i) data1.push_back(i);
-    for (int i = 0; i < N; ++i) data2.push_back(i);
+    for (int i = 0; i < N; ++i)
+        data1.push_back(i);
+    for (int i = 0; i < N; ++i)
+        data2.push_back(i);
 
     std::random_device rd;
     std::mt19937 generator(rd());

--- a/src/test/brie_test.cpp
+++ b/src/test/brie_test.cpp
@@ -716,7 +716,9 @@ namespace {
 template <typename Iter>
 int card(const range<Iter>& r) {
     int res = 0;
-    for (auto it = r.begin(); it != r.end(); ++it) res++;
+    for (auto it = r.begin(); it != r.end(); ++it) {
+        res++;
+    }
     return res;
 }
 

--- a/src/test/btree_set_test.cpp
+++ b/src/test/btree_set_test.cpp
@@ -543,7 +543,9 @@ TEST(BTreeSet, ChunkSplitStress) {
         // fill tree
         test_set t;
 
-        for (int x : data) t.insert(x);
+        for (int x : data) {
+            t.insert(x);
+        }
 
         for (int j = 1; j < 100; j++) {
             auto chunks = t.getChunks(j);

--- a/src/test/eqrel_datastructure_test.cpp
+++ b/src/test/eqrel_datastructure_test.cpp
@@ -112,10 +112,14 @@ TEST(PiggyTest, Append) {
     // larger than BLOCKSIZE
     constexpr size_t N = 10000;
 
-    for (size_t i = 0; i < N; ++i) pl.append(2);
+    for (size_t i = 0; i < N; ++i) {
+        pl.append(2);
+    }
     EXPECT_EQ(pl.size(), N + 3);
     // make sure that all of our inserties are exacties
-    for (size_t i = 3; i < N + 3; ++i) EXPECT_EQ(pl.get(i), 2);
+    for (size_t i = 3; i < N + 3; ++i) {
+        EXPECT_EQ(pl.get(i), 2);
+    }
 }
 
 TEST(PiggyTest, ElementCreation) {
@@ -311,7 +315,9 @@ TEST(DjTest, Clear) {
     EXPECT_EQ(ds.size(), 0);
 
     // get ready 2 double free y'all
-    for (size_t i = 0; i < 10000; ++i) ds.makeNode();
+    for (size_t i = 0; i < 10000; ++i) {
+        ds.makeNode();
+    }
     ds.unionNodes(1, 2);
     ds.clear();
     ds.clear();


### PR DESCRIPTION
Allows short single line case statements
Disallows short for loops (our existing approach, but previously not enforced by clang-format)

Related to #1407 