### PR TITLE
debugging only: fancy diffs in report

### DIFF
--- a/src/DebugReport.cpp
+++ b/src/DebugReport.cpp
@@ -16,12 +16,48 @@
 
 #include "DebugReport.h"
 #include "Global.h"
+#include "utility/FileUtil.h"
+#include "utility/tinyformat.h"
 #include <fstream>
 #include <ostream>
 #include <sstream>
 #include <vector>
 
 namespace souffle {
+
+namespace {
+/**
+ * Generate a full-content diff between two sources.
+ * Both arguments are passed into a `std::ostream` so you may exploit stream implementations.
+ */
+template <typename A, typename B>
+std::string generateDiff(const A& prev, const B& curr) {
+    TempFileStream in_prev;
+    TempFileStream in_curr;
+    in_prev << prev;
+    in_curr << curr;
+    in_prev.flush();
+    in_curr.flush();
+    std::string diff_cmd =
+            "diff --new-line-format='+%L' "
+            "     --old-line-format='-%L' "
+            "     --unchanged-line-format=' %L' ";
+    return execStdOut(diff_cmd + in_prev.getFileName() + " " + in_curr.getFileName()).str();
+}
+
+std::string replaceAll(std::string_view text, std::string_view key, std::string_view replacement) {
+    std::ostringstream ss;
+    for (auto tail = text; !tail.empty();) {
+        auto i = tail.find(key);
+        ss << tail.substr(0, i);
+        if (i == std::string::npos) break;
+
+        ss << replacement;
+        tail = tail.substr(i + key.length());
+    }
+    return ss.str();
+}
+}  // namespace
 
 void DebugReportSection::printIndex(std::ostream& out) const {
     out << "<a href=\"#" << id << "\">" << title << "</a>\n";
@@ -79,19 +115,21 @@ void DebugReport::flush() {
 }
 
 void DebugReport::addSection(std::string id, std::string title, const std::string_view code) {
-    std::ostringstream ss;
-    ss << "<pre>";
-    for (auto tail = code; !tail.empty();) {
-        auto i = tail.find("<");
-        ss << tail.substr(0, i);
-        if (i == std::string::npos) break;
+    addSection(DebugReportSection(
+            std::move(id), std::move(title), tfm::format("<pre>%s</pre>", replaceAll(code, "<", "&lt"))));
+}
 
-        ss << "&lt";
-        tail = tail.substr(i + 1);
-    }
-    ss << "</pre>";
-
-    addSection(DebugReportSection(std::move(id), std::move(title), ss.str()));
+void DebugReport::addCodeSection(std::string id, std::string title, std::string_view language,
+        std::string_view prev, std::string_view curr) {
+    auto diff =
+            replaceAll(replaceAll(prev.empty() ? curr : generateDiff(prev, curr), "\\", "\\\\"), "`", "\\`");
+    auto divId = nextUniqueId++;
+    auto html = R"(
+        <div id="code-id-%d"></div>
+        <script type="text/javascript"> renderDiff('%s', 'code-id-%d', `%s`) </script>
+    )";
+    addSection(DebugReportSection(
+            std::move(id), std::move(title), tfm::format(html, divId, language, divId, diff)));
 }
 
 void DebugReport::endSection(std::string currentSectionName, std::string currentSectionTitle) {
@@ -103,47 +141,155 @@ void DebugReport::endSection(std::string currentSectionName, std::string current
 }
 
 void DebugReport::print(std::ostream& out) const {
-    out << "<!DOCTYPE html>\n";
-    out << "<html lang='en-AU'>\n";
-    out << "<head>\n";
-    out << "<meta charset=\"UTF-8\">\n";
-    out << "<title>Souffle Debug Report (" << Global::config().get("") << ")</title>\n";
-    out << "<style>\n";
-    out << "ul { list-style-type: none; }\n";
-    out << "ul > li.leaf { display: inline-block; padding: 0em 1em; }\n";
-    out << "ul > li.nonleaf { padding: 0em 1em; }\n";
-    out << "* { font-family: sans-serif; }\n";
-    out << "pre { white-space: pre-wrap; font-family: monospace; }\n";
-    out << "a:link { text-decoration: none; color: blue; }\n";
-    out << "a:visited { text-decoration: none; color: blue; }\n";
-    out << "div.headerdiv { background-color:lightgrey; margin:10px; padding-left:10px; padding-right:10px; "
-           "padding-top:3px; padding-bottom:3px; border-radius:5px }\n";
-    out << ".headerdiv h1 { display:inline; }\n";
-    out << ".headerdiv a { float:right; }\n";
-    out << "</style>\n";
-    out << "<script>\n";
-    out << "function toggleVisibility(id) {\n";
-    out << "  var element = document.getElementById(id);\n";
-    out << "  if (element.style.display == 'none') {\n";
-    out << "    element.style.display = 'block';\n";
-    out << "  } else {\n";
-    out << "    element.style.display = 'none';\n";
-    out << "  }\n";
-    out << "}\n";
-    out << "</script>\n";
-    out << "</head>\n";
-    out << "<body>\n";
-    out << "<div class='headerdiv'><h1>Souffle Debug Report (" << Global::config().get("")
-        << ")</h1></div>\n";
+    out << R"(
+<!DOCTYPE html>
+<html lang='en-AU'>
+<head>
+<meta charset=\"UTF-8\">
+<title>Souffle Debug Report ()";
+    out << Global::config().get("") << R"()</title>
+<style>
+    ul { list-style-type: none; }
+    ul > li.leaf { display: inline-block; padding: 0em 1em; }
+    ul > li.nonleaf { padding: 0em 1em; }
+    * { font-family: sans-serif; }
+    pre { white-space: pre-wrap; font-family: monospace; }
+    a:link { text-decoration: none; color: blue; }
+    a:visited { text-decoration: none; color: blue; }
+    div.headerdiv { background-color:lightgrey; margin:10px; padding-left:10px; padding-right:10px;
+        padding-top:3px; padding-bottom:3px; border-radius:5px }
+    .headerdiv h1 { display:inline; }
+    .headerdiv a { float:right; }
+</style>
+
+<link rel="stylesheet" type="text/css" href=
+    "https://cdn.jsdelivr.net/npm/highlight.js@10.0.0/styles/default.min.css" />
+<script type="text/javascript" src=
+    "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.0.0/build/highlight.min.js"></script>
+
+<link rel="stylesheet" type="text/css" href=
+    "https://cdn.jsdelivr.net/npm/diff2html/bundles/css/diff2html.min.css" />
+<script type="text/javascript" src=
+    "https://cdn.jsdelivr.net/npm/diff2html/bundles/js/diff2html-ui-base.min.js"></script>
+
+<script>
+  function toggleVisibility(id) {
+    var element = document.getElementById(id);
+    if (element.style.display == 'none') {
+      element.style.display = 'block';
+    } else {
+      element.style.display = 'none';
+    }
+  }
+
+  if (typeof hljs !== 'undefined') {
+    hljs.registerLanguage('souffle', function (hljs) {
+      let COMMENT_MODES = [
+        hljs.C_LINE_COMMENT_MODE,
+        hljs.C_BLOCK_COMMENT_MODE,
+      ]
+
+      let KEYWORDS = {
+        $pattern: '\\.?\\w+',
+        literal: 'true false',
+        keyword: '.pragma .functor .component .decl .input .output ' +
+          'ord strlen strsub range matches land lor lxor lnot bwand bwor bwxor bwnot bshl bshr bshru',
+      }
+
+      let STRING = hljs.QUOTE_STRING_MODE
+      let NUMBERS = {
+        className: 'number', relevance: 0, variants: [
+          { begin: /0b[01]+/ },
+          { begin: /\d+\.\d+/ }, // float
+          { begin: /\d+\.\d+.\d+.\d+/ }, // IPv4 literal
+          { begin: /\d+u?/ },
+          { begin: /0x[a-fA-F0-9]+u?/ }
+        ]
+      }
+
+      let PREPROCESSOR = {
+        className: 'meta',
+        begin: /#\s*[a-z]+\b/,
+        end: /$/,
+        keywords: {
+          'meta-keyword': 'if else elif endif define undef warning error line pragma ifdef ifndef include'
+        },
+        contains: [
+          { begin: /\\\n/, relevance: 0 },
+          hljs.inherit(STRING, { className: 'meta-string' }),
+        ].concat(COMMENT_MODES)
+      };
+
+      let ATOM = { begin: /[a-z][A-Za-z0-9_]*/, relevance: 0 }
+      let VAR = {
+        className: 'symbol', relevance: 0, variants: [
+          { begin: /[A-Z][a-zA-Z0-9_]*/ },
+          { begin: /_[A-Za-z0-9_]*/ },
+        ]
+      }
+      let PARENTED = { begin: /\(/, end: /\)/, relevance: 0 }
+      let LIST = { begin: /\[/, end: /\]/ }
+      let PRED_OP = { begin: /:-/ } // relevance booster
+
+      let INNER = [
+        ATOM,
+        VAR,
+        PARENTED,
+        PRED_OP,
+        LIST,
+        STRING,
+        NUMBERS,
+      ].concat(COMMENT_MODES)
+
+      PARENTED.contains = INNER;
+      LIST.contains = INNER;
+
+      return {
+        name: 'souffle',
+        keywords: KEYWORDS,
+        contains: INNER.concat([{ begin: /\.$/ }]) // relevance booster
+      };
+    })
+    // TODO: Add a highlighter for `ram`
+    hljs.configure({ languages: ['souffle'] })
+  }
+
+  if (typeof Diff2HtmlUI !== 'undefined' && typeof hljs !== 'undefined') {
+    function renderDiff(lang, id, diff) {
+      // file extension determines the language used for highlighting
+      let file   = `Datalog.${lang}`
+      let prefix = `diff ${file} ${file}
+--- ${file}
++++ ${file}
+@@ -1 +1 @@
+`
+      new Diff2HtmlUI(document.getElementById(id), prefix + diff, {
+        drawFileList: false,
+        highlight: true,
+        matching: 'none',
+        outputFormat: 'side-by-side',
+        synchronisedScroll: true,
+      }, hljs).draw()
+    }
+  } else { // fallback to plain text
+    function renderDiff(lang, id, diff) {
+      document.getElementById(id).innerText = diff
+    }
+  }
+</script>
+</head>
+<body>
+<div class='headerdiv'><h1>Souffle Debug Report ()";
+    out << Global::config().get("") << ")</h1></div>\n";
     for (const DebugReportSection& section : sections) {
         section.printIndex(out);
     }
     for (const DebugReportSection& section : sections) {
         section.printContent(out);
     }
-    out << "<a href='#'>(return to top)</a>\n";
-    out << "</body>\n";
-    out << "</html>\n";
+    out << R"(<a href='#'>(return to top)</a>
+</body>
+</html>)";
 }
 
 }  // end of namespace souffle

--- a/src/DebugReport.h
+++ b/src/DebugReport.h
@@ -89,6 +89,8 @@ public:
     }
 
     void addSection(std::string id, std::string title, std::string_view code);
+    void addCodeSection(std::string id, std::string title, std::string_view language, std::string_view prev,
+            std::string_view curr);
 
     void startSection() {
         currentSubsections.emplace();
@@ -116,6 +118,7 @@ public:
 private:
     std::vector<DebugReportSection> sections;
     std::stack<std::vector<DebugReportSection>> currentSubsections;
+    uint32_t nextUniqueId = 0;  // used for generating unique HTML `id` tags
 
     bool empty() const {
         return sections.empty();

--- a/src/DebugReporter.cpp
+++ b/src/DebugReporter.cpp
@@ -42,25 +42,9 @@ bool DebugReporter::transform(AstTranslationUnit& translationUnit) {
     return changed;
 }
 
-DebugReportSection formatCodeSection(const std::string& id, const std::string& title, std::string code) {
-    std::stringstream codeHTML;
-    std::string escapedCode = std::move(code);
-    while (true) {
-        size_t i = escapedCode.find("<");
-        if (i == std::string::npos) {
-            break;
-        }
-        escapedCode.replace(i, 1, "&lt;");
-    }
-    codeHTML << "<pre>" << escapedCode << "</pre>\n";
-    return DebugReportSection(id, title, codeHTML.str());
-}
-
 void DebugReporter::generateDebugReport(AstTranslationUnit& tu, const std::string& preTransformDatalog) {
-    auto datalogSpec = pprint(*tu.getProgram());
-    tu.getDebugReport().addSection("dl", "Datalog",
-            preTransformDatalog.empty() ? std::move(datalogSpec)
-                                        : generateDiff(preTransformDatalog, datalogSpec));
+    tu.getDebugReport().addCodeSection(
+            "dl", "Datalog", "souffle", preTransformDatalog, pprint(*tu.getProgram()));
 }
 
 }  // end of namespace souffle

--- a/src/DebugReporter.h
+++ b/src/DebugReporter.h
@@ -58,25 +58,6 @@ public:
         return "DebugReporter";
     }
 
-    /**
-     * Generate a full-content diff between two sources.
-     * Both arguments are passed into a `std::ostream` so you may exploit stream implementations.
-     */
-    template <typename A, typename B>
-    static std::string generateDiff(const A& prev, const B& curr) {
-        TempFileStream in_prev;
-        TempFileStream in_curr;
-        in_prev << prev;
-        in_curr << curr;
-        in_prev.flush();
-        in_curr.flush();
-        std::string diff_cmd =
-                "diff --new-line-format='+%L' "
-                "     --old-line-format='-%L' "
-                "     --unchanged-line-format=' %L' ";
-        return execStdOut(diff_cmd + in_prev.getFileName() + " " + in_curr.getFileName()).str();
-    }
-
 private:
     std::unique_ptr<AstTransformer> wrappedTransformer;
 

--- a/src/RamTransformer.cpp
+++ b/src/RamTransformer.cpp
@@ -30,13 +30,9 @@
 namespace souffle {
 
 bool RamTransformer::apply(RamTranslationUnit& translationUnit) {
-    static const bool debug = Global::config().has("debug-report");
-    static const bool verbose = Global::config().has("verbose");
-    std::stringstream ramProgStrOld;
-
-    if (debug) {
-        ramProgStrOld << translationUnit.getProgram();
-    }
+    const bool debug = Global::config().has("debug-report");
+    const bool verbose = Global::config().has("verbose");
+    std::string ramProgStrOld = debug ? toString(translationUnit.getProgram()) : "";
 
     // invoke the transformation
     auto start = std::chrono::high_resolution_clock::now();
@@ -59,8 +55,8 @@ bool RamTransformer::apply(RamTranslationUnit& translationUnit) {
     if (debug) {
         translationUnit.getDebugReport().startSection();
         if (changed) {
-            translationUnit.getDebugReport().addSection(getName(), "RAM Program after " + getName(),
-                    DebugReporter::generateDiff(ramProgStrOld.str(), translationUnit.getProgram()));
+            translationUnit.getDebugReport().addCodeSection(getName(), "RAM Program after " + getName(),
+                    "ram", ramProgStrOld, toString(translationUnit.getProgram()));
 
             translationUnit.getDebugReport().endSection(getName(), getName());
         } else {


### PR DESCRIPTION
![Ekrankopio de 2020-05-10 04-28-16](https://user-images.githubusercontent.com/28301786/81494461-205dc080-9277-11ea-8713-68a5af237251.png)

Cute. Sort of handy. Has fallbacks if the rendering lib to load (e.g. offline).
Delegates rendering to [diff2html](https://github.com/rtfpessoa/diff2html) and [highlightjs](https://highlightjs.org/). These are loaded using their official jsdelivr host.

Points of concern:
1) Security:
a) Hostile source code could break out into a `script` block. Mitigations: Escaping has been added and is believed to be correct. The report feature is not expected to be used with adversary controlled source code.
b) DNS lookup hijack to redirect to hostile script. Mitigations: None. If someone can pull this off you're probably boned either way & they're gonna target more popular domains.
c) Bugs in diff2html or its dependencies that could result in RCE w/ hostile source code. Mitigations: None. Src is not expected to be hostile.
2) Licensing: We don't include any assets/code from diff2html, or its dependencies in the Souffle source code. Do we include license blurbs anyways? diff2html is MIT, highlightjs is BSD-3.

Future Work:
The highlighter for souffle was kitbashed together based on the prolog language example. It could do with some love, but I don't think anyone is going to cry over crappy code highlighting. RAM lacks a language definition entirely.
