### PR TITLE
Disable warnings with legacy flag

### DIFF
--- a/src/AstSemanticChecker.cpp
+++ b/src/AstSemanticChecker.cpp
@@ -218,10 +218,7 @@ AstSemanticCheckerImpl::AstSemanticCheckerImpl(AstTranslationUnit& tu) : tu(tu) 
                     return isA<RecordType>(type) && !isA<SubsetType>(type);
                 });
                 if (!validAttribute) {
-                    if (Global::config().has("legacy")) {
-                        report.addWarning("Atoms argument type is not a subtype of its declared type",
-                                arguments[i]->getSrcLoc());
-                    } else {
+                    if (!Global::config().has("legacy")) {
                         report.addError("Atoms argument type is not a subtype of its declared type",
                                 arguments[i]->getSrcLoc());
                     }

--- a/src/ParserDriver.cpp
+++ b/src/ParserDriver.cpp
@@ -176,7 +176,9 @@ void ParserDriver::addIoFromDeprecatedTag(AstRelation& rel) {
 
 std::set<RelationTag> ParserDriver::addDeprecatedTag(
         RelationTag tag, SrcLocation tagLoc, std::set<RelationTag> tags) {
-    warning(tagLoc, tfm::format("Deprecated %s qualifier was used", tag));
+    if (!Global::config().has("legacy")) {
+        warning(tagLoc, tfm::format("Deprecated %s qualifier was used", tag));
+    }
     return addTag(tag, std::move(tagLoc), std::move(tags));
 }
 
@@ -202,7 +204,9 @@ std::set<RelationTag> ParserDriver::addTag(RelationTag tag, std::vector<Relation
 
 Own<AstSubsetType> ParserDriver::mkDeprecatedSubType(
         AstQualifiedName name, AstQualifiedName baseTypeName, SrcLocation loc) {
-    warning(loc, "Deprecated type declaration used");
+    if (!Global::config().has("legacy")) {
+        warning(loc, "Deprecated type declaration used");
+    }
     return mk<AstSubsetType>(std::move(name), std::move(baseTypeName), std::move(loc));
 }
 


### PR DESCRIPTION
Currently, deprecated constructs produce a warning and are not suppressed with the flag `--legacy`. 

This fix suppresses warnings with flag `--legacy`. Souffle will behave like an older version being less picky about type issues. 