### PR TITLE
Add distribution for ARM64 debian-based distros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,44 @@ jobs:
       - docker exec souf /bin/sh -c ".travis/init_test.sh '--disable-openmp'"
       - docker exec -e SOUFFLE_CATEGORY -e SOUFFLE_CONFS souf /bin/sh -c ".travis/run_test.sh"
 
+  - stage: Testing
+    name: "arm-gcc-setup"
+    sudo: false
+    os: linux
+    compiler: gcc
+    language: cpp
+    addons:
+      apt:
+        packages:
+        - automake
+        - autoconf
+        - bison
+        - build-essential
+        - flex
+        - gdb
+        - libffi-dev
+        - libncurses5-dev
+        - libopenmpi-dev
+        - libsqlite3-dev
+        - libtool
+        - lsb-release
+        - mcpp
+        - pkg-config
+        - sqlite3
+        - swig
+        - zlib1g-dev
+        - bash-completion
+        - debhelper
+        - devscripts
+        - doxygen
+        - fakeroot
+        - git
+        - graphviz
+        - make
+    before_script: ".travis/init_test.sh"
+    script: ".travis/run_test.sh"
+    after_failure: ".travis/after_failure.sh"
+    arch: arm64
 # Testing stage without Evaluation tests (-j8,-c -j8)
   - stage: Testing
     <<: *osxgcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: generic
 dist: bionic
+arch: amd64
 
 _aliases:
   - &docker
@@ -47,6 +48,17 @@ jobs:
         paths: .
     script: docker exec souf /bin/sh -c "export CXX=g++ && .travis/init_test.sh '--enable-swig'"
   - stage: Warmup
+    name: "Build Bionic arm64  g++"
+    arch: arm64
+    # workaround travis-ci bugs
+    filter_secrets: false
+    <<: *docker
+    workspaces:
+      create:
+        name: bionic_gcc_arm
+        paths: .
+    script: docker exec souf /bin/sh -c "export CXX=g++ && .travis/init_test.sh '--enable-swig'"
+  - stage: Warmup
     name: "Build Bionic g++ 64bit"
     <<: *docker
     workspaces:
@@ -78,48 +90,6 @@ jobs:
       - docker exec souf /bin/sh -c ".travis/init_test.sh '--disable-openmp'"
       - docker exec -e SOUFFLE_CATEGORY -e SOUFFLE_CONFS souf /bin/sh -c ".travis/run_test.sh"
 
-  - stage: Testing
-    name: "arm-gcc-setup"
-    sudo: false
-    os: linux
-    compiler: gcc
-    language: cpp
-    # workaround travis-ci bugs
-    filter_secrets: false
-    addons:
-      apt:
-        packages:
-        - automake
-        - autoconf
-        - bison
-        - build-essential
-        - flex
-        - gdb
-        - libffi-dev
-        - libncurses5-dev
-        - libopenmpi-dev
-        - libsqlite3-dev
-        - libtool
-        - lsb-release
-        - mcpp
-        - pkg-config
-        - sqlite3
-        - swig
-        - zlib1g-dev
-        - bash-completion
-        - debhelper
-        - devscripts
-        - doxygen
-        - fakeroot
-        - git
-        - graphviz
-        - make
-    env:
-    - SOUFFLE_CATEGORY=Unit,Interface,Profile,Provenance SOUFFLE_CONFS=",-c"
-    before_script: ".travis/init_test.sh"
-    script: ".travis/run_test.sh"
-    after_failure: ".travis/after_failure.sh"
-    arch: arm64
 # Testing stage without Evaluation tests (-j8,-c -j8)
   - stage: Testing
     <<: *osxgcc
@@ -139,6 +109,17 @@ jobs:
     <<: *docker
     workspaces:
       use: bionic_gcc
+    env:
+    - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
+    script: docker exec -e SOUFFLE_CATEGORY -e SOUFFLE_CONFS souf /bin/sh -c ".travis/run_test.sh"
+  - stage: Testing
+    name: "Linux arm64 gcc non-eval"
+    arch: arm64
+    <<: *docker
+    workspaces:
+      use: bionic_gcc_arm
+    # workaround travis-ci bugs
+    filter_secrets: false
     env:
     - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
     script: docker exec -e SOUFFLE_CATEGORY -e SOUFFLE_CONFS souf /bin/sh -c ".travis/run_test.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -216,7 +216,7 @@ jobs:
     <<: *docker
     script:
       - docker exec souf /bin/sh -c ".travis/linux/install_debian_deps.sh"
-      - travis_wait 40 docker exec souf /bin/sh -c ".travis/linux/make_debian_package.sh"
+      - docker exec souf /bin/sh -c ".travis/linux/make_debian_package.sh 2"
     before_deploy:
       - .travis/bintray_json.sh debian arm64
     # deploy to bintray if we're in the souffle-lang repo

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,7 @@ jobs:
   # Make the linux deb packages and if successful upload to github releases and bintray
   # All PRs go to bintray unstable, tagged releases to bintray stable
   - stage: Packaging
-    name: "Debian package"
+    name: "Debian amd64 package"
     <<: *docker
     script:
       - docker exec souf /bin/sh -c ".travis/linux/install_debian_deps.sh"
@@ -224,6 +224,34 @@ jobs:
         token: $GHRELEASES_TOKEN
         file_glob: true
         file: deploy/*
+        on:
+          repo: souffle-lang/souffle
+          tags: true
+  - stage: Packaging
+    name: "Debian arm64 package"
+    arch: arm64
+    <<: *docker
+    script:
+      - docker exec souf /bin/sh -c ".travis/linux/install_debian_deps.sh"
+      - docker exec souf /bin/sh -c ".travis/linux/make_debian_package.sh"
+    before_deploy:
+      - .travis/bintray_json.sh debian arm64
+    # deploy to bintray if we're in the souffle-lang repo
+    # https://docs.travis-ci.com/user/deployment/bintray
+    deploy:
+      - provider: bintray
+        skip_cleanup: true
+        file: bintray-deb-unstable.json
+        user: souffle-lang
+        key: $BINTRAY_KEY
+        on:
+          branch: master
+          repo: souffle-lang/souffle
+      - provider: bintray
+        skip_cleanup: true
+        file: bintray-deb-stable.json
+        user: souffle-lang
+        key: $BINTRAY_KEY
         on:
           repo: souffle-lang/souffle
           tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,17 +48,6 @@ jobs:
         paths: .
     script: docker exec souf /bin/sh -c "export CXX=g++ && .travis/init_test.sh '--enable-swig'"
   - stage: Warmup
-    name: "Build Bionic arm64  g++"
-    arch: arm64
-    # workaround travis-ci bugs
-    filter_secrets: false
-    <<: *docker
-    workspaces:
-      create:
-        name: bionic_gcc_arm
-        paths: .
-    script: docker exec souf /bin/sh -c "export CXX=g++ && .travis/init_test.sh '--enable-swig'"
-  - stage: Warmup
     name: "Build Bionic g++ 64bit"
     <<: *docker
     workspaces:
@@ -111,19 +100,6 @@ jobs:
       use: bionic_gcc
     env:
     - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
-    script: docker exec -e SOUFFLE_CATEGORY -e SOUFFLE_CONFS souf /bin/sh -c ".travis/run_test.sh"
-  - stage: Testing
-    name: "Linux arm64 gcc non-eval"
-    arch: arm64
-    <<: *docker
-    workspaces:
-      use: bionic_gcc_arm
-    # workaround travis-ci bugs
-    filter_secrets: false
-    # Semantic test will fail due to UB in negative_numbers test
-    #  a = std::pow(2,31) => max or min int depending on platform
-    env:
-    - SOUFFLE_CATEGORY=Unit,Syntactic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
     script: docker exec -e SOUFFLE_CATEGORY -e SOUFFLE_CONFS souf /bin/sh -c ".travis/run_test.sh"
 
 # Testing stage for Evaluation tests without OpenMP (,-c)

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ stages:
   - Packaging
 
 jobs:
+  allow_failures:
+    - name: "Debian arm64 package"
   include:
 # Style check stage
   - stage: Warmup

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,8 @@ jobs:
         - git
         - graphviz
         - make
+    env:
+    - SOUFFLE_CATEGORY=Unit,Interface,Profile,Provenance SOUFFLE_CONFS=",-c"
     before_script: ".travis/init_test.sh"
     script: ".travis/run_test.sh"
     after_failure: ".travis/after_failure.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: generic
 dist: bionic
 arch: amd64
 
+# Travis-ci bugs prevent completion. A workaround is to disable secret filtering
+# In early 2018 said they are working on fixing their filter script, and in 10/2019
+# they were still working on it.
+filter_secrets: false
+
 _aliases:
   - &docker
     os: linux
@@ -208,13 +213,9 @@ jobs:
   - stage: Packaging
     name: "Debian arm64 package"
     arch: arm64
-    filter_secrets: false
     <<: *docker
     script:
       - docker exec souf /bin/sh -c ".travis/linux/install_debian_deps.sh"
-        # Travis-ci bugs prevent completion. A workaround is to disable secret filtering
-        # In early 2018 said they are working on fixing their filter script, and in 10/2019
-        # they were still working on it.
       - travis_wait 40 docker exec souf /bin/sh -c ".travis/linux/make_debian_package.sh"
     before_deploy:
       - .travis/bintray_json.sh debian arm64

--- a/.travis.yml
+++ b/.travis.yml
@@ -208,10 +208,14 @@ jobs:
   - stage: Packaging
     name: "Debian arm64 package"
     arch: arm64
+    filter_secrets: false
     <<: *docker
     script:
       - docker exec souf /bin/sh -c ".travis/linux/install_debian_deps.sh"
-      - docker exec souf /bin/sh -c ".travis/linux/make_debian_package.sh"
+        # Travis-ci bugs prevent completion. A workaround is to disable secret filtering
+        # In early 2018 said they are working on fixing their filter script, and in 10/2019
+        # they were still working on it.
+      - travis_wait 40 docker exec souf /bin/sh -c ".travis/linux/make_debian_package.sh"
     before_deploy:
       - .travis/bintray_json.sh debian arm64
     # deploy to bintray if we're in the souffle-lang repo

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,8 @@ jobs:
     os: linux
     compiler: gcc
     language: cpp
+    # workaround travis-ci bugs
+    filter_secrets: false
     addons:
       apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,8 +120,10 @@ jobs:
       use: bionic_gcc_arm
     # workaround travis-ci bugs
     filter_secrets: false
+    # Semantic test will fail due to UB in negative_numbers test
+    #  a = std::pow(2,31) => max or min int depending on platform
     env:
-    - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
+    - SOUFFLE_CATEGORY=Unit,Syntactic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
     script: docker exec -e SOUFFLE_CATEGORY -e SOUFFLE_CONFS souf /bin/sh -c ".travis/run_test.sh"
 
 # Testing stage for Evaluation tests without OpenMP (,-c)

--- a/.travis/bintray_json.sh
+++ b/.travis/bintray_json.sh
@@ -18,7 +18,7 @@ then
   #Fedora 27 x86_64
   DIST='fedora'
   RELEASE='27'
-  ARCH='x86_64'
+  ARCH="$5"
 
   FILES="[{\"includePattern\": \"deploy/(.*\.rpm)\", \"uploadPattern\": \"$DIST/$RELEASE/$ARCH/\$1\"
     }],"
@@ -32,7 +32,7 @@ then
   #Fedora 27 x86_64
   DIST='centos'
   RELEASE='7'
-  ARCH='x86_64'
+  ARCH="$5"
 
   FILES="[{\"includePattern\": \"deploy/(.*\.rpm)\", \"uploadPattern\": \"$DIST/$RELEASE/$ARCH/\$1\"
     }],"
@@ -43,12 +43,17 @@ then
 
 else
   DIST="$4"
+  ARCH="$5"
+  if [ "$ARCH" = "x86_64" ];
+  then
+    ARCH=amd64
+  fi
 
   FILES="[{\"includePattern\": \"deploy/(.*\.deb)\", \"uploadPattern\": \"pool/main/s/souffle/\$1\",
     \"matrixParams\": {
         \"deb_distribution\": \"$DIST\",
         \"deb_component\": \"main\",
-        \"deb_architecture\": \"amd64\",
+        \"deb_architecture\": \"$ARCH\",
         \"override\": 1 }
     }],"
 fi
@@ -80,20 +85,26 @@ cat > ${3} <<EOF
 }
 EOF
 }
+if [ -n "$2" ];
+then
+  ARCH="$2"
+else
+  ARCH=x86_64
+fi
 
 if [ "$1" = debian ];
 then
   VERSION=$(grep VERSION_CODENAME /etc/os-release |sed 's/VERSION_CODENAME=//')
-  print_json "deb"  "`git describe --tags --always`" "bintray-deb-stable.json" "$VERSION"
-  print_json "deb-unstable" "`git describe --tags --always`" "bintray-deb-unstable.json" "$VERSION"
+  print_json "deb"  "`git describe --tags --always`" "bintray-deb-stable.json" "$VERSION" "$ARCH"
+  print_json "deb-unstable" "`git describe --tags --always`" "bintray-deb-unstable.json" "$VERSION" "$ARCH"
 elif [ "$1" = fedora ];
 then
-  print_json "rpm"  "`git describe --tags --always`" "bintray-rpm-stable.json" "fedora"
-  print_json "rpm-unstable"  "`git describe --tags --always`" "bintray-rpm-unstable.json" "fedora"
+  print_json "rpm"  "`git describe --tags --always`" "bintray-rpm-stable.json" "fedora" "$ARCH"
+  print_json "rpm-unstable"  "`git describe --tags --always`" "bintray-rpm-unstable.json" "fedora" "$ARCH"
 elif [ "$1" = centos ];
 then
-  print_json "rpm"  "`git describe --tags --always`" "bintray-rpm-stable.json" "centos"
-  print_json "rpm-unstable"  "`git describe --tags --always`" "bintray-rpm-unstable.json" "centos"
+  print_json "rpm"  "`git describe --tags --always`" "bintray-rpm-stable.json" "centos" "$ARCH"
+  print_json "rpm-unstable"  "`git describe --tags --always`" "bintray-rpm-unstable.json" "centos" "$ARCH"
 elif [ "$1" = osx ];
 then
   print_json "osx"  "`git describe --tags --always`" "bintray-osx.json" "osx"

--- a/.travis/linux/install_debian_deps.sh
+++ b/.travis/linux/install_debian_deps.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 apt-get update -q
-apt-get install -y -q autoconf automake bash-completion bison build-essential clang debhelper default-jdk devscripts doxygen fakeroot flex g++ gdb git graphviz libffi-dev libncurses5-dev libsqlite3-dev libtool make mcpp pkg-config python3-dev sqlite swig zlib1g-dev
+apt-get install -y -q autoconf automake bash-completion bison build-essential clang debhelper default-jdk-headless devscripts doxygen fakeroot flex g++ gdb git graphviz libffi-dev libncurses5-dev libsqlite3-dev libtool make mcpp pkg-config python3-dev sqlite swig zlib1g-dev

--- a/.travis/linux/make_debian_package.sh
+++ b/.travis/linux/make_debian_package.sh
@@ -17,7 +17,21 @@ git describe --tags --abbrev=0 --always
 ./bootstrap
 ./configure --enable-host-packaging
 
-JOBS=$(nproc)
+if [ -n "$1" ];
+then
+  JOBS=$1
+else
+  JOBS=$(nproc)
+fi
+
+# In case nproc doesn't exist, set a default
+if [ -z "$JOBS" ];
+then
+  JOBS=2
+fi
+
+export AM_MAKEFLAGS=-j$JOBS
+
 make -j$JOBS package
 
 # compute md5 for package &


### PR DESCRIPTION
Travis has flaky support for arm64 (As for windows support) and the cpu speed is slow enough that souffle may not finish building a distro in time. As such, the new job for building an arm64 distro is allowed to fail. For the frequent unstable builds this is reasonable. For stable builds, the job can be manually re-run.