### PR TITLE
Add codecov yaml configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -24,3 +24,4 @@ fixes:
 
 ignore:
   - "tests/interface"
+  - "src/tests"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no
+
+fixes:
+  - "/souffle/include/souffle::"
+
+ignore:
+  - "tests/interface"


### PR DESCRIPTION
The codecov configuration may need some tweaking so I'm keeping this as a draft for now.

The codecov script works by searching for any gcno file and running gcov on it from that directory. All generated gcov files are then collated. Inherent to this process is that if the same gcov file is generated twice, we only see one version. This also goes wrong when the file was not compiled in the directory it is run from. To handle these problems, on our side we now run gcov ourselves for the cases where these happen. The codecov yml has also been modified to fix the paths used with compiled souffle.