### PR TITLE
Update centos dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -244,8 +244,8 @@ jobs:
   - stage: Packaging
     name: "CentOS package"
     <<: *docker
-    before_script: docker pull centos:7
-    script: docker run --mount src="$(pwd)",target=/souffle,type=bind centos:7 /bin/sh -c "cd /souffle && .travis/linux/install_centos_deps.sh && .travis/linux/make_centos_package.sh"
+    before_script: docker pull centos:8
+    script: docker run --mount src="$(pwd)",target=/souffle,type=bind centos:8 /bin/sh -c "cd /souffle && .travis/linux/install_centos_deps.sh && .travis/linux/make_centos_package.sh"
     before_deploy:
       - .travis/bintray_json.sh centos
     # deploy to bintray if we're in the souffle-lang repo

--- a/.travis/bintray_json.sh
+++ b/.travis/bintray_json.sh
@@ -31,7 +31,7 @@ then
 
   #Fedora 27 x86_64
   DIST='centos'
-  RELEASE='7'
+  RELEASE='8'
   ARCH="$5"
 
   FILES="[{\"includePattern\": \"deploy/(.*\.rpm)\", \"uploadPattern\": \"$DIST/$RELEASE/$ARCH/\$1\"

--- a/.travis/linux/install_centos_deps.sh
+++ b/.travis/linux/install_centos_deps.sh
@@ -21,15 +21,11 @@ travis_retry() {
   return $result
 }
 
-# Add our repo to get mcpp
-travis_retry yum install -y https://dl.bintray.com/souffle-lang/rpm-unstable/centos/7/x86_64/souffle-repo-centos-1.0.2-1.x86_64.rpm
-
 # Build dependencies
-travis_retry yum install -y -q autoconf automake bison clang doxygen flex gcc gcc-c++ git kernel-devel libffi-devel libtool make mcpp ncurses-devel python sqlite sqlite-devel sudo swig zlib-devel
+travis_retry yum install -y -q autoconf automake bison clang flex gcc gcc-c++ git kernel-devel libffi-devel libtool make mcpp ncurses-devel python3 sqlite sqlite-devel sudo swig zlib-devel
 
 # Set up a more recent gcc that supports C++11
 travis_retry yum install -y centos-release-scl
-travis_retry yum install -y devtoolset-7-gcc-c++
 
 # Set up the package builder
 travis_retry yum install -y -q rpm-build ruby-devel


### PR DESCRIPTION
Use CentOS8 instead of CentOS7 for CentOS distro testing. The build tools no longer work with CentOS7. The CentOS8 packages may also work with CentOS7, but if they don't, and the package support is needed, then a new packaging solution is needed.