### PR TITLE
Fixed issuing of subroutine lock code

### DIFF
--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -2241,7 +2241,7 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
                << "(const std::vector<RamDomain>& args, "
                   "std::vector<RamDomain>& ret) {\n";
 
-            // issue lock variable for return statements 
+            // issue lock variable for return statements
             bool needLock = false;
             visitDepthFirst(*sub.second, [&](const RamSubroutineReturnValue&) { needLock = true; });
             if (needLock) {
@@ -2251,8 +2251,8 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
             // emit code for subroutine
             emitCode(os, *sub.second);
 
-            // issue end of subroutine 
-            os << "}\n";  
+            // issue end of subroutine
+            os << "}\n";
             subroutineNum++;
         }
     }

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -2235,25 +2235,24 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
         // generate method for each subroutine
         subroutineNum = 0;
         for (auto& sub : prog.getSubroutines()) {
-            // method header
+            // issue method header
             os << "void "
                << "subroutine_" << subroutineNum
                << "(const std::vector<RamDomain>& args, "
                   "std::vector<RamDomain>& ret) {\n";
 
-            // a lock is needed when filling the subroutine return vectors
-            // for provenance subroutines
-            // TODO (b-scholz): Can we encapsulate this in RamReturn?
-            std::string pre("stratum_");
-            if ((sub.first).substr(0, pre.length()) != "stratum_") {
+            // issue lock variable for return statements 
+            bool needLock = false;
+            visitDepthFirst(*sub.second, [&](const RamSubroutineReturnValue&) { needLock = true; });
+            if (needLock) {
                 os << "std::mutex lock;\n";
             }
 
-            // generate code for body
+            // emit code for subroutine
             emitCode(os, *sub.second);
 
-            os << "return;\n";
-            os << "}\n";  // end of subroutine
+            // issue end of subroutine 
+            os << "}\n";  
             subroutineNum++;
         }
     }


### PR DESCRIPTION
This is related to PR #1478. 

For subroutines that have return statements, we require a lock variable. 

At the moment the check for issuing a lock variable was not clean. 