### PR TITLE
Rename RamSubroutineReturnValue

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -668,7 +668,7 @@ std::unique_ptr<RamOperation> AstTranslator::ProvenanceClauseTranslator::createO
         }
     }
 
-    return std::make_unique<RamSubroutineReturnValue>(std::move(values));
+    return std::make_unique<RamSubroutineReturn>(std::move(values));
 }
 
 std::unique_ptr<RamCondition> AstTranslator::ClauseTranslator::createCondition(
@@ -1498,10 +1498,10 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
             // create a RamQuery to return true/false
             appendStmt(searchSequence,
                     std::make_unique<RamQuery>(std::make_unique<RamFilter>(std::move(existenceCheck),
-                            std::make_unique<RamSubroutineReturnValue>(std::move(returnTrue)))));
+                            std::make_unique<RamSubroutineReturn>(std::move(returnTrue)))));
             appendStmt(searchSequence,
                     std::make_unique<RamQuery>(std::make_unique<RamFilter>(std::move(negativeExistenceCheck),
-                            std::make_unique<RamSubroutineReturnValue>(std::move(returnFalse)))));
+                            std::make_unique<RamSubroutineReturn>(std::move(returnFalse)))));
 
         } else if (auto con = dynamic_cast<AstConstraint*>(lit)) {
             VariablesToArguments varsToArgs(uniqueVariables);
@@ -1522,10 +1522,10 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
 
             appendStmt(searchSequence,
                     std::make_unique<RamQuery>(std::make_unique<RamFilter>(std::move(condition),
-                            std::make_unique<RamSubroutineReturnValue>(std::move(returnTrue)))));
+                            std::make_unique<RamSubroutineReturn>(std::move(returnTrue)))));
             appendStmt(searchSequence,
                     std::make_unique<RamQuery>(std::make_unique<RamFilter>(std::move(negativeCondition),
-                            std::make_unique<RamSubroutineReturnValue>(std::move(returnFalse)))));
+                            std::make_unique<RamSubroutineReturn>(std::move(returnFalse)))));
         }
 
         litNumber++;

--- a/src/InterpreterEngine.cpp
+++ b/src/InterpreterEngine.cpp
@@ -1073,7 +1073,7 @@ RamDomain InterpreterEngine::execute(const InterpreterNode* node, InterpreterCon
             return true;
         ESAC(Project)
 
-        CASE(SubroutineReturnValue)
+        CASE(SubroutineReturn)
             for (size_t i = 0; i < cur.getValues().size(); ++i) {
                 if (node->getChild(i) == nullptr) {
                     ctxt.addReturnValue(0);
@@ -1082,7 +1082,7 @@ RamDomain InterpreterEngine::execute(const InterpreterNode* node, InterpreterCon
                 }
             }
             return true;
-        ESAC(SubroutineReturnValue)
+        ESAC(SubroutineReturn)
 
         CASE_NO_CAST(Sequence)
             for (const auto& child : node->getChildren()) {

--- a/src/InterpreterGenerator.h
+++ b/src/InterpreterGenerator.h
@@ -379,7 +379,7 @@ public:
     }
 
     // -- return from subroutine --
-    NodePtr visitSubroutineReturnValue(const RamSubroutineReturn& ret) override {
+    NodePtr visitSubroutineReturn(const RamSubroutineReturn& ret) override {
         NodePtrVec children;
         for (const auto& value : ret.getValues()) {
             children.push_back(visit(value));

--- a/src/InterpreterGenerator.h
+++ b/src/InterpreterGenerator.h
@@ -379,7 +379,7 @@ public:
     }
 
     // -- return from subroutine --
-    NodePtr visitSubroutineReturnValue(const RamSubroutineReturnValue& ret) override {
+    NodePtr visitSubroutineReturnValue(const RamSubroutineReturn& ret) override {
         NodePtrVec children;
         for (const auto& value : ret.getValues()) {
             children.push_back(visit(value));

--- a/src/InterpreterGenerator.h
+++ b/src/InterpreterGenerator.h
@@ -384,7 +384,7 @@ public:
         for (const auto& value : ret.getValues()) {
             children.push_back(visit(value));
         }
-        return std::make_unique<InterpreterNode>(I_SubroutineReturnValue, &ret, std::move(children));
+        return std::make_unique<InterpreterNode>(I_SubroutineReturn, &ret, std::move(children));
     }
 
     NodePtr visitSequence(const RamSequence& seq) override {

--- a/src/InterpreterNode.h
+++ b/src/InterpreterNode.h
@@ -66,7 +66,7 @@ enum InterpreterNodeType {
     I_Break,
     I_Filter,
     I_Project,
-    I_SubroutineReturnValue,
+    I_SubroutineReturn,
     I_Sequence,
     I_Parallel,
     I_Loop,

--- a/src/RamLevelAnalysis.cpp
+++ b/src/RamLevelAnalysis.cpp
@@ -129,7 +129,7 @@ int RamLevelAnalysis::getLevel(const RamNode* node) const {
         }
 
         // return
-        int visitSubroutineReturnValue(const RamSubroutineReturn& ret) override {
+        int visitSubroutineReturn(const RamSubroutineReturn& ret) override {
             int level = -1;
             for (auto& exp : ret.getValues()) {
                 level = std::max(level, visit(exp));

--- a/src/RamLevelAnalysis.cpp
+++ b/src/RamLevelAnalysis.cpp
@@ -129,7 +129,7 @@ int RamLevelAnalysis::getLevel(const RamNode* node) const {
         }
 
         // return
-        int visitSubroutineReturnValue(const RamSubroutineReturnValue& ret) override {
+        int visitSubroutineReturnValue(const RamSubroutineReturn& ret) override {
             int level = -1;
             for (auto& exp : ret.getValues()) {
                 level = std::max(level, visit(exp));

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -1239,7 +1239,7 @@ protected:
 };
 
 /**
- * @class RamSubroutineReturnValue
+ * @class RamSubroutineReturn
  * @brief A statement for returning from a ram subroutine
  *
  * For example:
@@ -1248,9 +1248,9 @@ protected:
  *     RETURN (t0.0, t0.1)
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
-class RamSubroutineReturnValue : public RamOperation {
+class RamSubroutineReturn : public RamOperation {
 public:
-    RamSubroutineReturnValue(std::vector<std::unique_ptr<RamExpression>> vals)
+    RamSubroutineReturn(std::vector<std::unique_ptr<RamExpression>> vals)
             : expressions(std::move(vals)) {
         for (const auto& expr : expressions) {
             assert(expr != nullptr && "Expression is a null-pointer");
@@ -1270,12 +1270,12 @@ public:
         return res;
     }
 
-    RamSubroutineReturnValue* clone() const override {
+    RamSubroutineReturn* clone() const override {
         std::vector<std::unique_ptr<RamExpression>> newValues;
         for (auto& expr : expressions) {
             newValues.emplace_back(expr->clone());
         }
-        return new RamSubroutineReturnValue(std::move(newValues));
+        return new RamSubroutineReturn(std::move(newValues));
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -1298,7 +1298,7 @@ protected:
     }
 
     bool equal(const RamNode& node) const override {
-        const auto& other = static_cast<const RamSubroutineReturnValue&>(node);
+        const auto& other = static_cast<const RamSubroutineReturn&>(node);
         return equal_targets(expressions, other.expressions);
     }
 

--- a/src/RamOperation.h
+++ b/src/RamOperation.h
@@ -1250,8 +1250,7 @@ protected:
  */
 class RamSubroutineReturn : public RamOperation {
 public:
-    RamSubroutineReturn(std::vector<std::unique_ptr<RamExpression>> vals)
-            : expressions(std::move(vals)) {
+    RamSubroutineReturn(std::vector<std::unique_ptr<RamExpression>> vals) : expressions(std::move(vals)) {
         for (const auto& expr : expressions) {
             assert(expr != nullptr && "Expression is a null-pointer");
         }

--- a/src/RamVisitor.h
+++ b/src/RamVisitor.h
@@ -109,7 +109,7 @@ struct RamVisitor : public ram_visitor_tag {
         FORWARD(Filter);
         FORWARD(Break);
         FORWARD(Project);
-        FORWARD(SubroutineReturnValue);
+        FORWARD(SubroutineReturn);
         FORWARD(UnpackRecord);
         FORWARD(NestedIntrinsicOperator);
         FORWARD(ParallelScan);
@@ -185,7 +185,7 @@ protected:
 
     // -- operations --
     LINK(Project, Operation);
-    LINK(SubroutineReturnValue, Operation);
+    LINK(SubroutineReturn, Operation);
     LINK(UnpackRecord, TupleOperation);
     LINK(NestedIntrinsicOperator, TupleOperation)
     LINK(Scan, RelationOperation);

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -2243,7 +2243,7 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
 
             // issue lock variable for return statements
             bool needLock = false;
-            visitDepthFirst(*sub.second, [&](const RamSubroutineReturnValue&) { needLock = true; });
+            visitDepthFirst(*sub.second, [&](const RamSubroutineReturn&) { needLock = true; });
             if (needLock) {
                 os << "std::mutex lock;\n";
             }

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1730,7 +1730,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 
         // -- subroutine return --
 
-        void visitSubroutineReturnValue(const RamSubroutineReturnValue& ret, std::ostream& out) override {
+        void visitSubroutineReturnValue(const RamSubroutineReturn& ret, std::ostream& out) override {
             out << "std::lock_guard<std::mutex> guard(lock);\n";
             for (auto val : ret.getValues()) {
                 if (isRamUndefValue(val)) {

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -1730,7 +1730,7 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
 
         // -- subroutine return --
 
-        void visitSubroutineReturnValue(const RamSubroutineReturn& ret, std::ostream& out) override {
+        void visitSubroutineReturn(const RamSubroutineReturn& ret, std::ostream& out) override {
             out << "std::lock_guard<std::mutex> guard(lock);\n";
             for (auto val : ret.getValues()) {
                 if (isRamUndefValue(val)) {

--- a/src/tests/ram_arithmetic_test.cpp
+++ b/src/tests/ram_arithmetic_test.cpp
@@ -51,7 +51,7 @@ RamDomain evalExpression(std::unique_ptr<RamExpression> expression, SymbolTable&
 
     Global::config().set("jobs", "1");
     std::unique_ptr<RamStatement> query =
-            std::make_unique<RamQuery>(std::make_unique<RamSubroutineReturnValue>(std::move(returnValues)));
+            std::make_unique<RamQuery>(std::make_unique<RamSubroutineReturn>(std::move(returnValues)));
     std::map<std::string, std::unique_ptr<RamStatement>> subs;
     subs.insert(std::make_pair("test", std::move(query)));
     std::vector<std::unique_ptr<RamRelation>> rels;

--- a/src/tests/ram_operation_equal_clone_test.cpp
+++ b/src/tests/ram_operation_equal_clone_test.cpp
@@ -36,12 +36,12 @@ TEST(RamScan, CloneAndEquals) {
     //  RETURN number(0)
     std::vector<std::unique_ptr<RamExpression>> a_return_args;
     a_return_args.emplace_back(new RamSignedConstant(0));
-    auto a_return = std::make_unique<RamSubroutineReturnValue>(std::move(a_return_args));
+    auto a_return = std::make_unique<RamSubroutineReturn>(std::move(a_return_args));
     RamScan a(std::make_unique<RamRelationReference>(&A), 0, std::move(a_return), "RamScan test");
 
     std::vector<std::unique_ptr<RamExpression>> b_return_args;
     b_return_args.emplace_back(new RamSignedConstant(0));
-    auto b_return = std::make_unique<RamSubroutineReturnValue>(std::move(b_return_args));
+    auto b_return = std::make_unique<RamSubroutineReturn>(std::move(b_return_args));
     RamScan b(std::make_unique<RamRelationReference>(&A), 0, std::move(b_return), "RamScan test");
 
     EXPECT_EQ(a, b);
@@ -59,13 +59,13 @@ TEST(RamParallelScan, CloneAndEquals) {
     //  RETURN number(0)
     std::vector<std::unique_ptr<RamExpression>> a_return_args;
     a_return_args.emplace_back(new RamSignedConstant(0));
-    auto a_return = std::make_unique<RamSubroutineReturnValue>(std::move(a_return_args));
+    auto a_return = std::make_unique<RamSubroutineReturn>(std::move(a_return_args));
     RamParallelScan a(
             std::make_unique<RamRelationReference>(&A), 0, std::move(a_return), "RamParallelScan test");
 
     std::vector<std::unique_ptr<RamExpression>> b_return_args;
     b_return_args.emplace_back(new RamSignedConstant(0));
-    auto b_return = std::make_unique<RamSubroutineReturnValue>(std::move(b_return_args));
+    auto b_return = std::make_unique<RamSubroutineReturn>(std::move(b_return_args));
     RamParallelScan b(
             std::make_unique<RamRelationReference>(&A), 0, std::move(b_return), "RamParallelScan test");
 
@@ -168,7 +168,7 @@ TEST(RamChoice, CloneAndEquals) {
     std::vector<std::unique_ptr<RamExpression>> a_return_args;
     a_return_args.emplace_back(new RamTupleElement(1, 0));
     a_return_args.emplace_back(new RamTupleElement(1, 1));
-    auto a_return = std::make_unique<RamSubroutineReturnValue>(std::move(a_return_args));
+    auto a_return = std::make_unique<RamSubroutineReturn>(std::move(a_return_args));
     auto a_constraint1 = std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
             std::make_unique<RamTupleElement>(1, 0), std::make_unique<RamSignedConstant>(5));
     auto a_neg1 = std::make_unique<RamNegation>(std::move(a_constraint1));
@@ -182,7 +182,7 @@ TEST(RamChoice, CloneAndEquals) {
     std::vector<std::unique_ptr<RamExpression>> b_return_args;
     b_return_args.emplace_back(new RamTupleElement(1, 0));
     b_return_args.emplace_back(new RamTupleElement(1, 1));
-    auto b_return = std::make_unique<RamSubroutineReturnValue>(std::move(b_return_args));
+    auto b_return = std::make_unique<RamSubroutineReturn>(std::move(b_return_args));
     auto b_constraint1 = std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
             std::make_unique<RamTupleElement>(1, 0), std::make_unique<RamSignedConstant>(5));
     auto b_neg1 = std::make_unique<RamNegation>(std::move(b_constraint1));
@@ -210,7 +210,7 @@ TEST(RamParallelChoice, CloneAndEquals) {
     std::vector<std::unique_ptr<RamExpression>> a_return_args;
     a_return_args.emplace_back(new RamTupleElement(1, 0));
     a_return_args.emplace_back(new RamTupleElement(1, 1));
-    auto a_return = std::make_unique<RamSubroutineReturnValue>(std::move(a_return_args));
+    auto a_return = std::make_unique<RamSubroutineReturn>(std::move(a_return_args));
     auto a_constraint1 = std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
             std::make_unique<RamTupleElement>(1, 0), std::make_unique<RamSignedConstant>(5));
     auto a_neg1 = std::make_unique<RamNegation>(std::move(a_constraint1));
@@ -224,7 +224,7 @@ TEST(RamParallelChoice, CloneAndEquals) {
     std::vector<std::unique_ptr<RamExpression>> b_return_args;
     b_return_args.emplace_back(new RamTupleElement(1, 0));
     b_return_args.emplace_back(new RamTupleElement(1, 1));
-    auto b_return = std::make_unique<RamSubroutineReturnValue>(std::move(b_return_args));
+    auto b_return = std::make_unique<RamSubroutineReturn>(std::move(b_return_args));
     auto b_constraint1 = std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
             std::make_unique<RamTupleElement>(1, 0), std::make_unique<RamSignedConstant>(5));
     auto b_neg1 = std::make_unique<RamNegation>(std::move(b_constraint1));
@@ -252,7 +252,7 @@ TEST(RamIndexChoice, CloneAndEquals) {
     std::vector<std::unique_ptr<RamExpression>> a_return_args;
     a_return_args.emplace_back(new RamTupleElement(1, 0));
     a_return_args.emplace_back(new RamTupleElement(1, 1));
-    auto a_return = std::make_unique<RamSubroutineReturnValue>(std::move(a_return_args));
+    auto a_return = std::make_unique<RamSubroutineReturn>(std::move(a_return_args));
     auto a_constraint = std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
             std::make_unique<RamTupleElement>(1, 1), std::make_unique<RamSignedConstant>(5));
     auto a_neg = std::make_unique<RamNegation>(std::move(a_constraint));
@@ -267,7 +267,7 @@ TEST(RamIndexChoice, CloneAndEquals) {
     std::vector<std::unique_ptr<RamExpression>> b_return_args;
     b_return_args.emplace_back(new RamTupleElement(1, 0));
     b_return_args.emplace_back(new RamTupleElement(1, 1));
-    auto b_return = std::make_unique<RamSubroutineReturnValue>(std::move(b_return_args));
+    auto b_return = std::make_unique<RamSubroutineReturn>(std::move(b_return_args));
     auto b_constraint = std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
             std::make_unique<RamTupleElement>(1, 1), std::make_unique<RamSignedConstant>(5));
     auto b_neg = std::make_unique<RamNegation>(std::move(b_constraint));
@@ -295,7 +295,7 @@ TEST(RamiParallelIndexChoice, CloneAndEquals) {
     std::vector<std::unique_ptr<RamExpression>> a_return_args;
     a_return_args.emplace_back(new RamTupleElement(1, 0));
     a_return_args.emplace_back(new RamTupleElement(1, 1));
-    auto a_return = std::make_unique<RamSubroutineReturnValue>(std::move(a_return_args));
+    auto a_return = std::make_unique<RamSubroutineReturn>(std::move(a_return_args));
     auto a_constraint = std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
             std::make_unique<RamTupleElement>(1, 1), std::make_unique<RamSignedConstant>(5));
     auto a_neg = std::make_unique<RamNegation>(std::move(a_constraint));
@@ -310,7 +310,7 @@ TEST(RamiParallelIndexChoice, CloneAndEquals) {
     std::vector<std::unique_ptr<RamExpression>> b_return_args;
     b_return_args.emplace_back(new RamTupleElement(1, 0));
     b_return_args.emplace_back(new RamTupleElement(1, 1));
-    auto b_return = std::make_unique<RamSubroutineReturnValue>(std::move(b_return_args));
+    auto b_return = std::make_unique<RamSubroutineReturn>(std::move(b_return_args));
     auto b_constraint = std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
             std::make_unique<RamTupleElement>(1, 1), std::make_unique<RamSignedConstant>(5));
     auto b_neg = std::make_unique<RamNegation>(std::move(b_constraint));
@@ -336,13 +336,13 @@ TEST(RamAggregate, CloneAndEquals) {
     //  RETURN t0.0
     std::vector<std::unique_ptr<RamExpression>> a_return_args;
     a_return_args.emplace_back(new RamTupleElement(0, 0));
-    auto a_return = std::make_unique<RamSubroutineReturnValue>(std::move(a_return_args));
+    auto a_return = std::make_unique<RamSubroutineReturn>(std::move(a_return_args));
     RamAggregate a(std::move(a_return), AggregateOp::COUNT, std::make_unique<RamRelationReference>(&edge),
             std::make_unique<RamTupleElement>(0, 0), std::make_unique<RamTrue>(), 1);
 
     std::vector<std::unique_ptr<RamExpression>> b_return_args;
     b_return_args.emplace_back(new RamTupleElement(0, 0));
-    auto b_return = std::make_unique<RamSubroutineReturnValue>(std::move(b_return_args));
+    auto b_return = std::make_unique<RamSubroutineReturn>(std::move(b_return_args));
     RamAggregate b(std::move(b_return), AggregateOp::COUNT, std::make_unique<RamRelationReference>(&edge),
             std::make_unique<RamTupleElement>(0, 0), std::make_unique<RamTrue>(), 1);
     EXPECT_EQ(a, b);
@@ -361,7 +361,7 @@ TEST(RamIndexAggregate, CloneAndEquals) {
     //  RETURN t0.0
     std::vector<std::unique_ptr<RamExpression>> a_return_args;
     a_return_args.emplace_back(new RamTupleElement(0, 0));
-    auto a_return = std::make_unique<RamSubroutineReturnValue>(std::move(a_return_args));
+    auto a_return = std::make_unique<RamSubroutineReturn>(std::move(a_return_args));
     auto a_cond = std::make_unique<RamConstraint>(BinaryConstraintOp::GE,
             std::make_unique<RamTupleElement>(1, 1), std::make_unique<RamSignedConstant>(80));
     RamPattern a_criteria;
@@ -374,7 +374,7 @@ TEST(RamIndexAggregate, CloneAndEquals) {
 
     std::vector<std::unique_ptr<RamExpression>> b_return_args;
     b_return_args.emplace_back(new RamTupleElement(0, 0));
-    auto b_return = std::make_unique<RamSubroutineReturnValue>(std::move(b_return_args));
+    auto b_return = std::make_unique<RamSubroutineReturn>(std::move(b_return_args));
     auto b_cond = std::make_unique<RamConstraint>(BinaryConstraintOp::GE,
             std::make_unique<RamTupleElement>(1, 1), std::make_unique<RamSignedConstant>(80));
     RamPattern b_criteria;
@@ -398,7 +398,7 @@ TEST(RamUnpackedRecord, CloneAndEquals) {
     // RETURN number(0)
     std::vector<std::unique_ptr<RamExpression>> a_return_args;
     a_return_args.emplace_back(new RamSignedConstant(0));
-    auto a_return = std::make_unique<RamSubroutineReturnValue>(std::move(a_return_args));
+    auto a_return = std::make_unique<RamSubroutineReturn>(std::move(a_return_args));
     std::vector<std::unique_ptr<RamExpression>> a_record_args;
     a_record_args.emplace_back(new RamTupleElement(0, 0));
     a_record_args.emplace_back(new RamTupleElement(0, 2));
@@ -407,7 +407,7 @@ TEST(RamUnpackedRecord, CloneAndEquals) {
 
     std::vector<std::unique_ptr<RamExpression>> b_return_args;
     b_return_args.emplace_back(new RamSignedConstant(0));
-    auto b_return = std::make_unique<RamSubroutineReturnValue>(std::move(b_return_args));
+    auto b_return = std::make_unique<RamSubroutineReturn>(std::move(b_return_args));
     std::vector<std::unique_ptr<RamExpression>> b_record_args;
     b_record_args.emplace_back(new RamTupleElement(0, 0));
     b_record_args.emplace_back(new RamTupleElement(0, 2));
@@ -428,7 +428,7 @@ TEST(RamFilter, CloneAndEquals) {
     // RETURN number(0)
     std::vector<std::unique_ptr<RamExpression>> a_return_args;
     a_return_args.emplace_back(new RamSignedConstant(0));
-    auto a_return = std::make_unique<RamSubroutineReturnValue>(std::move(a_return_args));
+    auto a_return = std::make_unique<RamSubroutineReturn>(std::move(a_return_args));
     std::vector<std::unique_ptr<RamExpression>> a_existence_check_args;
     a_existence_check_args.emplace_back(new RamTupleElement(0, 1));
     auto a_existence_check = std::make_unique<RamExistenceCheck>(
@@ -438,7 +438,7 @@ TEST(RamFilter, CloneAndEquals) {
 
     std::vector<std::unique_ptr<RamExpression>> b_return_args;
     b_return_args.emplace_back(new RamSignedConstant(0));
-    auto b_return = std::make_unique<RamSubroutineReturnValue>(std::move(b_return_args));
+    auto b_return = std::make_unique<RamSubroutineReturn>(std::move(b_return_args));
     std::vector<std::unique_ptr<RamExpression>> b_existence_check_args;
     b_existence_check_args.emplace_back(new RamTupleElement(0, 1));
     auto b_existence_check = std::make_unique<RamExistenceCheck>(
@@ -460,13 +460,13 @@ TEST(RamBreak, CloneAndEquals) {
     // RETURN number(0)
     std::vector<std::unique_ptr<RamExpression>> a_return_args;
     a_return_args.emplace_back(new RamSignedConstant(0));
-    auto a_return = std::make_unique<RamSubroutineReturnValue>(std::move(a_return_args));
+    auto a_return = std::make_unique<RamSubroutineReturn>(std::move(a_return_args));
     RamBreak a(std::make_unique<RamEmptinessCheck>(std::make_unique<RamRelationReference>(&A)),
             std::move(a_return), "RamBreak test");
 
     std::vector<std::unique_ptr<RamExpression>> b_return_args;
     b_return_args.emplace_back(new RamSignedConstant(0));
-    auto b_return = std::make_unique<RamSubroutineReturnValue>(std::move(b_return_args));
+    auto b_return = std::make_unique<RamSubroutineReturn>(std::move(b_return_args));
     RamBreak b(std::make_unique<RamEmptinessCheck>(std::make_unique<RamRelationReference>(&A)),
             std::move(b_return), "RamBreak test");
     EXPECT_EQ(a, b);
@@ -499,21 +499,21 @@ TEST(RamProject, CloneAndEquals) {
     delete c;
 }
 
-TEST(RamSubroutineReturnValue, CloneAndEquals) {
+TEST(RamSubroutineReturn, CloneAndEquals) {
     // RETURN (t0.1, t0.2)
     std::vector<std::unique_ptr<RamExpression>> a_args;
     a_args.emplace_back(new RamTupleElement(0, 1));
     a_args.emplace_back(new RamTupleElement(0, 2));
-    RamSubroutineReturnValue a(std::move(a_args));
+    RamSubroutineReturn a(std::move(a_args));
 
     std::vector<std::unique_ptr<RamExpression>> b_args;
     b_args.emplace_back(new RamTupleElement(0, 1));
     b_args.emplace_back(new RamTupleElement(0, 2));
-    RamSubroutineReturnValue b(std::move(b_args));
+    RamSubroutineReturn b(std::move(b_args));
     EXPECT_EQ(a, b);
     EXPECT_NE(&a, &b);
 
-    RamSubroutineReturnValue* c = a.clone();
+    RamSubroutineReturn* c = a.clone();
     EXPECT_EQ(a, *c);
     EXPECT_NE(&a, c);
     delete c;
@@ -521,15 +521,15 @@ TEST(RamSubroutineReturnValue, CloneAndEquals) {
     // RETURN (number(0))
     std::vector<std::unique_ptr<RamExpression>> d_args;
     d_args.emplace_back(new RamSignedConstant(0));
-    RamSubroutineReturnValue d(std::move(d_args));
+    RamSubroutineReturn d(std::move(d_args));
 
     std::vector<std::unique_ptr<RamExpression>> e_args;
     e_args.emplace_back(new RamSignedConstant(0));
-    RamSubroutineReturnValue e(std::move(e_args));
+    RamSubroutineReturn e(std::move(e_args));
     EXPECT_EQ(d, e);
     EXPECT_NE(&d, &e);
 
-    RamSubroutineReturnValue* f = d.clone();
+    RamSubroutineReturn* f = d.clone();
     EXPECT_EQ(d, *f);
     EXPECT_NE(&d, f);
     delete f;

--- a/src/tests/ram_statement_equal_clone_test.cpp
+++ b/src/tests/ram_statement_equal_clone_test.cpp
@@ -136,7 +136,7 @@ TEST(RamQuery, CloneAndEquals) {
      */
     std::vector<std::unique_ptr<RamExpression>> d_return_value;
     d_return_value.emplace_back(new RamTupleElement(1, 0));
-    auto d_return = std::make_unique<RamSubroutineReturnValue>(std::move(d_return_value));
+    auto d_return = std::make_unique<RamSubroutineReturn>(std::move(d_return_value));
     // condition t1.0 = 0
     auto d_cond = std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
             std::make_unique<RamTupleElement>(1, 0), std::make_unique<RamSignedConstant>(0));
@@ -145,7 +145,7 @@ TEST(RamQuery, CloneAndEquals) {
 
     std::vector<std::unique_ptr<RamExpression>> e_return_value;
     e_return_value.emplace_back(new RamTupleElement(1, 0));
-    auto e_return = std::make_unique<RamSubroutineReturnValue>(std::move(e_return_value));
+    auto e_return = std::make_unique<RamSubroutineReturn>(std::move(e_return_value));
     // condition t1.0 = 0
     auto e_cond = std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
             std::make_unique<RamTupleElement>(1, 0), std::make_unique<RamSignedConstant>(0));


### PR DESCRIPTION
Currently, there is some inconsistency in naming `RamSubroutineArgument` and `RamSubroutineReturnValue`.
This pull-request changes the class name `RamSubroutineReturnValue` to `RamSubroutineReturn`.  