### PR TITLE
Remove redundant default testing

### DIFF
--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -196,8 +196,7 @@ m4_define([NEGATIVE_TEST],[
 dnl Defines most relevant Souffle flag configurations for testing.
 dnl NOTE: This is the default configuration that can be overridden
 dnl using SOUFFLE_CONFS environment variable.
-m4_define([DEFAULT_CONFS], [[],      dnl run default interpreter in sequential
-  [-j8],                             dnl run interpreter in parallel
+m4_define([DEFAULT_CONFS], [[-j8],   dnl run interpreter in parallel
   [-c -j8]                           dnl compile, then execute in parallel
 ])
 


### PR DESCRIPTION
The default tests currently run both `-j1` (the default if no option is given) and `-j8`. The souffle code executed by these two is the same, but OpenMP is instructed to use 1 thread rather than 8. This does not test souffle without OpenMP. To test single threaded non-OpenMP code souffle must first be compiled without OpenMP.

Since the tests are redundant for souffle, this PR removes one of the configurations. Note that our tests with Travis CI already explicitly test non-OpenMP versions. The result of the change is equivalent, but faster to complete.