### PR TITLE
Stop showing OpenMP warning if `--no-warn` is used

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -253,7 +253,7 @@ int main(int argc, char** argv) {
         }
 #else
         // Check that -j option has not been changed from the default
-        if (Global::config().get("jobs") != "1") {
+        if (Global::config().get("jobs") != "1" && !Global::config().has("no-warn")) {
             std::cerr << "\nThis installation of Souffle does not support concurrent jobs.\n";
         }
 #endif


### PR DESCRIPTION
Currently trying to use multiple threads with a non-OpenMP version of souffle emits a warning even if `--no-warn` has been requested. This PR is to fix that issue.