### PR TITLE
Extended program minimiser to cover more clause redundancies.

### DIFF
--- a/src/MinimiseProgramTransformer.cpp
+++ b/src/MinimiseProgramTransformer.cpp
@@ -465,8 +465,47 @@ bool reduceSingletonRelations(AstTranslationUnit& translationUnit) {
     return !canonicalName.empty();
 }
 
+/**
+ * Remove clauses that are only satisfied if they are already satisfied.
+ * @return true iff the program has changed
+ */
+bool removeRedundantClauses(AstTranslationUnit& translationUnit) {
+    auto& program = *translationUnit.getProgram();
+    auto isRedundant = [&](const AstClause* clause) {
+        const auto* head = clause->getHead();
+        for (const auto* lit : clause->getBodyLiterals()) {
+            if (*head == *lit) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    std::set<std::unique_ptr<AstClause>> clausesToRemove;
+    for (const auto* clause : program.getClauses()) {
+        if (isRedundant(clause)) {
+            clausesToRemove.insert(std::unique_ptr<AstClause>(clause->clone()));
+        }
+    }
+
+    for (auto& clause : clausesToRemove) {
+        program.removeClause(clause.get());
+    }
+    return clausesToRemove.empty();
+}
+
+/**
+ * Remove repeated literals within a clause.
+ * @return true iff the program has changed
+ */
+bool reduceClauseBodies(AstTranslationUnit& translationUnit) {
+    return false;
+}
+
 bool MinimiseProgramTransformer::transform(AstTranslationUnit& translationUnit) {
     bool changed = false;
+    changed |= reduceClauseBodies(translationUnit);
+    changed |= removeRedundantClauses(translationUnit);
     changed |= reduceLocallyEquivalentClauses(translationUnit);
     changed |= reduceSingletonRelations(translationUnit);
     return changed;

--- a/src/tests/ast_utils_test.cpp
+++ b/src/tests/ast_utils_test.cpp
@@ -353,7 +353,8 @@ TEST(AstUtils, RemoveClauseRedundancies) {
 
                 .decl q(X:number)
                 .output q()
-            )", e, d);
+            )",
+            e, d);
     std::make_unique<RemoveRelationCopiesTransformer>()->apply(*tu);
     std::make_unique<MinimiseProgramTransformer>()->apply(*tu);
     const auto& program = *tu->getProgram();

--- a/tests/semantic/progmin2/progmin2.dl
+++ b/tests/semantic/progmin2/progmin2.dl
@@ -25,6 +25,14 @@ C(a) :- F(_, a).
 D(x) :- F(x, x).
 E(y) :- F(y, y).
 
+// these two are equivalent
+D(x) :- A(x), A(x), A(x), B(x).
+D(x) :- B(x), A(x).
+
+// these two are redundant
+D(x) :- D(x).
+D(x) :- D(x), x != 1, A(x).
+
 G(x) :- A(x).
 G(x) :- B(x).
 G(x) :- C(x).


### PR DESCRIPTION
The program minimiser has been extended to cover more cases, this time centred around clause redundancies. Although they can appear in user code as well, clause redundancies are particularly commonplace as a side-effect of some intermediate transformations. For example, after the `RemoveRelationCopiesTransformer`, this code:

```
.decl A, B, C(X:number)
B(0).
A(X) :- B(X).
C(X) :- A(X), X != 3.
.output C()
```

is transformed into:

```
.decl B(X:number) 
.decl C(X:number) 
B(0).

B(X) :- B(X).

C(X) :- B(X), X != 3.
.output C
```

Notice the newly produced redundant clause: `B(X) :- B(X).`.

On a high level, this PR covers two main cases:
* If a clause contains a body atom equivalent to the head atom, then the clause is completely redundant and is removed. An example is `B(X) :- B(X), X != 1.`. Regardless of the result of the remaining literals, since `B(X)` is only true if `B(X)` is true in the body, the clause produces no new information, and can be safely removed.

* If a clause contains several repeated atoms, then the redundant atoms can be safely ignored. For example, `A(X) :- B(X), B(X), B(X), C(X).` can be reduced to `A(X) :- B(X), C(X).`. If an atom is true, it will remain true, thanks to the monotonicity of the computatoin.

As an example of the power of this PR, consider the following input program:

```
.decl a,b,c(X:number)

a(0).
b(1).

c(X) :- b(X).

a(X) :- b(X), c(X).
a(X) :- a(X).
a(X) :- a(X), X != 1.

q(X) :- a(X).

.decl q(X:number)
.output q()
```

Originally, this was transformed into:

```
.decl a(X:number) 
.decl b(X:number) 
.decl q(X:number) 
a(0).

b(1).
b(X) :- b(X).

a(X) :- b(X), b(X).
a(X) :- a(X).
a(X) :- a(X), X != 1.

q(X) :- a(X).
.output q
```

This PR further reduces it into:

```
.decl a(X:number) 
.decl b(X:number) 
.decl q(X:number) 
a(0).
b(1).
a(X) :-  b(X).
q(X) :-  a(X).
.output q
```

This PR resolves issue #1487.