### PR TITLE
Fix handling of functor paths

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,7 +77,7 @@ void executeBinary(const std::string& binaryFilename) {
         for (const std::string& library : splitString(Global::config().get("library-dir"), ' ')) {
             ldPath += library + ':';
         }
-        ldPath.back() = ' ';
+        ldPath.pop_back();
         setenv("LD_LIBRARY_PATH", ldPath.c_str(), 1);
         setenv("DYLD_LIBRARY_PATH", ldPath.c_str(), 1);
     }
@@ -167,8 +167,8 @@ int main(int argc, char** argv) {
                 {"swig", 's', "LANG", "", false,
                         "Generate SWIG interface for given language. The values <LANG> accepts is java and "
                         "python. "},
-                {"library-dir", 'L', "DIR", "", true, "Specify directory for library files."},
-                {"libraries", 'l', "FILE", "", true, "Specify libraries."},
+                {"library-dir", 'L', "DIR", "", false, "Specify directory for library files."},
+                {"libraries", 'l', "FILE", "", false, "Specify libraries."},
                 {"no-warn", 'w', "", "", false, "Disable warnings."},
                 {"magic-transform", 'm', "RELATIONS", "", false,
                         "Enable magic set transformation changes on the given relations, use '*' "

--- a/tests/interface.at
+++ b/tests/interface.at
@@ -76,7 +76,7 @@ m4_define([TEST_EVAL_FUNCTOR],[
   # TODO (darth_tytus): Investigate a better solution.
   cp ../../interface/functors/.libs/libfunctors.dylib /usr/local/lib/ 2>/dev/null
   # invoke souffle
-  AT_CHECK([LD_LIBRARY_PATH=. "$SOUFFLE" FLAGS -L. -D. -F FACTS PROGRAM 1>TESTNAME.out 2>TESTNAME.err], [0])
+  AT_CHECK([LD_LIBRARY_PATH=. "$SOUFFLE" FLAGS -D. -F FACTS PROGRAM 1>TESTNAME.out 2>TESTNAME.err], [0])
   SORTED_SAME_FILES([*.csv],[TESTDIR])
   SAME_FILE([TESTNAME.out],[TESTDIR/TESTNAME.out])
   SAME_FILE([TESTNAME.err],[TESTDIR/TESTNAME.err])


### PR DESCRIPTION
Current behaviour for functor library paths is to set the default path for functor libraries to true. This is not a valid path, and prevents the logic that inserts a default path if needed. We also generate invalid paths when we parse the options. Conveniently, the error is silent for a user-specified path. Inconveniently, the error is not silent when we specify a default.,

This PR fixes both issues and modifies the functor test to use the default path of '.'.

Fixes #1493 