### PR TITLE
Fix ResolveAliasesTransformer handling of record arguments.

### DIFF
--- a/src/ResolveAliasesTransformer.cpp
+++ b/src/ResolveAliasesTransformer.cpp
@@ -404,7 +404,7 @@ std::unique_ptr<AstClause> ResolveAliasesTransformer::removeComplexTermsInAtoms(
             std::vector<std::pair<std::unique_ptr<AstArgument>, std::unique_ptr<AstVariable>>>;
     substitution_map termToVar;
 
-    int varCounter = 0;
+    static int varCounter = 0;
     for (const AstArgument* arg : terms) {
         // create a new mapping for this term
         auto term = std::unique_ptr<AstArgument>(arg->clone());

--- a/src/ResolveAliasesTransformer.cpp
+++ b/src/ResolveAliasesTransformer.cpp
@@ -220,17 +220,22 @@ std::unique_ptr<AstClause> ResolveAliasesTransformer::resolveAliases(const AstCl
         return res;
     };
 
-    // find all variables appearing as functorless arguments in grounding atoms
-    // these variables are the source of groundedness
-    // e.g. a(y) :- b(x), y = x + 1. -- y is only grounded because x appears in b(x)
+    // variables appearing as functorless arguments in atoms or records should not
+    // be resolved
     std::set<std::string> baseGroundedVariables;
     for (const auto* atom : getBodyLiterals<AstAtom>(clause)) {
-        // TODO (azreika): getArguments for atoms [same way]
         for (const AstArgument* arg : atom->getArguments()) {
             if (const auto* var = dynamic_cast<const AstVariable*>(arg)) {
                 baseGroundedVariables.insert(var->getName());
             }
         }
+        visitDepthFirst(*atom, [&](const AstRecordInit& rec) {
+            for (const AstArgument* arg : rec.getArguments()) {
+                if (const auto* var = dynamic_cast<const AstVariable*>(arg)) {
+                    baseGroundedVariables.insert(var->getName());
+                }
+            }
+        });
     }
 
     // I) extract equations

--- a/tests/semantic/func_in_rec/func_in_rec.dl
+++ b/tests/semantic/func_in_rec/func_in_rec.dl
@@ -7,12 +7,17 @@
 // Checks that functors in body records operate correctly
 .type BoxedNumber = [x:number]
 .type BoxedBoxedNumber = [x:BoxedNumber]
+.type Pair = [x:number, y:number]
 
 .decl A(x:number)
 A(X) :- B(X, [Y], [[X*X*X]]), Y = -X*1.
 A(X+1) :- B(_, [X+1], _), A(X).
+A(X+1) :- A(X), B(X+1, _, _), C([X+1, X+2]).
 
 .decl B(x:number, y:BoxedNumber, z:BoxedBoxedNumber)
 .input B()
+
+.decl C(x:Pair)
+C([X,Y]) :- B(_, [X], [[Y]]).
 
 .output A()


### PR DESCRIPTION
This is an extension of PR #1502, fixing two related issues with alias resolution.

Two main changes:
* Fixes alias resolver to continue the incrementing count on each separate pass, rather than starting from 0 again
* Stops resolving functorless variables in record arguments, undoing the work of the previous PR

### Justification + Example

`ResolveAliasesTransformer` has three stages:
1. Resolve aliases - resolve equality constraints where necessary
2. Remove trivial inequalities - things of the form `E1 = E1`
3. Remove complex terms in atoms - essentially, extracting out functors into separate variables where necessary

To accomplish the third point, the alias resolver created new variables of the form " _tmp_N", where N is an incrementing counter. An important note is that, prior to this PR, the alias resolver started from 0 again on each pass.

Now, consider this running example across several consecutive passes of the transformer.
```
A(X) :- B(X), C(X+2), D([X+3, X+4]).
```

#### Pass 1
After one pass through the alias resolver, the only thing we do is extract out all the functors (correctly):
```
A(X) :- B(X), C(tmp0), D([tmp1]), tmp0 = X+1, tmp1 = X+2.
```

#### Pass 2
After another pass, we first resolve all equalities not contained in 'grounded' variables. Before this PR, this only included variables appearing as direct arguments of an atom - in this case, only `X` and `tmp0`. This means that we produce the following code: 
```
A(X) :- B(X), C(tmp0), D([X+2]), tmp0 = X+1, X+2 = X+2.
```
which, after stage 2, is reduced to:
```
A(X) :- B(X), C(tmp0), D([X+2]), tmp0 = X+1.
```
Finally, the third stage is run (removing complex terms). Remember again that this is a separate pass of the transformer and so, before this PR, the count would start at 0 again. This means we'd produce the following code:
```
A(X) :- B(X), C(tmp0), D([tmp0]), tmp0 = X+1, tmp0 = X+2.
```
We've used `tmp0` for two different functors! This rule will now trivially always produce the empty set.

Fixing the counter prevents the issue by avoiding naming conflicts, while adding variables in the records to the 'grounded' check prevents undoing the work of a previous transformer pass.