### PR TITLE
make sure souffle-compile has "-std=c++17" set

### DIFF
--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -48,7 +48,7 @@ set -e
 # set by autoconf
 CXX="$(printenv CXX || true)"
 test -z "$CXX" && CXX="@CXX@"
-CPPFLAGS="$(printenv CPPFLAGS || true) @CPPFLAGS@"
+CPPFLAGS="$(printenv CPPFLAGS || true) -std=c++17 @CPPFLAGS@"
 CXXFLAGS="$(printenv CXXFLAGS || true) @SOUFFLE_CXXFLAGS@ -march=native"
 LDFLAGS="$(printenv LDFLAGS || true) @LDFLAGS@"
 LIBS="$(printenv LIBS || true) @LIBS@"


### PR DESCRIPTION
Currently souffle-compile fails with gcc version 7.5.0 (tested within provided docker ubuntu:bionic) because of missing "-std=c++17". This should solve this issue, but also might introduce repeated "-std=c++17" option which in most cases should not produce any problem I think.