### PR TITLE
Add default filename for json output

### DIFF
--- a/src/WriteStreamCSV.h
+++ b/src/WriteStreamCSV.h
@@ -72,7 +72,7 @@ public:
     WriteFileCSV(const std::map<std::string, std::string>& rwOperation, const SymbolTable& symbolTable,
             const RecordTable& recordTable)
             : WriteStreamCSV(rwOperation, symbolTable, recordTable),
-              file(rwOperation.at("filename"), std::ios::out | std::ios::binary) {
+              file(getFileName(rwOperation), std::ios::out | std::ios::binary) {
         if (getOr(rwOperation, "headers", "false") == "true") {
             file << rwOperation.at("attributeNames") << std::endl;
         }
@@ -89,6 +89,10 @@ protected:
 
     void writeNextTuple(const RamDomain* tuple) override {
         writeNextTupleCSV(file, tuple);
+    }
+
+    static std::string getFileName(const std::map<std::string, std::string>& rwOperation) {
+        return getOr(rwOperation, "filename", rwOperation.at("name") + ".csv");
     }
 };
 

--- a/src/WriteStreamJSON.h
+++ b/src/WriteStreamJSON.h
@@ -114,7 +114,7 @@ public:
     WriteFileJSON(const std::map<std::string, std::string>& rwOperation, const SymbolTable& symbolTable,
             const RecordTable& recordTable)
             : WriteStreamJSON(rwOperation, symbolTable, recordTable), isFirst(true),
-              file(rwOperation.at("filename"), std::ios::out | std::ios::binary) {
+              file(getFileName(rwOperation), std::ios::out | std::ios::binary) {
         file << "[";
     }
 
@@ -138,6 +138,10 @@ protected:
             isFirst = false;
         }
         writeNextTupleJSON(file, tuple);
+    }
+
+    static std::string getFileName(const std::map<std::string, std::string>& rwOperation) {
+        return getOr(rwOperation, "filename", rwOperation.at("name") + ".json");
     }
 };
 


### PR DESCRIPTION
Currently if a filename is not set for json output, souffle exits when map::at is called to retrieve the filename. This PR sets a default name of '<relation name>.json'.