### PR TITLE
Singleton aggregate fix (don't create a new relation for the aggregate literal if it is the only literal in the rule)

### DIFF
--- a/src/ast/transform/AstTransforms.cpp
+++ b/src/ast/transform/AstTransforms.cpp
@@ -262,7 +262,10 @@ bool MaterializeSingletonAggregationTransformer::transform(AstTranslationUnit& t
     // collect references to clause / aggregate pairs
     visitDepthFirst(program, [&](const AstClause& clause) {
         visitDepthFirst(clause, [&](const AstAggregator& agg) {
-            if (!isSingleValued(agg, clause)) {
+            // if the aggregate isn't single valued
+            // (ie it relies on a grounding from the outer scope)
+            // or it's the only atom in the clause, then there's no point materialising it!
+            if (!isSingleValued(agg, clause) || clause.getBodyLiterals().size() == 1) {
                 return;
             }
             auto* foundAggregate = const_cast<AstAggregator*>(&agg);


### PR DESCRIPTION
The singleton aggregate transformer replaces an aggregate expression with a variable, and the variable (for example, z) takes a value from a synthesised relation __agg_rel_x(z). There is no point doing this when the aggregate atom is the only atom in the rule.  For example, what used to happen is that the input program

```
.decl Nat(n:number)
.decl Sum(n:number)

Nat(0).
Nat(n+1) :- Nat(n), n < 100.

Sum(n) :- n = sum n : Nat(n).
```

would be transformed to

```.decl Nat(n:number) 
.decl Sum(n:number) 
.decl __agg_rel_0(z:number) 
Nat(0).

Nat((n+1)) :- 
   Nat(n),
   n < 100.

Sum(z) :- 
   __agg_rel_0(z).

__agg_rel_0(sum  n0 : { Nat( n0) }).
```

Now it's just

```
.decl Nat(n:number) 
.decl Sum(n:number) 
Nat(0).

Nat((n+1)) :- 
   Nat(n),
   n < 100.

Sum(sum  n0 : { Nat( n0) }).
```

which seems a bit more sensible.