### PR TITLE
Standardise cloning

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -285,8 +285,8 @@ std::unique_ptr<RamCondition> AstTranslator::translateConstraint(
 
         /** for binary relations */
         std::unique_ptr<RamCondition> visitBinaryConstraint(const AstBinaryConstraint& binRel) override {
-            std::unique_ptr<RamExpression> valLHS = translator.translateValue(binRel.getLHS(), index);
-            std::unique_ptr<RamExpression> valRHS = translator.translateValue(binRel.getRHS(), index);
+            auto valLHS = translator.translateValue(binRel.getLHS(), index);
+            auto valRHS = translator.translateValue(binRel.getRHS(), index);
             return std::make_unique<RamConstraint>(
                     binRel.getOperator(), std::move(valLHS), std::move(valRHS));
         }
@@ -400,8 +400,7 @@ void AstTranslator::ClauseTranslator::indexValues(const AstNode* curNode,
         // check for variable references
         if (auto var = dynamic_cast<const AstVariable*>(arg)) {
             if (pos < relation->get()->getArity()) {
-                valueIndex.addVarReference(
-                        *var, arg_level[cur], pos, std::unique_ptr<RamRelationReference>(relation->clone()));
+                valueIndex.addVarReference(*var, arg_level[cur], pos, souffle::clone(relation));
             } else {
                 valueIndex.addVarReference(*var, arg_level[cur], pos);
             }
@@ -890,7 +889,7 @@ std::unique_ptr<RamStatement> AstTranslator::translateNonRecursiveRelation(
             const std::string logSizeStatement =
                     LogStatement::nNonrecursiveRule(relationName, srcLocation, clauseText);
             rule = std::make_unique<RamLogRelationTimer>(
-                    std::move(rule), logTimerStatement, std::unique_ptr<RamRelationReference>(rrel->clone()));
+                    std::move(rule), logTimerStatement, souffle::clone(rrel));
         }
 
         // add debug info
@@ -913,15 +912,13 @@ std::unique_ptr<RamStatement> AstTranslator::translateNonRecursiveRelation(
         if (!res.empty()) {
             const std::string logTimerStatement =
                     LogStatement::tNonrecursiveRelation(relationName, srcLocation);
-            std::unique_ptr<RamStatement> newStmt =
-                    std::make_unique<RamLogRelationTimer>(std::make_unique<RamSequence>(std::move(res)),
-                            logTimerStatement, std::unique_ptr<RamRelationReference>(rrel->clone()));
+            auto newStmt = std::make_unique<RamLogRelationTimer>(
+                    std::make_unique<RamSequence>(std::move(res)), logTimerStatement, souffle::clone(rrel));
             res.clear();
             appendStmt(res, std::move(newStmt));
         } else {
             // add table size printer
-            appendStmt(res, std::make_unique<RamLogSize>(
-                                    std::unique_ptr<RamRelationReference>(rrel->clone()), logSizeStatement));
+            appendStmt(res, std::make_unique<RamLogSize>(souffle::clone(rrel), logSizeStatement));
         }
     }
 
@@ -975,23 +972,17 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
         std::vector<std::unique_ptr<RamExpression>> values;
         if (src->get()->getArity() == 0) {
             return std::make_unique<RamQuery>(std::make_unique<RamFilter>(
-                    std::make_unique<RamNegation>(std::make_unique<RamEmptinessCheck>(
-                            std::unique_ptr<RamRelationReference>(src->clone()))),
-                    std::make_unique<RamProject>(
-                            std::unique_ptr<RamRelationReference>(dest->clone()), std::move(values))));
+                    std::make_unique<RamNegation>(std::make_unique<RamEmptinessCheck>(souffle::clone(src))),
+                    std::make_unique<RamProject>(souffle::clone(dest), std::move(values))));
         }
         for (std::size_t i = 0; i < dest->get()->getArity(); i++) {
             values.push_back(std::make_unique<RamTupleElement>(0, i));
         }
-        std::unique_ptr<RamStatement> stmt = std::make_unique<RamQuery>(
-                std::make_unique<RamScan>(std::unique_ptr<RamRelationReference>(src->clone()), 0,
-                        std::make_unique<RamProject>(
-                                std::unique_ptr<RamRelationReference>(dest->clone()), std::move(values))));
+        auto stmt = std::make_unique<RamQuery>(std::make_unique<RamScan>(souffle::clone(src), 0,
+                std::make_unique<RamProject>(souffle::clone(dest), std::move(values))));
         if (dest->get()->getRepresentation() == RelationRepresentation::EQREL) {
-            stmt = std::make_unique<RamSequence>(
-                    std::make_unique<RamExtend>(std::unique_ptr<RamRelationReference>(dest->clone()),
-                            std::unique_ptr<RamRelationReference>(src->clone())),
-                    std::move(stmt));
+            return std::make_unique<RamSequence>(
+                    std::make_unique<RamExtend>(souffle::clone(dest), souffle::clone(src)), std::move(stmt));
         }
         return stmt;
     };
@@ -1065,12 +1056,10 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
                 getBodyLiterals<AstAtom>(*r1)[j]->setQualifiedName(
                         translateDeltaRelation(atomRelation)->get()->getName());
                 if (Global::config().has("provenance")) {
-                    r1->addToBody(std::make_unique<AstProvenanceNegation>(
-                            std::unique_ptr<AstAtom>(cl->getHead()->clone())));
+                    r1->addToBody(std::make_unique<AstProvenanceNegation>(souffle::clone(cl->getHead())));
                 } else {
                     if (r1->getHead()->getArity() > 0) {
-                        r1->addToBody(std::make_unique<AstNegation>(
-                                std::unique_ptr<AstAtom>(cl->getHead()->clone())));
+                        r1->addToBody(std::make_unique<AstNegation>(souffle::clone(cl->getHead())));
                     }
                 }
 
@@ -1081,10 +1070,10 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
                 // reduce R to P ...
                 for (size_t k = j + 1; k < atoms.size(); k++) {
                     if (isInSameSCC(getAtomRelation(atoms[k], program))) {
-                        AstAtom* cur = getBodyLiterals<AstAtom>(*r1)[k]->clone();
+                        auto cur = souffle::clone(getBodyLiterals<AstAtom>(*r1)[k]);
                         cur->setQualifiedName(
                                 translateDeltaRelation(getAtomRelation(atoms[k], program))->get()->getName());
-                        r1->addToBody(std::make_unique<AstNegation>(std::unique_ptr<AstAtom>(cur)));
+                        r1->addToBody(std::make_unique<AstNegation>(std::move(cur)));
                     }
                 }
 
@@ -1138,7 +1127,7 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
             const SrcLocation& srcLocation = rel->getSrcLoc();
             const std::string logTimerStatement = LogStatement::tRecursiveRelation(relationName, srcLocation);
             const std::string logSizeStatement = LogStatement::nRecursiveRelation(relationName, srcLocation);
-            std::unique_ptr<RamStatement> newStmt = std::make_unique<RamLogRelationTimer>(
+            auto newStmt = std::make_unique<RamLogRelationTimer>(
                     std::make_unique<RamSequence>(std::move(loopRelSeq)), logTimerStatement,
                     translateNewRelation(rel));
             loopRelSeq.clear();
@@ -1148,7 +1137,7 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
         /* add rule computations of a relation to parallel statement */
         appendStmt(loopSeq, std::make_unique<RamSequence>(std::move(loopRelSeq)));
     }
-    std::unique_ptr<RamParallel> loop = std::make_unique<RamParallel>(std::move(loopSeq));
+    auto loop = std::make_unique<RamParallel>(std::move(loopSeq));
 
     /* construct exit conditions for odd and even iteration */
     auto addCondition = [](std::unique_ptr<RamCondition>& cond, std::unique_ptr<RamCondition> clause) {
@@ -1183,20 +1172,19 @@ std::unique_ptr<RamStatement> AstTranslator::translateRecursiveRelation(
 
 /** make a subroutine to search for subproofs */
 std::unique_ptr<RamStatement> AstTranslator::makeSubproofSubroutine(const AstClause& clause) {
-    auto intermediateClause =
-            std::make_unique<AstClause>(std::unique_ptr<AstAtom>(clause.getHead()->clone()));
+    auto intermediateClause = std::make_unique<AstClause>(souffle::clone(clause.getHead()));
 
     // create a clone where all the constraints are moved to the end
     for (auto bodyLit : clause.getBodyLiterals()) {
         // first add all the things that are not constraints
         if (dynamic_cast<AstConstraint*>(bodyLit) == nullptr) {
-            intermediateClause->addToBody(std::unique_ptr<AstLiteral>(bodyLit->clone()));
+            intermediateClause->addToBody(souffle::clone(bodyLit));
         }
     }
 
     // now add all constraints
     for (auto bodyLit : getBodyLiterals<AstConstraint>(clause)) {
-        intermediateClause->addToBody(std::unique_ptr<AstLiteral>(bodyLit->clone()));
+        intermediateClause->addToBody(souffle::clone(bodyLit));
     }
 
     // name unnamed variables
@@ -1211,16 +1199,16 @@ std::unique_ptr<RamStatement> AstTranslator::makeSubproofSubroutine(const AstCla
 
         if (auto var = dynamic_cast<AstVariable*>(arg)) {
             // FIXME: float equiv (`FEQ`)
-            intermediateClause->addToBody(std::make_unique<AstBinaryConstraint>(BinaryConstraintOp::EQ,
-                    std::unique_ptr<AstArgument>(var->clone()), std::make_unique<AstSubroutineArgument>(i)));
+            intermediateClause->addToBody(std::make_unique<AstBinaryConstraint>(
+                    BinaryConstraintOp::EQ, souffle::clone(var), std::make_unique<AstSubroutineArgument>(i)));
         } else if (auto func = dynamic_cast<AstFunctor*>(arg)) {
             auto opEq = func->getReturnType() == TypeAttribute::Float ? BinaryConstraintOp::FEQ
                                                                       : BinaryConstraintOp::EQ;
-            intermediateClause->addToBody(std::make_unique<AstBinaryConstraint>(opEq,
-                    std::unique_ptr<AstArgument>(func->clone()), std::make_unique<AstSubroutineArgument>(i)));
+            intermediateClause->addToBody(std::make_unique<AstBinaryConstraint>(
+                    opEq, souffle::clone(func), std::make_unique<AstSubroutineArgument>(i)));
         } else if (auto rec = dynamic_cast<AstRecordInit*>(arg)) {
-            intermediateClause->addToBody(std::make_unique<AstBinaryConstraint>(BinaryConstraintOp::EQ,
-                    std::unique_ptr<AstArgument>(rec->clone()), std::make_unique<AstSubroutineArgument>(i)));
+            intermediateClause->addToBody(std::make_unique<AstBinaryConstraint>(
+                    BinaryConstraintOp::EQ, souffle::clone(rec), std::make_unique<AstSubroutineArgument>(i)));
         }
     }
 
@@ -1240,7 +1228,7 @@ std::unique_ptr<RamStatement> AstTranslator::makeSubproofSubroutine(const AstCla
                 auto atomArgs = atom->getArguments();
                 // FIXME: float equiv (`FEQ`)
                 intermediateClause->addToBody(std::make_unique<AstBinaryConstraint>(BinaryConstraintOp::EQ,
-                        std::unique_ptr<AstArgument>(atomArgs[literalLevelIndex]->clone()),
+                        souffle::clone(atomArgs[literalLevelIndex]),
                         std::make_unique<AstSubroutineArgument>(levelIndex)));
             }
             levelIndex++;
@@ -1257,7 +1245,7 @@ std::unique_ptr<RamStatement> AstTranslator::makeSubproofSubroutine(const AstCla
                 auto atomArgs = atom->getArguments();
                 // arity - 1 is the level number in body atoms
                 intermediateClause->addToBody(std::make_unique<AstBinaryConstraint>(BinaryConstraintOp::LT,
-                        std::unique_ptr<AstArgument>(atomArgs[arity - 1]->clone()),
+                        souffle::clone(atomArgs[arity - 1]),
                         std::make_unique<AstSubroutineArgument>(levelIndex)));
             }
         }
@@ -1278,20 +1266,19 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
     // ...
 
     // clone clause for mutation, rearranging constraints to be at the end
-    auto clauseReplacedAggregates =
-            std::make_unique<AstClause>(std::unique_ptr<AstAtom>(clause.getHead()->clone()));
+    auto clauseReplacedAggregates = std::make_unique<AstClause>(souffle::clone(clause.getHead()));
 
     // create a clone where all the constraints are moved to the end
     for (auto bodyLit : clause.getBodyLiterals()) {
         // first add all the things that are not constraints
         if (dynamic_cast<AstConstraint*>(bodyLit) == nullptr) {
-            clauseReplacedAggregates->addToBody(std::unique_ptr<AstLiteral>(bodyLit->clone()));
+            clauseReplacedAggregates->addToBody(souffle::clone(bodyLit));
         }
     }
 
     // now add all constraints
     for (auto bodyLit : getBodyLiterals<AstConstraint>(clause)) {
-        clauseReplacedAggregates->addToBody(std::unique_ptr<AstLiteral>(bodyLit->clone()));
+        clauseReplacedAggregates->addToBody(souffle::clone(bodyLit));
     }
 
     int aggNumber = 0;
@@ -1361,7 +1348,7 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
     std::vector<std::unique_ptr<RamStatement>> searchSequence;
 
     // make a copy so that when we mutate clause, pointers to objects in newClause are not affected
-    auto newClause = std::unique_ptr<AstClause>(clauseReplacedAggregates->clone());
+    auto newClause = souffle::clone(clauseReplacedAggregates);
 
     // go through each body atom and create a return
     size_t litNumber = 0;
@@ -1393,10 +1380,9 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
             assert(query.size() == atom->getArity() && "wrong query tuple size");
 
             // create existence checks to check if the tuple exists or not
-            auto existenceCheck = std::make_unique<RamExistenceCheck>(
-                    std::unique_ptr<RamRelationReference>(relRef->clone()), std::move(query));
-            auto negativeExistenceCheck = std::make_unique<RamNegation>(
-                    std::unique_ptr<RamExistenceCheck>(existenceCheck->clone()));
+            auto existenceCheck =
+                    std::make_unique<RamExistenceCheck>(souffle::clone(relRef), std::move(query));
+            auto negativeExistenceCheck = std::make_unique<RamNegation>(souffle::clone(existenceCheck));
 
             // return true if the tuple exists
             std::vector<std::unique_ptr<RamExpression>> returnTrue;
@@ -1442,10 +1428,9 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
             assert(query.size() == atom->getArity() && "wrong query tuple size");
 
             // create existence checks to check if the tuple exists or not
-            auto existenceCheck = std::make_unique<RamExistenceCheck>(
-                    std::unique_ptr<RamRelationReference>(relRef->clone()), std::move(query));
-            auto negativeExistenceCheck = std::make_unique<RamNegation>(
-                    std::unique_ptr<RamExistenceCheck>(existenceCheck->clone()));
+            auto existenceCheck =
+                    std::make_unique<RamExistenceCheck>(souffle::clone(relRef), std::move(query));
+            auto negativeExistenceCheck = std::make_unique<RamNegation>(souffle::clone(existenceCheck));
 
             // return true if the tuple exists
             std::vector<std::unique_ptr<RamExpression>> returnTrue;
@@ -1469,8 +1454,7 @@ std::unique_ptr<RamStatement> AstTranslator::makeNegationSubproofSubroutine(cons
 
             // translate to a RamCondition
             auto condition = translateConstraint(con, ValueIndex());
-            auto negativeCondition =
-                    std::make_unique<RamNegation>(std::unique_ptr<RamCondition>(condition->clone()));
+            auto negativeCondition = std::make_unique<RamNegation>(souffle::clone(condition));
 
             // create a return true value
             std::vector<std::unique_ptr<RamExpression>> returnTrue;
@@ -1644,7 +1628,7 @@ void AstTranslator::translateProgram(const AstTranslationUnit& translationUnit) 
 
     // add main timer if profiling
     if (res.size() > 0 && Global::config().has("profile")) {
-        std::unique_ptr<RamStatement> newStmt = std::make_unique<RamLogTimer>(
+        auto newStmt = std::make_unique<RamLogTimer>(
                 std::make_unique<RamSequence>(std::move(res)), LogStatement::runtime());
         res.clear();
         appendStmt(res, std::move(newStmt));
@@ -1691,8 +1675,7 @@ std::unique_ptr<RamTranslationUnit> AstTranslator::translateUnit(AstTranslationU
     if (nullptr == ramMain) {
         ramMain = std::make_unique<RamSequence>();
     }
-    std::unique_ptr<RamProgram> ramProg =
-            std::make_unique<RamProgram>(std::move(rels), std::move(ramMain), std::move(ramSubs));
+    auto ramProg = std::make_unique<RamProgram>(std::move(rels), std::move(ramMain), std::move(ramSubs));
     if (!Global::config().get("debug-report").empty()) {
         if (ramProg) {
             auto ram_end = std::chrono::high_resolution_clock::now();

--- a/src/AstTranslator.h
+++ b/src/AstTranslator.h
@@ -106,7 +106,7 @@ private:
 
         Location(const Location& l) : identifier(l.identifier), element(l.element) {
             if (l.relation != nullptr) {
-                relation = std::unique_ptr<RamRelationReference>(l.relation->clone());
+                relation = souffle::clone(l.relation);
             }
         }
 

--- a/src/Synthesiser.cpp
+++ b/src/Synthesiser.cpp
@@ -272,9 +272,9 @@ void Synthesiser::emitCode(std::ostream& out, const RamStatement& stmt) {
                     bool needContext = false;
                     visitDepthFirst(*cur, [&](const RamExistenceCheck&) { needContext = true; });
                     if (needContext) {
-                        requireCtx.push_back(std::unique_ptr<RamCondition>(cur->clone()));
+                        requireCtx.push_back(souffle::clone(cur));
                     } else {
-                        freeOfCtx.push_back(std::unique_ptr<RamCondition>(cur->clone()));
+                        freeOfCtx.push_back(souffle::clone(cur));
                     }
                 }
                 // discharge conditions that do not require a context

--- a/src/ast/AstArgument.h
+++ b/src/ast/AstArgument.h
@@ -287,6 +287,7 @@ class AstFunctor : public AstTerm {
 public:
     virtual TypeAttribute getReturnType() const = 0;
     virtual TypeAttribute getArgType(const size_t arg) const = 0;
+    AstFunctor* clone() const override = 0;
 
 protected:
     using AstTerm::AstTerm;

--- a/src/ast/AstParserUtils.h
+++ b/src/ast/AstParserUtils.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "ast/AstAbstract.h"
+#include "utility/MiscUtil.h"
 #include <iosfwd>
 #include <memory>
 #include <utility>
@@ -65,7 +66,7 @@ private:
         std::unique_ptr<AstLiteral> atom;
 
         literal clone() const {
-            return literal(negated, std::unique_ptr<AstLiteral>(atom->clone()));
+            return literal(negated, souffle::clone(atom));
         }
     };
 

--- a/src/ast/AstUtils.cpp
+++ b/src/ast/AstUtils.cpp
@@ -223,9 +223,9 @@ bool isRule(const AstClause& clause) {
 AstClause* cloneHead(const AstClause* clause) {
     auto* clone = new AstClause();
     clone->setSrcLoc(clause->getSrcLoc());
-    clone->setHead(std::unique_ptr<AstAtom>(clause->getHead()->clone()));
+    clone->setHead(souffle::clone(clause->getHead()));
     if (clause->getExecutionPlan() != nullptr) {
-        clone->setExecutionPlan(std::unique_ptr<AstExecutionPlan>(clause->getExecutionPlan()->clone()));
+        clone->setExecutionPlan(souffle::clone(clause->getExecutionPlan()));
     }
     return clone;
 }
@@ -257,7 +257,7 @@ AstClause* reorderAtoms(const AstClause* clause, const std::vector<unsigned int>
             // Atoms should be reordered
             literalToAdd = bodyLiterals[atomPositions[newOrder[currentAtom++]]];
         }
-        newClause->addToBody(std::unique_ptr<AstLiteral>(literalToAdd->clone()));
+        newClause->addToBody(souffle::clone(literalToAdd));
     }
 
     return newClause;

--- a/src/ast/analysis/AstTypeAnalysis.cpp
+++ b/src/ast/analysis/AstTypeAnalysis.cpp
@@ -468,7 +468,7 @@ TypeConstraint isSubtypeOfComponent(
 }  // namespace
 
 /* Return a new clause with type-annotated variables */
-AstClause* createAnnotatedClause(
+std::unique_ptr<AstClause> createAnnotatedClause(
         const AstClause* clause, const std::map<const AstArgument*, TypeSet> argumentTypes) {
     // Annotates each variable with its type based on a given type analysis result
     struct TypeAnnotator : public AstNodeMapper {
@@ -501,7 +501,7 @@ AstClause* createAnnotatedClause(
      *  (2) Keep track of the addresses of equivalent arguments in the cloned clause
      * Method (2) was chosen to avoid having to recompute the analysis each time.
      */
-    AstClause* annotatedClause = clause->clone();
+    auto annotatedClause = souffle::clone(clause);
 
     // Maps x -> y, where x is the address of an argument in the original clause, and y
     // is the address of the equivalent argument in the clone.
@@ -778,8 +778,7 @@ void TypeAnalysis::run(const AstTranslationUnit& translationUnit) {
 
         if (debugStream != nullptr) {
             // Store an annotated clause for printing purposes
-            AstClause* annotatedClause = createAnnotatedClause(clause, clauseArgumentTypes);
-            annotatedClauses.emplace_back(annotatedClause);
+            annotatedClauses.emplace_back(createAnnotatedClause(clause, clauseArgumentTypes));
         }
     }
 }

--- a/src/ast/transform/AstTransforms.cpp
+++ b/src/ast/transform/AstTransforms.cpp
@@ -316,7 +316,7 @@ bool MaterializeSingletonAggregationTransformer::transform(AstTranslationUnit& t
                 assert(node != nullptr);
                 if (auto* current = dynamic_cast<AstAggregator*>(node.get())) {
                     if (*current == aggregate) {
-                        auto replacement = std::unique_ptr<AstVariable>(variable->clone());
+                        auto replacement = souffle::clone(variable);
                         assert(replacement != nullptr);
                         return replacement;
                     }
@@ -382,7 +382,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
             auto* aggClause = new AstClause();
             // create the body of the new materialised rule
             for (const auto& cur : agg.getBodyLiterals()) {
-                aggClause->addToBody(std::unique_ptr<AstLiteral>(cur->clone()));
+                aggClause->addToBody(souffle::clone(cur));
             }
             // find stuff for which we need a grounding
             for (const auto& argPair : getGroundedTerms(translationUnit, *aggClause)) {
@@ -404,7 +404,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
                         // if this atom contains the variable I need to ground, add it
                         if ((atomVariable != nullptr) && variable->getName() == atomVariable->getName()) {
                             // expand the body with this one so that it will ground this variable
-                            aggClause->addToBody(std::unique_ptr<AstLiteral>(atom->clone()));
+                            aggClause->addToBody(souffle::clone(atom));
                             break;
                         }
                     }
@@ -443,7 +443,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
                                 auto res = new AstVariable(name);
 
                                 // extend head
-                                head->addArgument(std::unique_ptr<AstArgument>(res->clone()));
+                                head->addArgument(souffle::clone(res));
 
                                 // return replacement
                                 return std::unique_ptr<AstNode>(res);
@@ -612,10 +612,10 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelationUses(
                 for (AstLiteral* lit : cl->getBodyLiterals()) {
                     if (auto* neg = dynamic_cast<AstNegation*>(lit)) {
                         if (getAtomRelation(neg->getAtom(), &program) != emptyRelation) {
-                            res->addToBody(std::unique_ptr<AstLiteral>(lit->clone()));
+                            res->addToBody(souffle::clone(lit));
                         }
                     } else {
-                        res->addToBody(std::unique_ptr<AstLiteral>(lit->clone()));
+                        res->addToBody(souffle::clone(lit));
                     }
                 }
 
@@ -673,7 +673,7 @@ bool RemoveBooleanConstraintsTransformer::transform(AstTranslationUnit& translat
 
                 // Only keep literals that aren't boolean constraints
                 if (containsFalse || containsTrue) {
-                    auto replacementAggregator = std::unique_ptr<AstAggregator>(aggr->clone());
+                    auto replacementAggregator = souffle::clone(aggr);
                     std::vector<std::unique_ptr<AstLiteral>> newBody;
 
                     bool isEmpty = true;
@@ -684,7 +684,7 @@ bool RemoveBooleanConstraintsTransformer::transform(AstTranslationUnit& translat
                             // Don't add in boolean constraints
                             if (dynamic_cast<AstBooleanConstraint*>(lit) == nullptr) {
                                 isEmpty = false;
-                                newBody.push_back(std::unique_ptr<AstLiteral>(lit->clone()));
+                                newBody.push_back(souffle::clone(lit));
                             }
                         }
 
@@ -741,7 +741,7 @@ bool RemoveBooleanConstraintsTransformer::transform(AstTranslationUnit& translat
                 // Only keep non-'true' literals
                 for (AstLiteral* lit : clause->getBodyLiterals()) {
                     if (dynamic_cast<AstBooleanConstraint*>(lit) == nullptr) {
-                        replacementClause->addToBody(std::unique_ptr<AstLiteral>(lit->clone()));
+                        replacementClause->addToBody(souffle::clone(lit));
                     }
                 }
 
@@ -895,7 +895,7 @@ bool PartitionBodyLiteralsTransformer::transform(AstTranslationUnit& translation
                     }
                 });
                 if (associated) {
-                    disconnectedClause->addToBody(std::unique_ptr<AstLiteral>(bodyLiteral->clone()));
+                    disconnectedClause->addToBody(souffle::clone(bodyLiteral));
                 }
             }
 
@@ -910,7 +910,7 @@ bool PartitionBodyLiteralsTransformer::transform(AstTranslationUnit& translation
         // a(x) <- b(x), c(y), d(z). --> a(x) <- newrel0(), newrel1(), b(x).
         auto* replacementClause = new AstClause();
         replacementClause->setSrcLoc(clause.getSrcLoc());
-        replacementClause->setHead(std::unique_ptr<AstAtom>(clause.getHead()->clone()));
+        replacementClause->setHead(souffle::clone(clause.getHead()));
 
         // Add the new propositions to the clause first
         for (AstAtom* newAtom : replacementAtoms) {
@@ -928,7 +928,7 @@ bool PartitionBodyLiteralsTransformer::transform(AstTranslationUnit& translation
                 }
             });
             if (associated || !hasVariables) {
-                replacementClause->addToBody(std::unique_ptr<AstLiteral>(bodyLiteral->clone()));
+                replacementClause->addToBody(souffle::clone(bodyLiteral));
             }
         }
 
@@ -1053,11 +1053,11 @@ bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUni
 
                 newClause->setSrcLoc(clause->getSrcLoc());
                 if (const AstExecutionPlan* plan = clause->getExecutionPlan()) {
-                    newClause->setExecutionPlan(std::unique_ptr<AstExecutionPlan>(plan->clone()));
+                    newClause->setExecutionPlan(souffle::clone(plan));
                 }
                 newClause->setHead(std::make_unique<AstAtom>(newRelationName.str()));
                 for (AstLiteral* lit : clause->getBodyLiterals()) {
-                    newClause->addToBody(std::unique_ptr<AstLiteral>(lit->clone()));
+                    newClause->addToBody(souffle::clone(lit));
                 }
 
                 program.addClause(std::move(newClause));
@@ -1220,10 +1220,10 @@ bool RemoveRedundantSumsTransformer::transform(AstTranslationUnit& translationUn
                         // Duplicate the body of the aggregate
                         std::vector<std::unique_ptr<AstLiteral>> newBody;
                         for (const auto& lit : agg->getBodyLiterals()) {
-                            newBody.push_back(std::unique_ptr<AstLiteral>(lit->clone()));
+                            newBody.push_back(souffle::clone(lit));
                         }
                         count->setBody(std::move(newBody));
-                        auto number = std::unique_ptr<AstNumericConstant>(constant->clone());
+                        auto number = souffle::clone(constant);
                         // Now it's constant * count : { ... }
                         auto result = std::make_unique<AstIntrinsicFunctor>(
                                 "*", std::move(number), std::move(count));
@@ -1287,9 +1287,8 @@ bool NormaliseConstraintsTransformer::transform(AstTranslationUnit& translationU
 
                 // create new constraint (+abdulX = constant)
                 auto newVariable = std::make_unique<AstVariable>(newVariableName.str());
-                constraints.insert(new AstBinaryConstraint(BinaryConstraintOp::EQ,
-                        std::unique_ptr<AstArgument>(newVariable->clone()),
-                        std::unique_ptr<AstArgument>(stringConstant->clone())));
+                constraints.insert(new AstBinaryConstraint(
+                        BinaryConstraintOp::EQ, souffle::clone(newVariable), souffle::clone(stringConstant)));
 
                 // update constant to be the variable created
                 return newVariable;
@@ -1308,9 +1307,8 @@ bool NormaliseConstraintsTransformer::transform(AstTranslationUnit& translationU
 
                 // create new constraint (+abdulX = constant)
                 auto newVariable = std::make_unique<AstVariable>(newVariableName.str());
-                constraints.insert(
-                        new AstBinaryConstraint(opEq, std::unique_ptr<AstArgument>(newVariable->clone()),
-                                std::unique_ptr<AstArgument>(numberConstant->clone())));
+                constraints.insert(new AstBinaryConstraint(
+                        opEq, souffle::clone(newVariable), souffle::clone(numberConstant)));
 
                 // update constant to be the variable created
                 return newVariable;
@@ -1366,7 +1364,7 @@ bool RemoveTypecastsTransformer::transform(AstTranslationUnit& translationUnit) 
             // if current node is a typecast, replace with the value directly
             if (auto* cast = dynamic_cast<AstTypeCast*>(node.get())) {
                 changed = true;
-                return std::unique_ptr<AstArgument>(cast->getValue()->clone());
+                return souffle::clone(cast->getValue());
             }
 
             // otherwise, return the original node
@@ -1631,18 +1629,18 @@ void FoldAnonymousRecords::transformClause(
 
                 // Else: repeated inequality.
             } else {
-                newBody.push_back(std::unique_ptr<AstLiteral>(literal->clone()));
+                newBody.push_back(souffle::clone(literal));
             }
 
             // else, we simply copy the literal.
         } else {
-            newBody.push_back(std::unique_ptr<AstLiteral>(literal->clone()));
+            newBody.push_back(souffle::clone(literal));
         }
     }
 
     // If no inequality: create a single modified clause.
     if (neqConstraint == nullptr) {
-        auto newClause = std::unique_ptr<AstClause>(clause.clone());
+        auto newClause = souffle::clone(&clause);
         newClause->setBodyLiterals(std::move(newBody));
         newClauses.emplace_back(std::move(newClause));
 
@@ -1651,7 +1649,7 @@ void FoldAnonymousRecords::transformClause(
         auto transformedLiterals = expandRecordBinaryConstraint(*neqConstraint);
 
         for (auto it = begin(transformedLiterals); it != end(transformedLiterals); ++it) {
-            auto newClause = std::unique_ptr<AstClause>(clause.clone());
+            auto newClause = souffle::clone(&clause);
             auto copyBody = souffle::clone(newBody);
             copyBody.push_back(std::move(*it));
 
@@ -1750,7 +1748,7 @@ bool ResolveAnonymousRecordsAliases::replaceNamedVariables(AstTranslationUnit& t
             if (auto variable = dynamic_cast<AstVariable*>(node.get())) {
                 auto iteratorToRecord = varToRecordMap.find(variable->getName());
                 if (iteratorToRecord != varToRecordMap.end()) {
-                    return std::unique_ptr<AstNode>(iteratorToRecord->second->clone());
+                    return souffle::clone(iteratorToRecord->second);
                 }
             }
 

--- a/src/ast/transform/AstTransforms.h
+++ b/src/ast/transform/AstTransforms.h
@@ -19,6 +19,7 @@
 #include "DebugReporter.h"
 #include "ast/transform/AstTransformer.h"
 #include "utility/ContainerUtil.h"
+#include "utility/MiscUtil.h"
 #include <functional>
 #include <map>
 #include <memory>
@@ -588,7 +589,7 @@ public:
     PipelineTransformer* clone() const override {
         std::vector<std::unique_ptr<AstTransformer>> transformers;
         for (const auto& transformer : pipeline) {
-            transformers.push_back(std::unique_ptr<AstTransformer>(transformer->clone()));
+            transformers.push_back(souffle::clone(transformer));
         }
         return new PipelineTransformer(std::move(transformers));
     }
@@ -641,7 +642,7 @@ public:
     }
 
     ConditionalTransformer* clone() const override {
-        return new ConditionalTransformer(condition, std::unique_ptr<AstTransformer>(transformer->clone()));
+        return new ConditionalTransformer(condition, souffle::clone(transformer));
     }
 
 private:
@@ -692,7 +693,7 @@ public:
     }
 
     WhileTransformer* clone() const override {
-        return new WhileTransformer(condition, std::unique_ptr<AstTransformer>(transformer->clone()));
+        return new WhileTransformer(condition, souffle::clone(transformer));
     }
 
 private:
@@ -740,7 +741,7 @@ public:
     }
 
     FixpointTransformer* clone() const override {
-        return new FixpointTransformer(std::unique_ptr<AstTransformer>(transformer->clone()));
+        return new FixpointTransformer(souffle::clone(transformer));
     }
 
 private:

--- a/src/ast/transform/MagicSet.cpp
+++ b/src/ast/transform/MagicSet.cpp
@@ -616,8 +616,7 @@ BindingStore bindComposites(const AstProgram* program) {
                 auto opEq = functor->getReturnType() == TypeAttribute::Float ? BinaryConstraintOp::FEQ
                                                                              : BinaryConstraintOp::EQ;
                 constraints.insert(
-                        new AstBinaryConstraint(opEq, std::unique_ptr<AstArgument>(newVariable->clone()),
-                                std::unique_ptr<AstArgument>(functor->clone())));
+                        new AstBinaryConstraint(opEq, souffle::clone(newVariable), souffle::clone(functor)));
 
                 // update functor to be the variable created
                 return newVariable;
@@ -634,9 +633,8 @@ BindingStore bindComposites(const AstProgram* program) {
 
                 // create new constraint (+recordX = original-record)
                 auto newVariable = std::make_unique<AstVariable>(newVariableName.str());
-                constraints.insert(new AstBinaryConstraint(BinaryConstraintOp::EQ,
-                        std::unique_ptr<AstArgument>(newVariable->clone()),
-                        std::unique_ptr<AstArgument>(record->clone())));
+                constraints.insert(new AstBinaryConstraint(
+                        BinaryConstraintOp::EQ, souffle::clone(newVariable), souffle::clone(record)));
 
                 // update record to be the variable created
                 return newVariable;
@@ -1000,7 +998,7 @@ AstRelation* createMagicRelation(AstRelation* original, const AstQualifiedName& 
     std::vector<AstAttribute*> attrs = original->getAttributes();
     for (size_t currentArg = 0; currentArg < original->getArity(); currentArg++) {
         if (adornment[currentArg] == 'b') {
-            newMagicRelation->addAttribute(std::unique_ptr<AstAttribute>(attrs[currentArg]->clone()));
+            newMagicRelation->addAttribute(souffle::clone(attrs[currentArg]));
         }
     }
 
@@ -1210,7 +1208,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
                             int argcount = 0;
                             for (AstAttribute* attr : originalRelation->getAttributes()) {
                                 if (currAdornment[argcount] == 'b') {
-                                    magicRelation->addAttribute(std::unique_ptr<AstAttribute>(attr->clone()));
+                                    magicRelation->addAttribute(souffle::clone(attr));
                                 }
                                 argcount++;
                             }
@@ -1233,7 +1231,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
                         int argCount = 0;
                         for (AstArgument* arg : atom->getArguments()) {
                             if (currAdornment[argCount] == 'b') {
-                                magicHead->addArgument(std::unique_ptr<AstArgument>(arg->clone()));
+                                magicHead->addArgument(souffle::clone(arg));
                             }
                             argCount++;
                         }
@@ -1262,7 +1260,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
                         argCount = 0;
                         for (AstArgument* arg : newClause->getHead()->getArguments()) {
                             if (headAdornment[argCount] == 'b') {
-                                addedMagicPred->addArgument(std::unique_ptr<AstArgument>(arg->clone()));
+                                addedMagicPred->addArgument(souffle::clone(arg));
                             }
                             argCount++;
                         }
@@ -1272,7 +1270,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
 
                         // add the rest of the necessary arguments
                         for (size_t j = 0; j < i; j++) {
-                            magicClause->addToBody(std::unique_ptr<AstLiteral>(body[j]->clone()));
+                            magicClause->addToBody(souffle::clone(body[j]));
                         }
 
                         // restore memorised bindings for all composite arguments
@@ -1293,10 +1291,9 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
                             if (compositeBindings.isVariableBoundComposite(argName)) {
                                 AstArgument* originalArgument =
                                         compositeBindings.cloneOriginalArgument(argName);
-                                magicClause->addToBody(
-                                        std::make_unique<AstBinaryConstraint>(BinaryConstraintOp::EQ,
-                                                std::unique_ptr<AstArgument>(compositeArgument->clone()),
-                                                std::unique_ptr<AstArgument>(originalArgument)));
+                                magicClause->addToBody(std::make_unique<AstBinaryConstraint>(
+                                        BinaryConstraintOp::EQ, souffle::clone(compositeArgument),
+                                        std::unique_ptr<AstArgument>(originalArgument)));
                             }
                         }
 
@@ -1315,7 +1312,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
 
                                 // add the constraint to the body of the clause
                                 magicClause->addToBody(std::make_unique<AstBinaryConstraint>(
-                                        BinaryConstraintOp::EQ, std::unique_ptr<AstArgument>(var->clone()),
+                                        BinaryConstraintOp::EQ, souffle::clone(var),
                                         std::unique_ptr<AstArgument>(embeddedConstant)));
                             }
                         }
@@ -1339,7 +1336,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
             std::vector<AstArgument*> args = newClauseHead->getArguments();
             for (size_t k = 0; k < args.size(); k++) {
                 if (headAdornment[k] == 'b') {
-                    newMagAtom->addArgument(std::unique_ptr<AstArgument>(args[k]->clone()));
+                    newMagAtom->addArgument(souffle::clone(args[k]));
                 }
             }
 
@@ -1399,7 +1396,7 @@ bool MagicSetTransformer::transform(AstTranslationUnit& translationUnit) {
 
             // copy over the attributes from the existing adorned version
             for (AstAttribute* attr : adornedRelation->getAttributes()) {
-                outputRelation->addAttribute(std::unique_ptr<AstAttribute>(attr->clone()));
+                outputRelation->addAttribute(souffle::clone(attr));
             }
 
             // rename it back to its original name

--- a/src/ast/transform/MagicSet.h
+++ b/src/ast/transform/MagicSet.h
@@ -147,7 +147,7 @@ public:
     }
 
     void addBinding(const std::string& newVariableName, const AstArgument* arg) {
-        originalArguments[newVariableName] = std::unique_ptr<AstArgument>(arg->clone());
+        originalArguments[newVariableName] = souffle::clone(arg);
 
         // find the variable dependencies
         std::set<std::string> dependencies;

--- a/src/ast/transform/MinimiseProgramTransformer.cpp
+++ b/src/ast/transform/MinimiseProgramTransformer.cpp
@@ -477,7 +477,7 @@ bool MinimiseProgramTransformer::reduceSingletonRelations(AstTranslationUnit& tr
             if (auto* atom = dynamic_cast<AstAtom*>(node.get())) {
                 auto pos = canonicalName.find(atom->getQualifiedName());
                 if (pos != canonicalName.end()) {
-                    auto newAtom = std::unique_ptr<AstAtom>(atom->clone());
+                    auto newAtom = souffle::clone(atom);
                     newAtom->setQualifiedName(pos->second);
                     return newAtom;
                 }
@@ -508,7 +508,7 @@ bool MinimiseProgramTransformer::removeRedundantClauses(AstTranslationUnit& tran
     std::set<std::unique_ptr<AstClause>> clausesToRemove;
     for (const auto* clause : program.getClauses()) {
         if (isRedundant(clause)) {
-            clausesToRemove.insert(std::unique_ptr<AstClause>(clause->clone()));
+            clausesToRemove.insert(souffle::clone(clause));
         }
     }
 
@@ -537,14 +537,14 @@ bool MinimiseProgramTransformer::reduceClauseBodies(AstTranslationUnit& translat
 
         if (!redundantPositions.empty()) {
             auto minimisedClause = std::make_unique<AstClause>();
-            minimisedClause->setHead(std::unique_ptr<AstAtom>(clause->getHead()->clone()));
+            minimisedClause->setHead(souffle::clone(clause->getHead()));
             for (size_t i = 0; i < bodyLiterals.size(); i++) {
                 if (!contains(redundantPositions, i)) {
-                    minimisedClause->addToBody(std::unique_ptr<AstLiteral>(bodyLiterals[i]->clone()));
+                    minimisedClause->addToBody(souffle::clone(bodyLiterals[i]));
                 }
             }
             clausesToAdd.insert(std::move(minimisedClause));
-            clausesToRemove.insert(std::unique_ptr<AstClause>(clause->clone()));
+            clausesToRemove.insert(souffle::clone(clause));
         }
     }
 
@@ -552,7 +552,7 @@ bool MinimiseProgramTransformer::reduceClauseBodies(AstTranslationUnit& translat
         program.removeClause(clause.get());
     }
     for (auto& clause : clausesToAdd) {
-        program.addClause(std::unique_ptr<AstClause>(clause->clone()));
+        program.addClause(souffle::clone(clause));
     }
 
     return !clausesToAdd.empty();

--- a/src/ram/RamCondition.h
+++ b/src/ram/RamCondition.h
@@ -114,8 +114,7 @@ public:
     }
 
     RamConjunction* clone() const override {
-        return new RamConjunction(
-                std::unique_ptr<RamCondition>(lhs->clone()), std::unique_ptr<RamCondition>(rhs->clone()));
+        return new RamConjunction(souffle::clone(lhs), souffle::clone(rhs));
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -165,7 +164,7 @@ public:
     }
 
     RamNegation* clone() const override {
-        return new RamNegation(std::unique_ptr<RamCondition>(operand->clone()));
+        return new RamNegation(souffle::clone(operand));
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -227,8 +226,7 @@ public:
     }
 
     RamConstraint* clone() const override {
-        return new RamConstraint(op, std::unique_ptr<RamExpression>(lhs->clone()),
-                std::unique_ptr<RamExpression>(rhs->clone()));
+        return new RamConstraint(op, souffle::clone(lhs), souffle::clone(rhs));
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -351,8 +349,7 @@ public:
         for (auto& cur : values) {
             newValues.emplace_back(cur->clone());
         }
-        return new RamExistenceCheck(
-                std::unique_ptr<RamRelationReference>(relationRef->clone()), std::move(newValues));
+        return new RamExistenceCheck(souffle::clone(relationRef), std::move(newValues));
     }
 };
 
@@ -371,8 +368,7 @@ public:
         for (auto& cur : values) {
             newValues.emplace_back(cur->clone());
         }
-        return new RamProvenanceExistenceCheck(
-                std::unique_ptr<RamRelationReference>(relationRef->clone()), std::move(newValues));
+        return new RamProvenanceExistenceCheck(souffle::clone(relationRef), std::move(newValues));
     }
 
 protected:
@@ -409,7 +405,7 @@ public:
     }
 
     RamEmptinessCheck* clone() const override {
-        return new RamEmptinessCheck(std::unique_ptr<RamRelationReference>(relationRef->clone()));
+        return new RamEmptinessCheck(souffle::clone(relationRef));
     }
 
     void apply(const RamNodeMapper& map) override {

--- a/src/ram/RamOperation.h
+++ b/src/ram/RamOperation.h
@@ -94,6 +94,8 @@ public:
         assert(nullptr != nestedOperation);
     }
 
+    RamNestedOperation* clone() const override = 0;
+
     /** @brief Get nested operation */
     RamOperation& getOperation() const {
         return *nestedOperation;
@@ -138,6 +140,8 @@ public:
     RamTupleOperation(int ident, std::unique_ptr<RamOperation> nested, std::string profileText = "")
             : RamNestedOperation(std::move(nested), std::move(profileText)), identifier(ident) {}
 
+    RamTupleOperation* clone() const override = 0;
+
     /** @brief Get identifier */
     int getTupleId() const {
         return identifier;
@@ -179,6 +183,8 @@ public:
               relationRef(std::move(relRef)) {
         assert(relationRef != nullptr && "relation reference is a null-pointer");
     }
+
+    RamRelationOperation* clone() const override = 0;
 
     /** @brief Get search relation */
     const RamRelation& getRelation() const {
@@ -226,8 +232,8 @@ public:
             : RamRelationOperation(std::move(rel), ident, std::move(nested), std::move(profileText)) {}
 
     RamScan* clone() const override {
-        return new RamScan(std::unique_ptr<RamRelationReference>(relationRef->clone()), getTupleId(),
-                std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
+        return new RamScan(
+                souffle::clone(relationRef), getTupleId(), souffle::clone(&getOperation()), getProfileText());
     }
 
 protected:
@@ -258,8 +264,8 @@ public:
             : RamScan(std::move(rel), ident, std::move(nested), profileText) {}
 
     RamParallelScan* clone() const override {
-        return new RamParallelScan(std::unique_ptr<RamRelationReference>(relationRef->clone()), getTupleId(),
-                std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
+        return new RamParallelScan(
+                souffle::clone(relationRef), getTupleId(), souffle::clone(&getOperation()), getProfileText());
     }
 
 protected:
@@ -330,9 +336,8 @@ public:
         for (const auto& i : queryPattern.second) {
             resQueryPattern.second.emplace_back(i->clone());
         }
-        return new RamIndexOperation(std::unique_ptr<RamRelationReference>(relationRef->clone()),
-                getTupleId(), std::move(resQueryPattern),
-                std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
+        return new RamIndexOperation(souffle::clone(relationRef), getTupleId(), std::move(resQueryPattern),
+                souffle::clone(&getOperation()), getProfileText());
     }
 
     /** @brief Helper method for printing */
@@ -424,9 +429,8 @@ public:
         for (const auto& i : queryPattern.second) {
             resQueryPattern.second.emplace_back(i->clone());
         }
-        return new RamIndexScan(std::unique_ptr<RamRelationReference>(relationRef->clone()), getTupleId(),
-                std::move(resQueryPattern), std::unique_ptr<RamOperation>(getOperation().clone()),
-                getProfileText());
+        return new RamIndexScan(souffle::clone(relationRef), getTupleId(), std::move(resQueryPattern),
+                souffle::clone(&getOperation()), getProfileText());
     }
 
 protected:
@@ -467,9 +471,8 @@ public:
         for (const auto& i : queryPattern.second) {
             resQueryPattern.second.emplace_back(i->clone());
         }
-        return new RamParallelIndexScan(std::unique_ptr<RamRelationReference>(relationRef->clone()),
-                getTupleId(), std::move(resQueryPattern),
-                std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
+        return new RamParallelIndexScan(souffle::clone(relationRef), getTupleId(), std::move(resQueryPattern),
+                souffle::clone(&getOperation()), getProfileText());
     }
 
 protected:
@@ -548,9 +551,8 @@ public:
     }
 
     RamChoice* clone() const override {
-        return new RamChoice(std::unique_ptr<RamRelationReference>(relationRef->clone()), getTupleId(),
-                std::unique_ptr<RamCondition>(condition->clone()),
-                std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
+        return new RamChoice(souffle::clone(relationRef), getTupleId(), souffle::clone(condition),
+                souffle::clone(&getOperation()), getProfileText());
     }
 
     std::vector<const RamNode*> getChildNodes() const override {
@@ -593,9 +595,8 @@ public:
             : RamChoice(std::move(rel), ident, std::move(cond), std::move(nested), profileText) {}
 
     RamParallelChoice* clone() const override {
-        return new RamParallelChoice(std::unique_ptr<RamRelationReference>(relationRef->clone()),
-                getTupleId(), std::unique_ptr<RamCondition>(condition->clone()),
-                std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
+        return new RamParallelChoice(souffle::clone(relationRef), getTupleId(), souffle::clone(condition),
+                souffle::clone(&getOperation()), getProfileText());
     }
 
 protected:
@@ -661,9 +662,8 @@ public:
         for (const auto& i : queryPattern.second) {
             resQueryPattern.second.emplace_back(i->clone());
         }
-        auto* res = new RamIndexChoice(std::unique_ptr<RamRelationReference>(relationRef->clone()),
-                getTupleId(), std::unique_ptr<RamCondition>(condition->clone()), std::move(resQueryPattern),
-                std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
+        auto* res = new RamIndexChoice(souffle::clone(relationRef), getTupleId(), souffle::clone(condition),
+                std::move(resQueryPattern), souffle::clone(&getOperation()), getProfileText());
         return res;
     }
 
@@ -713,9 +713,9 @@ public:
         for (const auto& i : queryPattern.second) {
             resQueryPattern.second.emplace_back(i->clone());
         }
-        auto* res = new RamParallelIndexChoice(std::unique_ptr<RamRelationReference>(relationRef->clone()),
-                getTupleId(), std::unique_ptr<RamCondition>(condition->clone()), std::move(resQueryPattern),
-                std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
+        auto* res = new RamParallelIndexChoice(souffle::clone(relationRef), getTupleId(),
+                souffle::clone(condition), std::move(resQueryPattern), souffle::clone(&getOperation()),
+                getProfileText());
         return res;
     }
 
@@ -834,10 +834,8 @@ public:
     }
 
     RamAggregate* clone() const override {
-        return new RamAggregate(std::unique_ptr<RamOperation>(getOperation().clone()), function,
-                std::unique_ptr<RamRelationReference>(relationRef->clone()),
-                std::unique_ptr<RamExpression>(expression->clone()),
-                std::unique_ptr<RamCondition>(condition->clone()), getTupleId());
+        return new RamAggregate(souffle::clone(&getOperation()), function, souffle::clone(relationRef),
+                souffle::clone(expression), souffle::clone(condition), getTupleId());
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -892,10 +890,8 @@ public:
         for (const auto& i : queryPattern.second) {
             pattern.second.emplace_back(i->clone());
         }
-        return new RamIndexAggregate(std::unique_ptr<RamOperation>(getOperation().clone()), function,
-                std::unique_ptr<RamRelationReference>(relationRef->clone()),
-                std::unique_ptr<RamExpression>(expression->clone()),
-                std::unique_ptr<RamCondition>(condition->clone()), std::move(pattern), getTupleId());
+        return new RamIndexAggregate(souffle::clone(&getOperation()), function, souffle::clone(relationRef),
+                souffle::clone(expression), souffle::clone(condition), std::move(pattern), getTupleId());
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -1036,8 +1032,8 @@ public:
     }
 
     RamUnpackRecord* clone() const override {
-        return new RamUnpackRecord(std::unique_ptr<RamOperation>(getOperation().clone()), getTupleId(),
-                std::unique_ptr<RamExpression>(getExpression().clone()), arity);
+        return new RamUnpackRecord(
+                souffle::clone(&getOperation()), getTupleId(), souffle::clone(&getExpression()), arity);
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -1076,6 +1072,8 @@ public:
             : RamNestedOperation(std::move(nested), std::move(profileText)), condition(std::move(cond)) {
         assert(condition != nullptr && "Condition is a null-pointer");
     }
+
+    RamAbstractConditional* clone() const override = 0;
 
     /** @brief Get condition that must be satisfied */
     const RamCondition& getCondition() const {
@@ -1124,8 +1122,7 @@ public:
             : RamAbstractConditional(std::move(cond), std::move(nested), std::move(profileText)) {}
 
     RamFilter* clone() const override {
-        return new RamFilter(std::unique_ptr<RamCondition>(condition->clone()),
-                std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
+        return new RamFilter(souffle::clone(condition), souffle::clone(&getOperation()), getProfileText());
     }
 
 protected:
@@ -1156,8 +1153,7 @@ public:
             : RamAbstractConditional(std::move(cond), std::move(nested), std::move(profileText)) {}
 
     RamBreak* clone() const override {
-        return new RamBreak(std::unique_ptr<RamCondition>(condition->clone()),
-                std::unique_ptr<RamOperation>(getOperation().clone()), getProfileText());
+        return new RamBreak(souffle::clone(condition), souffle::clone(&getOperation()), getProfileText());
     }
 
 protected:
@@ -1214,8 +1210,7 @@ public:
         for (auto& expr : expressions) {
             newValues.emplace_back(expr->clone());
         }
-        return new RamProject(
-                std::unique_ptr<RamRelationReference>(relationRef->clone()), std::move(newValues));
+        return new RamProject(souffle::clone(relationRef), std::move(newValues));
     }
 
     void apply(const RamNodeMapper& map) override {

--- a/src/ram/RamProgram.h
+++ b/src/ram/RamProgram.h
@@ -101,12 +101,12 @@ public:
 
     RamProgram* clone() const override {
         auto* res = new RamProgram();
-        res->main = std::unique_ptr<RamStatement>(main->clone());
+        res->main = souffle::clone(main);
         for (auto& rel : relations) {
-            res->relations.push_back(std::unique_ptr<RamRelation>(rel->clone()));
+            res->relations.push_back(souffle::clone(rel));
         }
         for (auto& sub : subroutines) {
-            res->subroutines[sub.first] = std::unique_ptr<RamStatement>(sub.second->clone());
+            res->subroutines[sub.first] = souffle::clone(sub.second);
         }
         std::map<const RamRelation*, const RamRelation*> refMap;
         res->apply(makeLambdaRamMapper([&](std::unique_ptr<RamNode> node) -> std::unique_ptr<RamNode> {

--- a/src/ram/RamStatement.h
+++ b/src/ram/RamStatement.h
@@ -116,7 +116,7 @@ public:
     }
 
     RamIO* clone() const override {
-        return new RamIO(std::unique_ptr<RamRelationReference>(relationRef->clone()), directives);
+        return new RamIO(souffle::clone(relationRef), directives);
     }
 
 protected:
@@ -155,7 +155,7 @@ public:
     RamClear(std::unique_ptr<RamRelationReference> relRef) : RamRelationStatement(std::move(relRef)) {}
 
     RamClear* clone() const override {
-        return new RamClear(std::unique_ptr<RamRelationReference>(relationRef->clone()));
+        return new RamClear(souffle::clone(relationRef));
     }
 
 protected:
@@ -247,8 +247,7 @@ public:
     }
 
     RamExtend* clone() const override {
-        auto* res = new RamExtend(std::unique_ptr<RamRelationReference>(second->clone()),
-                std::unique_ptr<RamRelationReference>(first->clone()));
+        auto* res = new RamExtend(souffle::clone(second), souffle::clone(first));
         return res;
     }
 
@@ -277,8 +276,7 @@ public:
             : RamBinRelationStatement(std::move(f), std::move(s)) {}
 
     RamSwap* clone() const override {
-        return new RamSwap(std::unique_ptr<RamRelationReference>(first->clone()),
-                std::unique_ptr<RamRelationReference>(second->clone()));
+        return new RamSwap(souffle::clone(first), souffle::clone(second));
     }
 
 protected:
@@ -319,7 +317,7 @@ public:
     }
 
     RamQuery* clone() const override {
-        return new RamQuery(std::unique_ptr<RamOperation>(operation->clone()));
+        return new RamQuery(souffle::clone(operation));
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -408,7 +406,7 @@ public:
     RamSequence* clone() const override {
         auto* res = new RamSequence();
         for (auto& cur : statements) {
-            res->statements.push_back(std::unique_ptr<RamStatement>(cur->clone()));
+            res->statements.push_back(souffle::clone(cur));
         }
         return res;
     }
@@ -450,7 +448,7 @@ public:
     RamParallel* clone() const override {
         auto* res = new RamParallel();
         for (auto& cur : statements) {
-            res->statements.push_back(std::unique_ptr<RamStatement>(cur->clone()));
+            res->statements.push_back(souffle::clone(cur));
         }
         return res;
     }
@@ -494,7 +492,7 @@ public:
     }
 
     RamLoop* clone() const override {
-        return new RamLoop(std::unique_ptr<RamStatement>(body->clone()));
+        return new RamLoop(souffle::clone(body));
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -545,7 +543,7 @@ public:
     }
 
     RamExit* clone() const override {
-        return new RamExit(std::unique_ptr<RamCondition>(condition->clone()));
+        return new RamExit(souffle::clone(condition));
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -641,8 +639,7 @@ public:
     }
 
     RamLogRelationTimer* clone() const override {
-        return new RamLogRelationTimer(std::unique_ptr<RamStatement>(statement->clone()), message,
-                std::unique_ptr<RamRelationReference>(relationRef->clone()));
+        return new RamLogRelationTimer(souffle::clone(statement), message, souffle::clone(relationRef));
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -688,7 +685,7 @@ public:
     }
 
     RamLogTimer* clone() const override {
-        return new RamLogTimer(std::unique_ptr<RamStatement>(statement->clone()), message);
+        return new RamLogTimer(souffle::clone(statement), message);
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -724,7 +721,7 @@ public:
     }
 
     RamDebugInfo* clone() const override {
-        return new RamDebugInfo(std::unique_ptr<RamStatement>(statement->clone()), message);
+        return new RamDebugInfo(souffle::clone(statement), message);
     }
 
     void apply(const RamNodeMapper& map) override {
@@ -754,7 +751,7 @@ public:
     }
 
     RamLogSize* clone() const override {
-        return new RamLogSize(std::unique_ptr<RamRelationReference>(relationRef->clone()), message);
+        return new RamLogSize(souffle::clone(relationRef), message);
     }
 
 protected:

--- a/src/ram/RamUtils.h
+++ b/src/ram/RamUtils.h
@@ -75,10 +75,9 @@ inline std::unique_ptr<RamCondition> toCondition(const std::vector<std::unique_p
     std::unique_ptr<RamCondition> result;
     for (auto const& cur : conds) {
         if (result == nullptr) {
-            result = std::unique_ptr<RamCondition>(cur->clone());
+            result = souffle::clone(cur);
         } else {
-            result = std::make_unique<RamConjunction>(
-                    std::move(result), std::unique_ptr<RamCondition>(cur->clone()));
+            result = std::make_unique<RamConjunction>(std::move(result), souffle::clone(cur));
         }
     }
     return result;

--- a/src/ram/transform/RamTransforms.cpp
+++ b/src/ram/transform/RamTransforms.cpp
@@ -54,14 +54,12 @@ bool ExpandFilterTransformer::expandFilters(RamProgram& program) {
                     changed = true;
                     std::vector<std::unique_ptr<RamFilter>> filters;
                     for (auto& cond : conditionList) {
-                        auto tempCond = cond->clone();
                         if (filters.empty()) {
-                            filters.emplace_back(
-                                    std::make_unique<RamFilter>(std::unique_ptr<RamCondition>(tempCond),
-                                            std::unique_ptr<RamOperation>(filter->getOperation().clone())));
+                            filters.emplace_back(std::make_unique<RamFilter>(
+                                    souffle::clone(cond), souffle::clone(&filter->getOperation())));
                         } else {
                             filters.emplace_back(std::make_unique<RamFilter>(
-                                    std::unique_ptr<RamCondition>(tempCond), std::move(filters.back())));
+                                    souffle::clone(cond), std::move(filters.back())));
                         }
                     }
                     node = std::move(filters.back());
@@ -99,7 +97,7 @@ bool ReorderConditionsTransformer::reorderConditions(RamProgram& program) {
                     changed = true;
                     node = std::make_unique<RamFilter>(
                             std::unique_ptr<RamCondition>(toCondition(sortedConds)),
-                            std::unique_ptr<RamOperation>(filter->getOperation().clone()));
+                            souffle::clone(&filter->getOperation()));
                 }
             }
             node->apply(makeLambdaRamMapper(filterRewriter));
@@ -133,9 +131,7 @@ bool CollapseFiltersTransformer::collapseFilters(RamProgram& program) {
                 if (canCollapse) {
                     changed = true;
                     node = std::make_unique<RamFilter>(toCondition(conditions),
-                            std::unique_ptr<RamOperation>(
-                                    dynamic_cast<RamOperation*>(prevFilter->getOperation().clone())),
-                            prevFilter->getProfileText());
+                            souffle::clone(&prevFilter->getOperation()), prevFilter->getProfileText());
                 }
             }
             node->apply(makeLambdaRamMapper(filterRewriter));
@@ -168,7 +164,7 @@ bool EliminateDuplicatesTransformer::eliminateDuplicates(RamProgram& program) {
                 if (eliminatedDuplicate) {
                     changed = true;
                     node = std::make_unique<RamFilter>(std::unique_ptr<RamCondition>(toCondition(conds)),
-                            std::unique_ptr<RamOperation>(filter->getOperation().clone()));
+                            souffle::clone(&filter->getOperation()));
                 }
             }
             node->apply(makeLambdaRamMapper(filterRewriter));
@@ -205,7 +201,7 @@ bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
                     changed = true;
                     newCondition = addCondition(std::move(newCondition), condition.clone());
                     node->apply(makeLambdaRamMapper(filterRewriter));
-                    return std::unique_ptr<RamOperation>(filter->getOperation().clone());
+                    return souffle::clone(&filter->getOperation());
                 }
             }
             node->apply(makeLambdaRamMapper(filterRewriter));
@@ -217,8 +213,8 @@ bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
             // insert new filter operation at outer-most level of the query
             changed = true;
             auto* nestedOp = const_cast<RamOperation*>(&mQuery->getOperation());
-            mQuery->rewrite(nestedOp, std::make_unique<RamFilter>(std::move(newCondition),
-                                              std::unique_ptr<RamOperation>(nestedOp->clone())));
+            mQuery->rewrite(
+                    nestedOp, std::make_unique<RamFilter>(std::move(newCondition), souffle::clone(nestedOp)));
         }
     });
 
@@ -235,7 +231,7 @@ bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
                     changed = true;
                     newCondition = addCondition(std::move(newCondition), condition.clone());
                     node->apply(makeLambdaRamMapper(filterRewriter));
-                    return std::unique_ptr<RamOperation>(filter->getOperation().clone());
+                    return souffle::clone(&filter->getOperation());
                 }
             }
             node->apply(makeLambdaRamMapper(filterRewriter));
@@ -246,9 +242,8 @@ bool HoistConditionsTransformer::hoistConditions(RamProgram& program) {
         if (newCondition != nullptr) {
             // insert new filter operation after the search operation
             changed = true;
-            tupleOp->rewrite(&tupleOp->getOperation(),
-                    std::make_unique<RamFilter>(std::move(newCondition),
-                            std::unique_ptr<RamOperation>(tupleOp->getOperation().clone())));
+            tupleOp->rewrite(&tupleOp->getOperation(), std::make_unique<RamFilter>(std::move(newCondition),
+                                                               souffle::clone(&tupleOp->getOperation())));
         }
     });
     return changed;
@@ -325,7 +320,7 @@ ExpressionPair MakeIndexTransformer::getLowerUpperExpression(
                 if (lhs->getTupleId() == identifier && rla->getLevel(rhs) < identifier) {
                     element = lhs->getElement();
                     std::vector<std::unique_ptr<RamExpression>> expressions;
-                    expressions.push_back(std::unique_ptr<RamExpression>(rhs->clone()));
+                    expressions.push_back(souffle::clone(rhs));
                     expressions.push_back(std::make_unique<RamSignedConstant>(RamDomain(1)));
 
                     return {std::make_unique<RamUndefValue>(),
@@ -340,7 +335,7 @@ ExpressionPair MakeIndexTransformer::getLowerUpperExpression(
                 if (rhs->getTupleId() == identifier && rla->getLevel(lhs) < identifier) {
                     element = rhs->getElement();
                     std::vector<std::unique_ptr<RamExpression>> expressions;
-                    expressions.push_back(std::unique_ptr<RamExpression>(lhs->clone()));
+                    expressions.push_back(souffle::clone(lhs));
                     expressions.push_back(std::make_unique<RamSignedConstant>(RamDomain(1)));
 
                     return {std::make_unique<RamIntrinsicOperator>(FunctorOp::ADD, std::move(expressions)),
@@ -358,7 +353,7 @@ ExpressionPair MakeIndexTransformer::getLowerUpperExpression(
                 if (lhs->getTupleId() == identifier && rla->getLevel(rhs) < identifier) {
                     element = lhs->getElement();
                     std::vector<std::unique_ptr<RamExpression>> expressions;
-                    expressions.push_back(std::unique_ptr<RamExpression>(rhs->clone()));
+                    expressions.push_back(souffle::clone(rhs));
                     expressions.push_back(std::make_unique<RamSignedConstant>(RamDomain(1)));
 
                     return {std::make_unique<RamIntrinsicOperator>(FunctorOp::ADD, std::move(expressions)),
@@ -373,7 +368,7 @@ ExpressionPair MakeIndexTransformer::getLowerUpperExpression(
                 if (rhs->getTupleId() == identifier && rla->getLevel(lhs) < identifier) {
                     element = rhs->getElement();
                     std::vector<std::unique_ptr<RamExpression>> expressions;
-                    expressions.push_back(std::unique_ptr<RamExpression>(lhs->clone()));
+                    expressions.push_back(souffle::clone(lhs));
                     expressions.push_back(std::make_unique<RamSignedConstant>(RamDomain(1)));
 
                     return {std::make_unique<RamUndefValue>(),
@@ -431,22 +426,19 @@ std::unique_ptr<RamCondition> MakeIndexTransformer::constructPattern(RamPattern&
                 if (!isRamUndefValue(lowerExpression.get()) && !isRamUndefValue(upperExpression.get())) {
                     // FIXME: `FEQ` handling; need to know if the expr is a float exp or not
                     addCondition(std::make_unique<RamConstraint>(BinaryConstraintOp::EQ,
-                            std::unique_ptr<RamExpression>(queryPattern.first[element]->clone()),
-                            std::move(lowerExpression)));
+                            souffle::clone(queryPattern.first[element]), std::move(lowerExpression)));
                 }
                 // new lower bound i.e. Tuple[level, element] >= <expr2>
                 // we need to hoist <expr1> >= <expr2> to the outer loop
                 else if (!isRamUndefValue(lowerExpression.get()) && isRamUndefValue(upperExpression.get())) {
                     addCondition(std::make_unique<RamConstraint>(BinaryConstraintOp::GE,
-                            std::unique_ptr<RamExpression>(queryPattern.first[element]->clone()),
-                            std::move(lowerExpression)));
+                            souffle::clone(queryPattern.first[element]), std::move(lowerExpression)));
                 }
                 // new upper bound i.e. Tuple[level, element] <= <expr2>
                 // we need to hoist <expr1> <= <expr2> to the outer loop
                 else if (isRamUndefValue(lowerExpression.get()) && !isRamUndefValue(upperExpression.get())) {
                     addCondition(std::make_unique<RamConstraint>(BinaryConstraintOp::LE,
-                            std::unique_ptr<RamExpression>(queryPattern.first[element]->clone()),
-                            std::move(upperExpression)));
+                            souffle::clone(queryPattern.first[element]), std::move(upperExpression)));
                 }
                 // if either bound is defined but they aren't equal we must consider the cases for updating
                 // them note that at this point we know that if we have a lower/upper bound it can't be the
@@ -460,15 +452,13 @@ std::unique_ptr<RamCondition> MakeIndexTransformer::constructPattern(RamPattern&
                     // need to hoist <expr2> >= <expr1> to the outer loop
                     if (!isRamUndefValue(queryPattern.first[element].get())) {
                         addCondition(std::make_unique<RamConstraint>(BinaryConstraintOp::GE,
-                                std::unique_ptr<RamExpression>(lowerExpression->clone()),
-                                std::move(queryPattern.first[element])));
+                                souffle::clone(lowerExpression), std::move(queryPattern.first[element])));
                     }
                     // if Tuple[level, element] <= <expr1> and we see Tuple[level, element] = <expr2>
                     // need to hoist <expr2> <= <expr1> to the outer loop
                     if (!isRamUndefValue(queryPattern.second[element].get())) {
                         addCondition(std::make_unique<RamConstraint>(BinaryConstraintOp::LE,
-                                std::unique_ptr<RamExpression>(upperExpression->clone()),
-                                std::move(queryPattern.second[element])));
+                                souffle::clone(upperExpression), std::move(queryPattern.second[element])));
                     }
                     // finally replace bounds with equality constraint
                     queryPattern.first[element] = std::move(lowerExpression);
@@ -519,11 +509,10 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteAggregate(const RamAg
         std::unique_ptr<RamCondition> condition = constructPattern(
                 queryPattern, indexable, toConjunctionList(&agg->getCondition()), identifier);
         if (indexable) {
-            return std::make_unique<RamIndexAggregate>(
-                    std::unique_ptr<RamOperation>(agg->getOperation().clone()), agg->getFunction(),
-                    std::make_unique<RamRelationReference>(&rel),
-                    std::unique_ptr<RamExpression>(agg->getExpression().clone()), std::move(condition),
-                    std::move(queryPattern), agg->getTupleId());
+            return std::make_unique<RamIndexAggregate>(souffle::clone(&agg->getOperation()),
+                    agg->getFunction(), std::make_unique<RamRelationReference>(&rel),
+                    souffle::clone(&agg->getExpression()), std::move(condition), std::move(queryPattern),
+                    agg->getTupleId());
         }
     }
     return nullptr;
@@ -543,7 +532,7 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteScan(const RamScan* s
         std::unique_ptr<RamCondition> condition = constructPattern(
                 queryPattern, indexable, toConjunctionList(&filter->getCondition()), identifier);
         if (indexable) {
-            std::unique_ptr<RamOperation> op = std::unique_ptr<RamOperation>(filter->getOperation().clone());
+            std::unique_ptr<RamOperation> op = souffle::clone(&filter->getOperation());
             if (!isRamTrue(condition.get())) {
                 op = std::make_unique<RamFilter>(std::move(condition), std::move(op));
             }
@@ -571,7 +560,7 @@ std::unique_ptr<RamOperation> MakeIndexTransformer::rewriteIndexScan(const RamIn
         if (indexable) {
             // Merge Index Pattern here
 
-            std::unique_ptr<RamOperation> op = std::unique_ptr<RamOperation>(filter->getOperation().clone());
+            std::unique_ptr<RamOperation> op = souffle::clone(&filter->getOperation());
             if (!isRamTrue(condition.get())) {
                 op = std::make_unique<RamFilter>(std::move(condition), std::move(op));
             }
@@ -654,14 +643,14 @@ bool IndexedInequalityTransformer::transformIndexToFilter(RamProgram& program) {
                     if (!isRamUndefValue(pattern.first[i])) {
                         lowerBound = std::make_unique<RamConstraint>(BinaryConstraintOp::GE,
                                 std::make_unique<RamTupleElement>(indexOperation->getTupleId(), i),
-                                std::unique_ptr<RamExpression>(pattern.first[i]->clone()));
+                                souffle::clone(pattern.first[i]));
                         condition = addCondition(std::move(condition), lowerBound->clone());
                     }
 
                     if (!isRamUndefValue(pattern.second[i])) {
                         upperBound = std::make_unique<RamConstraint>(BinaryConstraintOp::LE,
                                 std::make_unique<RamTupleElement>(indexOperation->getTupleId(), i),
-                                std::unique_ptr<RamExpression>(pattern.second[i]->clone()));
+                                souffle::clone(pattern.second[i]));
                         condition = addCondition(std::move(condition), upperBound->clone());
                     }
 
@@ -671,7 +660,7 @@ bool IndexedInequalityTransformer::transformIndexToFilter(RamProgram& program) {
                 }
 
                 if (condition) {
-                    auto nestedOp = std::unique_ptr<RamOperation>(indexOperation->getOperation().clone());
+                    auto nestedOp = souffle::clone(&indexOperation->getOperation());
                     auto filter = std::make_unique<RamFilter>(std::move(condition), std::move(nestedOp));
 
                     // need to rewrite the node with the same index operation
@@ -689,14 +678,12 @@ bool IndexedInequalityTransformer::transformIndexToFilter(RamProgram& program) {
                     } else if (const RamIndexChoice* ichoice = dynamic_cast<RamIndexChoice*>(node.get())) {
                         node = std::make_unique<RamIndexChoice>(
                                 std::make_unique<RamRelationReference>(&ichoice->getRelation()),
-                                ichoice->getTupleId(),
-                                std::unique_ptr<RamCondition>(ichoice->getCondition().clone()),
+                                ichoice->getTupleId(), souffle::clone(&ichoice->getCondition()),
                                 std::move(updatedPattern), std::move(filter), ichoice->getProfileText());
                     } else if (const RamIndexAggregate* iagg = dynamic_cast<RamIndexAggregate*>(node.get())) {
                         node = std::make_unique<RamIndexAggregate>(std::move(filter), iagg->getFunction(),
                                 std::make_unique<RamRelationReference>(&iagg->getRelation()),
-                                std::unique_ptr<RamExpression>(iagg->getExpression().clone()),
-                                std::unique_ptr<RamCondition>(iagg->getCondition().clone()),
+                                souffle::clone(&iagg->getExpression()), souffle::clone(&iagg->getCondition()),
                                 std::move(updatedPattern), iagg->getTupleId());
                     } else {
                         fatal("New RamIndexOperation subclass found but not supported while making index.");
@@ -735,30 +722,24 @@ bool IndexedInequalityTransformer::transformIndexToFilter(RamProgram& program) {
                     if (const RamIndexScan* iscan = dynamic_cast<RamIndexScan*>(node.get())) {
                         node = std::make_unique<RamScan>(
                                 std::make_unique<RamRelationReference>(&iscan->getRelation()),
-                                iscan->getTupleId(),
-                                std::unique_ptr<RamOperation>(iscan->getOperation().clone()),
+                                iscan->getTupleId(), souffle::clone(&iscan->getOperation()),
                                 iscan->getProfileText());
                     } else if (const RamParallelIndexScan* pscan =
                                        dynamic_cast<RamParallelIndexScan*>(node.get())) {
                         node = std::make_unique<RamParallelScan>(
                                 std::make_unique<RamRelationReference>(&pscan->getRelation()),
-                                pscan->getTupleId(),
-                                std::unique_ptr<RamOperation>(pscan->getOperation().clone()),
+                                pscan->getTupleId(), souffle::clone(&pscan->getOperation()),
                                 pscan->getProfileText());
                     } else if (const RamIndexChoice* ichoice = dynamic_cast<RamIndexChoice*>(node.get())) {
                         node = std::make_unique<RamChoice>(
                                 std::make_unique<RamRelationReference>(&ichoice->getRelation()),
-                                ichoice->getTupleId(),
-                                std::unique_ptr<RamCondition>(ichoice->getCondition().clone()),
-                                std::unique_ptr<RamOperation>(ichoice->getOperation().clone()),
-                                ichoice->getProfileText());
+                                ichoice->getTupleId(), souffle::clone(&ichoice->getCondition()),
+                                souffle::clone(&ichoice->getOperation()), ichoice->getProfileText());
                     } else if (const RamIndexAggregate* iagg = dynamic_cast<RamIndexAggregate*>(node.get())) {
-                        node = std::make_unique<RamAggregate>(
-                                std::unique_ptr<RamOperation>(iagg->getOperation().clone()),
+                        node = std::make_unique<RamAggregate>(souffle::clone(&iagg->getOperation()),
                                 iagg->getFunction(),
                                 std::make_unique<RamRelationReference>(&iagg->getRelation()),
-                                std::unique_ptr<RamExpression>(iagg->getExpression().clone()),
-                                std::unique_ptr<RamCondition>(iagg->getCondition().clone()),
+                                souffle::clone(&iagg->getExpression()), souffle::clone(&iagg->getCondition()),
                                 iagg->getTupleId());
                     } else {
                         fatal("New RamIndexOperation subclass found but not supported while transforming "
@@ -784,11 +765,9 @@ bool ReorderFilterBreak::reorderFilterBreak(RamProgram& program) {
                 if (const RamBreak* br = dynamic_cast<RamBreak*>(&filter->getOperation())) {
                     changed = true;
                     // convert to break-filter nesting
-                    node = std::make_unique<RamBreak>(
-                            std::unique_ptr<RamCondition>(br->getCondition().clone()),
-                            std::make_unique<RamFilter>(
-                                    std::unique_ptr<RamCondition>(filter->getCondition().clone()),
-                                    std::unique_ptr<RamOperation>(br->getOperation().clone())));
+                    node = std::make_unique<RamBreak>(souffle::clone(&br->getCondition()),
+                            std::make_unique<RamFilter>(souffle::clone(&filter->getCondition()),
+                                    souffle::clone(&br->getOperation())));
                 }
             }
             node->apply(makeLambdaRamMapper(filterRewriter));
@@ -892,8 +871,8 @@ std::unique_ptr<RamOperation> ChoiceConversionTransformer::rewriteScan(const Ram
         const int identifier = scan->getTupleId();
 
         return std::make_unique<RamChoice>(std::make_unique<RamRelationReference>(&scan->getRelation()),
-                identifier, std::unique_ptr<RamCondition>(filter->getCondition().clone()),
-                std::unique_ptr<RamOperation>(scan->getOperation().clone()), scan->getProfileText());
+                identifier, souffle::clone(&filter->getCondition()), souffle::clone(&scan->getOperation()),
+                scan->getProfileText());
     }
     return nullptr;
 }
@@ -941,8 +920,8 @@ std::unique_ptr<RamOperation> ChoiceConversionTransformer::rewriteIndexScan(cons
         }
 
         return std::make_unique<RamIndexChoice>(std::make_unique<RamRelationReference>(&rel), identifier,
-                std::unique_ptr<RamCondition>(filter->getCondition().clone()), std::move(newValues),
-                std::unique_ptr<RamOperation>(filter->getOperation().clone()), indexScan->getProfileText());
+                souffle::clone(&filter->getCondition()), std::move(newValues),
+                souffle::clone(&filter->getOperation()), indexScan->getProfileText());
     }
     return nullptr;
 }
@@ -1027,10 +1006,9 @@ bool HoistAggregateTransformer::hoistAggregate(RamProgram& program) {
                 assert(tupleOp != nullptr && "aggregate conversion to tuple operation failed");
                 if (rla->getLevel(tupleOp) == -1 && !priorTupleOp) {
                     changed = true;
-                    newAgg = std::unique_ptr<RamNestedOperation>(
-                            dynamic_cast<RamNestedOperation*>(tupleOp->clone()));
+                    newAgg = souffle::clone(tupleOp);
                     assert(newAgg != nullptr && "failed to make a clone");
-                    return std::unique_ptr<RamOperation>(tupleOp->getOperation().clone());
+                    return souffle::clone(&tupleOp->getOperation());
                 }
             } else if (nullptr != dynamic_cast<RamTupleOperation*>(node.get())) {
                 // tuple operation that is a non-aggregate
@@ -1041,8 +1019,7 @@ bool HoistAggregateTransformer::hoistAggregate(RamProgram& program) {
         };
         const_cast<RamQuery*>(&query)->apply(makeLambdaRamMapper(aggRewriter));
         if (newAgg != nullptr) {
-            newAgg->rewrite(
-                    &newAgg->getOperation(), std::unique_ptr<RamOperation>(query.getOperation().clone()));
+            newAgg->rewrite(&newAgg->getOperation(), souffle::clone(&query.getOperation()));
             const_cast<RamQuery*>(&query)->rewrite(&query.getOperation(), std::move(newAgg));
         }
     });
@@ -1066,10 +1043,9 @@ bool HoistAggregateTransformer::hoistAggregate(RamProgram& program) {
                     if (dataDepLevel != priorOpLevel) {
                         changed = true;
                         newLevel = dataDepLevel;
-                        newAgg = std::unique_ptr<RamNestedOperation>(
-                                dynamic_cast<RamNestedOperation*>(tupleOp->clone()));
+                        newAgg = souffle::clone(tupleOp);
                         assert(newAgg != nullptr && "failed to make a clone");
-                        return std::unique_ptr<RamOperation>(tupleOp->getOperation().clone());
+                        return souffle::clone(&tupleOp->getOperation());
                     }
                 }
             } else if (const RamTupleOperation* tupleOp = dynamic_cast<RamTupleOperation*>(node.get())) {
@@ -1078,8 +1054,7 @@ bool HoistAggregateTransformer::hoistAggregate(RamProgram& program) {
             node->apply(makeLambdaRamMapper(aggRewriter));
             if (auto* search = dynamic_cast<RamTupleOperation*>(node.get())) {
                 if (newAgg != nullptr && search->getTupleId() == newLevel) {
-                    newAgg->rewrite(&newAgg->getOperation(),
-                            std::unique_ptr<RamOperation>(search->getOperation().clone()));
+                    newAgg->rewrite(&newAgg->getOperation(), souffle::clone(&search->getOperation()));
                     search->rewrite(&search->getOperation(), std::move(newAgg));
                 }
             }
@@ -1104,8 +1079,7 @@ bool ParallelTransformer::parallelizeOperations(RamProgram& program) {
                         changed = true;
                         return std::make_unique<RamParallelScan>(
                                 std::make_unique<RamRelationReference>(&scan->getRelation()),
-                                scan->getTupleId(),
-                                std::unique_ptr<RamOperation>(scan->getOperation().clone()),
+                                scan->getTupleId(), souffle::clone(&scan->getOperation()),
                                 scan->getProfileText());
                     }
                 }
@@ -1114,10 +1088,8 @@ bool ParallelTransformer::parallelizeOperations(RamProgram& program) {
                     changed = true;
                     return std::make_unique<RamParallelChoice>(
                             std::make_unique<RamRelationReference>(&choice->getRelation()),
-                            choice->getTupleId(),
-                            std::unique_ptr<RamCondition>(choice->getCondition().clone()),
-                            std::unique_ptr<RamOperation>(choice->getOperation().clone()),
-                            choice->getProfileText());
+                            choice->getTupleId(), souffle::clone(&choice->getCondition()),
+                            souffle::clone(&choice->getOperation()), choice->getProfileText());
                 }
             } else if (const RamIndexScan* indexScan = dynamic_cast<RamIndexScan*>(node.get())) {
                 if (indexScan->getTupleId() == 0) {
@@ -1126,8 +1098,7 @@ bool ParallelTransformer::parallelizeOperations(RamProgram& program) {
                     RamPattern queryPattern = clone(indexScan->getRangePattern());
                     return std::make_unique<RamParallelIndexScan>(
                             std::make_unique<RamRelationReference>(&rel), indexScan->getTupleId(),
-                            std::move(queryPattern),
-                            std::unique_ptr<RamOperation>(indexScan->getOperation().clone()),
+                            std::move(queryPattern), souffle::clone(&indexScan->getOperation()),
                             indexScan->getProfileText());
                 }
             } else if (const RamIndexChoice* indexChoice = dynamic_cast<RamIndexChoice*>(node.get())) {
@@ -1137,10 +1108,8 @@ bool ParallelTransformer::parallelizeOperations(RamProgram& program) {
                     RamPattern queryPattern = clone(indexChoice->getRangePattern());
                     return std::make_unique<RamParallelIndexChoice>(
                             std::make_unique<RamRelationReference>(&rel), indexChoice->getTupleId(),
-                            std::unique_ptr<RamCondition>(indexChoice->getCondition().clone()),
-                            std::move(queryPattern),
-                            std::unique_ptr<RamOperation>(indexChoice->getOperation().clone()),
-                            indexChoice->getProfileText());
+                            souffle::clone(&indexChoice->getCondition()), std::move(queryPattern),
+                            souffle::clone(&indexChoice->getOperation()), indexChoice->getProfileText());
                 }
             }
             node->apply(makeLambdaRamMapper(parallelRewriter));


### PR DESCRIPTION
Refactor to use `souffle::clone` more consistently, instead of `std::unique_ptr<...>(...->clone())`.