### PR TITLE
Provenance existence check fix

### DIFF
--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -308,8 +308,8 @@ std::unique_ptr<RamCondition> AstTranslator::translateConstraint(
                 // undefined value for rule number
                 values.push_back(std::make_unique<RamUndefValue>());
                 // add the height annotation for provenanceNotExists
-                for (size_t h = 1; h < auxiliaryArity; h++) {
-                    values.push_back(translator.translateValue(args[arity + h], index));
+                for (size_t height = 1; height < auxiliaryArity; height++) {
+                    values.push_back(translator.translateValue(args[arity + height], index));
                 }
             }
             return std::make_unique<RamNegation>(std::make_unique<RamProvenanceExistenceCheck>(
@@ -324,18 +324,20 @@ std::unique_ptr<RamCondition> AstTranslator::translateConstraint(
             size_t arity = atom->getArity() - auxiliaryArity;
             std::vector<std::unique_ptr<RamExpression>> values;
 
-            auto args = atom->getArguments();
-            for (size_t i = 0; i < arity; i++) {
-                values.push_back(translator.translateValue(args[i], index));
-            }
-            for (size_t i = 0; i < auxiliaryArity; i++) {
-                values.push_back(std::make_unique<RamUndefValue>());
-            }
-            if (arity > 0) {
+            if (arity == 0) {
+                // for a nullary, negation is a simple emptiness check
+                return std::make_unique<RamEmptinessCheck>(translator.translateRelation(atom));
+            } else {
+                // else, we construct the atom and create a negation
+                auto args = atom->getArguments();
+                for (size_t i = 0; i < arity; i++) {
+                    values.push_back(translator.translateValue(args[i], index));
+                }
+                for (size_t i = 0; i < auxiliaryArity; i++) {
+                    values.push_back(std::make_unique<RamUndefValue>());
+                }
                 return std::make_unique<RamNegation>(std::make_unique<RamExistenceCheck>(
                         translator.translateRelation(atom), std::move(values)));
-            } else {
-                return std::make_unique<RamEmptinessCheck>(translator.translateRelation(atom));
             }
         }
     };

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -322,23 +322,23 @@ std::unique_ptr<RamCondition> AstTranslator::translateConstraint(
             size_t auxiliaryArity = translator.getEvaluationArity(atom);
             assert(auxiliaryArity <= atom->getArity() && "auxiliary arity out of bounds");
             size_t arity = atom->getArity() - auxiliaryArity;
-            std::vector<std::unique_ptr<RamExpression>> values;
 
             if (arity == 0) {
                 // for a nullary, negation is a simple emptiness check
                 return std::make_unique<RamEmptinessCheck>(translator.translateRelation(atom));
-            } else {
-                // else, we construct the atom and create a negation
-                auto args = atom->getArguments();
-                for (size_t i = 0; i < arity; i++) {
-                    values.push_back(translator.translateValue(args[i], index));
-                }
-                for (size_t i = 0; i < auxiliaryArity; i++) {
-                    values.push_back(std::make_unique<RamUndefValue>());
-                }
-                return std::make_unique<RamNegation>(std::make_unique<RamExistenceCheck>(
-                        translator.translateRelation(atom), std::move(values)));
             }
+
+            // else, we construct the atom and create a negation
+            std::vector<std::unique_ptr<RamExpression>> values;
+            auto args = atom->getArguments();
+            for (size_t i = 0; i < arity; i++) {
+                values.push_back(translator.translateValue(args[i], index));
+            }
+            for (size_t i = 0; i < auxiliaryArity; i++) {
+                values.push_back(std::make_unique<RamUndefValue>());
+            }
+            return std::make_unique<RamNegation>(std::make_unique<RamExistenceCheck>(
+                    translator.translateRelation(atom), std::move(values)));
         }
     };
     return ConstraintTranslator(*this, index)(*lit);

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -308,8 +308,8 @@ std::unique_ptr<RamCondition> AstTranslator::translateConstraint(
                 // undefined value for rule number
                 values.push_back(std::make_unique<RamUndefValue>());
                 // add the height annotation for provenanceNotExists
-                for (size_t h = 0; h + 1 < auxiliaryArity; h++) {
-                    values.push_back(translator.translateValue(args[arity + h + 1], index));
+                for (size_t h = 1; h < auxiliaryArity; h++) {
+                    values.push_back(translator.translateValue(args[arity + h], index));
                 }
             }
             return std::make_unique<RamNegation>(std::make_unique<RamProvenanceExistenceCheck>(

--- a/src/AstTranslator.cpp
+++ b/src/AstTranslator.cpp
@@ -295,7 +295,7 @@ std::unique_ptr<RamCondition> AstTranslator::translateConstraint(
         std::unique_ptr<RamCondition> visitProvenanceNegation(const AstProvenanceNegation& neg) override {
             const auto* atom = neg.getAtom();
             size_t auxiliaryArity = translator.getEvaluationArity(atom);
-            assert(auxiliaryArity < atom->getArity() && "auxiliary arity out of bounds");
+            assert(auxiliaryArity <= atom->getArity() && "auxiliary arity out of bounds");
             size_t arity = atom->getArity() - auxiliaryArity;
             std::vector<std::unique_ptr<RamExpression>> values;
 

--- a/src/ast/AstVisitor.h
+++ b/src/ast/AstVisitor.h
@@ -98,8 +98,8 @@ struct AstVisitor : public ast_visitor_tag {
 
         // literals
         FORWARD(Atom)
-        FORWARD(Negation)
         FORWARD(ProvenanceNegation)
+        FORWARD(Negation)
         FORWARD(BooleanConstraint)
         FORWARD(BinaryConstraint)
 

--- a/src/ram/RamVisitor.h
+++ b/src/ram/RamVisitor.h
@@ -99,8 +99,8 @@ struct RamVisitor : public ram_visitor_tag {
         FORWARD(True);
         FORWARD(False);
         FORWARD(EmptinessCheck);
-        FORWARD(ExistenceCheck);
         FORWARD(ProvenanceExistenceCheck);
+        FORWARD(ExistenceCheck);
         FORWARD(Conjunction);
         FORWARD(Negation);
         FORWARD(Constraint);
@@ -218,8 +218,8 @@ protected:
     LINK(Conjunction, Condition);
     LINK(Negation, Condition);
     LINK(Constraint, Condition);
-    LINK(ExistenceCheck, AbstractExistenceCheck);
     LINK(ProvenanceExistenceCheck, AbstractExistenceCheck);
+    LINK(ExistenceCheck, AbstractExistenceCheck);
     LINK(EmptinessCheck, Condition);
     LINK(AbstractExistenceCheck, Condition);
 

--- a/src/ram/analysis/RamIndexAnalysis.cpp
+++ b/src/ram/analysis/RamIndexAnalysis.cpp
@@ -412,8 +412,9 @@ SearchSignature RamIndexAnalysis::getSearchSignature(
     auto auxiliaryArity = provExistCheck->getRelation().getAuxiliaryArity();
 
     // values.size() - auxiliaryArity because we discard the height annotations
-    auto const numSig = values.size() - auxiliaryArity;
-    return searchSignature(auxiliaryArity, values.begin(), values.begin() + numSig);
+    auto const numSig = values.size(); // - auxiliaryArity;
+    // return searchSignature(auxiliaryArity, values.begin(), values.begin() + numSig);
+    return searchSignature(provExistCheck->getRelation().getArity(), provExistCheck->getValues());
 }
 
 SearchSignature RamIndexAnalysis::getSearchSignature(const RamExistenceCheck* existCheck) const {

--- a/src/ram/analysis/RamIndexAnalysis.cpp
+++ b/src/ram/analysis/RamIndexAnalysis.cpp
@@ -426,13 +426,6 @@ SearchSignature RamIndexAnalysis::getSearchSignature(
     }
 
     return keys;
-
-    /*
-    // values.size() - auxiliaryArity because we discard the height annotations
-    auto const numSig = values.size(); // - auxiliaryArity;
-    // return searchSignature(auxiliaryArity, values.begin(), values.begin() + numSig);
-    return searchSignature(provExistCheck->getRelation().getArity(), provExistCheck->getValues());
-    */
 }
 
 SearchSignature RamIndexAnalysis::getSearchSignature(const RamExistenceCheck* existCheck) const {

--- a/src/ram/analysis/RamIndexAnalysis.cpp
+++ b/src/ram/analysis/RamIndexAnalysis.cpp
@@ -411,10 +411,28 @@ SearchSignature RamIndexAnalysis::getSearchSignature(
     const auto values = provExistCheck->getValues();
     auto auxiliaryArity = provExistCheck->getRelation().getAuxiliaryArity();
 
+    SearchSignature keys(values.size());
+
+    // all payload attributes should be equalities
+    for (size_t i = 0; i < values.size() - auxiliaryArity; i++) {
+        if (!isRamUndefValue(values[i])) {
+            keys.set(i, AttributeConstraint::Equal);
+        }
+    }
+
+    // all auxiliary attributes should be free
+    for (size_t i = values.size() - auxiliaryArity; i < values.size(); i++) {
+        keys.set(i, AttributeConstraint::None);
+    }
+
+    return keys;
+
+    /*
     // values.size() - auxiliaryArity because we discard the height annotations
     auto const numSig = values.size(); // - auxiliaryArity;
     // return searchSignature(auxiliaryArity, values.begin(), values.begin() + numSig);
     return searchSignature(provExistCheck->getRelation().getArity(), provExistCheck->getValues());
+    */
 }
 
 SearchSignature RamIndexAnalysis::getSearchSignature(const RamExistenceCheck* existCheck) const {


### PR DESCRIPTION
This change reinstates AstProvenanceNegation and RamProvenanceExistenceCheck. These were previously not properly generated, because AstProvenanceNegation was moved to be a subclass of AstNegation, which took priority in visitors.

This has now been resolved, along with other fixes for code that wasn't previously touched.