### PR TITLE
Protect threaded access to record map

### DIFF
--- a/src/RecordTable.h
+++ b/src/RecordTable.h
@@ -117,8 +117,13 @@ public:
     }
     /** @brief convert record reference to a record */
     const RamDomain* unpack(RamDomain ref, size_t arity) const {
-        auto iter = maps.find(arity);
-        assert(iter != maps.end() && "Attempting to unpack non-existing record");
+        std::unordered_map<size_t, RecordMap>::const_iterator iter;
+#pragma omp critical(RecordTableGetForArity)
+        {
+            // Find a previously emplaced map
+            iter = maps.find(arity);
+        }
+        assert(iter != maps.end() && "Attempting to unpack record for non-existing arity");
         return (iter->second).unpack(ref);
     }
 


### PR DESCRIPTION
Record map access is currently not thread-safe. Maps may not be inserted before they are retrieved. This PR wraps the map retrieval in the same omp critical section as the map insertion.