### PR TITLE
Extended program minimiser to support clauses with aggregators.

### DIFF
--- a/src/ast/transform/MinimiseProgram.cpp
+++ b/src/ast/transform/MinimiseProgram.cpp
@@ -96,7 +96,7 @@ private:
     bool fullyNormalised{true};
     std::set<std::string> variables{};
     std::set<std::string> constants{};
-    std::vector<NormalisedClauseElementRepr> clauseElements;
+    std::vector<NormalisedClauseElementRepr> clauseElements{};
 
     /**
      * Parse an atom with a preset name qualifier into the element list.

--- a/src/ast/transform/MinimiseProgram.cpp
+++ b/src/ast/transform/MinimiseProgram.cpp
@@ -16,6 +16,7 @@
 
 #include "ast/transform/MinimiseProgram.h"
 #include "BinaryConstraintOps.h"
+#include "ast/Aggregator.h"
 #include "ast/Argument.h"
 #include "ast/Atom.h"
 #include "ast/BinaryConstraint.h"
@@ -71,7 +72,7 @@ public:
 
         // body
         for (const auto* lit : clause->getBodyLiterals()) {
-            addClauseBodyLiteral(lit);
+            addClauseBodyLiteral("@min:level:0", lit);
         }
     }
 
@@ -100,12 +101,12 @@ private:
     /**
      * Parse an atom with a preset name qualifier into the element list.
      */
-    void addClauseAtom(std::string qualifier, const AstAtom* atom);
+    void addClauseAtom(const std::string& qualifier, const std::string& level, const AstAtom* atom);
 
     /**
      * Parse a body literal into the element list.
      */
-    void addClauseBodyLiteral(const AstLiteral* lit);
+    void addClauseBodyLiteral(const std::string& level, const AstLiteral* lit);
 
     /**
      * Return a normalised string repr of an argument.
@@ -114,33 +115,39 @@ private:
 };
 
 void MinimiseProgramTransformer::NormalisedClauseRepr::addClauseAtom(
-        std::string qualifier, const AstAtom* atom) {
+        const std::string& qualifier, const std::string& level, const AstAtom* atom) {
     AstQualifiedName name(atom->getQualifiedName());
     name.prepend(qualifier);
 
     std::vector<std::string> vars;
+    vars.push_back(level);
     for (const auto* arg : atom->getArguments()) {
         vars.push_back(normaliseArgument(arg));
     }
     clauseElements.push_back({.name = name, .params = vars});
 }
 
-void MinimiseProgramTransformer::NormalisedClauseRepr::addClauseBodyLiteral(const AstLiteral* lit) {
+void MinimiseProgramTransformer::NormalisedClauseRepr::addClauseBodyLiteral(
+        const std::string& level, const AstLiteral* lit) {
     if (const auto* atom = dynamic_cast<const AstAtom*>(lit)) {
-        addClauseAtom("@min:atom", atom);
+        addClauseAtom("@min:atom", level, atom);
     } else if (const auto* neg = dynamic_cast<const AstNegation*>(lit)) {
-        addClauseAtom("@min:neg", neg->getAtom());
+        addClauseAtom("@min:neg", level, neg->getAtom());
     } else if (const auto* bc = dynamic_cast<const AstBinaryConstraint*>(lit)) {
         AstQualifiedName name(toBinaryConstraintSymbol(bc->getOperator()));
         name.prepend("@min:operator");
         std::vector<std::string> vars;
+        vars.push_back(level);
         vars.push_back(normaliseArgument(bc->getLHS()));
         vars.push_back(normaliseArgument(bc->getRHS()));
         clauseElements.push_back({.name = name, .params = vars});
     } else {
+        assert(lit != nullptr && "unexpected nullptr lit");
         fullyNormalised = false;
+        std::stringstream qualifier;
+        qualifier << "@min:unhandled:lit:" << level;
         AstQualifiedName name(toString(*lit));
-        name.prepend("@min:unhandled:lit");
+        name.prepend(qualifier.str());
         clauseElements.push_back({.name = name, .params = std::vector<std::string>()});
     }
 }
@@ -169,6 +176,40 @@ std::string MinimiseProgramTransformer::NormalisedClauseRepr::normaliseArgument(
         name << "@min:unnamed:" << countUnnamed++;
         variables.insert(name.str());
         return name.str();
+    } else if (auto* aggr = dynamic_cast<const AstAggregator*>(arg)) {
+        // Set the level to uniquely identify the aggregator
+        static size_t countAggrs = 0;
+        std::stringstream levelID;
+        levelID << "@min:level:" << ++countAggrs;
+        variables.insert(levelID.str());
+
+        // Set the type signature of this aggregator
+        std::stringstream aggrTypeSignature;
+        aggrTypeSignature << "@min:aggrtype";
+        std::vector<std::string> aggrTypeSignatureComponents;
+
+        // - the operator is fixed and cannot be changed
+        aggrTypeSignature << ":" << aggr->getOperator();
+
+        // - the level can be remapped as a variable
+        aggrTypeSignatureComponents.push_back(levelID.str());
+
+        // - the normalised target expression can be remapped as a variable
+        if (aggr->getTargetExpression() != nullptr) {
+            std::string normalisedExpr = normaliseArgument(aggr->getTargetExpression());
+            aggrTypeSignatureComponents.push_back(normalisedExpr);
+        }
+
+        // Type signature is its own special atom
+        clauseElements.push_back({.name = aggrTypeSignature.str(), .params = aggrTypeSignatureComponents});
+
+        // Add each contained normalised clause literal, tying it with the new level
+        for (const auto* literal : aggr->getBodyLiterals()) {
+            addClauseBodyLiteral(levelID.str(), literal);
+        }
+
+        // Aggregator identified by the level ID
+        return levelID.str();
     } else {
         fullyNormalised = false;
         return "@min:unhandled:arg";

--- a/src/ast/transform/MinimiseProgram.cpp
+++ b/src/ast/transform/MinimiseProgram.cpp
@@ -62,7 +62,7 @@ public:
 
     NormalisedClauseRepr(const AstClause* clause) {
         // head
-        AstQualifiedName name("min:head");
+        AstQualifiedName name("@min:head");
         std::vector<std::string> headVars;
         for (const auto* arg : clause->getHead()->getArguments()) {
             headVars.push_back(normaliseArgument(arg));
@@ -353,9 +353,8 @@ bool MinimiseProgramTransformer::areBijectivelyEquivalent(
     }
 
     // create permutation matrix
-    permutationMatrix[0][0] = 1;
-    for (size_t i = 1; i < size; i++) {
-        for (size_t j = 1; j < size; j++) {
+    for (size_t i = 0; i < size; i++) {
+        for (size_t j = 0; j < size; j++) {
             if (leftElements[i].name == rightElements[j].name) {
                 permutationMatrix[i][j] = 1;
             }

--- a/src/tests/ast_transformers_test.cpp
+++ b/src/tests/ast_transformers_test.cpp
@@ -334,19 +334,19 @@ TEST(AstTransformers, CheckAggregatorEquivalence) {
                     B(X),
                     X < max Y : { C(Y), B(Y), Y < 2 },
                     A(Z),
-                    Z = sum A : { C(A), B(A) }.
+                    Z = sum A : { C(A), B(A), A > count : { A(M), C(M) } }.
 
                 D(V) :-
                     B(V),
                     A(W),
-                    W = sum test1 : { C(test1), B(test1) },
+                    W = sum test1 : { C(test1), B(test1), test1 > count : { C(X), A(X) } },
                     V < max test2 : { C(test2), B(test2), test2 < 2 }.
 
                 // third not equivalent
                 D(V) :-
                     B(V),
                     A(W),
-                    W = min test1 : { C(test1), B(test1) },
+                    W = min test1 : { C(test1), B(test1), test1 > count : { C(X), A(X) } },
                     V < max test2 : { C(test2), B(test2), test2 < 2 }.
 
                 .output D()
@@ -367,12 +367,12 @@ TEST(AstTransformers, CheckAggregatorEquivalence) {
     const auto& dClauses = getClauses(program, "D");
     EXPECT_EQ(2, dClauses.size());
     EXPECT_EQ(
-            "D(X) :- \n   B(X),\n   X < max Y : { C(Y),B(Y),Y < 2 },\n   A(Z),\n   Z = sum A : { C(A),B(A) "
-            "}.",
+            "D(X) :- \n   B(X),\n   X < max Y : { C(Y),B(Y),Y < 2 },\n   A(Z),\n   Z = sum A : { C(A),B(A),A "
+            "> count : { A(M),C(M) } }.",
             toString(*dClauses[0]));
     EXPECT_EQ(
-            "D(V) :- \n   B(V),\n   A(W),\n   W = min test1 : { C(test1),B(test1) },\n   V < max test2 : { "
-            "C(test2),B(test2),test2 < 2 }.",
+            "D(V) :- \n   B(V),\n   A(W),\n   W = min test1 : { C(test1),B(test1),test1 > count : { "
+            "C(X),A(X) } },\n   V < max test2 : { C(test2),B(test2),test2 < 2 }.",
             toString(*dClauses[1]));
 }
 

--- a/src/tests/ast_transformers_test.cpp
+++ b/src/tests/ast_transformers_test.cpp
@@ -332,7 +332,7 @@ TEST(AstTransformers, CheckAggregatorEquivalence) {
                 // first and second are equivalent
                 D(X) :-
                     B(X),
-                    X < max Y : { C(Y), B(Y) },
+                    X < max Y : { C(Y), B(Y), Y < 2 },
                     A(Z),
                     Z = sum A : { C(A), B(A) }.
 
@@ -340,14 +340,14 @@ TEST(AstTransformers, CheckAggregatorEquivalence) {
                     B(V),
                     A(W),
                     W = sum test1 : { C(test1), B(test1) },
-                    V < max test2 : { C(test2), B(test2) }.
+                    V < max test2 : { C(test2), B(test2), test2 < 2 }.
 
                 // third not equivalent
                 D(V) :-
                     B(V),
                     A(W),
                     W = min test1 : { C(test1), B(test1) },
-                    V < max test2 : { C(test2), B(test2) }.
+                    V < max test2 : { C(test2), B(test2), test2 < 2 }.
 
                 .output D()
             )",
@@ -366,11 +366,13 @@ TEST(AstTransformers, CheckAggregatorEquivalence) {
     // D should now only have the two clauses non-equivalent clauses
     const auto& dClauses = getClauses(program, "D");
     EXPECT_EQ(2, dClauses.size());
-    EXPECT_EQ("D(X) :- \n   B(X),\n   X < max Y : { C(Y),B(Y) },\n   A(Z),\n   Z = sum A : { C(A),B(A) }.",
+    EXPECT_EQ(
+            "D(X) :- \n   B(X),\n   X < max Y : { C(Y),B(Y),Y < 2 },\n   A(Z),\n   Z = sum A : { C(A),B(A) "
+            "}.",
             toString(*dClauses[0]));
     EXPECT_EQ(
             "D(V) :- \n   B(V),\n   A(W),\n   W = min test1 : { C(test1),B(test1) },\n   V < max test2 : { "
-            "C(test2),B(test2) }.",
+            "C(test2),B(test2),test2 < 2 }.",
             toString(*dClauses[1]));
 }
 


### PR DESCRIPTION
Aggregators are now normalisable, allowing the program minimiser to apply bijective equivalence checks to clauses containing them.

The normalisation of aggregators is special, as nested atoms cannot be replaced with atoms in other aggregator bodies, or in the outer scope. To get around this, each aggregator in a clause is assigned a unique incrementing scope ID, and all atom normalisations are passed an extra argument denoting the scope they are contained in. In addition, each aggregator "scope" is assigned a type signature based on the aggregator type - namely, a static "operator" (like `sum`) and a variable target expresion. Aggregator IDs can only be swapped if the structure of the clause remains the same, and their type signatures map.

For example, consider the following aggregator:

```
D(X) :- 
   B(X),
   X < max Y : { C(Y),B(Y),Y < 2 },
   A(Z),
   Z = sum A : { C(A),B(A),A > count : { A(M),C(M) } }.
```

The outer scope is given the ID `0`, the RHS of ` X < ... ` is given the ID `1`, the first layer on the RHS of `Z = ...` constraint the ID `2`, and the final inner aggregator the ID `3`. The final normalisation will look something like this:

```
head:[X] // the head atom

// Scope 0
atom:B:[scope:0,X] // the B atom in the outer scope (scope 0)
operator.<:[scope:0,X,scope:1] // X < [second scope], in the outer scope
atom:A:[scope:0,Z] // A(Z) in the outer scope
operator:=:[scope:0,Z,scope:2] // Z = [third scope], in the outer scope

// Scope 1, first aggregator
aggrtype:max:[scope:1,Y] // scope 1 is a max aggregator with normalised target expression Y
atom:C:[scope:1,Y] // C(Y) is an atom in scope 1
atom:B:[scope:1,Y] // B(Y) is an atom in scope 1
operator:<:[scope:1,Y,cst:num:2] // Y < 2 is a constraint in scope 1

// Scope 2, second aggregator
aggrtype:sum:[scope:2,A] // scope 2 is a sum aggregator with normalised target expression A
atom:C:[scope:2, A] // C(A)
atom:B:[scope:2, A] // B(A)
operator:>:[scope:2,A,scope:3] // A > [fourth scope], within the second aggregator

// Scope 3, inner aggregator in scope 2
aggrtype:count:[scope:3] // scope 3 is a count aggregator, with no target expression
atom:A:[scope:3,M] // A(M)
atom:C:[scope:3,M] // C(M)
```

This PR means that duplicate aggregators produced by intermediate transformations are removed, solving issue #1433. 