### PR TITLE
Rename RAM Analyses

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -355,12 +355,12 @@ souffle_sources = \
         ram/Utils.h                                        \
         ram/Visitor.h                                      \
         ram/analysis/Analysis.h                            \
-        ram/analysis/ComplexityAnalysis.cpp                \
-        ram/analysis/ComplexityAnalysis.h                  \
-        ram/analysis/IndexAnalysis.cpp                     \
-        ram/analysis/IndexAnalysis.h                       \
-        ram/analysis/LevelAnalysis.cpp                     \
-        ram/analysis/LevelAnalysis.h                       \
+        ram/analysis/Complexity.cpp                        \
+        ram/analysis/Complexity.h                          \
+        ram/analysis/Index.cpp                             \
+        ram/analysis/Index.h                               \
+        ram/analysis/Level.cpp                             \
+        ram/analysis/Level.h                               \
         ram/transform/ChoiceConversion.cpp                 \
         ram/transform/ChoiceConversion.h                   \
         ram/transform/CollapseFilters.cpp                  \

--- a/src/interpreter/InterpreterEngine.h
+++ b/src/interpreter/InterpreterEngine.h
@@ -23,7 +23,7 @@
 #include "interpreter/InterpreterNode.h"
 #include "interpreter/InterpreterRelation.h"
 #include "ram/TranslationUnit.h"
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include "souffle/RamTypes.h"
 #include "souffle/RecordTable.h"
 #include "souffle/SymbolTable.h"

--- a/src/interpreter/InterpreterGenerator.h
+++ b/src/interpreter/InterpreterGenerator.h
@@ -31,7 +31,7 @@
 #include "ram/Statement.h"
 #include "ram/Utils.h"
 #include "ram/Visitor.h"
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include "souffle/RamTypes.h"
 #include "souffle/utility/MiscUtil.h"
 #include <algorithm>

--- a/src/interpreter/InterpreterRelation.cpp
+++ b/src/interpreter/InterpreterRelation.cpp
@@ -15,7 +15,7 @@
  ***********************************************************************/
 
 #include "interpreter/InterpreterRelation.h"
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include <algorithm>
 #include <cassert>
 #include <set>

--- a/src/interpreter/InterpreterRelation.h
+++ b/src/interpreter/InterpreterRelation.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "interpreter/InterpreterIndex.h"
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include <cstddef>
 #include <cstdint>
 #include <deque>

--- a/src/ram/analysis/Complexity.cpp
+++ b/src/ram/analysis/Complexity.cpp
@@ -8,13 +8,13 @@
 
 /************************************************************************
  *
- * @file ComplexityAnalysis.cpp
+ * @file Complexity.cpp
  *
  * Implementation of RAM Complexity Analysis
  *
  ***********************************************************************/
 
-#include "ram/analysis/ComplexityAnalysis.h"
+#include "ram/analysis/Complexity.h"
 #include "ram/Condition.h"
 #include "ram/Expression.h"
 #include "ram/Node.h"

--- a/src/ram/analysis/Complexity.h
+++ b/src/ram/analysis/Complexity.h
@@ -8,7 +8,7 @@
 
 /************************************************************************
  *
- * @file ComplexityAnalysis.h
+ * @file Complexity.h
  *
  * Get the complexity of an expression/condition in terms of
  * database operations. The complexity of an expression/condition is a

--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -8,13 +8,13 @@
 
 /************************************************************************
  *
- * @file IndexAnalysis.cpp
+ * @file Index.cpp
  *
  * Computes indexes for relations in a translation unit
  *
  ***********************************************************************/
 
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include "ram/Condition.h"
 #include "ram/Expression.h"
 #include "ram/Node.h"

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -8,7 +8,7 @@
 
 /***************************************************************************
  *
- * @file IndexAnalysis.h
+ * @file Index.h
  *
  * Computes indexes for relations in a translation unit
  *
@@ -100,7 +100,7 @@ std::ostream& operator<<(std::ostream& out, const SearchSignature& signature);
  * @class MaxMatching
  * @Brief Computes a maximum matching with Hopcroft-Karp algorithm
  *
- * This class is a helper class for RamIndexAnalysis.
+ * This class is a helper class for RamIndex.
  *
  * This implements a standard maximum matching algorithm for a bi-partite graph
  * also known as a marriage problem. Given a set of edges in a bi-partite graph

--- a/src/ram/analysis/Level.cpp
+++ b/src/ram/analysis/Level.cpp
@@ -8,13 +8,13 @@
 
 /************************************************************************
  *
- * @file LevelAnalysis.cpp
+ * @file Level.cpp
  *
  * Implementation of RAM Level Analysis
  *
  ***********************************************************************/
 
-#include "ram/analysis/LevelAnalysis.h"
+#include "ram/analysis/Level.h"
 #include "ram/Condition.h"
 #include "ram/Expression.h"
 #include "ram/Node.h"

--- a/src/ram/analysis/Level.h
+++ b/src/ram/analysis/Level.h
@@ -8,7 +8,7 @@
 
 /************************************************************************
  *
- * @file LevelAnalysis.h
+ * @file Level.h
  *
  * Get level of an expression/condition. The level of a condition/expression
  * determines the outer-most scope in a loop-next of a query,  for which the

--- a/src/ram/transform/ChoiceConversion.h
+++ b/src/ram/transform/ChoiceConversion.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "ram/TranslationUnit.h"
-#include "ram/analysis/LevelAnalysis.h"
+#include "ram/analysis/Level.h"
 #include "ram/transform/Transformer.h"
 #include <memory>
 #include <string>

--- a/src/ram/transform/HoistAggregate.h
+++ b/src/ram/transform/HoistAggregate.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "ram/TranslationUnit.h"
-#include "ram/analysis/LevelAnalysis.h"
+#include "ram/analysis/Level.h"
 #include "ram/transform/Transformer.h"
 #include <string>
 

--- a/src/ram/transform/HoistConditions.h
+++ b/src/ram/transform/HoistConditions.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "ram/TranslationUnit.h"
-#include "ram/analysis/LevelAnalysis.h"
+#include "ram/analysis/Level.h"
 #include "ram/transform/Transformer.h"
 #include <string>
 

--- a/src/ram/transform/IndexedInequality.h
+++ b/src/ram/transform/IndexedInequality.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "ram/TranslationUnit.h"
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include "ram/transform/Transformer.h"
 #include <string>
 

--- a/src/ram/transform/MakeIndex.h
+++ b/src/ram/transform/MakeIndex.h
@@ -21,7 +21,7 @@
 #include "ram/Operation.h"
 #include "ram/Scan.h"
 #include "ram/TranslationUnit.h"
-#include "ram/analysis/LevelAnalysis.h"
+#include "ram/analysis/Level.h"
 #include "ram/transform/Transformer.h"
 #include <cstddef>
 #include <memory>

--- a/src/ram/transform/ReorderConditions.cpp
+++ b/src/ram/transform/ReorderConditions.cpp
@@ -20,7 +20,7 @@
 #include "ram/Statement.h"
 #include "ram/Utils.h"
 #include "ram/Visitor.h"
-#include "ram/analysis/ComplexityAnalysis.h"
+#include "ram/analysis/Complexity.h"
 #include "souffle/utility/MiscUtil.h"
 #include <algorithm>
 #include <functional>

--- a/src/ram/transform/ReorderConditions.h
+++ b/src/ram/transform/ReorderConditions.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "ram/TranslationUnit.h"
-#include "ram/analysis/ComplexityAnalysis.h"
+#include "ram/analysis/Complexity.h"
 #include "ram/transform/Transformer.h"
 #include <string>
 

--- a/src/ram/transform/ReportIndex.h
+++ b/src/ram/transform/ReportIndex.h
@@ -16,9 +16,9 @@
 
 #include "ram/Operation.h"
 #include "ram/TranslationUnit.h"
-#include "ram/analysis/ComplexityAnalysis.h"
-#include "ram/analysis/IndexAnalysis.h"
-#include "ram/analysis/LevelAnalysis.h"
+#include "ram/analysis/Complexity.h"
+#include "ram/analysis/Index.h"
+#include "ram/analysis/Level.h"
 #include "ram/transform/Transformer.h"
 #include <cstddef>
 #include <memory>

--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -29,7 +29,7 @@
 #include "ram/TranslationUnit.h"
 #include "ram/Utils.h"
 #include "ram/Visitor.h"
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include "souffle/BinaryConstraintOps.h"
 #include "souffle/RamTypes.h"
 #include "souffle/SymbolTable.h"

--- a/src/synthesiser/SynthesiserRelation.cpp
+++ b/src/synthesiser/SynthesiserRelation.cpp
@@ -9,7 +9,7 @@
 #include "synthesiser/SynthesiserRelation.h"
 #include "Global.h"
 #include "RelationTag.h"
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include "souffle/utility/StreamUtil.h"
 #include <algorithm>
 #include <cassert>

--- a/src/synthesiser/SynthesiserRelation.h
+++ b/src/synthesiser/SynthesiserRelation.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "ram/Relation.h"
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include <cstddef>
 #include <memory>
 #include <ostream>

--- a/src/tests/interpreter_relation_test.cpp
+++ b/src/tests/interpreter_relation_test.cpp
@@ -18,7 +18,7 @@
 
 #include "interpreter/InterpreterProgInterface.h"
 #include "interpreter/InterpreterRelation.h"
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include "souffle/SouffleInterface.h"
 #include "souffle/SymbolTable.h"
 #include <iosfwd>

--- a/src/tests/matching_test.cpp
+++ b/src/tests/matching_test.cpp
@@ -16,7 +16,7 @@
 
 #include "tests/test.h"
 
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include <cstddef>
 #include <cstdint>
 #include <set>

--- a/src/tests/max_matching_test.cpp
+++ b/src/tests/max_matching_test.cpp
@@ -17,7 +17,7 @@
 #include "tests/test.h"
 
 #include "ram/analysis/Analysis.h"
-#include "ram/analysis/IndexAnalysis.h"
+#include "ram/analysis/Index.h"
 #include <set>
 #include <string>
 


### PR DESCRIPTION
Trim the Analysis suffix from Analyses in the analysis directory. Relates to #462 