### PR TITLE
Packaging fixes/simplifying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,3 @@ stamp-h1
 
 utilities/bash-completion
 debian/changelog
-/man/souffle-compile.1
-/man/souffle-config.1
-/man/souffle-profile.1
-/man/souffle.1

--- a/configure.ac
+++ b/configure.ac
@@ -291,6 +291,6 @@ AC_SUBST(SOUFFLE_CXXFLAGS)
 CXXFLAGS="-Wall -Wextra $CXXFLAGS $ENV_CXXFLAGS"
 
 AC_OUTPUT(
-  [ src/souffle-compile src/souffle-config debian/changelog man/souffle.1 man/souffle-compile.1 man/souffle-config.1 man/souffle-profile.1],
+  [ src/souffle-compile src/souffle-config debian/changelog ],
   [ chmod +x src/souffle-compile src/souffle-config ]
 )

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,9 @@ AC_CONFIG_AUX_DIR([auxfiles])
 AC_PREREQ(2.68)
 AC_COPYRIGHT(['2013-15 Oracle and/or its affiliates'])
 
+DEBDATE=$(date -R)
+AC_SUBST([DEBDATE])
+
 ISODATE=$(date +%Y-%m-%d)
 AC_SUBST([ISODATE])
 

--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -1,4 +1,13 @@
 souffle (@VERSION@-1) UNRELEASED; urgency=low
+
+  * UNSTABLE WORK IN PROGRESS
+  * Enhanced MST (azreika)
+  * Restructuring for reability and maintainability (b-scholz, mmcgr)
+  * Various bugfixes
+
+ -- Martin McGrane <mmcgrane@it.usyd.edu.au>  @DEBDATE@
+
+souffle (2.0.1); urgency=low
   * Stop overmaterialising aggregate bodies (rdowavic)
   * Parallelise aggregate computation (rdowavic)
   * Add JSON IO (GaloisNeko)

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Source: souffle
-Maintainer: Kostyantyn Vorobyov <k.a.vorobyov@gmail.com>
+Maintainer: Martin McGrane <mmcgrane@it.usyd.edu.au>
 Section: misc
 Priority: optional
 Standards-Version: 4.3.0

--- a/debian/control
+++ b/debian/control
@@ -3,13 +3,13 @@ Maintainer: Kostyantyn Vorobyov <k.a.vorobyov@gmail.com>
 Section: misc
 Priority: optional
 Standards-Version: 4.3.0
-Build-Depends: autoconf, automake, bison, debhelper (>= 11), flex, g++ (>= 7), libsqlite3-dev, zlib1g-dev, libncurses5-dev, bash-completion
+Build-Depends: autoconf, automake, bash-completion, bison, debhelper (>= 11), flex, g++ (>= 7), libffi-dev, libncurses5-dev, libsqlite3-dev, mcpp, sqlite3, zlib1g-dev
 Homepage: https://souffle-lang.org/
 Vcs-Git: https://github.com/souffle-lang/souffle.git
 
 Package: souffle
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, g++ (>= 7), mcpp, zlib1g-dev, libffi-dev, libsqlite3-dev, libncurses5-dev
+Depends: ${shlibs:Depends}, ${misc:Depends}, g++ (>= 7), libffi-dev, libncurses5-dev, libsqlite3-dev, mcpp, zlib1g-dev
 Description: Translator of declarative Datalog programs into the C++ language.
  Soufflé is a translator of declarative Datalog programs into the C++ language.
  Soufflé is used as a domain-specific language for static program analysis, over

--- a/man/souffle-compile.1
+++ b/man/souffle-compile.1
@@ -1,4 +1,4 @@
-.TH SOUFFLE-COMPILE 1 @ISODATE@
+.TH SOUFFLE-COMPILE 1 2020-07-29
 
 .SH NAME
 .B souffle-compile
@@ -39,7 +39,7 @@ Enable warnings
 souffle-compile [options] <FILE>.cpp
 
 .SH VERSION
-@PACKAGE_VERSION@
+2.0.1
 
 .SH LICENSE
 Copyright (c) 2016 Oracle and/or its affiliates. All Rights reserved.

--- a/man/souffle-config.1
+++ b/man/souffle-config.1
@@ -1,4 +1,4 @@
-.TH SOUFFLE-CONFIG 1 @ISODATE@
+.TH SOUFFLE-CONFIG 1 2020-07-29
 
 .SH NAME
 .B souffle-config - short description of souffle-config
@@ -22,7 +22,7 @@ show a help page.
 list the libraries needed to compile with souffle.
 
 .SH VERSION
-@PACKAGE_VERSION@
+2.0.1
 
 .SH LICENSE
 Copyright (c) 2016 Oracle and/or its affiliates. All Rights reserved.

--- a/man/souffle-profile.1
+++ b/man/souffle-profile.1
@@ -1,4 +1,4 @@
-.TH SOUFFLE-PROFILE 1 @ISODATE@
+.TH SOUFFLE-PROFILE 1 2020-07-29
 
 .SH NAME
 .B souffle-profile 
@@ -41,7 +41,7 @@ enable profiling of a running program
 .B souffle-profile -v | -h | <log-file> [ -c <command> | -j | -l ]
 
 .SH VERSION
-@PACKAGE_VERSION@
+2.0.1
 
 .SH LICENSE
 Copyright (c) 2016 Oracle and/or its affiliates. All Rights reserved.

--- a/man/souffle.1
+++ b/man/souffle.1
@@ -1,4 +1,4 @@
-.TH SOUFFLE 1 @ISODATE@
+.TH SOUFFLE 1 2020-07-29
 
 .SH NAME
 .B souffle
@@ -115,7 +115,7 @@ souffle program.dl
 souffle -c program.dl -Ffacts -D- -j20
 
 .SH VERSION
-@PACKAGE_VERSION@
+2.0.1
 
 .SH LICENSE
 Copyright (c) 2016 Oracle and/or its affiliates. All Rights reserved.


### PR DESCRIPTION
 * Automate dates in changelog
 * Update changelog to show correct history (Added some of the changes as well, but the work in progress part is the important one for the unstable packages.)
 * Stop automating dates/versions in man pages - that incorrectly suggests the man page is updated
 * Update build dependencies - this includes test dependencies