### PR TITLE
Refactor circular dependency between AstProgram/Utils

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,6 +130,7 @@ souffle_sources = \
         ast/Node.h                                         \
         ast/NumericConstant.h                              \
         ast/Pragma.h                                       \
+        ast/Program.cpp                                    \
         ast/Program.h                                      \
         ast/ProvenanceNegation.h                           \
         ast/QualifiedName.h                                \

--- a/src/ast/Program.cpp
+++ b/src/ast/Program.cpp
@@ -1,0 +1,99 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file Program.cpp
+ *
+ * Defines the program class
+ *
+ * TODO(b-scholz): Remove ast/utility/Utils.h dependency!
+ *
+ ***********************************************************************/
+
+#include "ast/Program.h"
+#include "ast/Clause.h"
+#include "ast/Directive.h"
+#include "ast/FunctorDeclaration.h"
+#include "ast/Pragma.h"
+#include "ast/QualifiedName.h"
+#include "ast/Relation.h"
+#include "ast/Type.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include <cassert>
+#include <utility>
+#include <vector>
+
+namespace souffle {
+
+void AstProgram::addRelation(Own<AstRelation> relation) {
+    auto* existingRelation = getIf(getRelations(), [&](const AstRelation* current) {
+        return current->getQualifiedName() == relation->getQualifiedName();
+    });
+    assert(existingRelation == nullptr && "Redefinition of relation!");
+    relations.push_back(std::move(relation));
+}
+
+bool AstProgram::removeRelationDecl(const AstQualifiedName& name) {
+    for (auto it = relations.begin(); it != relations.end(); it++) {
+        const auto& rel = *it;
+        if (rel->getQualifiedName() == name) {
+            relations.erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+void AstProgram::addClause(Own<AstClause> clause) {
+    assert(clause != nullptr && "Undefined clause");
+    assert(clause->getHead() != nullptr && "Undefined head of the clause");
+    clauses.push_back(std::move(clause));
+}
+
+bool AstProgram::removeClause(const AstClause* clause) {
+    for (auto it = clauses.begin(); it != clauses.end(); it++) {
+        if (**it == *clause) {
+            clauses.erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool AstProgram::removeDirective(const AstDirective* directive) {
+    for (auto it = directives.begin(); it != directives.end(); it++) {
+        if (**it == *directive) {
+            directives.erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+void AstProgram::addType(Own<AstType> type) {
+    auto* existingType = getIf(getTypes(),
+            [&](const AstType* current) { return current->getQualifiedName() == type->getQualifiedName(); });
+    assert(existingType == nullptr && "Redefinition of type!");
+    types.push_back(std::move(type));
+}
+
+void AstProgram::addPragma(Own<AstPragma> pragma) {
+    assert(pragma && "NULL pragma");
+    pragmaDirectives.push_back(std::move(pragma));
+}
+
+void AstProgram::addFunctorDeclaration(Own<souffle::AstFunctorDeclaration> f) {
+    auto* existingFunctorDecl = getIf(getFunctorDeclarations(),
+            [&](const AstFunctorDeclaration* current) { return current->getName() == f->getName(); });
+    assert(existingFunctorDecl == nullptr && "Redefinition of functor!");
+    functors.push_back(std::move(f));
+}
+
+}  // namespace souffle

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -29,8 +29,8 @@
 #include "ast/Relation.h"
 #include "ast/Type.h"
 #include "ast/utility/NodeMapper.h"
-#include "ast/utility/Utils.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <algorithm>
 #include <cassert>
@@ -85,22 +85,10 @@ public:
     }
 
     /* Add relation */
-    void addRelation(Own<AstRelation> r) {
-        assert(getRelation(*this, r->getQualifiedName()) == nullptr && "Redefinition of relation!");
-        relations.push_back(std::move(r));
-    }
+    void addRelation(Own<AstRelation> relation);
 
     /** Remove relation */
-    bool removeRelationDecl(const AstQualifiedName& name) {
-        for (auto it = relations.begin(); it != relations.end(); it++) {
-            const auto& rel = *it;
-            if (rel->getQualifiedName() == name) {
-                relations.erase(it);
-                return true;
-            }
-        }
-        return false;
-    }
+    bool removeRelationDecl(const AstQualifiedName& name);
 
     /** Set clauses */
     void setClauses(VecOwn<AstClause> newClauses) {
@@ -108,33 +96,13 @@ public:
     }
 
     /** Add a clause */
-    void addClause(Own<AstClause> clause) {
-        assert(clause != nullptr && "Undefined clause");
-        assert(clause->getHead() != nullptr && "Undefined head of the clause");
-        clauses.push_back(std::move(clause));
-    }
+    void addClause(Own<AstClause> clause);
 
     /** Remove a clause */
-    bool removeClause(const AstClause* clause) {
-        for (auto it = clauses.begin(); it != clauses.end(); it++) {
-            if (**it == *clause) {
-                clauses.erase(it);
-                return true;
-            }
-        }
-        return false;
-    }
+    bool removeClause(const AstClause* clause);
 
     /** Remove a directive */
-    bool removeDirective(const AstDirective* directive) {
-        for (auto it = directives.begin(); it != directives.end(); it++) {
-            if (**it == *directive) {
-                directives.erase(it);
-                return true;
-            }
-        }
-        return false;
-    }
+    bool removeDirective(const AstDirective* directive);
 
     /** Return components */
     std::vector<AstComponent*> getComponents() const {
@@ -264,23 +232,11 @@ protected:
     friend class ComponentInstantiationTransformer;
     friend class ParserDriver;
 
-    /* Add type */
-    void addType(Own<AstType> type) {
-        assert(getType(*this, type->getQualifiedName()) == nullptr && "Redefinition of type!");
-        types.push_back(std::move(type));
-    }
+    void addType(Own<AstType> type);
 
-    /** Add a pragma */
-    void addPragma(Own<AstPragma> pragma) {
-        assert(pragma && "NULL pragma");
-        pragmaDirectives.push_back(std::move(pragma));
-    }
+    void addPragma(Own<AstPragma> pragma);
 
-    /** Add functor */
-    void addFunctorDeclaration(Own<souffle::AstFunctorDeclaration> f) {
-        assert(getFunctorDeclaration(*this, f->getName()) == nullptr && "Redefinition of functor!");
-        functors.push_back(std::move(f));
-    }
+    void addFunctorDeclaration(Own<souffle::AstFunctorDeclaration> functor);
 
     /** Add component */
     void addComponent(Own<AstComponent> c) {

--- a/src/ast/transform/RemoveRedundantRelations.cpp
+++ b/src/ast/transform/RemoveRedundantRelations.cpp
@@ -17,6 +17,7 @@
 #include "ast/Relation.h"
 #include "ast/TranslationUnit.h"
 #include "ast/analysis/RedundantRelations.h"
+#include "ast/utility/Utils.h"
 #include <set>
 
 namespace souffle {

--- a/src/ast/transform/UserDefinedFunctors.cpp
+++ b/src/ast/transform/UserDefinedFunctors.cpp
@@ -41,7 +41,9 @@ bool AstUserDefinedFunctorsTransformer::transform(AstTranslationUnit& translatio
 
             if (auto* userFunctor = dynamic_cast<AstUserDefinedFunctor*>(node.get())) {
                 const AstFunctorDeclaration* functorDeclaration =
-                        getFunctorDeclaration(program, userFunctor->getName());
+                        getIf(program.getFunctorDeclarations(), [&](const AstFunctorDeclaration* current) {
+                            return current->getName() == userFunctor->getName();
+                        });
 
                 // Check if the functor has been declared
                 if (functorDeclaration == nullptr) {

--- a/src/ast/utility/Utils.cpp
+++ b/src/ast/utility/Utils.cpp
@@ -94,15 +94,6 @@ AstRelation* getRelation(const AstProgram& program, const AstQualifiedName& name
     return getIf(program.getRelations(), [&](const AstRelation* r) { return r->getQualifiedName() == name; });
 }
 
-const AstType* getType(const AstProgram& program, const AstQualifiedName& name) {
-    return getIf(program.getTypes(), [&](const AstType* t) { return t->getQualifiedName() == name; });
-}
-
-const AstFunctorDeclaration* getFunctorDeclaration(const AstProgram& program, const std::string& name) {
-    return getIf(program.getFunctorDeclarations(),
-            [&](const AstFunctorDeclaration* f) { return f->getName() == name; });
-}
-
 void removeRelation(AstTranslationUnit& tu, const AstQualifiedName& name) {
     if (getRelation(*tu.getProgram(), name) != nullptr) {
         removeRelationClauses(tu, name);

--- a/src/ast/utility/Utils.h
+++ b/src/ast/utility/Utils.h
@@ -114,24 +114,6 @@ std::vector<AstClause*> getClauses(const AstProgram& program, const AstRelation&
 AstRelation* getRelation(const AstProgram& program, const AstQualifiedName& name);
 
 /**
- * Returns the type with the given name in the program.
- *
- * @param program the program
- * @param name the name of the type to search for
- * @return the type if it exists; nullptr otherwise
- */
-const AstType* getType(const AstProgram& program, const AstQualifiedName& name);
-
-/**
- * Returns the functor declaration with the given name in the program.
- *
- * @param program the program
- * @param name the name of the functor declaration to search for
- * @return the functor declaration if it exists; nullptr otherwise
- */
-const AstFunctorDeclaration* getFunctorDeclaration(const AstProgram& program, const std::string& name);
-
-/**
  * Remove relation and all its clauses from the program.
  *
  * @param tu the translation unit


### PR DESCRIPTION
`ast/utility/Utils` was used within `AstProgram` to test for uniqueness of inserted elements, by retrieving them from AstProgram. This PR removes that circular dependency, and simplifies some of the utilities for working with AstProgram lists.