### PR TITLE
Simplify travis osx gcc test that approaches timeout limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ jobs:
     <<: *osxgcc
     name: "OSX gcc non-eval"
     env:
-    - SOUFFLE_CATEGORY=Unit,Syntactic,Semantic,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
+    - SOUFFLE_CATEGORY=Unit,Interface,Profile SOUFFLE_CONFS="-j8,-c -j8"
   - stage: Testing
     name: "Linux clang non-eval"
     <<: *docker


### PR DESCRIPTION
One of the osx tests on travis routinely exceeds the travis timeout on any forks of the souffle repository. This PR removes some of the more redundant parts of the travis testing.