### PR TITLE
Add ast namespace

### DIFF
--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -31,10 +31,10 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstAggregator
+ * @class Aggregator
  * @brief Defines the aggregator class
  *
  * Example:
@@ -43,12 +43,10 @@ namespace souffle {
  * Aggregates over a sub-query using an aggregate operator
  * and an expression.
  */
-class AstAggregator : public AstArgument {
+class Aggregator : public Argument {
 public:
-    AstAggregator(AggregateOp fun, Own<AstArgument> expr = nullptr, VecOwn<AstLiteral> body = {},
-            SrcLocation loc = {})
-            : AstArgument(std::move(loc)), fun(fun), targetExpression(std::move(expr)),
-              body(std::move(body)) {}
+    Aggregator(AggregateOp fun, Own<Argument> expr = nullptr, VecOwn<Literal> body = {}, SrcLocation loc = {})
+            : Argument(std::move(loc)), fun(fun), targetExpression(std::move(expr)), body(std::move(body)) {}
 
     /** Return aggregate operator */
     AggregateOp getOperator() const {
@@ -61,22 +59,22 @@ public:
     }
 
     /** Return target expression */
-    const AstArgument* getTargetExpression() const {
+    const Argument* getTargetExpression() const {
         return targetExpression.get();
     }
 
     /** Return body literals */
-    std::vector<AstLiteral*> getBodyLiterals() const {
+    std::vector<Literal*> getBodyLiterals() const {
         return toPtrVector(body);
     }
 
     /** Set body */
-    void setBody(VecOwn<AstLiteral> bodyLiterals) {
+    void setBody(VecOwn<Literal> bodyLiterals) {
         body = std::move(bodyLiterals);
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
-        auto res = AstArgument::getChildNodes();
+    std::vector<const Node*> getChildNodes() const override {
+        auto res = Argument::getChildNodes();
         if (targetExpression) {
             res.push_back(targetExpression.get());
         }
@@ -86,11 +84,11 @@ public:
         return res;
     }
 
-    AstAggregator* clone() const override {
-        return new AstAggregator(fun, souffle::clone(targetExpression), souffle::clone(body), getSrcLoc());
+    Aggregator* clone() const override {
+        return new Aggregator(fun, souffle::clone(targetExpression), souffle::clone(body), getSrcLoc());
     }
 
-    void apply(const AstNodeMapper& map) override {
+    void apply(const NodeMapper& map) override {
         if (targetExpression) {
             targetExpression = map(std::move(targetExpression));
         }
@@ -108,8 +106,8 @@ protected:
         os << " : { " << join(body) << " }";
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstAggregator&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Aggregator&>(node);
         return fun == other.fun && equal_ptr(targetExpression, other.targetExpression) &&
                equal_targets(body, other.body);
     }
@@ -119,10 +117,10 @@ private:
     AggregateOp fun;
 
     /** Aggregate expression */
-    Own<AstArgument> targetExpression;
+    Own<Argument> targetExpression;
 
     /** Body literal of sub-query */
-    VecOwn<AstLiteral> body;
+    VecOwn<Literal> body;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/AlgebraicDataType.h
+++ b/src/ast/AlgebraicDataType.h
@@ -31,10 +31,10 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstAlgebraicDataType
+ * @class AlgebraicDataType
  * @brief Combination of types using sums and products.
  *
  * ADT combines a simpler types using product types and sum types.
@@ -46,14 +46,14 @@ namespace souffle {
  * arguments.
  *
  */
-class AstAlgebraicDataType : public AstType {
+class AlgebraicDataType : public Type {
 public:
-    AstAlgebraicDataType(AstQualifiedName name, VecOwn<AstBranchDeclaration> branches, SrcLocation loc = {})
-            : AstType(std::move(name), std::move(loc)), branches(std::move(branches)) {
+    AlgebraicDataType(QualifiedName name, VecOwn<BranchDeclaration> branches, SrcLocation loc = {})
+            : Type(std::move(name), std::move(loc)), branches(std::move(branches)) {
         assert(!this->branches.empty());
     };
 
-    std::vector<AstBranchDeclaration*> getBranches() const {
+    std::vector<BranchDeclaration*> getBranches() const {
         return toPtrVector(branches);
     }
 
@@ -61,19 +61,19 @@ public:
         os << tfm::format(".type %s = %s", getQualifiedName(), join(branches, " | "));
     }
 
-    AstAlgebraicDataType* clone() const override {
-        return new AstAlgebraicDataType(getQualifiedName(), souffle::clone(branches), getSrcLoc());
+    AlgebraicDataType* clone() const override {
+        return new AlgebraicDataType(getQualifiedName(), souffle::clone(branches), getSrcLoc());
     }
 
 protected:
-    bool equal(const AstNode& node) const override {
-        const auto& other = dynamic_cast<const AstAlgebraicDataType&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = dynamic_cast<const AlgebraicDataType&>(node);
         return getQualifiedName() == other.getQualifiedName() && branches == other.branches;
     }
 
 private:
     /** The list of branches for this sum type. */
-    VecOwn<AstBranchDeclaration> branches;
+    VecOwn<BranchDeclaration> branches;
 };
 
-}  // namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Argument.h
+++ b/src/ast/Argument.h
@@ -18,18 +18,18 @@
 
 #include "ast/Node.h"
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstArgument
+ * @class Argument
  * @brief An abstract class for arguments
  */
-class AstArgument : public AstNode {
+class Argument : public Node {
 public:
-    using AstNode::AstNode;
+    using Node::Node;
 
     /** Create clone */
-    AstArgument* clone() const override = 0;
+    Argument* clone() const override = 0;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Atom.h
+++ b/src/ast/Atom.h
@@ -32,23 +32,23 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstAtom
+ * @class Atom
  * @brief An atom class
  *
  * An atom representing the use of a relation
  * either in the head or in the body of a clause,
  * e.g., parent(x,y), !parent(x,y), ...
  */
-class AstAtom : public AstLiteral {
+class Atom : public Literal {
 public:
-    AstAtom(AstQualifiedName name = {}, VecOwn<AstArgument> args = {}, SrcLocation loc = {})
-            : AstLiteral(std::move(loc)), name(std::move(name)), arguments(std::move(args)) {}
+    Atom(QualifiedName name = {}, VecOwn<Argument> args = {}, SrcLocation loc = {})
+            : Literal(std::move(loc)), name(std::move(name)), arguments(std::move(args)) {}
 
     /** Return qualified name */
-    const AstQualifiedName& getQualifiedName() const {
+    const QualifiedName& getQualifiedName() const {
         return name;
     }
 
@@ -58,32 +58,32 @@ public:
     }
 
     /** Set qualified name */
-    void setQualifiedName(AstQualifiedName n) {
+    void setQualifiedName(QualifiedName n) {
         name = std::move(n);
     }
 
     /** Add argument to the atom */
-    void addArgument(Own<AstArgument> arg) {
+    void addArgument(Own<Argument> arg) {
         arguments.push_back(std::move(arg));
     }
 
     /** Return arguments */
-    std::vector<AstArgument*> getArguments() const {
+    std::vector<Argument*> getArguments() const {
         return toPtrVector(arguments);
     }
 
-    AstAtom* clone() const override {
-        return new AstAtom(name, souffle::clone(arguments), getSrcLoc());
+    Atom* clone() const override {
+        return new Atom(name, souffle::clone(arguments), getSrcLoc());
     }
 
-    void apply(const AstNodeMapper& map) override {
+    void apply(const NodeMapper& map) override {
         for (auto& arg : arguments) {
             arg = map(std::move(arg));
         }
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
-        std::vector<const AstNode*> res;
+    std::vector<const Node*> getChildNodes() const override {
+        std::vector<const Node*> res;
         for (auto& cur : arguments) {
             res.push_back(cur.get());
         }
@@ -95,16 +95,16 @@ protected:
         os << getQualifiedName() << "(" << join(arguments) << ")";
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstAtom&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Atom&>(node);
         return name == other.name && equal_targets(arguments, other.arguments);
     }
 
     /** Name of atom */
-    AstQualifiedName name;
+    QualifiedName name;
 
     /** Arguments of atom */
-    VecOwn<AstArgument> arguments;
+    VecOwn<Argument> arguments;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Attribute.h
+++ b/src/ast/Attribute.h
@@ -23,20 +23,20 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstAttribute
+ * @class Attribute
  * @brief Attribute class
  *
  * Example:
  *    x: number
  * An attribute consists of a name and its type name.
  */
-class AstAttribute : public AstNode {
+class Attribute : public Node {
 public:
-    AstAttribute(std::string n, AstQualifiedName t, SrcLocation loc = {})
-            : AstNode(std::move(loc)), name(std::move(n)), typeName(std::move(t)) {}
+    Attribute(std::string n, QualifiedName t, SrcLocation loc = {})
+            : Node(std::move(loc)), name(std::move(n)), typeName(std::move(t)) {}
 
     /** Return attribute name */
     const std::string& getName() const {
@@ -44,17 +44,17 @@ public:
     }
 
     /** Return type name */
-    const AstQualifiedName& getTypeName() const {
+    const QualifiedName& getTypeName() const {
         return typeName;
     }
 
     /** Set type name */
-    void setTypeName(AstQualifiedName name) {
+    void setTypeName(QualifiedName name) {
         typeName = std::move(name);
     }
 
-    AstAttribute* clone() const override {
-        return new AstAttribute(name, typeName, getSrcLoc());
+    Attribute* clone() const override {
+        return new Attribute(name, typeName, getSrcLoc());
     }
 
 protected:
@@ -62,8 +62,8 @@ protected:
         os << name << ":" << typeName;
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstAttribute&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Attribute&>(node);
         return name == other.name && typeName == other.typeName;
     }
 
@@ -72,7 +72,7 @@ private:
     std::string name;
 
     /** Type name */
-    AstQualifiedName typeName;
+    QualifiedName typeName;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/BinaryConstraint.h
+++ b/src/ast/BinaryConstraint.h
@@ -31,10 +31,10 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstBinaryConstraint
+ * @class BinaryConstraint
  * @brief Binary constraint class
  *
  * Example:
@@ -43,18 +43,18 @@ namespace souffle {
  * A binary constraint has a constraint operator, a left-hand side
  * expression, and right-hand side expression.
  */
-class AstBinaryConstraint : public AstConstraint {
+class BinaryConstraint : public Constraint {
 public:
-    AstBinaryConstraint(BinaryConstraintOp o, Own<AstArgument> ls, Own<AstArgument> rs, SrcLocation loc = {})
-            : AstConstraint(std::move(loc)), operation(o), lhs(std::move(ls)), rhs(std::move(rs)) {}
+    BinaryConstraint(BinaryConstraintOp o, Own<Argument> ls, Own<Argument> rs, SrcLocation loc = {})
+            : Constraint(std::move(loc)), operation(o), lhs(std::move(ls)), rhs(std::move(rs)) {}
 
     /** Return left-hand side argument */
-    AstArgument* getLHS() const {
+    Argument* getLHS() const {
         return lhs.get();
     }
 
     /** Return right-hand side argument */
-    AstArgument* getRHS() const {
+    Argument* getRHS() const {
         return rhs.get();
     }
 
@@ -68,16 +68,16 @@ public:
         operation = op;
     }
 
-    AstBinaryConstraint* clone() const override {
-        return new AstBinaryConstraint(operation, souffle::clone(lhs), souffle::clone(rhs), getSrcLoc());
+    BinaryConstraint* clone() const override {
+        return new BinaryConstraint(operation, souffle::clone(lhs), souffle::clone(rhs), getSrcLoc());
     }
 
-    void apply(const AstNodeMapper& map) override {
+    void apply(const NodeMapper& map) override {
         lhs = map(std::move(lhs));
         rhs = map(std::move(rhs));
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodes() const override {
         return {lhs.get(), rhs.get()};
     }
 
@@ -86,9 +86,9 @@ protected:
         os << *lhs << " " << operation << " " << *rhs;
     }
 
-    bool equal(const AstNode& node) const override {
-        assert(isA<AstBinaryConstraint>(&node));
-        const auto& other = static_cast<const AstBinaryConstraint&>(node);
+    bool equal(const Node& node) const override {
+        assert(isA<BinaryConstraint>(&node));
+        const auto& other = static_cast<const BinaryConstraint&>(node);
         return operation == other.operation && equal_ptr(lhs, other.lhs) && equal_ptr(rhs, other.rhs);
     }
 
@@ -96,10 +96,10 @@ protected:
     BinaryConstraintOp operation;
 
     /** Left-hand side argument of binary constraint */
-    Own<AstArgument> lhs;
+    Own<Argument> lhs;
 
     /** Right-hand side argument of binary constraint */
-    Own<AstArgument> rhs;
+    Own<Argument> rhs;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/BooleanConstraint.h
+++ b/src/ast/BooleanConstraint.h
@@ -24,10 +24,10 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstBooleanConstraint
+ * @class BooleanConstraint
  * @brief Boolean constraint class
  *
  * Example:
@@ -35,10 +35,10 @@ namespace souffle {
  *
  * Boolean constraint representing either the 'true' or the 'false' value
  */
-class AstBooleanConstraint : public AstConstraint {
+class BooleanConstraint : public Constraint {
 public:
-    AstBooleanConstraint(bool truthValue, SrcLocation loc = {})
-            : AstConstraint(std::move(loc)), truthValue(truthValue) {}
+    BooleanConstraint(bool truthValue, SrcLocation loc = {})
+            : Constraint(std::move(loc)), truthValue(truthValue) {}
 
     /** Check whether constraint holds */
     bool isTrue() const {
@@ -50,8 +50,8 @@ public:
         truthValue = value;
     }
 
-    AstBooleanConstraint* clone() const override {
-        return new AstBooleanConstraint(truthValue, getSrcLoc());
+    BooleanConstraint* clone() const override {
+        return new BooleanConstraint(truthValue, getSrcLoc());
     }
 
 protected:
@@ -59,9 +59,9 @@ protected:
         os << (truthValue ? "true" : "false");
     }
 
-    bool equal(const AstNode& node) const override {
-        assert(isA<AstBooleanConstraint>(&node));
-        const auto& other = static_cast<const AstBooleanConstraint&>(node);
+    bool equal(const Node& node) const override {
+        assert(isA<BooleanConstraint>(&node));
+        const auto& other = static_cast<const BooleanConstraint&>(node);
         return truthValue == other.truthValue;
     }
 
@@ -69,4 +69,4 @@ protected:
     bool truthValue;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/BranchDeclaration.h
+++ b/src/ast/BranchDeclaration.h
@@ -27,10 +27,10 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstBranchDeclaration
+ * @class BranchDeclaration
  * @brief Wrapper for the single branch declaration (product type) inside ADT declaration.
  *
  * @param constructor An entity used to create a variant type. Can be though of as a name of the branch.
@@ -39,21 +39,21 @@ namespace souffle {
  * A branch declaration corresponds to a product type and forms a part of ADT declaration.
  * Currently it's required for all the branches to have unique names.
  */
-class AstBranchDeclaration : public AstNode {
+class BranchDeclaration : public Node {
 public:
-    AstBranchDeclaration(std::string constructor, VecOwn<AstAttribute> fields, SrcLocation loc = {})
-            : AstNode(std::move(loc)), constructor(std::move(constructor)), fields(std::move(fields)){};
+    BranchDeclaration(std::string constructor, VecOwn<Attribute> fields, SrcLocation loc = {})
+            : Node(std::move(loc)), constructor(std::move(constructor)), fields(std::move(fields)){};
 
     const std::string& getConstructor() const {
         return constructor;
     }
 
-    std::vector<AstAttribute*> getFields() {
+    std::vector<Attribute*> getFields() {
         return toPtrVector(fields);
     }
 
-    AstBranchDeclaration* clone() const override {
-        return new AstBranchDeclaration(constructor, souffle::clone(fields), getSrcLoc());
+    BranchDeclaration* clone() const override {
+        return new BranchDeclaration(constructor, souffle::clone(fields), getSrcLoc());
     }
 
 protected:
@@ -63,7 +63,7 @@ protected:
 
 private:
     std::string constructor;
-    VecOwn<AstAttribute> fields;
+    VecOwn<Attribute> fields;
 };
 
-}  // namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/BranchInit.h
+++ b/src/ast/BranchInit.h
@@ -28,10 +28,10 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstBranchInit
+ * @class BranchInit
  * @brief Initialization of ADT instance.
  *
  * @param constructor An entity used to create a variant type. Can be though of as a name of the branch.
@@ -40,17 +40,17 @@ namespace souffle {
  * $Constructor(args...)
  * In case of the branch with no arguments it is simplified to $Constructor.
  */
-class AstBranchInit : public AstTerm {
+class BranchInit : public Term {
 public:
-    AstBranchInit(std::string constructor, VecOwn<AstArgument> args, SrcLocation loc = {})
-            : AstTerm(std::move(args), std::move(loc)), constructor(std::move(constructor)) {}
+    BranchInit(std::string constructor, VecOwn<Argument> args, SrcLocation loc = {})
+            : Term(std::move(args), std::move(loc)), constructor(std::move(constructor)) {}
 
     const std::string& getConstructor() const {
         return constructor;
     }
 
-    AstBranchInit* clone() const override {
-        return new AstBranchInit(constructor, souffle::clone(args), getSrcLoc());
+    BranchInit* clone() const override {
+        return new BranchInit(constructor, souffle::clone(args), getSrcLoc());
     }
 
 protected:
@@ -59,8 +59,8 @@ protected:
     }
 
     /** Implements the node comparison for this node type */
-    bool equal(const AstNode& node) const override {
-        const auto& other = dynamic_cast<const AstBranchInit&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = dynamic_cast<const BranchInit&>(node);
         return (constructor == other.constructor) && equal_targets(args, other.args);
     }
 
@@ -69,4 +69,4 @@ private:
     std::string constructor;
 };
 
-}  // namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -32,55 +32,55 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstClause
+ * @class Clause
  * @brief Intermediate representation of a horn clause
  *
  *  A clause can either be:
  *      - a fact  - a clause with no body (e.g., X(a,b))
  *      - a rule  - a clause with a head and a body (e.g., Y(a,b) -: X(a,b))
  */
-class AstClause : public AstNode {
+class Clause : public Node {
 public:
-    AstClause(Own<AstAtom> head = {}, VecOwn<AstLiteral> bodyLiterals = {}, Own<AstExecutionPlan> plan = {},
+    Clause(Own<Atom> head = {}, VecOwn<Literal> bodyLiterals = {}, Own<ExecutionPlan> plan = {},
             SrcLocation loc = {})
-            : AstNode(std::move(loc)), head(std::move(head)), bodyLiterals(std::move(bodyLiterals)),
+            : Node(std::move(loc)), head(std::move(head)), bodyLiterals(std::move(bodyLiterals)),
               plan(std::move(plan)) {}
 
     /** Add a literal to the body of the clause */
-    void addToBody(Own<AstLiteral> literal) {
+    void addToBody(Own<Literal> literal) {
         bodyLiterals.push_back(std::move(literal));
     }
 
     /** Set the head of clause to @p h */
-    void setHead(Own<AstAtom> h) {
+    void setHead(Own<Atom> h) {
         head = std::move(h);
     }
 
     /** Set the bodyLiterals of clause to @p body */
-    void setBodyLiterals(VecOwn<AstLiteral> body) {
+    void setBodyLiterals(VecOwn<Literal> body) {
         bodyLiterals = std::move(body);
     }
 
     /** Return the atom that represents the head of the clause */
-    AstAtom* getHead() const {
+    Atom* getHead() const {
         return head.get();
     }
 
     /** Obtains a copy of the internally maintained body literals */
-    std::vector<AstLiteral*> getBodyLiterals() const {
+    std::vector<Literal*> getBodyLiterals() const {
         return toPtrVector(bodyLiterals);
     }
 
     /** Obtains the execution plan associated to this clause or null if there is none */
-    const AstExecutionPlan* getExecutionPlan() const {
+    const ExecutionPlan* getExecutionPlan() const {
         return plan.get();
     }
 
     /** Updates the execution plan associated to this clause */
-    void setExecutionPlan(Own<AstExecutionPlan> plan) {
+    void setExecutionPlan(Own<ExecutionPlan> plan) {
         this->plan = std::move(plan);
     }
 
@@ -89,20 +89,20 @@ public:
         plan = nullptr;
     }
 
-    AstClause* clone() const override {
-        return new AstClause(
+    Clause* clone() const override {
+        return new Clause(
                 souffle::clone(head), souffle::clone(bodyLiterals), souffle::clone(plan), getSrcLoc());
     }
 
-    void apply(const AstNodeMapper& map) override {
+    void apply(const NodeMapper& map) override {
         head = map(std::move(head));
         for (auto& lit : bodyLiterals) {
             lit = map(std::move(lit));
         }
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
-        std::vector<const AstNode*> res = {head.get()};
+    std::vector<const Node*> getChildNodes() const override {
+        std::vector<const Node*> res = {head.get()};
         for (auto& cur : bodyLiterals) {
             res.push_back(cur.get());
         }
@@ -123,20 +123,20 @@ protected:
         }
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstClause&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Clause&>(node);
         return equal_ptr(head, other.head) && equal_targets(bodyLiterals, other.bodyLiterals) &&
                equal_ptr(plan, other.plan);
     }
 
     /** Head of the clause */
-    Own<AstAtom> head;
+    Own<Atom> head;
 
     /** Body literals of clause */
-    VecOwn<AstLiteral> bodyLiterals;
+    VecOwn<Literal> bodyLiterals;
 
     /** User defined execution plan (if not defined, plan is null) */
-    Own<AstExecutionPlan> plan;
+    Own<ExecutionPlan> plan;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -35,10 +35,10 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstComponent
+ * @class Component
  * @brief Component class
  *
  * Example:
@@ -49,90 +49,90 @@ namespace souffle {
  *
  * Component consists of type declaration, relations, rules, etc.
  */
-class AstComponent : public AstNode {
+class Component : public Node {
 public:
     /** Get component type */
-    const AstComponentType* getComponentType() const {
+    const ComponentType* getComponentType() const {
         return componentType.get();
     }
 
     /** Set component type */
-    void setComponentType(Own<AstComponentType> other) {
+    void setComponentType(Own<ComponentType> other) {
         componentType = std::move(other);
     }
 
     /** Get base components */
-    const std::vector<AstComponentType*> getBaseComponents() const {
+    const std::vector<ComponentType*> getBaseComponents() const {
         return toPtrVector(baseComponents);
     }
 
     /** Add base components */
-    void addBaseComponent(Own<AstComponentType> component) {
+    void addBaseComponent(Own<ComponentType> component) {
         baseComponents.push_back(std::move(component));
     }
 
     /** Add type */
-    void addType(Own<AstType> t) {
+    void addType(Own<Type> t) {
         types.push_back(std::move(t));
     }
 
     /** Get types */
-    std::vector<AstType*> getTypes() const {
+    std::vector<Type*> getTypes() const {
         return toPtrVector(types);
     }
 
     /** Copy base components */
-    void copyBaseComponents(const AstComponent& other) {
+    void copyBaseComponents(const Component& other) {
         baseComponents = souffle::clone(other.baseComponents);
     }
 
     /** Add relation */
-    void addRelation(Own<AstRelation> r) {
+    void addRelation(Own<Relation> r) {
         relations.push_back(std::move(r));
     }
 
     /** Get relations */
-    std::vector<AstRelation*> getRelations() const {
+    std::vector<Relation*> getRelations() const {
         return toPtrVector(relations);
     }
 
     /** Add clause */
-    void addClause(Own<AstClause> c) {
+    void addClause(Own<Clause> c) {
         clauses.push_back(std::move(c));
     }
 
     /** Get clauses */
-    std::vector<AstClause*> getClauses() const {
+    std::vector<Clause*> getClauses() const {
         return toPtrVector(clauses);
     }
 
     /** Add directive */
-    void addDirective(Own<AstDirective> directive) {
+    void addDirective(Own<Directive> directive) {
         directives.push_back(std::move(directive));
     }
 
     /** Get directive statements */
-    std::vector<AstDirective*> getDirectives() const {
+    std::vector<Directive*> getDirectives() const {
         return toPtrVector(directives);
     }
 
     /** Add components */
-    void addComponent(Own<AstComponent> c) {
+    void addComponent(Own<Component> c) {
         components.push_back(std::move(c));
     }
 
     /** Get components */
-    std::vector<AstComponent*> getComponents() const {
+    std::vector<Component*> getComponents() const {
         return toPtrVector(components);
     }
 
     /** Add instantiation */
-    void addInstantiation(Own<AstComponentInit> i) {
+    void addInstantiation(Own<ComponentInit> i) {
         instantiations.push_back(std::move(i));
     }
 
     /** Get instantiation */
-    std::vector<AstComponentInit*> getInstantiations() const {
+    std::vector<ComponentInit*> getInstantiations() const {
         return toPtrVector(instantiations);
     }
 
@@ -146,8 +146,8 @@ public:
         return overrideRules;
     }
 
-    AstComponent* clone() const override {
-        auto* res = new AstComponent();
+    Component* clone() const override {
+        auto* res = new Component();
         res->componentType = souffle::clone(componentType);
         res->baseComponents = souffle::clone(baseComponents);
         res->components = souffle::clone(components);
@@ -160,7 +160,7 @@ public:
         return res;
     }
 
-    void apply(const AstNodeMapper& mapper) override {
+    void apply(const NodeMapper& mapper) override {
         componentType = mapper(std::move(componentType));
         for (auto& cur : baseComponents) {
             cur = mapper(std::move(cur));
@@ -185,8 +185,8 @@ public:
         }
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
-        std::vector<const AstNode*> res;
+    std::vector<const Node*> getChildNodes() const override {
+        std::vector<const Node*> res;
 
         res.push_back(componentType.get());
         for (const auto& cur : baseComponents) {
@@ -233,8 +233,8 @@ protected:
         os << "}\n";
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstComponent&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Component&>(node);
 
         if (equal_ptr(componentType, other.componentType)) {
             return true;
@@ -267,31 +267,31 @@ protected:
     }
 
     /** Name of component and its formal component arguments. */
-    Own<AstComponentType> componentType;
+    Own<ComponentType> componentType;
 
     /** Base components of component */
-    VecOwn<AstComponentType> baseComponents;
+    VecOwn<ComponentType> baseComponents;
 
     /** Types declarations */
-    VecOwn<AstType> types;
+    VecOwn<Type> types;
 
     /** Relations */
-    VecOwn<AstRelation> relations;
+    VecOwn<Relation> relations;
 
     /** Clauses */
-    VecOwn<AstClause> clauses;
+    VecOwn<Clause> clauses;
 
     /** I/O directives */
-    VecOwn<AstDirective> directives;
+    VecOwn<Directive> directives;
 
     /** Nested components */
-    VecOwn<AstComponent> components;
+    VecOwn<Component> components;
 
     /** Nested component instantiations. */
-    VecOwn<AstComponentInit> instantiations;
+    VecOwn<ComponentInit> instantiations;
 
     /** Clauses of relations that are overwritten by this component */
     std::set<std::string> overrideRules;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/ComponentInit.h
+++ b/src/ast/ComponentInit.h
@@ -27,10 +27,10 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstComponentInit
+ * @class ComponentInit
  * @brief Component initialization class
  *
  * Example:
@@ -38,10 +38,10 @@ namespace souffle {
  *
  * Intialization of a component with type parameters
  */
-class AstComponentInit : public AstNode {
+class ComponentInit : public Node {
 public:
-    AstComponentInit(std::string name, Own<AstComponentType> type, SrcLocation loc = {})
-            : AstNode(std::move(loc)), instanceName(std::move(name)), componentType(std::move(type)) {}
+    ComponentInit(std::string name, Own<ComponentType> type, SrcLocation loc = {})
+            : Node(std::move(loc)), instanceName(std::move(name)), componentType(std::move(type)) {}
 
     /** Return instance name */
     const std::string& getInstanceName() const {
@@ -54,24 +54,24 @@ public:
     }
 
     /** Return component type */
-    const AstComponentType* getComponentType() const {
+    const ComponentType* getComponentType() const {
         return componentType.get();
     }
 
     /** Set component type */
-    void setComponentType(Own<AstComponentType> type) {
+    void setComponentType(Own<ComponentType> type) {
         componentType = std::move(type);
     }
 
-    AstComponentInit* clone() const override {
-        return new AstComponentInit(instanceName, souffle::clone(componentType), getSrcLoc());
+    ComponentInit* clone() const override {
+        return new ComponentInit(instanceName, souffle::clone(componentType), getSrcLoc());
     }
 
-    void apply(const AstNodeMapper& mapper) override {
+    void apply(const NodeMapper& mapper) override {
         componentType = mapper(std::move(componentType));
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodes() const override {
         return {componentType.get()};
     }
 
@@ -80,8 +80,8 @@ protected:
         os << ".init " << instanceName << " = " << *componentType;
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstComponentInit&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const ComponentInit&>(node);
         return instanceName == other.instanceName && *componentType == *other.componentType;
     }
 
@@ -89,7 +89,7 @@ protected:
     std::string instanceName;
 
     /** Actual component arguments for instantiation */
-    Own<AstComponentType> componentType;
+    Own<ComponentType> componentType;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/ComponentType.h
+++ b/src/ast/ComponentType.h
@@ -25,10 +25,10 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstComponentType
+ * @class ComponentType
  * @brief Component type of a component
  *
  * Example:
@@ -36,10 +36,10 @@ namespace souffle {
  * where name is the component name and < Type, Type, ... > is a
  * list of component type parameters (either actual or formal).
  */
-class AstComponentType : public AstNode {
+class ComponentType : public Node {
 public:
-    AstComponentType(std::string name = "", std::vector<AstQualifiedName> params = {}, SrcLocation loc = {})
-            : AstNode(std::move(loc)), name(std::move(name)), typeParams(std::move(params)) {}
+    ComponentType(std::string name = "", std::vector<QualifiedName> params = {}, SrcLocation loc = {})
+            : Node(std::move(loc)), name(std::move(name)), typeParams(std::move(params)) {}
 
     /** Return component name */
     const std::string& getName() const {
@@ -52,17 +52,17 @@ public:
     }
 
     /** Return component type parameters */
-    const std::vector<AstQualifiedName>& getTypeParameters() const {
+    const std::vector<QualifiedName>& getTypeParameters() const {
         return typeParams;
     }
 
     /** Set component type parameters */
-    void setTypeParameters(const std::vector<AstQualifiedName>& params) {
+    void setTypeParameters(const std::vector<QualifiedName>& params) {
         typeParams = params;
     }
 
-    AstComponentType* clone() const override {
-        return new AstComponentType(name, typeParams, getSrcLoc());
+    ComponentType* clone() const override {
+        return new ComponentType(name, typeParams, getSrcLoc());
     }
 
 protected:
@@ -73,8 +73,8 @@ protected:
         }
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstComponentType&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const ComponentType&>(node);
         return name == other.name && typeParams == other.typeParams;
     }
 
@@ -83,7 +83,7 @@ private:
     std::string name;
 
     /** Component type parameters */
-    std::vector<AstQualifiedName> typeParams;
+    std::vector<QualifiedName> typeParams;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Constant.h
+++ b/src/ast/Constant.h
@@ -23,15 +23,15 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstConstant
+ * @class Constant
  * @brief Abstract constant class
  */
-class AstConstant : public AstArgument {
+class Constant : public Argument {
 public:
-    AstConstant* clone() const override = 0;
+    Constant* clone() const override = 0;
 
     /** Get string representation of Constant */
     const std::string& getConstant() const {
@@ -43,17 +43,17 @@ protected:
         os << getConstant();
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstConstant&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Constant&>(node);
         return constant == other.constant;
     }
 
-    AstConstant(std::string value, SrcLocation loc = {})
-            : AstArgument(std::move(loc)), constant(std::move(value)){};
+    Constant(std::string value, SrcLocation loc = {})
+            : Argument(std::move(loc)), constant(std::move(value)){};
 
 private:
     /** String representation of constant */
     const std::string constant;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Constraint.h
+++ b/src/ast/Constraint.h
@@ -18,17 +18,17 @@
 
 #include "ast/Literal.h"
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstConstraint
+ * @class Constraint
  * @brief Abstract class for AST constraints
  */
-class AstConstraint : public AstLiteral {
+class Constraint : public Literal {
 public:
-    using AstLiteral::AstLiteral;
+    using Literal::Literal;
 
-    AstConstraint* clone() const override = 0;
+    Constraint* clone() const override = 0;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Counter.h
+++ b/src/ast/Counter.h
@@ -19,18 +19,18 @@
 #include "ast/Argument.h"
 #include <ostream>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstCounter
+ * @class Counter
  * @brief counter functor (incrementing a value after each invocation)
  */
-class AstCounter : public AstArgument {
+class Counter : public Argument {
 public:
-    using AstArgument::AstArgument;
+    using Argument::Argument;
 
-    AstCounter* clone() const override {
-        return new AstCounter(getSrcLoc());
+    Counter* clone() const override {
+        return new Counter(getSrcLoc());
     }
 
 protected:
@@ -39,4 +39,4 @@ protected:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Directive.h
+++ b/src/ast/Directive.h
@@ -26,49 +26,49 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
-enum class AstDirectiveType { input, output, printsize, limitsize };
+enum class DirectiveType { input, output, printsize, limitsize };
 
 // FIXME: I'm going crazy defining these. There has to be a library that does this boilerplate for us.
-inline std::ostream& operator<<(std::ostream& os, AstDirectiveType e) {
+inline std::ostream& operator<<(std::ostream& os, DirectiveType e) {
     switch (e) {
-        case AstDirectiveType::input: return os << "input";
-        case AstDirectiveType::output: return os << "output";
-        case AstDirectiveType::printsize: return os << "printsize";
-        case AstDirectiveType::limitsize: return os << "limitsize";
+        case DirectiveType::input: return os << "input";
+        case DirectiveType::output: return os << "output";
+        case DirectiveType::printsize: return os << "printsize";
+        case DirectiveType::limitsize: return os << "limitsize";
     }
 
     UNREACHABLE_BAD_CASE_ANALYSIS
 }
 
 /**
- * @class AstDirective
+ * @class Directive
  * @brief a directive has a type (e.g. input/output/printsize/limitsize), qualified relation name, and a key
  * value map for storing parameters of the directive.
  */
-class AstDirective : public AstNode {
+class Directive : public Node {
 public:
-    AstDirective(AstDirectiveType type, AstQualifiedName name, SrcLocation loc = {})
-            : AstNode(std::move(loc)), type(type), name(std::move(name)) {}
+    Directive(DirectiveType type, QualifiedName name, SrcLocation loc = {})
+            : Node(std::move(loc)), type(type), name(std::move(name)) {}
 
     /** Get directive type */
-    AstDirectiveType getType() const {
+    DirectiveType getType() const {
         return type;
     }
 
     /** Set directive  type */
-    void setType(AstDirectiveType type) {
+    void setType(DirectiveType type) {
         this->type = type;
     }
 
     /** Get relation name */
-    const AstQualifiedName& getQualifiedName() const {
+    const QualifiedName& getQualifiedName() const {
         return name;
     }
 
     /** Set relation name */
-    void setQualifiedName(AstQualifiedName name) {
+    void setQualifiedName(QualifiedName name) {
         this->name = std::move(name);
     }
 
@@ -92,8 +92,8 @@ public:
         return directives;
     }
 
-    AstDirective* clone() const override {
-        auto res = new AstDirective(type, name, getSrcLoc());
+    Directive* clone() const override {
+        auto res = new Directive(type, name, getSrcLoc());
         res->directives = directives;
         return res;
     }
@@ -108,19 +108,19 @@ protected:
         }
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstDirective&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Directive&>(node);
         return other.type == type && other.name == name && other.directives == directives;
     }
 
     /** Type of directive */
-    AstDirectiveType type;
+    DirectiveType type;
 
     /** Relation name of the directive */
-    AstQualifiedName name;
+    QualifiedName name;
 
     /** Parameters of directive */
     std::map<std::string, std::string> directives;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/ExecutionOrder.h
+++ b/src/ast/ExecutionOrder.h
@@ -24,18 +24,18 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstExecutionOrder
+ * @class ExecutionOrder
  * @brief An execution order for atoms within a clause;
  *        one or more execution orders form a plan.
  */
-class AstExecutionOrder : public AstNode {
+class ExecutionOrder : public Node {
 public:
     using ExecOrder = std::vector<unsigned int>;
 
-    AstExecutionOrder(ExecOrder order = {}, SrcLocation loc = {}) : order(std::move(order)) {
+    ExecutionOrder(ExecOrder order = {}, SrcLocation loc = {}) : order(std::move(order)) {
         setSrcLoc(std::move(loc));
     }
 
@@ -44,8 +44,8 @@ public:
         return order;
     }
 
-    AstExecutionOrder* clone() const override {
-        return new AstExecutionOrder(order, getSrcLoc());
+    ExecutionOrder* clone() const override {
+        return new ExecutionOrder(order, getSrcLoc());
     }
 
 protected:
@@ -53,8 +53,8 @@ protected:
         out << "(" << join(order) << ")";
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstExecutionOrder&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const ExecutionOrder&>(node);
         return order == other.order;
     }
 
@@ -63,4 +63,4 @@ private:
     ExecOrder order;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -28,10 +28,10 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @brief AstExecutionPlan
+ * @brief ExecutionPlan
  * @class Defines a user-defined execution plan for a clause.
  *
  * An user-defined execution plan consists of one or more
@@ -42,39 +42,39 @@ namespace souffle {
  *   .plan 0:(1,2,3), 2:(3,2,1)
  *
  */
-class AstExecutionPlan : public AstNode {
+class ExecutionPlan : public Node {
 public:
     /** Set execution order for a given rule version */
-    void setOrderFor(int version, Own<AstExecutionOrder> plan) {
+    void setOrderFor(int version, Own<ExecutionOrder> plan) {
         plans[version] = std::move(plan);
     }
 
     /** Get orders */
-    std::map<int, const AstExecutionOrder*> getOrders() const {
-        std::map<int, const AstExecutionOrder*> result;
+    std::map<int, const ExecutionOrder*> getOrders() const {
+        std::map<int, const ExecutionOrder*> result;
         for (auto& plan : plans) {
             result.insert(std::make_pair(plan.first, plan.second.get()));
         }
         return result;
     }
 
-    AstExecutionPlan* clone() const override {
-        auto res = new AstExecutionPlan();
+    ExecutionPlan* clone() const override {
+        auto res = new ExecutionPlan();
         res->setSrcLoc(getSrcLoc());
         for (auto& plan : plans) {
-            res->setOrderFor(plan.first, Own<AstExecutionOrder>(plan.second->clone()));
+            res->setOrderFor(plan.first, Own<ExecutionOrder>(plan.second->clone()));
         }
         return res;
     }
 
-    void apply(const AstNodeMapper& map) override {
+    void apply(const NodeMapper& map) override {
         for (auto& plan : plans) {
             plan.second = map(std::move(plan.second));
         }
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
-        std::vector<const AstNode*> childNodes;
+    std::vector<const Node*> getChildNodes() const override {
+        std::vector<const Node*> childNodes;
         for (auto& plan : plans) {
             childNodes.push_back(plan.second.get());
         }
@@ -90,14 +90,14 @@ protected:
         }
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstExecutionPlan&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const ExecutionPlan&>(node);
         return equal_targets(plans, other.plans);
     }
 
 private:
     /** Mapping versions of clauses to execution orders */
-    std::map<int, Own<AstExecutionOrder>> plans;
+    std::map<int, Own<ExecutionOrder>> plans;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Functor.h
+++ b/src/ast/Functor.h
@@ -20,14 +20,14 @@
 #include "souffle/TypeAttribute.h"
 #include <cstddef>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstFunctor
+ * @class Functor
  * @brief Abstract functor class
  */
 
-class AstFunctor : public AstTerm {
+class Functor : public Term {
 public:
     /** Return return type of functor */
     virtual TypeAttribute getReturnType() const = 0;
@@ -35,10 +35,10 @@ public:
     /** Return argument type of functor */
     virtual TypeAttribute getArgType(const size_t arg) const = 0;
 
-    AstFunctor* clone() const override = 0;
+    Functor* clone() const override = 0;
 
 protected:
-    using AstTerm::AstTerm;
+    using Term::Term;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/FunctorDeclaration.h
+++ b/src/ast/FunctorDeclaration.h
@@ -30,21 +30,21 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstFunctorDeclaration
+ * @class FunctorDeclaration
  * @brief User-defined functor declaration
  *
  * Example:
  *    .declfun foo(x:number, y:number):number
  */
 
-class AstFunctorDeclaration : public AstNode {
+class FunctorDeclaration : public Node {
 public:
-    AstFunctorDeclaration(std::string name, std::vector<TypeAttribute> argsTypes, TypeAttribute returnType,
+    FunctorDeclaration(std::string name, std::vector<TypeAttribute> argsTypes, TypeAttribute returnType,
             bool stateful, SrcLocation loc = {})
-            : AstNode(std::move(loc)), name(std::move(name)), argsTypes(std::move(argsTypes)),
+            : Node(std::move(loc)), name(std::move(name)), argsTypes(std::move(argsTypes)),
               returnType(returnType), stateful(stateful) {
         assert(this->name.length() > 0 && "functor name is empty");
     }
@@ -74,8 +74,8 @@ public:
         return stateful;
     }
 
-    AstFunctorDeclaration* clone() const override {
-        return new AstFunctorDeclaration(name, argsTypes, returnType, stateful, getSrcLoc());
+    FunctorDeclaration* clone() const override {
+        return new FunctorDeclaration(name, argsTypes, returnType, stateful, getSrcLoc());
     }
 
 protected:
@@ -100,8 +100,8 @@ protected:
         out << std::endl;
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstFunctorDeclaration&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const FunctorDeclaration&>(node);
         return name == other.name && argsTypes == other.argsTypes && returnType == other.returnType &&
                stateful == other.stateful;
     }
@@ -119,4 +119,4 @@ protected:
     const bool stateful;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/IntrinsicFunctor.h
+++ b/src/ast/IntrinsicFunctor.h
@@ -31,24 +31,24 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstIntrinsicFunctor
+ * @class IntrinsicFunctor
  * @brief Intrinsic Functor class for functors are in-built.
  */
-class AstIntrinsicFunctor : public AstFunctor {
+class IntrinsicFunctor : public Functor {
 public:
     template <typename... Operands>
-    AstIntrinsicFunctor(std::string op, Operands&&... operands)
-            : AstFunctor(std::forward<Operands>(operands)...), function(std::move(op)) {}
+    IntrinsicFunctor(std::string op, Operands&&... operands)
+            : Functor(std::forward<Operands>(operands)...), function(std::move(op)) {}
 
     template <typename... Operands>
-    AstIntrinsicFunctor(SrcLocation loc, std::string op, Operands&&... operands)
-            : AstFunctor(std::move(loc), std::forward<Operands>(operands)...), function(std::move(op)) {}
+    IntrinsicFunctor(SrcLocation loc, std::string op, Operands&&... operands)
+            : Functor(std::move(loc), std::forward<Operands>(operands)...), function(std::move(op)) {}
 
-    AstIntrinsicFunctor(std::string op, VecOwn<AstArgument> args, SrcLocation loc = {})
-            : AstFunctor(std::move(args), std::move(loc)), function(std::move(op)) {}
+    IntrinsicFunctor(std::string op, VecOwn<Argument> args, SrcLocation loc = {})
+            : Functor(std::move(args), std::move(loc)), function(std::move(op)) {}
 
     /** Get function */
     const std::string& getFunction() const {
@@ -61,12 +61,12 @@ public:
     }
 
     /** Get function information */
-    const IntrinsicFunctor* getFunctionInfo() const {
+    const souffle::IntrinsicFunctor* getFunctionInfo() const {
         return info;
     }
 
     /** Set function information */
-    void setFunctionInfo(const IntrinsicFunctor& info) {
+    void setFunctionInfo(const souffle::IntrinsicFunctor& info) {
         this->info = &info;
     }
 
@@ -82,14 +82,14 @@ public:
         return info->params.at(info->variadic ? 0 : arg);
     }
 
-    AstIntrinsicFunctor* clone() const override {
-        return new AstIntrinsicFunctor(function, info, souffle::clone(args), getSrcLoc());
+    IntrinsicFunctor* clone() const override {
+        return new IntrinsicFunctor(function, info, souffle::clone(args), getSrcLoc());
     }
 
 protected:
-    AstIntrinsicFunctor(
-            std::string op, const IntrinsicFunctor* info, VecOwn<AstArgument> args, SrcLocation loc = {})
-            : AstFunctor(std::move(args), std::move(loc)), function(std::move(op)), info(info) {
+    IntrinsicFunctor(std::string op, const souffle::IntrinsicFunctor* info, VecOwn<Argument> args,
+            SrcLocation loc = {})
+            : Functor(std::move(args), std::move(loc)), function(std::move(op)), info(info) {
         assert((!info || info->symbol == function) && "functor info must match symbol");
     }
 
@@ -102,16 +102,16 @@ protected:
         }
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstIntrinsicFunctor&>(node);
-        return function == other.function && info == other.info && AstFunctor::equal(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const IntrinsicFunctor&>(node);
+        return function == other.function && info == other.info && Functor::equal(node);
     }
 
     /** Function */
     std::string function;
 
     /** Functor information */
-    const IntrinsicFunctor* info = nullptr;
+    const souffle::IntrinsicFunctor* info = nullptr;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Literal.h
+++ b/src/ast/Literal.h
@@ -18,20 +18,20 @@
 
 #include "ast/Node.h"
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstLiteral
+ * @class Literal
  * @brief Defines an abstract class for literals in a horn clause.
  *
  * Literals can be atoms, binary relations, and negated atoms
  * in the body and head of a clause.
  */
-class AstLiteral : public AstNode {
+class Literal : public Node {
 public:
-    using AstNode::AstNode;
+    using Node::Node;
 
-    AstLiteral* clone() const override = 0;
+    Literal* clone() const override = 0;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Negation.h
+++ b/src/ast/Negation.h
@@ -30,10 +30,10 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstNegation
+ * @class Negation
  * @brief Negation of an atom negated atom
  *
  * Example:
@@ -41,25 +41,24 @@ namespace souffle {
  *
  * A negated atom can only occur in the body of a clause.
  */
-class AstNegation : public AstLiteral {
+class Negation : public Literal {
 public:
-    AstNegation(Own<AstAtom> atom, SrcLocation loc = {})
-            : AstLiteral(std::move(loc)), atom(std::move(atom)) {}
+    Negation(Own<Atom> atom, SrcLocation loc = {}) : Literal(std::move(loc)), atom(std::move(atom)) {}
 
     /** Get negated atom */
-    AstAtom* getAtom() const {
+    Atom* getAtom() const {
         return atom.get();
     }
 
-    AstNegation* clone() const override {
-        return new AstNegation(souffle::clone(atom), getSrcLoc());
+    Negation* clone() const override {
+        return new Negation(souffle::clone(atom), getSrcLoc());
     }
 
-    void apply(const AstNodeMapper& map) override {
+    void apply(const NodeMapper& map) override {
         atom = map(std::move(atom));
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodes() const override {
         return {atom.get()};
     }
 
@@ -68,14 +67,14 @@ protected:
         os << "!" << *atom;
     }
 
-    bool equal(const AstNode& node) const override {
-        assert(isA<AstNegation>(&node));
-        const auto& other = static_cast<const AstNegation&>(node);
+    bool equal(const Node& node) const override {
+        assert(isA<Negation>(&node));
+        const auto& other = static_cast<const Negation&>(node);
         return equal_ptr(atom, other.atom);
     }
 
     /** Negated atom */
-    Own<AstAtom> atom;
+    Own<Atom> atom;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/NilConstant.h
+++ b/src/ast/NilConstant.h
@@ -21,19 +21,19 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstNilConstant
+ * @class NilConstant
  * @brief Defines the nil constant
  */
-class AstNilConstant : public AstConstant {
+class NilConstant : public Constant {
 public:
-    AstNilConstant(SrcLocation loc = {}) : AstConstant("nil", std::move(loc)) {}
+    NilConstant(SrcLocation loc = {}) : Constant("nil", std::move(loc)) {}
 
-    AstNilConstant* clone() const override {
-        return new AstNilConstant(getSrcLoc());
+    NilConstant* clone() const override {
+        return new NilConstant(getSrcLoc());
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Node.h
+++ b/src/ast/Node.h
@@ -23,25 +23,25 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
-class AstNodeMapper;
+class NodeMapper;
 
 /**
- *  @class AstNode
+ *  @class Node
  *  @brief Abstract class for syntactic elements in an input program.
  */
-class AstNode {
+class Node {
 public:
-    AstNode(SrcLocation loc = {}) : location(std::move(loc)){};
-    virtual ~AstNode() = default;
+    Node(SrcLocation loc = {}) : location(std::move(loc)){};
+    virtual ~Node() = default;
 
-    /** Return source location of the AstNode */
+    /** Return source location of the Node */
     const SrcLocation& getSrcLoc() const {
         return location;
     }
 
-    /** Set source location for the AstNode */
+    /** Set source location for the Node */
     void setSrcLoc(SrcLocation l) {
         location = std::move(l);
     }
@@ -52,7 +52,7 @@ public:
     }
 
     /** Equivalence check for two AST nodes */
-    bool operator==(const AstNode& other) const {
+    bool operator==(const Node& other) const {
         if (this == &other) {
             return true;
         } else if (typeid(*this) == typeid(*&other)) {
@@ -62,23 +62,23 @@ public:
     }
 
     /** Inequality check for two AST nodes */
-    bool operator!=(const AstNode& other) const {
+    bool operator!=(const Node& other) const {
         return !(*this == other);
     }
 
     /** Create a clone (i.e. deep copy) of this node */
-    virtual AstNode* clone() const = 0;
+    virtual Node* clone() const = 0;
 
     /** Apply the mapper to all child nodes */
-    virtual void apply(const AstNodeMapper& /* mapper */) {}
+    virtual void apply(const NodeMapper& /* mapper */) {}
 
     /** Obtain a list of all embedded AST child nodes */
-    virtual std::vector<const AstNode*> getChildNodes() const {
+    virtual std::vector<const Node*> getChildNodes() const {
         return {};
     }
 
     /** Print node onto an output stream */
-    friend std::ostream& operator<<(std::ostream& out, const AstNode& node) {
+    friend std::ostream& operator<<(std::ostream& out, const Node& node) {
         node.print(out);
         return out;
     }
@@ -88,7 +88,7 @@ protected:
     virtual void print(std::ostream& os) const = 0;
 
     /** Abstract equality check for two AST nodes */
-    virtual bool equal(const AstNode& /* other */) const {
+    virtual bool equal(const Node& /* other */) const {
         return true;
     }
 
@@ -97,4 +97,4 @@ private:
     SrcLocation location;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/NumericConstant.h
+++ b/src/ast/NumericConstant.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
  * Numeric Constant
@@ -33,23 +33,23 @@ namespace souffle {
  * If this is the case, the typesystem will be forced to use it.
  * Otherwise the type is inferred from context.
  */
-class AstNumericConstant : public AstConstant {
+class NumericConstant : public Constant {
 public:
     enum class Type { Int, Uint, Float };
 
-    AstNumericConstant(RamSigned value) : AstConstant(std::to_string(value)), type(Type::Int) {}
+    NumericConstant(RamSigned value) : Constant(std::to_string(value)), type(Type::Int) {}
 
-    AstNumericConstant(std::string constant, SrcLocation loc) : AstConstant(std::move(constant)) {
+    NumericConstant(std::string constant, SrcLocation loc) : Constant(std::move(constant)) {
         setSrcLoc(std::move(loc));
     }
 
-    AstNumericConstant(std::string constant, std::optional<Type> type = std::nullopt, SrcLocation loc = {})
-            : AstConstant(std::move(constant)), type(type) {
+    NumericConstant(std::string constant, std::optional<Type> type = std::nullopt, SrcLocation loc = {})
+            : Constant(std::move(constant)), type(type) {
         setSrcLoc(std::move(loc));
     }
 
-    AstNumericConstant* clone() const override {
-        auto* copy = new AstNumericConstant(getConstant(), getType());
+    NumericConstant* clone() const override {
+        auto* copy = new NumericConstant(getConstant(), getType());
         copy->setSrcLoc(getSrcLoc());
         return copy;
     }
@@ -63,13 +63,13 @@ public:
     }
 
 protected:
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstNumericConstant&>(node);
-        return AstConstant::equal(node) && type == other.type;
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const NumericConstant&>(node);
+        return Constant::equal(node) && type == other.type;
     }
 
 private:
     std::optional<Type> type;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Pragma.h
+++ b/src/ast/Pragma.h
@@ -22,19 +22,19 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstPragma
+ * @class Pragma
  * @brief Representation of a global option
  */
-class AstPragma : public AstNode {
+class Pragma : public Node {
 public:
-    AstPragma(std::string key, std::string value, SrcLocation loc = {})
-            : AstNode(std::move(loc)), key(std::move(key)), value(std::move(value)) {}
+    Pragma(std::string key, std::string value, SrcLocation loc = {})
+            : Node(std::move(loc)), key(std::move(key)), value(std::move(value)) {}
 
-    AstPragma* clone() const override {
-        return new AstPragma(key, value, getSrcLoc());
+    Pragma* clone() const override {
+        return new Pragma(key, value, getSrcLoc());
     }
 
     /* Get kvp */
@@ -47,8 +47,8 @@ protected:
         os << ".pragma " << key << " " << value << "\n";
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstPragma&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Pragma&>(node);
         return other.key == key && other.value == value;
     }
 
@@ -59,4 +59,4 @@ protected:
     std::string value;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Program.cpp
+++ b/src/ast/Program.cpp
@@ -30,17 +30,17 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
-void AstProgram::addRelation(Own<AstRelation> relation) {
-    auto* existingRelation = getIf(getRelations(), [&](const AstRelation* current) {
+void Program::addRelation(Own<Relation> relation) {
+    auto* existingRelation = getIf(getRelations(), [&](const Relation* current) {
         return current->getQualifiedName() == relation->getQualifiedName();
     });
     assert(existingRelation == nullptr && "Redefinition of relation!");
     relations.push_back(std::move(relation));
 }
 
-bool AstProgram::removeRelationDecl(const AstQualifiedName& name) {
+bool Program::removeRelationDecl(const QualifiedName& name) {
     for (auto it = relations.begin(); it != relations.end(); it++) {
         const auto& rel = *it;
         if (rel->getQualifiedName() == name) {
@@ -51,13 +51,13 @@ bool AstProgram::removeRelationDecl(const AstQualifiedName& name) {
     return false;
 }
 
-void AstProgram::addClause(Own<AstClause> clause) {
+void Program::addClause(Own<Clause> clause) {
     assert(clause != nullptr && "Undefined clause");
     assert(clause->getHead() != nullptr && "Undefined head of the clause");
     clauses.push_back(std::move(clause));
 }
 
-bool AstProgram::removeClause(const AstClause* clause) {
+bool Program::removeClause(const Clause* clause) {
     for (auto it = clauses.begin(); it != clauses.end(); it++) {
         if (**it == *clause) {
             clauses.erase(it);
@@ -67,7 +67,7 @@ bool AstProgram::removeClause(const AstClause* clause) {
     return false;
 }
 
-bool AstProgram::removeDirective(const AstDirective* directive) {
+bool Program::removeDirective(const Directive* directive) {
     for (auto it = directives.begin(); it != directives.end(); it++) {
         if (**it == *directive) {
             directives.erase(it);
@@ -77,23 +77,23 @@ bool AstProgram::removeDirective(const AstDirective* directive) {
     return false;
 }
 
-void AstProgram::addType(Own<AstType> type) {
+void Program::addType(Own<Type> type) {
     auto* existingType = getIf(getTypes(),
-            [&](const AstType* current) { return current->getQualifiedName() == type->getQualifiedName(); });
+            [&](const Type* current) { return current->getQualifiedName() == type->getQualifiedName(); });
     assert(existingType == nullptr && "Redefinition of type!");
     types.push_back(std::move(type));
 }
 
-void AstProgram::addPragma(Own<AstPragma> pragma) {
+void Program::addPragma(Own<Pragma> pragma) {
     assert(pragma && "NULL pragma");
     pragmas.push_back(std::move(pragma));
 }
 
-void AstProgram::addFunctorDeclaration(Own<souffle::AstFunctorDeclaration> f) {
+void Program::addFunctorDeclaration(Own<FunctorDeclaration> f) {
     auto* existingFunctorDecl = getIf(getFunctorDeclarations(),
-            [&](const AstFunctorDeclaration* current) { return current->getName() == f->getName(); });
+            [&](const FunctorDeclaration* current) { return current->getName() == f->getName(); });
     assert(existingFunctorDecl == nullptr && "Redefinition of functor!");
     functors.push_back(std::move(f));
 }
 
-}  // namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -38,81 +38,87 @@
 #include <vector>
 
 namespace souffle {
+class ParserDriver;
+}
+namespace souffle::ast {
 
+namespace transform {
+class ComponentInstantiationTransformer;
+}
 /**
- * @class AstProgram
+ * @class Program
  * @brief The program class consists of relations, clauses and types.
  */
-class AstProgram : public AstNode {
+class Program : public Node {
 public:
     /** Return types */
-    std::vector<AstType*> getTypes() const {
+    std::vector<Type*> getTypes() const {
         return toPtrVector(types);
     }
 
     /** Return relations */
-    std::vector<AstRelation*> getRelations() const {
+    std::vector<Relation*> getRelations() const {
         return toPtrVector(relations);
     }
 
     /** Return clauses */
-    std::vector<AstClause*> getClauses() const {
+    std::vector<Clause*> getClauses() const {
         return toPtrVector(clauses);
     }
 
     /** Return functor declarations */
-    std::vector<AstFunctorDeclaration*> getFunctorDeclarations() const {
+    std::vector<FunctorDeclaration*> getFunctorDeclarations() const {
         return toPtrVector(functors);
     }
 
     /** Return relation directives */
-    std::vector<AstDirective*> getDirectives() const {
+    std::vector<Directive*> getDirectives() const {
         return toPtrVector(directives);
     }
 
     /** Add relation directive */
-    void addDirective(Own<AstDirective> directive) {
+    void addDirective(Own<Directive> directive) {
         assert(directive && "NULL directive");
         directives.push_back(std::move(directive));
     }
 
     /** Return pragma directives */
-    const VecOwn<AstPragma>& getPragmaDirectives() const {
+    const VecOwn<Pragma>& getPragmaDirectives() const {
         return pragmas;
     }
 
     /* Add relation */
-    void addRelation(Own<AstRelation> relation);
+    void addRelation(Own<Relation> relation);
 
     /** Remove relation */
-    bool removeRelationDecl(const AstQualifiedName& name);
+    bool removeRelationDecl(const QualifiedName& name);
 
     /** Set clauses */
-    void setClauses(VecOwn<AstClause> newClauses) {
+    void setClauses(VecOwn<Clause> newClauses) {
         clauses = std::move(newClauses);
     }
 
     /** Add a clause */
-    void addClause(Own<AstClause> clause);
+    void addClause(Own<Clause> clause);
 
     /** Remove a clause */
-    bool removeClause(const AstClause* clause);
+    bool removeClause(const Clause* clause);
 
     /** Remove a directive */
-    bool removeDirective(const AstDirective* directive);
+    bool removeDirective(const Directive* directive);
 
     /** Return components */
-    std::vector<AstComponent*> getComponents() const {
+    std::vector<Component*> getComponents() const {
         return toPtrVector(components);
     }
 
     /** Return component instantiation */
-    std::vector<AstComponentInit*> getComponentInstantiations() const {
+    std::vector<ComponentInit*> getComponentInstantiations() const {
         return toPtrVector(instantiations);
     }
 
-    AstProgram* clone() const override {
-        auto res = new AstProgram();
+    Program* clone() const override {
+        auto res = new Program();
         res->pragmas = souffle::clone(pragmas);
         res->components = souffle::clone(components);
         res->instantiations = souffle::clone(instantiations);
@@ -124,7 +130,7 @@ public:
         return res;
     }
 
-    void apply(const AstNodeMapper& map) override {
+    void apply(const NodeMapper& map) override {
         for (auto& cur : pragmas) {
             cur = map(std::move(cur));
         }
@@ -151,8 +157,8 @@ public:
         }
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
-        std::vector<const AstNode*> res;
+    std::vector<const Node*> getChildNodes() const override {
+        std::vector<const Node*> res;
         for (const auto& cur : pragmas) {
             res.push_back(cur.get());
         }
@@ -196,8 +202,8 @@ protected:
         show(directives, "\n\n");
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstProgram&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Program&>(node);
         if (!equal_targets(pragmas, other.pragmas)) {
             return false;
         }
@@ -226,50 +232,50 @@ protected:
     }
 
 protected:
-    friend class ComponentInstantiationTransformer;
-    friend class ParserDriver;
+    friend class transform::ComponentInstantiationTransformer;
+    friend class souffle::ParserDriver;
 
-    void addType(Own<AstType> type);
+    void addType(Own<Type> type);
 
-    void addPragma(Own<AstPragma> pragma);
+    void addPragma(Own<Pragma> pragma);
 
-    void addFunctorDeclaration(Own<souffle::AstFunctorDeclaration> functor);
+    void addFunctorDeclaration(Own<FunctorDeclaration> functor);
 
     /** Add component */
-    void addComponent(Own<AstComponent> component) {
+    void addComponent(Own<Component> component) {
         assert(component && "NULL component");
         components.push_back(std::move(component));
     }
 
     /** Add component instantiation */
-    void addInstantiation(Own<AstComponentInit> instantiation) {
+    void addInstantiation(Own<ComponentInit> instantiation) {
         assert(instantiation && "NULL instantiation");
         instantiations.push_back(std::move(instantiation));
     }
 
     /** Program types  */
-    VecOwn<AstType> types;
+    VecOwn<Type> types;
 
     /** Program relations */
-    VecOwn<AstRelation> relations;
+    VecOwn<Relation> relations;
 
     /** External Functors */
-    VecOwn<AstFunctorDeclaration> functors;
+    VecOwn<FunctorDeclaration> functors;
 
     /** Program clauses */
-    VecOwn<AstClause> clauses;
+    VecOwn<Clause> clauses;
 
     /** Directives */
-    VecOwn<AstDirective> directives;
+    VecOwn<Directive> directives;
 
     /** Component definitions */
-    VecOwn<AstComponent> components;
+    VecOwn<Component> components;
 
     /** Component instantiations */
-    VecOwn<AstComponentInit> instantiations;
+    VecOwn<ComponentInit> instantiations;
 
     /** Pragmas */
-    VecOwn<AstPragma> pragmas;
+    VecOwn<Pragma> pragmas;
 };
 
-}  // namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/ProvenanceNegation.h
+++ b/src/ast/ProvenanceNegation.h
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <memory>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
  * Subclass of Literal that represents a negated atom, * e.g., !parent(x,y).
@@ -31,12 +31,12 @@ namespace souffle {
  *
  * Specialised for provenance: used for existence check that tuple doesn't already exist
  */
-class AstProvenanceNegation : public AstNegation {
+class ProvenanceNegation : public Negation {
 public:
-    using AstNegation::AstNegation;
+    using Negation::Negation;
 
-    AstProvenanceNegation* clone() const override {
-        return new AstProvenanceNegation(souffle::clone(atom), getSrcLoc());
+    ProvenanceNegation* clone() const override {
+        return new ProvenanceNegation(souffle::clone(atom), getSrcLoc());
     }
 
 protected:
@@ -45,4 +45,4 @@ protected:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/QualifiedName.h
+++ b/src/ast/QualifiedName.h
@@ -23,23 +23,23 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstQualifiedName
+ * @class QualifiedName
  * @brief Qualified Name class defines fully/partially qualified names
  * to identify objects in components.
  */
-class AstQualifiedName {
+class QualifiedName {
 public:
-    AstQualifiedName() : qualifiers() {}
-    AstQualifiedName(const std::string& name) : qualifiers({name}) {}
-    AstQualifiedName(const char* name) : AstQualifiedName(std::string(name)) {}
-    AstQualifiedName(const std::vector<std::string> qualifiers) : qualifiers(qualifiers) {}
-    AstQualifiedName(const AstQualifiedName&) = default;
-    AstQualifiedName(AstQualifiedName&&) = default;
-    AstQualifiedName& operator=(const AstQualifiedName&) = default;
-    AstQualifiedName& operator=(AstQualifiedName&&) = default;
+    QualifiedName() : qualifiers() {}
+    QualifiedName(const std::string& name) : qualifiers({name}) {}
+    QualifiedName(const char* name) : QualifiedName(std::string(name)) {}
+    QualifiedName(const std::vector<std::string> qualifiers) : qualifiers(qualifiers) {}
+    QualifiedName(const QualifiedName&) = default;
+    QualifiedName(QualifiedName&&) = default;
+    QualifiedName& operator=(const QualifiedName&) = default;
+    QualifiedName& operator=(QualifiedName&&) = default;
 
     /** append qualifiers */
     void append(std::string name) {
@@ -68,15 +68,15 @@ public:
         return ss.str();
     }
 
-    bool operator==(const AstQualifiedName& other) const {
+    bool operator==(const QualifiedName& other) const {
         return qualifiers == other.qualifiers;
     }
 
-    bool operator!=(const AstQualifiedName& other) const {
+    bool operator!=(const QualifiedName& other) const {
         return !(*this == other);
     }
 
-    bool operator<(const AstQualifiedName& other) const {
+    bool operator<(const QualifiedName& other) const {
         return std::lexicographical_compare(
                 qualifiers.begin(), qualifiers.end(), other.qualifiers.begin(), other.qualifiers.end());
     }
@@ -86,7 +86,7 @@ public:
         out << join(qualifiers, ".");
     }
 
-    friend std::ostream& operator<<(std::ostream& out, const AstQualifiedName& id) {
+    friend std::ostream& operator<<(std::ostream& out, const QualifiedName& id) {
         id.print(out);
         return out;
     }
@@ -96,10 +96,10 @@ private:
     std::vector<std::string> qualifiers;
 };
 
-inline AstQualifiedName operator+(const std::string& name, const AstQualifiedName& id) {
-    AstQualifiedName res = id;
+inline QualifiedName operator+(const std::string& name, const QualifiedName& id) {
+    QualifiedName res = id;
     res.prepend(name);
     return res;
 }
 
-}  // namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/RecordInit.h
+++ b/src/ast/RecordInit.h
@@ -27,19 +27,19 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstRecordInit
+ * @class RecordInit
  * @brief Defines a record initialization class
  */
-class AstRecordInit : public AstTerm {
+class RecordInit : public Term {
 public:
-    AstRecordInit(VecOwn<AstArgument> operands = {}, SrcLocation loc = {})
-            : AstTerm(std::move(operands), std::move(loc)) {}
+    RecordInit(VecOwn<Argument> operands = {}, SrcLocation loc = {})
+            : Term(std::move(operands), std::move(loc)) {}
 
-    AstRecordInit* clone() const override {
-        return new AstRecordInit(souffle::clone(args), getSrcLoc());
+    RecordInit* clone() const override {
+        return new RecordInit(souffle::clone(args), getSrcLoc());
     }
 
 protected:
@@ -48,4 +48,4 @@ protected:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/RecordType.h
+++ b/src/ast/RecordType.h
@@ -32,37 +32,37 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstRecordType
+ * @class RecordType
  * @brief Record type class for record type declarations
  *
  * A record type aggregates a list of fields (i.e. name & type) into a new type.
  * Each record type has a name making the record type unique.
  */
-class AstRecordType : public AstType {
+class RecordType : public Type {
 public:
-    AstRecordType(AstQualifiedName name, VecOwn<AstAttribute> fields, SrcLocation loc = {})
-            : AstType(std::move(name), std::move(loc)), fields(std::move(fields)) {}
+    RecordType(QualifiedName name, VecOwn<Attribute> fields, SrcLocation loc = {})
+            : Type(std::move(name), std::move(loc)), fields(std::move(fields)) {}
 
     /** Add field to record type */
-    void add(std::string name, AstQualifiedName type) {
-        fields.push_back(mk<AstAttribute>(std::move(name), std::move(type)));
+    void add(std::string name, QualifiedName type) {
+        fields.push_back(mk<Attribute>(std::move(name), std::move(type)));
     }
 
     /** Get fields of record */
-    std::vector<AstAttribute*> getFields() const {
+    std::vector<Attribute*> getFields() const {
         return toPtrVector(fields);
     }
 
     /** Set field type */
-    void setFieldType(size_t idx, AstQualifiedName type) {
+    void setFieldType(size_t idx, QualifiedName type) {
         fields.at(idx)->setTypeName(std::move(type));
     }
 
-    AstRecordType* clone() const override {
-        return new AstRecordType(getQualifiedName(), souffle::clone(fields), getSrcLoc());
+    RecordType* clone() const override {
+        return new RecordType(getQualifiedName(), souffle::clone(fields), getSrcLoc());
     }
 
 protected:
@@ -70,14 +70,14 @@ protected:
         os << tfm::format(".type %s = [%s]", getQualifiedName(), join(fields, ", "));
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = dynamic_cast<const AstRecordType&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = dynamic_cast<const RecordType&>(node);
         return getQualifiedName() == other.getQualifiedName() && equal_targets(fields, other.fields);
     }
 
 private:
     /** record fields */
-    VecOwn<AstAttribute> fields;
+    VecOwn<Attribute> fields;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Relation.h
+++ b/src/ast/Relation.h
@@ -34,31 +34,31 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstRelation
+ * @class Relation
  * @brief Defines a relation with a name, attributes, qualifiers, and internal representation.
  */
-class AstRelation : public AstNode {
+class Relation : public Node {
 public:
-    AstRelation() = default;
-    AstRelation(AstQualifiedName name, SrcLocation loc = {}) : name(std::move(name)) {
+    Relation() = default;
+    Relation(QualifiedName name, SrcLocation loc = {}) : name(std::move(name)) {
         setSrcLoc(std::move(loc));
     }
 
     /** Get qualified relation name */
-    const AstQualifiedName& getQualifiedName() const {
+    const QualifiedName& getQualifiedName() const {
         return name;
     }
 
     /** Set name for this relation */
-    void setQualifiedName(AstQualifiedName n) {
+    void setQualifiedName(QualifiedName n) {
         name = std::move(n);
     }
 
     /** Add a new used type to this relation */
-    void addAttribute(Own<AstAttribute> attr) {
+    void addAttribute(Own<Attribute> attr) {
         assert(attr && "Undefined attribute");
         attributes.push_back(std::move(attr));
     }
@@ -69,12 +69,12 @@ public:
     }
 
     /** Set relation attributes */
-    void setAttributes(VecOwn<AstAttribute> attrs) {
+    void setAttributes(VecOwn<Attribute> attrs) {
         attributes = std::move(attrs);
     }
 
     /** Get relation attributes */
-    std::vector<AstAttribute*> getAttributes() const {
+    std::vector<Attribute*> getAttributes() const {
         return toPtrVector(attributes);
     }
 
@@ -108,22 +108,22 @@ public:
         return qualifiers.find(q) != qualifiers.end();
     }
 
-    AstRelation* clone() const override {
-        auto res = new AstRelation(name, getSrcLoc());
+    Relation* clone() const override {
+        auto res = new Relation(name, getSrcLoc());
         res->attributes = souffle::clone(attributes);
         res->qualifiers = qualifiers;
         res->representation = representation;
         return res;
     }
 
-    void apply(const AstNodeMapper& map) override {
+    void apply(const NodeMapper& map) override {
         for (auto& cur : attributes) {
             cur = map(std::move(cur));
         }
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
-        std::vector<const AstNode*> res;
+    std::vector<const Node*> getChildNodes() const override {
+        std::vector<const Node*> res;
         for (const auto& cur : attributes) {
             res.push_back(cur.get());
         }
@@ -136,16 +136,16 @@ protected:
            << " " << representation;
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstRelation&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Relation&>(node);
         return name == other.name && equal_targets(attributes, other.attributes);
     }
 
     /** Name of relation */
-    AstQualifiedName name;
+    QualifiedName name;
 
     /** Attributes of the relation */
-    VecOwn<AstAttribute> attributes;
+    VecOwn<Attribute> attributes;
 
     /** Qualifiers of relation */
     std::set<RelationQualifier> qualifiers;
@@ -155,14 +155,14 @@ protected:
 };
 
 /**
- * @class AstNameComparison
+ * @class NameComparison
  * @brief Comparator for relations
  *
- * Lexicographical order for AstRelation
+ * Lexicographical order for Relation
  * using the qualified name as an ordering criteria.
  */
-struct AstNameComparison {
-    bool operator()(const AstRelation* x, const AstRelation* y) const {
+struct NameComparison {
+    bool operator()(const Relation* x, const Relation* y) const {
         if (x != nullptr && y != nullptr) {
             return x->getQualifiedName() < y->getQualifiedName();
         }
@@ -171,6 +171,6 @@ struct AstNameComparison {
 };
 
 /** Relation set */
-using AstRelationSet = std::set<const AstRelation*, AstNameComparison>;
+using RelationSet = std::set<const Relation*, NameComparison>;
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/StringConstant.h
+++ b/src/ast/StringConstant.h
@@ -22,20 +22,20 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstStringConstant
+ * @class StringConstant
  * @brief String constant class
  */
-class AstStringConstant : public AstConstant {
+class StringConstant : public Constant {
 public:
-    explicit AstStringConstant(std::string value, SrcLocation loc = {}) : AstConstant(std::move(value)) {
+    explicit StringConstant(std::string value, SrcLocation loc = {}) : Constant(std::move(value)) {
         setSrcLoc(std::move(loc));
     }
 
-    AstStringConstant* clone() const override {
-        auto* res = new AstStringConstant(getConstant());
+    StringConstant* clone() const override {
+        auto* res = new StringConstant(getConstant());
         res->setSrcLoc(getSrcLoc());
         return res;
     }
@@ -46,4 +46,4 @@ protected:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/SubroutineArgument.h
+++ b/src/ast/SubroutineArgument.h
@@ -24,23 +24,23 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstSubroutineArgument
+ * @class SubroutineArgument
  * @brief Defines the argument class for subrountines
  */
-class AstSubroutineArgument : public AstArgument {
+class SubroutineArgument : public Argument {
 public:
-    AstSubroutineArgument(size_t index, SrcLocation loc = {}) : AstArgument(std::move(loc)), index(index) {}
+    SubroutineArgument(size_t index, SrcLocation loc = {}) : Argument(std::move(loc)), index(index) {}
 
     /** Return argument index */
     size_t getNumber() const {
         return index;
     }
 
-    AstSubroutineArgument* clone() const override {
-        return new AstSubroutineArgument(index, getSrcLoc());
+    SubroutineArgument* clone() const override {
+        return new SubroutineArgument(index, getSrcLoc());
     }
 
 protected:
@@ -48,8 +48,8 @@ protected:
         os << "arg(" << index << ")";
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstSubroutineArgument&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const SubroutineArgument&>(node);
         return index == other.index;
     }
 
@@ -58,4 +58,4 @@ private:
     size_t index;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/SubsetType.h
+++ b/src/ast/SubsetType.h
@@ -24,26 +24,26 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstSubsetType
+ * @class SubsetType
  * @brief Defines subset type class
  *
  * Example:
  *    .type A <: B
  */
-class AstSubsetType : public AstType {
+class SubsetType : public Type {
 public:
-    AstSubsetType(AstQualifiedName name, AstQualifiedName baseTypeName, SrcLocation loc = {})
-            : AstType(std::move(name), std::move(loc)), baseType(std::move(baseTypeName)) {}
+    SubsetType(QualifiedName name, QualifiedName baseTypeName, SrcLocation loc = {})
+            : Type(std::move(name), std::move(loc)), baseType(std::move(baseTypeName)) {}
 
-    AstSubsetType* clone() const override {
-        return new AstSubsetType(getQualifiedName(), getBaseType(), getSrcLoc());
+    SubsetType* clone() const override {
+        return new SubsetType(getQualifiedName(), getBaseType(), getSrcLoc());
     }
 
     /** Return base type */
-    const AstQualifiedName& getBaseType() const {
+    const QualifiedName& getBaseType() const {
         return baseType;
     }
 
@@ -52,14 +52,14 @@ protected:
         os << ".type " << getQualifiedName() << " <: " << getBaseType();
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstSubsetType&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const SubsetType&>(node);
         return getQualifiedName() == other.getQualifiedName() && baseType == other.baseType;
     }
 
 private:
     /** Base type */
-    const AstQualifiedName baseType;
+    const QualifiedName baseType;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Term.h
+++ b/src/ast/Term.h
@@ -27,63 +27,63 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstTerm
+ * @class Term
  * @brief Defines an abstract term class used for functors and other constructors
  */
-class AstTerm : public AstArgument {
+class Term : public Argument {
 protected:
     template <typename... Operands>
-    AstTerm(Operands&&... operands) : AstTerm(asVec(std::forward<Operands>(operands)...)) {}
+    Term(Operands&&... operands) : Term(asVec(std::forward<Operands>(operands)...)) {}
 
     template <typename... Operands>
-    AstTerm(SrcLocation loc, Operands&&... operands)
-            : AstTerm(asVec(std::forward<Operands>(operands)...), std::move(loc)) {}
+    Term(SrcLocation loc, Operands&&... operands)
+            : Term(asVec(std::forward<Operands>(operands)...), std::move(loc)) {}
 
-    AstTerm(VecOwn<AstArgument> operands, SrcLocation loc = {})
-            : AstArgument(std::move(loc)), args(std::move(operands)) {}
+    Term(VecOwn<Argument> operands, SrcLocation loc = {})
+            : Argument(std::move(loc)), args(std::move(operands)) {}
 
 public:
     /** Get arguments */
-    std::vector<AstArgument*> getArguments() const {
+    std::vector<Argument*> getArguments() const {
         return toPtrVector(args);
     }
 
     /** Add argument to argument list */
-    void addArgument(Own<AstArgument> arg) {
+    void addArgument(Own<Argument> arg) {
         args.push_back(std::move(arg));
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
-        auto res = AstArgument::getChildNodes();
+    std::vector<const Node*> getChildNodes() const override {
+        auto res = Argument::getChildNodes();
         for (auto& cur : args) {
             res.push_back(cur.get());
         }
         return res;
     }
 
-    void apply(const AstNodeMapper& map) override {
+    void apply(const NodeMapper& map) override {
         for (auto& arg : args) {
             arg = map(std::move(arg));
         }
     }
 
 protected:
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstTerm&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Term&>(node);
         return equal_targets(args, other.args);
     }
 
     /** Arguments */
-    VecOwn<AstArgument> args;
+    VecOwn<Argument> args;
 
 private:
     template <typename... Operands>
-    static VecOwn<AstArgument> asVec(Operands... ops) {
-        Own<AstArgument> ary[] = {std::move(ops)...};
-        VecOwn<AstArgument> xs;
+    static VecOwn<Argument> asVec(Operands... ops) {
+        Own<Argument> ary[] = {std::move(ops)...};
+        VecOwn<Argument> xs;
         for (auto&& x : ary) {
             xs.push_back(std::move(x));
         }
@@ -91,4 +91,4 @@ private:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/TranslationUnit.h
+++ b/src/ast/TranslationUnit.h
@@ -24,17 +24,17 @@
 #include "ast/analysis/SumTypeBranches.h"
 #include "ast/analysis/Type.h"
 #include "reports/DebugReport.h"
+#include "reports/ErrorReport.h"
 #include <map>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <utility>
 
-namespace souffle {
-class ErrorReport;
+namespace souffle::ast {
 
 /**
- * @class AstTranslationUnit
+ * @class TranslationUnit
  * @brief Translation unit class for the translation pipeline
  *
  * The translation unit class consisting of
@@ -42,12 +42,12 @@ class ErrorReport;
  * cached analysis results.
  */
 
-class AstTranslationUnit {
+class TranslationUnit {
 public:
-    AstTranslationUnit(Own<AstProgram> program, ErrorReport& e, DebugReport& d)
+    TranslationUnit(Own<Program> program, ErrorReport& e, DebugReport& d)
             : program(std::move(program)), errorReport(e), debugReport(d) {}
 
-    virtual ~AstTranslationUnit() = default;
+    virtual ~TranslationUnit() = default;
 
     /** get analysis: analysis is generated on the fly if not present */
     template <class Analysis>
@@ -62,8 +62,8 @@ public:
             if (debug) {
                 std::stringstream ss;
                 analyses[name]->print(ss);
-                if (!isA<PrecedenceGraphAnalysis>(analyses[name].get()) &&
-                        !isA<SCCGraphAnalysis>(analyses[name].get())) {
+                if (!isA<analysis::PrecedenceGraphAnalysis>(analyses[name].get()) &&
+                        !isA<analysis::SCCGraphAnalysis>(analyses[name].get())) {
                     debugReport.addSection(name, "Ast Analysis [" + name + "]", ss.str());
                 } else {
                     debugReport.addSection(
@@ -75,12 +75,12 @@ public:
     }
 
     /** Return the program */
-    AstProgram* getProgram() {
+    Program* getProgram() {
         return program.get();
     }
 
     /** Return the program */
-    const AstProgram* getProgram() const {
+    const Program* getProgram() const {
         return program.get();
     }
 
@@ -111,10 +111,10 @@ public:
 
 private:
     /** Cached analyses */
-    mutable std::map<std::string, Own<AstAnalysis>> analyses;
+    mutable std::map<std::string, Own<analysis::Analysis>> analyses;
 
     /** AST program */
-    Own<AstProgram> program;
+    Own<Program> program;
 
     /** Error report capturing errors while compiling */
     ErrorReport& errorReport;
@@ -123,4 +123,4 @@ private:
     DebugReport& debugReport;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Type.h
+++ b/src/ast/Type.h
@@ -22,32 +22,31 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
  *  @class Type
  *  @brief An abstract base class for types
  */
-class AstType : public AstNode {
+class Type : public Node {
 public:
-    AstType(AstQualifiedName name = {}, SrcLocation loc = {})
-            : AstNode(std::move(loc)), name(std::move(name)) {}
+    Type(QualifiedName name = {}, SrcLocation loc = {}) : Node(std::move(loc)), name(std::move(name)) {}
 
     /** Return type name */
-    const AstQualifiedName& getQualifiedName() const {
+    const QualifiedName& getQualifiedName() const {
         return name;
     }
 
     /** Set type name */
-    void setQualifiedName(AstQualifiedName name) {
+    void setQualifiedName(QualifiedName name) {
         this->name = std::move(name);
     }
 
-    AstType* clone() const override = 0;
+    Type* clone() const override = 0;
 
 private:
     /** type name */
-    AstQualifiedName name;
+    QualifiedName name;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -29,44 +29,44 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstTypeCast
+ * @class TypeCast
  * @brief Defines a type cast class for expressions
  */
 
-class AstTypeCast : public AstArgument {
+class TypeCast : public Argument {
 public:
-    AstTypeCast(Own<AstArgument> value, AstQualifiedName type, SrcLocation loc = {})
-            : AstArgument(std::move(loc)), value(std::move(value)), type(std::move(type)) {}
+    TypeCast(Own<Argument> value, QualifiedName type, SrcLocation loc = {})
+            : Argument(std::move(loc)), value(std::move(value)), type(std::move(type)) {}
 
     /** Return value */
-    AstArgument* getValue() const {
+    Argument* getValue() const {
         return value.get();
     }
 
     /** Return cast type */
-    const AstQualifiedName& getType() const {
+    const QualifiedName& getType() const {
         return type;
     }
 
     /** Set cast type */
-    void setType(const AstQualifiedName& type) {
+    void setType(const QualifiedName& type) {
         this->type = type;
     }
 
-    std::vector<const AstNode*> getChildNodes() const override {
-        auto res = AstArgument::getChildNodes();
+    std::vector<const Node*> getChildNodes() const override {
+        auto res = Argument::getChildNodes();
         res.push_back(value.get());
         return res;
     }
 
-    AstTypeCast* clone() const override {
-        return new AstTypeCast(souffle::clone(value), type, getSrcLoc());
+    TypeCast* clone() const override {
+        return new TypeCast(souffle::clone(value), type, getSrcLoc());
     }
 
-    void apply(const AstNodeMapper& map) override {
+    void apply(const NodeMapper& map) override {
         value = map(std::move(value));
     }
 
@@ -75,16 +75,16 @@ protected:
         os << "as(" << *value << "," << type << ")";
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstTypeCast&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const TypeCast&>(node);
         return type == other.type && equal_ptr(value, other.value);
     }
 
     /** Casted value */
-    Own<AstArgument> value;
+    Own<Argument> value;
 
     /** Cast type */
-    AstQualifiedName type;
+    QualifiedName type;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/UnionType.h
+++ b/src/ast/UnionType.h
@@ -28,10 +28,10 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstUnionType
+ * @class UnionType
  * @brief The union type class
  *
  * Example:
@@ -41,28 +41,28 @@ namespace souffle {
  * Each of the enumerated types become a sub-type of the new
  * union type.
  */
-class AstUnionType : public AstType {
+class UnionType : public Type {
 public:
-    AstUnionType(AstQualifiedName name, std::vector<AstQualifiedName> types, SrcLocation loc = {})
-            : AstType(std::move(name), std::move(loc)), types(std::move(types)) {}
+    UnionType(QualifiedName name, std::vector<QualifiedName> types, SrcLocation loc = {})
+            : Type(std::move(name), std::move(loc)), types(std::move(types)) {}
 
     /** Return list of unioned types */
-    const std::vector<AstQualifiedName>& getTypes() const {
+    const std::vector<QualifiedName>& getTypes() const {
         return types;
     }
 
     /** Add another unioned type */
-    void add(AstQualifiedName type) {
+    void add(QualifiedName type) {
         types.push_back(std::move(type));
     }
 
     /** Set type */
-    void setType(size_t idx, AstQualifiedName type) {
+    void setType(size_t idx, QualifiedName type) {
         types.at(idx) = std::move(type);
     }
 
-    AstUnionType* clone() const override {
-        return new AstUnionType(getQualifiedName(), types, getSrcLoc());
+    UnionType* clone() const override {
+        return new UnionType(getQualifiedName(), types, getSrcLoc());
     }
 
 protected:
@@ -70,14 +70,14 @@ protected:
         os << ".type " << getQualifiedName() << " = " << join(types, " | ");
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstUnionType&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const UnionType&>(node);
         return getQualifiedName() == other.getQualifiedName() && types == other.types;
     }
 
 private:
     /** List of unioned types */
-    std::vector<AstQualifiedName> types;
+    std::vector<QualifiedName> types;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/UnnamedVariable.h
+++ b/src/ast/UnnamedVariable.h
@@ -19,18 +19,18 @@
 #include "ast/Argument.h"
 #include <ostream>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstUnnamedVariable
+ * @class UnnamedVariable
  * @brief Unnamed variable class
  */
-class AstUnnamedVariable : public AstArgument {
+class UnnamedVariable : public Argument {
 public:
-    using AstArgument::AstArgument;
+    using Argument::Argument;
 
-    AstUnnamedVariable* clone() const override {
-        return new AstUnnamedVariable(getSrcLoc());
+    UnnamedVariable* clone() const override {
+        return new UnnamedVariable(getSrcLoc());
     }
 
 protected:
@@ -39,4 +39,4 @@ protected:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/UserDefinedFunctor.h
+++ b/src/ast/UserDefinedFunctor.h
@@ -31,18 +31,18 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstUserDefinedFunctor
+ * @class UserDefinedFunctor
  * @brief User-Defined functor class
  */
-class AstUserDefinedFunctor : public AstFunctor {
+class UserDefinedFunctor : public Functor {
 public:
-    explicit AstUserDefinedFunctor(std::string name) : AstFunctor({}, {}), name(std::move(name)){};
+    explicit UserDefinedFunctor(std::string name) : Functor({}, {}), name(std::move(name)){};
 
-    AstUserDefinedFunctor(std::string name, VecOwn<AstArgument> args, SrcLocation loc = {})
-            : AstFunctor(std::move(args), std::move(loc)), name(std::move(name)){};
+    UserDefinedFunctor(std::string name, VecOwn<Argument> args, SrcLocation loc = {})
+            : Functor(std::move(args), std::move(loc)), name(std::move(name)){};
 
     /** return the name */
     const std::string& getName() const {
@@ -77,8 +77,8 @@ public:
         return stateful;
     }
 
-    AstUserDefinedFunctor* clone() const override {
-        auto res = new AstUserDefinedFunctor(name, souffle::clone(args), getSrcLoc());
+    UserDefinedFunctor* clone() const override {
+        auto res = new UserDefinedFunctor(name, souffle::clone(args), getSrcLoc());
         // Only copy types if they have already been set.
         if (returnType.has_value()) {
             res->setTypes(argTypes.value(), returnType.value(), stateful);
@@ -91,9 +91,9 @@ protected:
         os << '@' << name << "(" << join(args) << ")";
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstUserDefinedFunctor&>(node);
-        return name == other.name && AstFunctor::equal(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const UserDefinedFunctor&>(node);
+        return name == other.name && Functor::equal(node);
     }
 
     /** Argument types */
@@ -109,4 +109,4 @@ protected:
     const std::string name;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/Variable.h
+++ b/src/ast/Variable.h
@@ -23,16 +23,15 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 /**
- * @class AstVariable
+ * @class Variable
  * @brief Named variable class
  */
-class AstVariable : public AstArgument {
+class Variable : public Argument {
 public:
-    AstVariable(std::string name, SrcLocation loc = {})
-            : AstArgument(std::move(loc)), name(std::move(name)) {}
+    Variable(std::string name, SrcLocation loc = {}) : Argument(std::move(loc)), name(std::move(name)) {}
 
     /** Set variable name */
     void setName(std::string name) {
@@ -44,8 +43,8 @@ public:
         return name;
     }
 
-    AstVariable* clone() const override {
-        return new AstVariable(name, getSrcLoc());
+    Variable* clone() const override {
+        return new Variable(name, getSrcLoc());
     }
 
 protected:
@@ -53,8 +52,8 @@ protected:
         os << name;
     }
 
-    bool equal(const AstNode& node) const override {
-        const auto& other = static_cast<const AstVariable&>(node);
+    bool equal(const Node& node) const override {
+        const auto& other = static_cast<const Variable&>(node);
         return name == other.name;
     }
 
@@ -62,4 +61,4 @@ protected:
     std::string name;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/analysis/Analysis.h
+++ b/src/ast/analysis/Analysis.h
@@ -20,20 +20,22 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
-class AstTranslationUnit;
+class TranslationUnit;
+
+namespace analysis {
 
 /**
  * Abstract class for a AST Analysis.
  */
-class AstAnalysis {
+class Analysis {
 public:
-    AstAnalysis(std::string identifier) : identifier(std::move(identifier)) {}
-    virtual ~AstAnalysis() = default;
+    Analysis(std::string identifier) : identifier(std::move(identifier)) {}
+    virtual ~Analysis() = default;
 
     /** run analysis for a Ast translation unit */
-    virtual void run(const AstTranslationUnit& /*translationUnit*/) = 0;
+    virtual void run(const TranslationUnit& /*translationUnit*/) = 0;
 
     /** print the analysis result in HTML format */
     virtual void print(std::ostream&) const {}
@@ -44,7 +46,7 @@ public:
     }
 
     /** define output stream operator */
-    friend std::ostream& operator<<(std::ostream& out, const AstAnalysis& other) {
+    friend std::ostream& operator<<(std::ostream& out, const Analysis& other) {
         other.print(out);
         return out;
     }
@@ -53,4 +55,5 @@ protected:
     const std::string identifier;
 };
 
-}  // end of namespace souffle
+}  // namespace analysis
+}  // namespace souffle::ast

--- a/src/ast/analysis/AuxArity.cpp
+++ b/src/ast/analysis/AuxArity.cpp
@@ -18,9 +18,9 @@
 #include "Global.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
-size_t AuxiliaryArity::computeArity(const AstRelation* /* relation */) const {
+size_t AuxiliaryArity::computeArity(const Relation* /* relation */) const {
     if (Global::config().has("provenance")) {
         return 2;
     } else {
@@ -28,4 +28,4 @@ size_t AuxiliaryArity::computeArity(const AstRelation* /* relation */) const {
     }
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/AuxArity.cpp
+++ b/src/ast/analysis/AuxArity.cpp
@@ -20,7 +20,7 @@
 
 namespace souffle::ast::analysis {
 
-size_t AuxiliaryArity::computeArity(const Relation* /* relation */) const {
+size_t AuxiliaryArityAnalysis::computeArity(const AstRelation* /* relation */) const {
     if (Global::config().has("provenance")) {
         return 2;
     } else {

--- a/src/ast/analysis/AuxArity.cpp
+++ b/src/ast/analysis/AuxArity.cpp
@@ -16,11 +16,10 @@
 
 #include "ast/analysis/AuxArity.h"
 #include "Global.h"
-#include <string>
 
 namespace souffle::ast::analysis {
 
-size_t AuxiliaryArityAnalysis::computeArity(const AstRelation* /* relation */) const {
+size_t AuxiliaryArityAnalysis::computeArity(const Relation* /* relation */) const {
     if (Global::config().has("provenance")) {
         return 2;
     } else {

--- a/src/ast/analysis/AuxArity.h
+++ b/src/ast/analysis/AuxArity.h
@@ -24,18 +24,18 @@
 #include "ast/utility/Utils.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
 /**
  * Determine the auxiliary arity for relations
  */
-class AuxiliaryArity : public AstAnalysis {
+class AuxiliaryArity : public Analysis {
 public:
     static constexpr const char* name = "auxiliary-arity";
 
-    AuxiliaryArity() : AstAnalysis(name) {}
+    AuxiliaryArity() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override {
+    void run(const TranslationUnit& translationUnit) override {
         program = translationUnit.getProgram();
     }
 
@@ -44,7 +44,7 @@ public:
      * @param atom the atom to report on
      * @return number of auxiliary attributes
      */
-    size_t getArity(const AstAtom* atom) const {
+    size_t getArity(const Atom* atom) const {
         return computeArity(getRelation(*program, atom->getQualifiedName()));
     }
 
@@ -53,7 +53,7 @@ public:
      * @param relation the relation to report on
      * @return number of auxiliary attributes
      */
-    size_t getArity(const AstRelation* relation) const {
+    size_t getArity(const Relation* relation) const {
         return computeArity(relation);
     }
 
@@ -63,9 +63,9 @@ private:
      * @param relation the relation to report on
      * @return number of auxiliary attributes
      */
-    size_t computeArity(const AstRelation* relation) const;
+    size_t computeArity(const Relation* relation) const;
 
-    const AstProgram* program = nullptr;
+    const Program* program = nullptr;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/AuxArity.h
+++ b/src/ast/analysis/AuxArity.h
@@ -29,11 +29,11 @@ namespace souffle::ast::analysis {
 /**
  * Determine the auxiliary arity for relations
  */
-class AuxiliaryArity : public Analysis {
+class AuxiliaryArityAnalysis : public Analysis {
 public:
     static constexpr const char* name = "auxiliary-arity";
 
-    AuxiliaryArity() : Analysis(name) {}
+    AuxiliaryArityAnalysis() : Analysis(name) {}
 
     void run(const TranslationUnit& translationUnit) override {
         program = translationUnit.getProgram();

--- a/src/ast/analysis/ClauseNormalisation.h
+++ b/src/ast/analysis/ClauseNormalisation.h
@@ -30,18 +30,22 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
+
+class TranslationUnit;
+
+namespace analysis {
 
 class NormalisedClause {
 public:
     struct NormalisedClauseElement {
-        AstQualifiedName name;
+        QualifiedName name;
         std::vector<std::string> params;
     };
 
     NormalisedClause() = default;
 
-    NormalisedClause(const AstClause* clause);
+    NormalisedClause(const Clause* clause);
 
     bool isFullyNormalised() const {
         return fullyNormalised;
@@ -69,33 +73,34 @@ private:
     /**
      * Parse an atom with a preset name qualifier into the element list.
      */
-    void addClauseAtom(const std::string& qualifier, const std::string& scopeID, const AstAtom* atom);
+    void addClauseAtom(const std::string& qualifier, const std::string& scopeID, const Atom* atom);
 
     /**
      * Parse a body literal into the element list.
      */
-    void addClauseBodyLiteral(const std::string& scopeID, const AstLiteral* lit);
+    void addClauseBodyLiteral(const std::string& scopeID, const Literal* lit);
 
     /**
      * Return a normalised string repr of an argument.
      */
-    std::string normaliseArgument(const AstArgument* arg);
+    std::string normaliseArgument(const Argument* arg);
 };
 
-class ClauseNormalisationAnalysis : public AstAnalysis {
+class ClauseNormalisationAnalysis : public Analysis {
 public:
     static constexpr const char* name = "clause-normalisation";
 
-    ClauseNormalisationAnalysis() : AstAnalysis(name) {}
+    ClauseNormalisationAnalysis() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     void print(std::ostream& os) const override;
 
-    const NormalisedClause& getNormalisation(const AstClause* clause) const;
+    const NormalisedClause& getNormalisation(const Clause* clause) const;
 
 private:
-    std::map<const AstClause*, NormalisedClause> normalisations;
+    std::map<const Clause*, NormalisedClause> normalisations;
 };
 
-}  // namespace souffle
+}  // namespace analysis
+}  // namespace souffle::ast

--- a/src/ast/analysis/ComponentLookup.cpp
+++ b/src/ast/analysis/ComponentLookup.cpp
@@ -8,7 +8,7 @@
 
 /************************************************************************
  *
- * @file ComponentLookup.cpp
+ * @file ComponentLookupAnalysis.cpp
  *
  * Implements the component lookup
  *
@@ -24,7 +24,7 @@
 
 namespace souffle::ast::analysis {
 
-void ComponentLookup::run(const TranslationUnit& translationUnit) {
+void ComponentLookupAnalysis::run(const TranslationUnit& translationUnit) {
     const Program* program = translationUnit.getProgram();
     for (Component* component : program->getComponents()) {
         globalScopeComponents.insert(component);
@@ -39,7 +39,7 @@ void ComponentLookup::run(const TranslationUnit& translationUnit) {
     });
 }
 
-const Component* ComponentLookup::getComponent(
+const Component* ComponentLookupAnalysis::getComponent(
         const Component* scope, const std::string& name, const TypeBinding& activeBinding) const {
     // forward according to binding (we do not do this recursively on purpose)
     QualifiedName boundName = activeBinding.find(name);

--- a/src/ast/analysis/ComponentLookup.cpp
+++ b/src/ast/analysis/ComponentLookup.cpp
@@ -22,36 +22,36 @@
 #include "ast/utility/Visitor.h"
 #include "souffle/utility/StringUtil.h"
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
-void ComponentLookup::run(const AstTranslationUnit& translationUnit) {
-    const AstProgram* program = translationUnit.getProgram();
-    for (AstComponent* component : program->getComponents()) {
+void ComponentLookup::run(const TranslationUnit& translationUnit) {
+    const Program* program = translationUnit.getProgram();
+    for (Component* component : program->getComponents()) {
         globalScopeComponents.insert(component);
         enclosingComponent[component] = nullptr;
     }
-    visitDepthFirst(*program, [&](const AstComponent& cur) {
+    visitDepthFirst(*program, [&](const Component& cur) {
         nestedComponents[&cur];
-        for (AstComponent* nestedComponent : cur.getComponents()) {
+        for (Component* nestedComponent : cur.getComponents()) {
             nestedComponents[&cur].insert(nestedComponent);
             enclosingComponent[nestedComponent] = &cur;
         }
     });
 }
 
-const AstComponent* ComponentLookup::getComponent(
-        const AstComponent* scope, const std::string& name, const TypeBinding& activeBinding) const {
+const Component* ComponentLookup::getComponent(
+        const Component* scope, const std::string& name, const TypeBinding& activeBinding) const {
     // forward according to binding (we do not do this recursively on purpose)
-    AstQualifiedName boundName = activeBinding.find(name);
+    QualifiedName boundName = activeBinding.find(name);
     if (boundName.empty()) {
         // compName is not bound to anything => just just compName
         boundName = name;
     }
 
     // search nested scopes bottom up
-    const AstComponent* searchScope = scope;
+    const Component* searchScope = scope;
     while (searchScope != nullptr) {
-        for (const AstComponent* cur : searchScope->getComponents()) {
+        for (const Component* cur : searchScope->getComponents()) {
             if (cur->getComponentType()->getName() == toString(boundName)) {
                 return cur;
             }
@@ -66,7 +66,7 @@ const AstComponent* ComponentLookup::getComponent(
     }
 
     // check global scope
-    for (const AstComponent* cur : globalScopeComponents) {
+    for (const Component* cur : globalScopeComponents) {
         if (cur->getComponentType()->getName() == toString(boundName)) {
             return cur;
         }
@@ -76,4 +76,4 @@ const AstComponent* ComponentLookup::getComponent(
     return nullptr;
 }
 
-}  // end namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/ComponentLookup.h
+++ b/src/ast/analysis/ComponentLookup.h
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
 /**
  * Class that encapsulates std::map of types binding that comes from .init c = Comp<MyType>
@@ -35,8 +35,8 @@ public:
     /**
      * Returns binding for given name or empty string if such binding does not exist.
      */
-    const AstQualifiedName& find(const AstQualifiedName& name) const {
-        const static AstQualifiedName unknown;
+    const QualifiedName& find(const QualifiedName& name) const {
+        const static QualifiedName unknown;
         auto pos = binding.find(name);
         if (pos == binding.end()) {
             return unknown;
@@ -44,8 +44,8 @@ public:
         return pos->second;
     }
 
-    TypeBinding extend(const std::vector<AstQualifiedName>& formalParams,
-            const std::vector<AstQualifiedName>& actualParams) const {
+    TypeBinding extend(const std::vector<QualifiedName>& formalParams,
+            const std::vector<QualifiedName>& actualParams) const {
         TypeBinding result;
         if (formalParams.size() != actualParams.size()) {
             return *this;  // invalid init => will trigger a semantic error
@@ -68,16 +68,16 @@ private:
      * Key value pair. Keys are names that should be forwarded to value,
      * which is the actual name. Example T->MyImplementation.
      */
-    std::map<AstQualifiedName, AstQualifiedName> binding;
+    std::map<QualifiedName, QualifiedName> binding;
 };
 
-class ComponentLookup : public AstAnalysis {
+class ComponentLookup : public Analysis {
 public:
     static constexpr const char* name = "component-lookup";
 
-    ComponentLookup() : AstAnalysis(name) {}
+    ComponentLookup() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     /**
      * Performs a lookup operation for a component with the given name within the addressed scope.
@@ -86,16 +86,16 @@ public:
      * @param name the name of the component to be looking for
      * @return a pointer to the obtained component or null if there is no such component.
      */
-    const AstComponent* getComponent(
-            const AstComponent* scope, const std::string& name, const TypeBinding& activeBinding) const;
+    const Component* getComponent(
+            const Component* scope, const std::string& name, const TypeBinding& activeBinding) const;
 
 private:
     // components defined outside of any components
-    std::set<const AstComponent*> globalScopeComponents;
+    std::set<const Component*> globalScopeComponents;
     // components defined inside a component
-    std::map<const AstComponent*, std::set<const AstComponent*>> nestedComponents;
+    std::map<const Component*, std::set<const Component*>> nestedComponents;
     // component definition enclosing a component definition
-    std::map<const AstComponent*, const AstComponent*> enclosingComponent;
+    std::map<const Component*, const Component*> enclosingComponent;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/ComponentLookup.h
+++ b/src/ast/analysis/ComponentLookup.h
@@ -71,11 +71,11 @@ private:
     std::map<QualifiedName, QualifiedName> binding;
 };
 
-class ComponentLookup : public Analysis {
+class ComponentLookupAnalysis : public Analysis {
 public:
     static constexpr const char* name = "component-lookup";
 
-    ComponentLookup() : Analysis(name) {}
+    ComponentLookupAnalysis() : Analysis(name) {}
 
     void run(const TranslationUnit& translationUnit) override;
 

--- a/src/ast/analysis/ConstraintSystem.h
+++ b/src/ast/analysis/ConstraintSystem.h
@@ -25,7 +25,7 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
 //----------------------------------------------------------------------
 //                      forward declarations
@@ -424,4 +424,4 @@ public:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/Ground.h
+++ b/src/ast/analysis/Ground.h
@@ -21,7 +21,7 @@
 #include "ast/TranslationUnit.h"
 #include <map>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
 /**
  * Analyse the given clause and computes for each contained argument
@@ -32,6 +32,6 @@ namespace souffle {
  * @return a map mapping each contained argument to a boolean indicating
  *      whether the argument represents a grounded value or not
  */
-std::map<const AstArgument*, bool> getGroundedTerms(const AstTranslationUnit& tu, const AstClause& clause);
+std::map<const Argument*, bool> getGroundedTerms(const TranslationUnit& tu, const Clause& clause);
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/IOType.cpp
+++ b/src/ast/analysis/IOType.cpp
@@ -27,23 +27,23 @@
 #include <ostream>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
-void IOType::run(const AstTranslationUnit& translationUnit) {
-    const AstProgram& program = *translationUnit.getProgram();
-    visitDepthFirst(program, [&](const AstDirective& directive) {
+void IOType::run(const TranslationUnit& translationUnit) {
+    const Program& program = *translationUnit.getProgram();
+    visitDepthFirst(program, [&](const Directive& directive) {
         auto* relation = getRelation(program, directive.getQualifiedName());
         if (relation == nullptr) {
             return;
         }
         switch (directive.getType()) {
-            case AstDirectiveType::input: inputRelations.insert(relation); break;
-            case AstDirectiveType::output: outputRelations.insert(relation); break;
-            case AstDirectiveType::printsize:
+            case ast::DirectiveType::input: inputRelations.insert(relation); break;
+            case ast::DirectiveType::output: outputRelations.insert(relation); break;
+            case ast::DirectiveType::printsize:
                 printSizeRelations.insert(relation);
                 outputRelations.insert(relation);
                 break;
-            case AstDirectiveType::limitsize:
+            case ast::DirectiveType::limitsize:
                 limitSizeRelations.insert(relation);
                 assert(directive.hasDirective("n") && "limitsize has no n directive");
                 limitSize[relation] = stoi(directive.getDirective("n"));
@@ -53,11 +53,11 @@ void IOType::run(const AstTranslationUnit& translationUnit) {
 }
 
 void IOType::print(std::ostream& os) const {
-    auto show = [](std::ostream& os, const AstRelation* r) { os << r->getQualifiedName(); };
+    auto show = [](std::ostream& os, const Relation* r) { os << r->getQualifiedName(); };
     os << "input relations: {" << join(inputRelations, ", ", show) << "}\n";
     os << "output relations: {" << join(outputRelations, ", ", show) << "}\n";
     os << "printsize relations: {" << join(printSizeRelations, ", ", show) << "}\n";
     os << "limitsize relations: {" << join(limitSizeRelations, ", ", show) << "}\n";
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/IOType.cpp
+++ b/src/ast/analysis/IOType.cpp
@@ -8,7 +8,7 @@
 
 /************************************************************************
  *
- * @file IOType.cpp
+ * @file IOTypeAnalysis.cpp
  *
  * Implements methods to identify a relation as input, output, or printsize.
  *
@@ -29,7 +29,7 @@
 
 namespace souffle::ast::analysis {
 
-void IOType::run(const TranslationUnit& translationUnit) {
+void IOTypeAnalysis::run(const TranslationUnit& translationUnit) {
     const Program& program = *translationUnit.getProgram();
     visitDepthFirst(program, [&](const Directive& directive) {
         auto* relation = getRelation(program, directive.getQualifiedName());
@@ -52,7 +52,7 @@ void IOType::run(const TranslationUnit& translationUnit) {
     });
 }
 
-void IOType::print(std::ostream& os) const {
+void IOTypeAnalysis::print(std::ostream& os) const {
     auto show = [](std::ostream& os, const Relation* r) { os << r->getQualifiedName(); };
     os << "input relations: {" << join(inputRelations, ", ", show) << "}\n";
     os << "output relations: {" << join(outputRelations, ", ", show) << "}\n";

--- a/src/ast/analysis/IOType.h
+++ b/src/ast/analysis/IOType.h
@@ -30,11 +30,11 @@ class TranslationUnit;
 
 namespace analysis {
 
-class IOType : public Analysis {
+class IOTypeAnalysis : public Analysis {
 public:
     static constexpr const char* name = "IO-type-analysis";
 
-    IOType() : Analysis(name) {}
+    IOTypeAnalysis() : Analysis(name) {}
 
     void run(const TranslationUnit& translationUnit) override;
 

--- a/src/ast/analysis/IOType.h
+++ b/src/ast/analysis/IOType.h
@@ -24,37 +24,39 @@
 #include <string>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
-class AstTranslationUnit;
+class TranslationUnit;
 
-class IOType : public AstAnalysis {
+namespace analysis {
+
+class IOType : public Analysis {
 public:
     static constexpr const char* name = "IO-type-analysis";
 
-    IOType() : AstAnalysis(name) {}
+    IOType() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     void print(std::ostream& os) const override;
 
-    bool isInput(const AstRelation* relation) const {
+    bool isInput(const Relation* relation) const {
         return inputRelations.count(relation) != 0;
     }
 
-    bool isOutput(const AstRelation* relation) const {
+    bool isOutput(const Relation* relation) const {
         return outputRelations.count(relation) != 0;
     }
 
-    bool isPrintSize(const AstRelation* relation) const {
+    bool isPrintSize(const Relation* relation) const {
         return printSizeRelations.count(relation) != 0;
     }
 
-    bool isLimitSize(const AstRelation* relation) const {
+    bool isLimitSize(const Relation* relation) const {
         return limitSizeRelations.count(relation) != 0;
     }
 
-    std::size_t getLimitSize(const AstRelation* relation) const {
+    std::size_t getLimitSize(const Relation* relation) const {
         auto iter = limitSize.find(relation);
         if (iter != limitSize.end()) {
             return (*iter).second;
@@ -62,15 +64,17 @@ public:
             return 0;
     }
 
-    bool isIO(const AstRelation* relation) const {
+    bool isIO(const Relation* relation) const {
         return isInput(relation) || isOutput(relation) || isPrintSize(relation);
     }
 
 private:
-    std::set<const AstRelation*> inputRelations;
-    std::set<const AstRelation*> outputRelations;
-    std::set<const AstRelation*> printSizeRelations;
-    std::set<const AstRelation*> limitSizeRelations;
-    std::map<const AstRelation*, std::size_t> limitSize;
+    std::set<const Relation*> inputRelations;
+    std::set<const Relation*> outputRelations;
+    std::set<const Relation*> printSizeRelations;
+    std::set<const Relation*> limitSizeRelations;
+    std::map<const Relation*, std::size_t> limitSize;
 };
-}  // end of namespace souffle
+
+}  // namespace analysis
+}  // namespace souffle::ast

--- a/src/ast/analysis/PrecedenceGraph.cpp
+++ b/src/ast/analysis/PrecedenceGraph.cpp
@@ -32,9 +32,9 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
-void PrecedenceGraphAnalysis::run(const AstTranslationUnit& translationUnit) {
+void PrecedenceGraphAnalysis::run(const TranslationUnit& translationUnit) {
     /* Get relations */
     const auto& program = *translationUnit.getProgram();
     const auto& relationDetail = *translationUnit.getAnalysis<RelationDetailCacheAnalysis>();
@@ -42,10 +42,10 @@ void PrecedenceGraphAnalysis::run(const AstTranslationUnit& translationUnit) {
     for (const auto* r : program.getRelations()) {
         backingGraph.insert(r);
         for (const auto& c : relationDetail.getClauses(r)) {
-            visitDepthFirst(c->getBodyLiterals(), [&](const AstAtom& atom) {
+            visitDepthFirst(c->getBodyLiterals(), [&](const Atom& atom) {
                 backingGraph.insert(relationDetail.getRelation(atom.getQualifiedName()), r);
             });
-            visitDepthFirst(c->getHead()->getArguments(), [&](const AstAtom& atom) {
+            visitDepthFirst(c->getHead()->getArguments(), [&](const Atom& atom) {
                 backingGraph.insert(relationDetail.getRelation(atom.getQualifiedName()), r);
             });
         }
@@ -57,15 +57,15 @@ void PrecedenceGraphAnalysis::print(std::ostream& os) const {
     std::stringstream ss;
     ss << "digraph {\n";
     /* Print node of dependence graph */
-    for (const AstRelation* rel : backingGraph.vertices()) {
+    for (const Relation* rel : backingGraph.vertices()) {
         if (rel != nullptr) {
             ss << "\t\"" << rel->getQualifiedName() << "\" [label = \"" << rel->getQualifiedName()
                << "\"];\n";
         }
     }
-    for (const AstRelation* rel : backingGraph.vertices()) {
+    for (const Relation* rel : backingGraph.vertices()) {
         if (rel != nullptr) {
-            for (const AstRelation* adjRel : backingGraph.successors(rel)) {
+            for (const Relation* adjRel : backingGraph.successors(rel)) {
                 if (adjRel != nullptr) {
                     ss << "\t\"" << rel->getQualifiedName() << "\" -> \"" << adjRel->getQualifiedName()
                        << "\";\n";
@@ -77,4 +77,4 @@ void PrecedenceGraphAnalysis::print(std::ostream& os) const {
     printHTMLGraph(os, ss.str(), getName());
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/PrecedenceGraph.h
+++ b/src/ast/analysis/PrecedenceGraph.h
@@ -23,31 +23,34 @@
 #include "ast/analysis/Analysis.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast {
 
-class AstTranslationUnit;
+class TranslationUnit;
+
+namespace analysis {
 
 /**
  * Analysis pass computing the precedence graph of the relations of the datalog progam.
  */
-class PrecedenceGraphAnalysis : public AstAnalysis {
+class PrecedenceGraphAnalysis : public Analysis {
 public:
     static constexpr const char* name = "precedence-graph";
 
-    PrecedenceGraphAnalysis() : AstAnalysis(name) {}
+    PrecedenceGraphAnalysis() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     /** Output precedence graph in graphviz format to a given stream */
     void print(std::ostream& os) const override;
 
-    const Graph<const AstRelation*, AstNameComparison>& graph() const {
+    const Graph<const Relation*, NameComparison>& graph() const {
         return backingGraph;
     }
 
 private:
     /** Adjacency list of precedence graph (determined by the dependencies of the relations) */
-    Graph<const AstRelation*, AstNameComparison> backingGraph;
+    Graph<const Relation*, NameComparison> backingGraph;
 };
 
-}  // end of namespace souffle
+}  // namespace analysis
+}  // namespace souffle::ast

--- a/src/ast/analysis/ProfileUse.cpp
+++ b/src/ast/analysis/ProfileUse.cpp
@@ -10,7 +10,7 @@
  *
  * @file ProfileUse.cpp
  *
- * Implements an AstAnalysis that provides profile information
+ * Implements an Analysis that provides profile information
  * from a profile log file for profile-guided optimisations.
  *
  ***********************************************************************/
@@ -24,12 +24,12 @@
 #include <limits>
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
 /**
  * Run analysis, i.e., retrieve profile information
  */
-void AstProfileUseAnalysis::run(const AstTranslationUnit&) {
+void ProfileUseAnalysis::run(const TranslationUnit&) {
     if (Global::config().has("profile-use")) {
         std::string filename = Global::config().get("profile-use");
         profile::Reader(filename, programRun).processFile();
@@ -39,19 +39,19 @@ void AstProfileUseAnalysis::run(const AstTranslationUnit&) {
 /**
  * Print analysis
  */
-void AstProfileUseAnalysis::print(std::ostream&) const {}
+void ProfileUseAnalysis::print(std::ostream&) const {}
 
 /**
  * Check whether relation size is defined in profile
  */
-bool AstProfileUseAnalysis::hasRelationSize(const AstQualifiedName& rel) {
+bool ProfileUseAnalysis::hasRelationSize(const QualifiedName& rel) {
     return programRun->getRelation(rel.toString()) != nullptr;
 }
 
 /**
  * Get relation size from profile
  */
-size_t AstProfileUseAnalysis::getRelationSize(const AstQualifiedName& rel) {
+size_t ProfileUseAnalysis::getRelationSize(const QualifiedName& rel) {
     if (const auto* profRel = programRun->getRelation(rel.toString())) {
         return profRel->size();
     } else {
@@ -59,4 +59,4 @@ size_t AstProfileUseAnalysis::getRelationSize(const AstQualifiedName& rel) {
     }
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/ProfileUse.h
+++ b/src/ast/analysis/ProfileUse.h
@@ -25,35 +25,38 @@
 #include <memory>
 #include <string>
 
-namespace souffle {
-class AstTranslationUnit;
+namespace souffle::ast {
+class TranslationUnit;
+
+namespace analysis {
 
 /**
- * AstAnalysis that loads profile data and has a profile query interface.
+ * Analysis that loads profile data and has a profile query interface.
  */
-class AstProfileUseAnalysis : public AstAnalysis {
+class ProfileUseAnalysis : public Analysis {
 public:
     /** Name of analysis */
     static constexpr const char* name = "profile-use";
 
-    AstProfileUseAnalysis()
-            : AstAnalysis(name), programRun(std::make_shared<profile::ProgramRun>(profile::ProgramRun())) {}
+    ProfileUseAnalysis()
+            : Analysis(name), programRun(std::make_shared<profile::ProgramRun>(profile::ProgramRun())) {}
 
     /** Run analysis */
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     /** Output some profile information */
     void print(std::ostream& os) const override;
 
     /** Check whether the relation size exists in profile */
-    bool hasRelationSize(const AstQualifiedName& rel);
+    bool hasRelationSize(const QualifiedName& rel);
 
     /** Return size of relation in the profile */
-    size_t getRelationSize(const AstQualifiedName& rel);
+    size_t getRelationSize(const QualifiedName& rel);
 
 private:
     /** performance model of profile run */
     std::shared_ptr<profile::ProgramRun> programRun;
 };
 
-}  // end of namespace souffle
+}  // namespace analysis
+}  // namespace souffle::ast

--- a/src/ast/analysis/RecursiveClauses.h
+++ b/src/ast/analysis/RecursiveClauses.h
@@ -23,33 +23,36 @@
 #include <set>
 #include <string>
 
-namespace souffle {
+namespace souffle::ast {
 
-class AstClause;
-class AstTranslationUnit;
+class Clause;
+class TranslationUnit;
+
+namespace analysis {
 
 /**
  * Analysis pass identifying clauses which are recursive.
  */
-class RecursiveClausesAnalysis : public AstAnalysis {
+class RecursiveClausesAnalysis : public Analysis {
 public:
     static constexpr const char* name = "recursive-clauses";
 
-    RecursiveClausesAnalysis() : AstAnalysis(name) {}
+    RecursiveClausesAnalysis() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     void print(std::ostream& os) const override;
 
-    bool recursive(const AstClause* clause) const {
+    bool recursive(const Clause* clause) const {
         return recursiveClauses.count(clause) != 0u;
     }
 
 private:
-    std::set<const AstClause*> recursiveClauses;
+    std::set<const Clause*> recursiveClauses;
 
     /** Determines whether the given clause is recursive within the given program */
-    bool computeIsRecursive(const AstClause& clause, const AstTranslationUnit& translationUnit) const;
+    bool computeIsRecursive(const Clause& clause, const TranslationUnit& translationUnit) const;
 };
 
-}  // end of namespace souffle
+}  // namespace analysis
+}  // namespace souffle::ast

--- a/src/ast/analysis/RedundantRelations.cpp
+++ b/src/ast/analysis/RedundantRelations.cpp
@@ -35,7 +35,7 @@ void RedundantRelationsAnalysis::run(const TranslationUnit& translationUnit) {
 
     std::set<const Relation*> work;
     std::set<const Relation*> notRedundant;
-    auto* ioType = translationUnit.getAnalysis<IOType>();
+    auto* ioType = translationUnit.getAnalysis<IOTypeAnalysis>();
 
     const std::vector<Relation*>& relations = translationUnit.getProgram()->getRelations();
     /* Add all output relations to the work set */

--- a/src/ast/analysis/RedundantRelations.cpp
+++ b/src/ast/analysis/RedundantRelations.cpp
@@ -28,18 +28,18 @@
 #include <set>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
-void RedundantRelationsAnalysis::run(const AstTranslationUnit& translationUnit) {
+void RedundantRelationsAnalysis::run(const TranslationUnit& translationUnit) {
     precedenceGraph = translationUnit.getAnalysis<PrecedenceGraphAnalysis>();
 
-    std::set<const AstRelation*> work;
-    std::set<const AstRelation*> notRedundant;
+    std::set<const Relation*> work;
+    std::set<const Relation*> notRedundant;
     auto* ioType = translationUnit.getAnalysis<IOType>();
 
-    const std::vector<AstRelation*>& relations = translationUnit.getProgram()->getRelations();
+    const std::vector<Relation*>& relations = translationUnit.getProgram()->getRelations();
     /* Add all output relations to the work set */
-    for (const AstRelation* r : relations) {
+    for (const Relation* r : relations) {
         if (ioType->isOutput(r)) {
             work.insert(r);
         }
@@ -49,13 +49,13 @@ void RedundantRelationsAnalysis::run(const AstTranslationUnit& translationUnit) 
        output relations. */
     while (!work.empty()) {
         /* Chose one element in the work set and add it to notRedundant */
-        const AstRelation* u = *(work.begin());
+        const Relation* u = *(work.begin());
         work.erase(work.begin());
         notRedundant.insert(u);
 
         /* Find all predecessors of u and add them to the worklist
             if they are not in the set notRedundant */
-        for (const AstRelation* predecessor : precedenceGraph->graph().predecessors(u)) {
+        for (const Relation* predecessor : precedenceGraph->graph().predecessors(u)) {
             if (notRedundant.count(predecessor) == 0u) {
                 work.insert(predecessor);
             }
@@ -64,7 +64,7 @@ void RedundantRelationsAnalysis::run(const AstTranslationUnit& translationUnit) 
 
     /* All remaining relations are redundant. */
     redundantRelations.clear();
-    for (const AstRelation* r : relations) {
+    for (const Relation* r : relations) {
         if (notRedundant.count(r) == 0u) {
             redundantRelations.insert(r);
         }
@@ -75,4 +75,4 @@ void RedundantRelationsAnalysis::print(std::ostream& os) const {
     os << redundantRelations << std::endl;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/RedundantRelations.h
+++ b/src/ast/analysis/RedundantRelations.h
@@ -22,33 +22,36 @@
 #include <set>
 #include <string>
 
-namespace souffle {
-class AstTranslationUnit;
+namespace souffle::ast {
+class TranslationUnit;
+class Relation;
+
+namespace analysis {
 class PrecedenceGraphAnalysis;
-class AstRelation;
 
 /**
  * Analysis pass identifying relations which do not contribute to the computation
  * of the output relations.
  */
-class RedundantRelationsAnalysis : public AstAnalysis {
+class RedundantRelationsAnalysis : public Analysis {
 public:
     static constexpr const char* name = "redundant-relations";
 
-    RedundantRelationsAnalysis() : AstAnalysis(name) {}
+    RedundantRelationsAnalysis() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     void print(std::ostream& os) const override;
 
-    const std::set<const AstRelation*>& getRedundantRelations() const {
+    const std::set<const Relation*>& getRedundantRelations() const {
         return redundantRelations;
     }
 
 private:
     PrecedenceGraphAnalysis* precedenceGraph = nullptr;
 
-    std::set<const AstRelation*> redundantRelations;
+    std::set<const Relation*> redundantRelations;
 };
 
-}  // end of namespace souffle
+}  // namespace analysis
+}  // namespace souffle::ast

--- a/src/ast/analysis/RelationDetailCache.cpp
+++ b/src/ast/analysis/RelationDetailCache.cpp
@@ -28,18 +28,18 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
-void RelationDetailCacheAnalysis::run(const AstTranslationUnit& translationUnit) {
+void RelationDetailCacheAnalysis::run(const TranslationUnit& translationUnit) {
     const auto& program = *translationUnit.getProgram();
     for (auto* rel : program.getRelations()) {
         nameToRelation[rel->getQualifiedName()] = rel;
-        nameToClauses[rel->getQualifiedName()] = std::set<AstClause*>();
+        nameToClauses[rel->getQualifiedName()] = std::set<Clause*>();
     }
     for (auto* clause : program.getClauses()) {
         const auto& relationName = clause->getHead()->getQualifiedName();
         if (nameToClauses.find(relationName) == nameToClauses.end()) {
-            nameToClauses[relationName] = std::set<AstClause*>();
+            nameToClauses[relationName] = std::set<Clause*>();
         }
         nameToClauses.at(relationName).insert(clause);
     }
@@ -56,4 +56,4 @@ void RelationDetailCacheAnalysis::print(std::ostream& os) const {
     }
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/RelationDetailCache.h
+++ b/src/ast/analysis/RelationDetailCache.h
@@ -26,46 +26,49 @@
 #include <set>
 #include <string>
 
-namespace souffle {
+namespace souffle::ast {
 
-class AstClause;
-class AstTranslationUnit;
+class Clause;
+class TranslationUnit;
+
+namespace analysis {
 
 /**
  * Analysis pass mapping identifiers with relations and clauses.
  */
-class RelationDetailCacheAnalysis : public AstAnalysis {
+class RelationDetailCacheAnalysis : public Analysis {
 public:
     static constexpr const char* name = "relation-detail";
 
-    RelationDetailCacheAnalysis() : AstAnalysis(name) {}
+    RelationDetailCacheAnalysis() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     void print(std::ostream& os) const override;
 
-    AstRelation* getRelation(const AstQualifiedName& name) const {
+    Relation* getRelation(const QualifiedName& name) const {
         if (nameToRelation.find(name) != nameToRelation.end()) {
             return nameToRelation.at(name);
         }
         return nullptr;
     }
 
-    std::set<AstClause*> getClauses(const AstRelation* rel) const {
+    std::set<Clause*> getClauses(const Relation* rel) const {
         assert(rel != nullptr && "invalid relation");
         return getClauses(rel->getQualifiedName());
     }
 
-    std::set<AstClause*> getClauses(const AstQualifiedName& name) const {
+    std::set<Clause*> getClauses(const QualifiedName& name) const {
         if (nameToClauses.find(name) != nameToClauses.end()) {
             return nameToClauses.at(name);
         }
-        return std::set<AstClause*>();
+        return std::set<Clause*>();
     }
 
 private:
-    std::map<AstQualifiedName, AstRelation*> nameToRelation;
-    std::map<AstQualifiedName, std::set<AstClause*>> nameToClauses;
+    std::map<QualifiedName, Relation*> nameToRelation;
+    std::map<QualifiedName, std::set<Clause*>> nameToClauses;
 };
 
-}  // end of namespace souffle
+}  // namespace analysis
+}  // namespace souffle::ast

--- a/src/ast/analysis/RelationSchedule.h
+++ b/src/ast/analysis/RelationSchedule.h
@@ -29,7 +29,7 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
 /**
  * A single step in a relation schedule, consisting of the relations computed in the step
@@ -37,16 +37,16 @@ namespace souffle {
  */
 class RelationScheduleAnalysisStep {
 public:
-    RelationScheduleAnalysisStep(std::set<const AstRelation*> computedRelations,
-            std::set<const AstRelation*> expiredRelations, const bool isRecursive)
+    RelationScheduleAnalysisStep(std::set<const Relation*> computedRelations,
+            std::set<const Relation*> expiredRelations, const bool isRecursive)
             : computedRelations(std::move(computedRelations)), expiredRelations(std::move(expiredRelations)),
               isRecursive(isRecursive) {}
 
-    const std::set<const AstRelation*>& computed() const {
+    const std::set<const Relation*>& computed() const {
         return computedRelations;
     }
 
-    const std::set<const AstRelation*>& expired() const {
+    const std::set<const Relation*>& expired() const {
         return expiredRelations;
     }
 
@@ -63,21 +63,21 @@ public:
     }
 
 private:
-    std::set<const AstRelation*> computedRelations;
-    std::set<const AstRelation*> expiredRelations;
+    std::set<const Relation*> computedRelations;
+    std::set<const Relation*> expiredRelations;
     const bool isRecursive;
 };
 
 /**
  * Analysis pass computing a schedule for computing relations.
  */
-class RelationScheduleAnalysis : public AstAnalysis {
+class RelationScheduleAnalysis : public Analysis {
 public:
     static constexpr const char* name = "relation-schedule";
 
-    RelationScheduleAnalysis() : AstAnalysis(name) {}
+    RelationScheduleAnalysis() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     const std::vector<RelationScheduleAnalysisStep>& schedule() const {
         return relationSchedule;
@@ -93,8 +93,8 @@ private:
     /** Relations computed and expired relations at each step */
     std::vector<RelationScheduleAnalysisStep> relationSchedule;
 
-    std::vector<std::set<const AstRelation*>> computeRelationExpirySchedule(
-            const AstTranslationUnit& translationUnit);
+    std::vector<std::set<const Relation*>> computeRelationExpirySchedule(
+            const TranslationUnit& translationUnit);
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/SCCGraph.cpp
+++ b/src/ast/analysis/SCCGraph.cpp
@@ -35,7 +35,7 @@ namespace souffle::ast::analysis {
 
 void SCCGraphAnalysis::run(const TranslationUnit& translationUnit) {
     precedenceGraph = translationUnit.getAnalysis<PrecedenceGraphAnalysis>();
-    ioType = translationUnit.getAnalysis<IOType>();
+    ioType = translationUnit.getAnalysis<IOTypeAnalysis>();
     sccToRelation.clear();
     relationToScc.clear();
     predecessors.clear();

--- a/src/ast/analysis/SCCGraph.cpp
+++ b/src/ast/analysis/SCCGraph.cpp
@@ -31,9 +31,9 @@
 #include <set>
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
-void SCCGraphAnalysis::run(const AstTranslationUnit& translationUnit) {
+void SCCGraphAnalysis::run(const TranslationUnit& translationUnit) {
     precedenceGraph = translationUnit.getAnalysis<PrecedenceGraphAnalysis>();
     ioType = translationUnit.getAnalysis<IOType>();
     sccToRelation.clear();
@@ -42,16 +42,16 @@ void SCCGraphAnalysis::run(const AstTranslationUnit& translationUnit) {
     successors.clear();
 
     /* Compute SCC */
-    std::vector<AstRelation*> relations = translationUnit.getProgram()->getRelations();
+    std::vector<Relation*> relations = translationUnit.getProgram()->getRelations();
     size_t counter = 0;
     size_t numSCCs = 0;
-    std::stack<const AstRelation*> S;
-    std::stack<const AstRelation*> P;
-    std::map<const AstRelation*, size_t> preOrder;  // Pre-order number of a node (for Gabow's Algo)
-    for (const AstRelation* relation : relations) {
+    std::stack<const Relation*> S;
+    std::stack<const Relation*> P;
+    std::map<const Relation*, size_t> preOrder;  // Pre-order number of a node (for Gabow's Algo)
+    for (const Relation* relation : relations) {
         relationToScc[relation] = preOrder[relation] = (size_t)-1;
     }
-    for (const AstRelation* relation : relations) {
+    for (const Relation* relation : relations) {
         if (preOrder[relation] == (size_t)-1) {
             scR(relation, preOrder, counter, S, P, numSCCs);
         }
@@ -60,8 +60,8 @@ void SCCGraphAnalysis::run(const AstTranslationUnit& translationUnit) {
     /* Build SCC graph */
     successors.resize(numSCCs);
     predecessors.resize(numSCCs);
-    for (const AstRelation* u : relations) {
-        for (const AstRelation* v : precedenceGraph->graph().predecessors(u)) {
+    for (const Relation* u : relations) {
+        for (const Relation* v : precedenceGraph->graph().predecessors(u)) {
             auto scc_u = relationToScc[u];
             auto scc_v = relationToScc[v];
             assert(scc_u < numSCCs && "Wrong range");
@@ -75,7 +75,7 @@ void SCCGraphAnalysis::run(const AstTranslationUnit& translationUnit) {
 
     /* Store the relations for each SCC */
     sccToRelation.resize(numSCCs);
-    for (const AstRelation* relation : relations) {
+    for (const Relation* relation : relations) {
         sccToRelation[relationToScc[relation]].insert(relation);
     }
 }
@@ -83,13 +83,12 @@ void SCCGraphAnalysis::run(const AstTranslationUnit& translationUnit) {
 /* Compute strongly connected components using Gabow's algorithm (cf. Algorithms in
  * Java by Robert Sedgewick / Part 5 / Graph *  algorithms). The algorithm has linear
  * runtime. */
-void SCCGraphAnalysis::scR(const AstRelation* w, std::map<const AstRelation*, size_t>& preOrder,
-        size_t& counter, std::stack<const AstRelation*>& S, std::stack<const AstRelation*>& P,
-        size_t& numSCCs) {
+void SCCGraphAnalysis::scR(const Relation* w, std::map<const Relation*, size_t>& preOrder, size_t& counter,
+        std::stack<const Relation*>& S, std::stack<const Relation*>& P, size_t& numSCCs) {
     preOrder[w] = counter++;
     S.push(w);
     P.push(w);
-    for (const AstRelation* t : precedenceGraph->graph().predecessors(w)) {
+    for (const Relation* t : precedenceGraph->graph().predecessors(w)) {
         if (preOrder[t] == (size_t)-1) {
             scR(t, preOrder, counter, S, P, numSCCs);
         } else if (relationToScc[t] == (size_t)-1) {
@@ -104,7 +103,7 @@ void SCCGraphAnalysis::scR(const AstRelation* w, std::map<const AstRelation*, si
         return;
     }
 
-    const AstRelation* v;
+    const Relation* v;
     do {
         v = S.top();
         S.pop();
@@ -122,7 +121,7 @@ void SCCGraphAnalysis::print(std::ostream& os) const {
     for (size_t scc = 0; scc < getNumberOfSCCs(); scc++) {
         ss << "\t" << name << "_" << scc << "[label = \"";
         ss << join(getInternalRelations(scc), ",\\n",
-                [](std::ostream& out, const AstRelation* rel) { out << rel->getQualifiedName(); });
+                [](std::ostream& out, const Relation* rel) { out << rel->getQualifiedName(); });
         ss << "\" ];" << std::endl;
     }
     for (size_t scc = 0; scc < getNumberOfSCCs(); scc++) {
@@ -134,4 +133,4 @@ void SCCGraphAnalysis::print(std::ostream& os) const {
     printHTMLGraph(os, ss.str(), getName());
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/SCCGraph.h
+++ b/src/ast/analysis/SCCGraph.h
@@ -30,20 +30,22 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
-class AstTranslationUnit;
+class TranslationUnit;
+
+namespace analysis {
 
 /**
  * Analysis pass computing the strongly connected component (SCC) graph for the datalog program.
  */
-class SCCGraphAnalysis : public AstAnalysis {
+class SCCGraphAnalysis : public Analysis {
 public:
     static constexpr const char* name = "scc-graph";
 
-    SCCGraphAnalysis() : AstAnalysis(name) {}
+    SCCGraphAnalysis() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     /** Get the number of SCCs in the graph. */
     size_t getNumberOfSCCs() const {
@@ -51,7 +53,7 @@ public:
     }
 
     /** Get the SCC of the given relation. */
-    size_t getSCC(const AstRelation* rel) const {
+    size_t getSCC(const Relation* rel) const {
         return relationToScc.at(rel);
     }
 
@@ -66,7 +68,7 @@ public:
     }
 
     /** Get all SCCs containing a successor of a given relation. */
-    std::set<size_t> getSuccessorSCCs(const AstRelation* relation) const {
+    std::set<size_t> getSuccessorSCCs(const Relation* relation) const {
         std::set<size_t> successorSccs;
         const auto scc = relationToScc.at(relation);
         for (const auto& successor : precedenceGraph->graph().successors(relation)) {
@@ -79,7 +81,7 @@ public:
     }
 
     /** Get all SCCs containing a predecessor of a given relation. */
-    std::set<size_t> getPredecessorSCCs(const AstRelation* relation) const {
+    std::set<size_t> getPredecessorSCCs(const Relation* relation) const {
         std::set<size_t> predecessorSccs;
         const auto scc = relationToScc.at(relation);
         for (const auto& predecessor : precedenceGraph->graph().predecessors(relation)) {
@@ -92,13 +94,13 @@ public:
     }
 
     /** Get all internal relations of a given SCC. */
-    const std::set<const AstRelation*>& getInternalRelations(const size_t scc) const {
+    const std::set<const Relation*>& getInternalRelations(const size_t scc) const {
         return sccToRelation.at(scc);
     }
 
     /** Get all external output predecessor relations of a given SCC. */
-    std::set<const AstRelation*> getExternalOutputPredecessorRelations(const size_t scc) const {
-        std::set<const AstRelation*> externOutPreds;
+    std::set<const Relation*> getExternalOutputPredecessorRelations(const size_t scc) const {
+        std::set<const Relation*> externOutPreds;
         for (const auto& relation : getInternalRelations(scc)) {
             for (const auto& predecessor : precedenceGraph->graph().predecessors(relation)) {
                 if (relationToScc.at(predecessor) != scc && ioType->isOutput(predecessor)) {
@@ -110,8 +112,8 @@ public:
     }
 
     /** Get all external non-output predecessor relations of a given SCC. */
-    std::set<const AstRelation*> getExternalNonOutputPredecessorRelations(const size_t scc) const {
-        std::set<const AstRelation*> externNonOutPreds;
+    std::set<const Relation*> getExternalNonOutputPredecessorRelations(const size_t scc) const {
+        std::set<const Relation*> externNonOutPreds;
         for (const auto& relation : getInternalRelations(scc)) {
             for (const auto& predecessor : precedenceGraph->graph().predecessors(relation)) {
                 if (relationToScc.at(predecessor) != scc && !ioType->isOutput(predecessor)) {
@@ -123,8 +125,8 @@ public:
     }
 
     /** Get all external predecessor relations of a given SCC. */
-    std::set<const AstRelation*> getExternalPredecessorRelations(const size_t scc) const {
-        std::set<const AstRelation*> externPreds;
+    std::set<const Relation*> getExternalPredecessorRelations(const size_t scc) const {
+        std::set<const Relation*> externPreds;
         for (const auto& relation : getInternalRelations(scc)) {
             for (const auto& predecessor : precedenceGraph->graph().predecessors(relation)) {
                 if (relationToScc.at(predecessor) != scc) {
@@ -136,8 +138,8 @@ public:
     }
 
     /** Get all internal output relations of a given SCC. */
-    std::set<const AstRelation*> getInternalOutputRelations(const size_t scc) const {
-        std::set<const AstRelation*> internOuts;
+    std::set<const Relation*> getInternalOutputRelations(const size_t scc) const {
+        std::set<const Relation*> internOuts;
         for (const auto& relation : getInternalRelations(scc)) {
             if (ioType->isOutput(relation)) {
                 internOuts.insert(relation);
@@ -147,8 +149,8 @@ public:
     }
 
     /** Get all internal relations of a given SCC with external successors. */
-    std::set<const AstRelation*> getInternalRelationsWithExternalSuccessors(const size_t scc) const {
-        std::set<const AstRelation*> internsWithExternSuccs;
+    std::set<const Relation*> getInternalRelationsWithExternalSuccessors(const size_t scc) const {
+        std::set<const Relation*> internsWithExternSuccs;
         for (const auto& relation : getInternalRelations(scc)) {
             for (const auto& successor : precedenceGraph->graph().successors(relation)) {
                 if (relationToScc.at(successor) != scc) {
@@ -161,8 +163,8 @@ public:
     }
 
     /** Get all internal non-output relations of a given SCC with external successors. */
-    std::set<const AstRelation*> getInternalNonOutputRelationsWithExternalSuccessors(const size_t scc) const {
-        std::set<const AstRelation*> internNonOutsWithExternSuccs;
+    std::set<const Relation*> getInternalNonOutputRelationsWithExternalSuccessors(const size_t scc) const {
+        std::set<const Relation*> internNonOutsWithExternSuccs;
         for (const auto& relation : getInternalRelations(scc)) {
             if (!ioType->isOutput(relation)) {
                 for (const auto& successor : precedenceGraph->graph().successors(relation)) {
@@ -177,8 +179,8 @@ public:
     }
 
     /** Get all internal input relations of a given SCC. */
-    std::set<const AstRelation*> getInternalInputRelations(const size_t scc) const {
-        std::set<const AstRelation*> internIns;
+    std::set<const Relation*> getInternalInputRelations(const size_t scc) const {
+        std::set<const Relation*> internIns;
         for (const auto& relation : getInternalRelations(scc)) {
             if (ioType->isInput(relation)) {
                 internIns.insert(relation);
@@ -189,9 +191,9 @@ public:
 
     /** Return if the given SCC is recursive. */
     bool isRecursive(const size_t scc) const {
-        const std::set<const AstRelation*>& sccRelations = sccToRelation.at(scc);
+        const std::set<const Relation*>& sccRelations = sccToRelation.at(scc);
         if (sccRelations.size() == 1) {
-            const AstRelation* singleRelation = *sccRelations.begin();
+            const Relation* singleRelation = *sccRelations.begin();
             if (precedenceGraph->graph().predecessors(singleRelation).count(singleRelation) == 0u) {
                 return false;
             }
@@ -206,7 +208,7 @@ private:
     PrecedenceGraphAnalysis* precedenceGraph = nullptr;
 
     /** Map from node number to SCC number */
-    std::map<const AstRelation*, size_t> relationToScc;
+    std::map<const Relation*, size_t> relationToScc;
 
     /** Adjacency lists for the SCC graph */
     std::vector<std::set<size_t>> successors;
@@ -215,13 +217,14 @@ private:
     std::vector<std::set<size_t>> predecessors;
 
     /** Relations contained in a SCC */
-    std::vector<std::set<const AstRelation*>> sccToRelation;
+    std::vector<std::set<const Relation*>> sccToRelation;
 
     /** Recursive scR method for computing SCC */
-    void scR(const AstRelation* relation, std::map<const AstRelation*, size_t>& preOrder, size_t& counter,
-            std::stack<const AstRelation*>& S, std::stack<const AstRelation*>& P, size_t& numSCCs);
+    void scR(const Relation* relation, std::map<const Relation*, size_t>& preOrder, size_t& counter,
+            std::stack<const Relation*>& S, std::stack<const Relation*>& P, size_t& numSCCs);
 
     IOType* ioType = nullptr;
 };
 
-}  // end of namespace souffle
+}  // namespace analysis
+}  // namespace souffle::ast

--- a/src/ast/analysis/SCCGraph.h
+++ b/src/ast/analysis/SCCGraph.h
@@ -223,7 +223,7 @@ private:
     void scR(const Relation* relation, std::map<const Relation*, size_t>& preOrder, size_t& counter,
             std::stack<const Relation*>& S, std::stack<const Relation*>& P, size_t& numSCCs);
 
-    IOType* ioType = nullptr;
+    IOTypeAnalysis* ioType = nullptr;
 };
 
 }  // namespace analysis

--- a/src/ast/analysis/SumTypeBranches.cpp
+++ b/src/ast/analysis/SumTypeBranches.cpp
@@ -25,12 +25,12 @@
 #include "ast/utility/Visitor.h"
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
-void SumTypeBranchesAnalysis::run(const AstTranslationUnit& tu) {
+void SumTypeBranchesAnalysis::run(const TranslationUnit& tu) {
     const TypeEnvironment& env = tu.getAnalysis<TypeEnvironmentAnalysis>()->getTypeEnvironment();
 
-    visitDepthFirst(tu.getProgram()->getTypes(), [&](const AstAlgebraicDataType& adt) {
+    visitDepthFirst(tu.getProgram()->getTypes(), [&](const ast::AlgebraicDataType& adt) {
         auto typeName = adt.getQualifiedName();
         if (!env.isType(typeName)) return;
 
@@ -40,4 +40,4 @@ void SumTypeBranchesAnalysis::run(const AstTranslationUnit& tu) {
     });
 }
 
-}  // namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/SumTypeBranches.h
+++ b/src/ast/analysis/SumTypeBranches.h
@@ -21,15 +21,17 @@
 #include <map>
 #include <string>
 
-namespace souffle {
+namespace souffle::ast {
 
-class SumTypeBranchesAnalysis : public AstAnalysis {
+namespace analysis {
+
+class SumTypeBranchesAnalysis : public Analysis {
 public:
     static constexpr const char* name = "sum-type-branches";
 
-    SumTypeBranchesAnalysis() : AstAnalysis(name) {}
+    SumTypeBranchesAnalysis() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     /**
      * A type can be nullptr in case of a malformed program.
@@ -50,4 +52,5 @@ private:
     std::map<std::string, const Type*> branchToType;
 };
 
-}  // namespace souffle
+}  // namespace analysis
+}  // namespace souffle::ast

--- a/src/ast/analysis/TopologicallySortedSCCGraph.cpp
+++ b/src/ast/analysis/TopologicallySortedSCCGraph.cpp
@@ -26,7 +26,7 @@
 #include <set>
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
 int TopologicallySortedSCCGraphAnalysis::topologicalOrderingCost(
         const std::vector<size_t>& permutationOfSCCs) const {
@@ -124,7 +124,7 @@ void TopologicallySortedSCCGraphAnalysis::computeTopologicalOrdering(size_t scc,
     }
 }
 
-void TopologicallySortedSCCGraphAnalysis::run(const AstTranslationUnit& translationUnit) {
+void TopologicallySortedSCCGraphAnalysis::run(const TranslationUnit& translationUnit) {
     // obtain the scc graph
     sccGraph = translationUnit.getAnalysis<SCCGraphAnalysis>();
     // clear the list of ordered sccs
@@ -166,7 +166,7 @@ void TopologicallySortedSCCGraphAnalysis::print(std::ostream& os) const {
     for (size_t i = 0; i < sccOrder.size(); i++) {
         os << i << ": [";
         os << join(sccGraph->getInternalRelations(sccOrder[i]), ", ",
-                [](std::ostream& out, const AstRelation* rel) { out << rel->getQualifiedName(); });
+                [](std::ostream& out, const Relation* rel) { out << rel->getQualifiedName(); });
         os << "]" << std::endl;
     }
     os << std::endl;
@@ -174,4 +174,4 @@ void TopologicallySortedSCCGraphAnalysis::print(std::ostream& os) const {
     os << "cost: " << topologicalOrderingCost(sccOrder) << std::endl;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/TopologicallySortedSCCGraph.h
+++ b/src/ast/analysis/TopologicallySortedSCCGraph.h
@@ -27,21 +27,24 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
-class AstTranslationUnit;
+class TranslationUnit;
+
+namespace analysis {
+
 class SCCGraphAnalysis;
 
 /**
  * Analysis pass computing a topologically sorted strongly connected component (SCC) graph.
  */
-class TopologicallySortedSCCGraphAnalysis : public AstAnalysis {
+class TopologicallySortedSCCGraphAnalysis : public Analysis {
 public:
     static constexpr const char* name = "topological-scc-graph";
 
-    TopologicallySortedSCCGraphAnalysis() : AstAnalysis(name) {}
+    TopologicallySortedSCCGraphAnalysis() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     const std::vector<size_t>& order() const {
         return sccOrder;
@@ -83,4 +86,5 @@ private:
     void computeTopologicalOrdering(size_t scc, std::vector<bool>& visited);
 };
 
-}  // end of namespace souffle
+}  // namespace analysis
+}  // namespace souffle::ast

--- a/src/ast/analysis/Type.h
+++ b/src/ast/analysis/Type.h
@@ -25,22 +25,22 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
-class TypeAnalysis : public AstAnalysis {
+class TypeAnalysis : public Analysis {
 public:
     static constexpr const char* name = "type-analysis";
 
-    TypeAnalysis() : AstAnalysis(name) {}
+    TypeAnalysis() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     void print(std::ostream& os) const override;
 
     /**
      * Get the computed types for the given argument.
      */
-    TypeSet const& getTypes(const AstArgument* argument) const {
+    TypeSet const& getTypes(const Argument* argument) const {
         return argumentTypes.at(argument);
     }
 
@@ -54,13 +54,13 @@ public:
      * @param program the program
      * @return a map mapping each contained argument to a a set of types
      */
-    static std::map<const AstArgument*, TypeSet> analyseTypes(
-            const AstTranslationUnit&, const AstClause&, std::ostream* /*logs*/ = nullptr);
+    static std::map<const Argument*, TypeSet> analyseTypes(
+            const TranslationUnit&, const Clause&, std::ostream* /*logs*/ = nullptr);
 
 private:
-    std::map<const AstArgument*, TypeSet> argumentTypes;
-    VecOwn<AstClause> annotatedClauses;
+    std::map<const Argument*, TypeSet> argumentTypes;
+    VecOwn<Clause> annotatedClauses;
     std::stringstream analysisLogs;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/TypeEnvironment.h
+++ b/src/ast/analysis/TypeEnvironment.h
@@ -27,15 +27,15 @@
 #include <set>
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
-class TypeEnvironmentAnalysis : public AstAnalysis {
+class TypeEnvironmentAnalysis : public Analysis {
 public:
     static constexpr const char* name = "type-environment";
 
-    TypeEnvironmentAnalysis() : AstAnalysis(name) {}
+    TypeEnvironmentAnalysis() : Analysis(name) {}
 
-    void run(const AstTranslationUnit& translationUnit) override;
+    void run(const TranslationUnit& translationUnit) override;
 
     void print(std::ostream& os) const override;
 
@@ -43,25 +43,25 @@ public:
         return env;
     }
 
-    const std::set<AstQualifiedName>& getPrimitiveTypesInUnion(const AstQualifiedName& identifier) const {
+    const std::set<QualifiedName>& getPrimitiveTypesInUnion(const QualifiedName& identifier) const {
         return primitiveTypesInUnions.at(identifier);
     }
 
-    bool isCyclic(const AstQualifiedName& identifier) const {
+    bool isCyclic(const QualifiedName& identifier) const {
         return contains(cyclicTypes, identifier);
     }
 
 private:
     TypeEnvironment env;
-    std::map<AstQualifiedName, std::set<AstQualifiedName>> primitiveTypesInUnions;
-    std::set<AstQualifiedName> cyclicTypes;
+    std::map<QualifiedName, std::set<QualifiedName>> primitiveTypesInUnions;
+    std::set<QualifiedName> cyclicTypes;
 
     /**
      * Recursively create a type in env, that is
      * first create its base types and then the type itself.
      */
-    const Type* createType(const AstQualifiedName& typeName,
-            const std::map<AstQualifiedName, const AstType*>& nameToAstType);
+    const Type* createType(
+            const QualifiedName& typeName, const std::map<QualifiedName, const ast::Type*>& nameToType);
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/analysis/TypeSystem.cpp
+++ b/src/ast/analysis/TypeSystem.cpp
@@ -23,7 +23,7 @@
 #include <cassert>
 #include <initializer_list>
 
-namespace souffle {
+namespace souffle::ast::analysis {
 
 void SubsetType::print(std::ostream& out) const {
     out << tfm::format("%s <: %s", getName(), baseType.getName());
@@ -64,7 +64,7 @@ TypeSet TypeEnvironment::initializePrimitiveTypes() {
 #undef CREATE_PRIMITIVE
 }
 
-bool TypeEnvironment::isType(const AstQualifiedName& ident) const {
+bool TypeEnvironment::isType(const QualifiedName& ident) const {
     return types.find(ident) != types.end();
 }
 
@@ -72,11 +72,11 @@ bool TypeEnvironment::isType(const Type& type) const {
     return this == &type.getTypeEnvironment();
 }
 
-const Type& TypeEnvironment::getType(const AstQualifiedName& ident) const {
+const Type& TypeEnvironment::getType(const QualifiedName& ident) const {
     return *types.at(ident);
 }
 
-const Type& TypeEnvironment::getType(const AstType& astTypeDeclaration) const {
+const Type& TypeEnvironment::getType(const ast::Type& astTypeDeclaration) const {
     return getType(astTypeDeclaration.getQualifiedName());
 }
 
@@ -389,4 +389,4 @@ bool areEquivalentTypes(const Type& a, const Type& b) {
     return isSubtypeOf(a, b) && isSubtypeOf(b, a);
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::analysis

--- a/src/ast/tests/ast_parser_utils_test.cpp
+++ b/src/ast/tests/ast_parser_utils_test.cpp
@@ -27,7 +27,7 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 namespace test {
 
@@ -35,13 +35,13 @@ TEST(RuleBody, Basic) {
     RuleBody body;
 
     // start with an A
-    auto a = RuleBody::atom(mk<AstAtom>("A"));
+    auto a = RuleBody::atom(mk<Atom>("A"));
     EXPECT_EQ("A()", toString(a));
 
-    a.conjunct(RuleBody::atom(mk<AstAtom>("B")));
+    a.conjunct(RuleBody::atom(mk<Atom>("B")));
     EXPECT_EQ("A(),B()", toString(a));
 
-    a.disjunct(RuleBody::atom(mk<AstAtom>("C")));
+    a.disjunct(RuleBody::atom(mk<Atom>("C")));
     EXPECT_EQ("A(),B();C()", toString(a));
 }
 
@@ -49,18 +49,18 @@ TEST(RuleBody, Negation) {
     RuleBody body = RuleBody::getTrue();
 
     RuleBody AB = RuleBody::getTrue();
-    AB.conjunct(RuleBody::atom(mk<AstAtom>("A")));
-    AB.conjunct(RuleBody::atom(mk<AstAtom>("B")));
+    AB.conjunct(RuleBody::atom(mk<Atom>("A")));
+    AB.conjunct(RuleBody::atom(mk<Atom>("B")));
     EXPECT_EQ("A(),B()", toString(AB));
 
     RuleBody CD = RuleBody::getTrue();
-    CD.conjunct(RuleBody::atom(mk<AstAtom>("C")));
-    CD.conjunct(RuleBody::atom(mk<AstAtom>("D")));
+    CD.conjunct(RuleBody::atom(mk<Atom>("C")));
+    CD.conjunct(RuleBody::atom(mk<Atom>("D")));
     EXPECT_EQ("C(),D()", toString(CD));
 
     RuleBody EF = RuleBody::getTrue();
-    EF.conjunct(RuleBody::atom(mk<AstAtom>("E")));
-    EF.conjunct(RuleBody::atom(mk<AstAtom>("F")));
+    EF.conjunct(RuleBody::atom(mk<Atom>("E")));
+    EF.conjunct(RuleBody::atom(mk<Atom>("F")));
     EXPECT_EQ("E(),F()", toString(EF));
 
     RuleBody full = RuleBody::getFalse();
@@ -83,18 +83,18 @@ TEST(RuleBody, ClauseBodyExtraction) {
     RuleBody body = RuleBody::getTrue();
 
     RuleBody AB = RuleBody::getTrue();
-    AB.conjunct(RuleBody::atom(mk<AstAtom>("A")));
-    AB.conjunct(RuleBody::atom(mk<AstAtom>("B")));
+    AB.conjunct(RuleBody::atom(mk<Atom>("A")));
+    AB.conjunct(RuleBody::atom(mk<Atom>("B")));
     EXPECT_EQ("A(),B()", toString(AB));
 
     RuleBody CD = RuleBody::getTrue();
-    CD.conjunct(RuleBody::atom(mk<AstAtom>("C")));
-    CD.conjunct(RuleBody::atom(mk<AstAtom>("D")));
+    CD.conjunct(RuleBody::atom(mk<Atom>("C")));
+    CD.conjunct(RuleBody::atom(mk<Atom>("D")));
     EXPECT_EQ("C(),D()", toString(CD));
 
     RuleBody EF = RuleBody::getTrue();
-    EF.conjunct(RuleBody::atom(mk<AstAtom>("E")));
-    EF.conjunct(RuleBody::atom(mk<AstAtom>("F")));
+    EF.conjunct(RuleBody::atom(mk<Atom>("E")));
+    EF.conjunct(RuleBody::atom(mk<Atom>("F")));
     EXPECT_EQ("E(),F()", toString(EF));
 
     RuleBody full = RuleBody::getFalse();
@@ -113,4 +113,4 @@ TEST(RuleBody, ClauseBodyExtraction) {
 }
 
 }  // end namespace test
-}  // end namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/tests/ast_print_test.cpp
+++ b/src/ast/tests/ast_print_test.cpp
@@ -41,30 +41,30 @@
 #include <utility>
 #include <vector>
 
-namespace souffle::test {
+namespace souffle::ast::test {
 
-inline Own<AstTranslationUnit> makeATU(std::string program = ".decl A,B,C(x:number)") {
+inline Own<TranslationUnit> makeATU(std::string program = ".decl A,B,C(x:number)") {
     ErrorReport e;
     DebugReport d;
     return ParserDriver::parseTranslationUnit(program, e, d);
 }
 
-inline Own<AstTranslationUnit> makePrintedATU(Own<AstTranslationUnit>& tu) {
+inline Own<TranslationUnit> makePrintedATU(Own<TranslationUnit>& tu) {
     std::stringstream ss;
     ss << *tu->getProgram();
     return makeATU(ss.str());
 }
 
-inline Own<AstClause> makeClauseA(Own<AstArgument> headArgument) {
-    auto headAtom = mk<AstAtom>("A");
+inline Own<Clause> makeClauseA(Own<Argument> headArgument) {
+    auto headAtom = mk<Atom>("A");
     headAtom->addArgument(std::move(headArgument));
-    auto clause = mk<AstClause>();
+    auto clause = mk<Clause>();
     clause->setHead(std::move(headAtom));
     return clause;
 }
 
 TEST(AstPrint, NilConstant) {
-    auto testArgument = mk<AstNilConstant>();
+    auto testArgument = mk<NilConstant>();
 
     auto tu1 = makeATU();
     tu1->getProgram()->addClause(makeClauseA(std::move(testArgument)));
@@ -73,7 +73,7 @@ TEST(AstPrint, NilConstant) {
 }
 
 TEST(AstPrint, NumberConstant) {
-    auto testArgument = mk<AstNumericConstant>("2");
+    auto testArgument = mk<NumericConstant>("2");
 
     EXPECT_EQ(testArgument, testArgument);
 
@@ -86,7 +86,7 @@ TEST(AstPrint, NumberConstant) {
 TEST(AstPrint, StringConstant) {
     ErrorReport e;
     DebugReport d;
-    auto testArgument = mk<AstStringConstant>("test string");
+    auto testArgument = mk<StringConstant>("test string");
 
     auto tu1 = ParserDriver::parseTranslationUnit(".decl A,B,C(x:number)", e, d);
     tu1->getProgram()->addClause(makeClauseA(std::move(testArgument)));
@@ -95,7 +95,7 @@ TEST(AstPrint, StringConstant) {
 }
 
 TEST(AstPrint, Variable) {
-    auto testArgument = mk<AstVariable>("testVar");
+    auto testArgument = mk<Variable>("testVar");
 
     auto tu1 = makeATU();
     tu1->getProgram()->addClause(makeClauseA(std::move(testArgument)));
@@ -104,7 +104,7 @@ TEST(AstPrint, Variable) {
 }
 
 TEST(AstPrint, UnnamedVariable) {
-    auto testArgument = mk<AstUnnamedVariable>();
+    auto testArgument = mk<UnnamedVariable>();
 
     auto tu1 = makeATU();
     tu1->getProgram()->addClause(makeClauseA(std::move(testArgument)));
@@ -113,7 +113,7 @@ TEST(AstPrint, UnnamedVariable) {
 }
 
 TEST(AstPrint, Counter) {
-    auto testArgument = mk<AstCounter>();
+    auto testArgument = mk<Counter>();
 
     auto tu1 = makeATU();
     tu1->getProgram()->addClause(makeClauseA(std::move(testArgument)));
@@ -122,12 +122,12 @@ TEST(AstPrint, Counter) {
 }
 
 TEST(AstPrint, AggregatorMin) {
-    auto atom = mk<AstAtom>("B");
-    atom->addArgument(mk<AstVariable>("x"));
-    auto min = mk<AstAggregator>(AggregateOp::MIN, mk<AstVariable>("x"));
+    auto atom = mk<Atom>("B");
+    atom->addArgument(mk<Variable>("x"));
+    auto min = mk<Aggregator>(AggregateOp::MIN, mk<Variable>("x"));
 
-    VecOwn<AstLiteral> body;
-    body.push_back(mk<AstAtom>("B"));
+    VecOwn<Literal> body;
+    body.push_back(mk<Atom>("B"));
 
     min->setBody(std::move(body));
 
@@ -139,11 +139,11 @@ TEST(AstPrint, AggregatorMin) {
 }
 
 TEST(AstPrint, AggregatorMax) {
-    auto atom = mk<AstAtom>("B");
-    atom->addArgument(mk<AstVariable>("x"));
-    auto max = mk<AstAggregator>(AggregateOp::MAX, mk<AstVariable>("x"));
+    auto atom = mk<Atom>("B");
+    atom->addArgument(mk<Variable>("x"));
+    auto max = mk<Aggregator>(AggregateOp::MAX, mk<Variable>("x"));
 
-    VecOwn<AstLiteral> body;
+    VecOwn<Literal> body;
     body.push_back(std::move(atom));
     max->setBody(std::move(body));
 
@@ -155,11 +155,11 @@ TEST(AstPrint, AggregatorMax) {
 }
 
 TEST(AstPrint, AggregatorCount) {
-    auto atom = mk<AstAtom>("B");
-    atom->addArgument(mk<AstVariable>("x"));
-    auto count = mk<AstAggregator>(AggregateOp::COUNT);
+    auto atom = mk<Atom>("B");
+    atom->addArgument(mk<Variable>("x"));
+    auto count = mk<Aggregator>(AggregateOp::COUNT);
 
-    VecOwn<AstLiteral> body;
+    VecOwn<Literal> body;
     body.push_back(std::move(atom));
     count->setBody(std::move(body));
 
@@ -171,11 +171,11 @@ TEST(AstPrint, AggregatorCount) {
 }
 
 TEST(AstPrint, AggregatorSum) {
-    auto atom = mk<AstAtom>("B");
-    atom->addArgument(mk<AstVariable>("x"));
-    auto sum = mk<AstAggregator>(AggregateOp::SUM, mk<AstVariable>("x"));
+    auto atom = mk<Atom>("B");
+    atom->addArgument(mk<Variable>("x"));
+    auto sum = mk<Aggregator>(AggregateOp::SUM, mk<Variable>("x"));
 
-    VecOwn<AstLiteral> body;
+    VecOwn<Literal> body;
     body.push_back(std::move(atom));
     sum->setBody(std::move(body));
 
@@ -186,4 +186,4 @@ TEST(AstPrint, AggregatorSum) {
     EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
 }
 
-}  // end namespace souffle::test
+}  // namespace souffle::ast::test

--- a/src/ast/tests/ast_program_test.cpp
+++ b/src/ast/tests/ast_program_test.cpp
@@ -39,33 +39,33 @@
 #include <utility>
 #include <vector>
 
-namespace souffle::test {
+namespace souffle::ast::test {
 
-inline Own<AstTranslationUnit> makeATU(std::string program) {
+inline Own<TranslationUnit> makeATU(std::string program) {
     ErrorReport e;
     DebugReport d;
     return ParserDriver::parseTranslationUnit(program, e, d);
 }
 
-inline Own<AstClause> makeClause(std::string name, Own<AstArgument> headArgument) {
-    auto headAtom = mk<AstAtom>(name);
+inline Own<Clause> makeClause(std::string name, Own<Argument> headArgument) {
+    auto headAtom = mk<Atom>(name);
     headAtom->addArgument(std::move(headArgument));
-    auto clause = mk<AstClause>();
+    auto clause = mk<Clause>();
     clause->setHead(std::move(headAtom));
     return clause;
 }
 
-TEST(AstProgram, Parse) {
+TEST(Program, Parse) {
     ErrorReport e;
     DebugReport d;
     // check the empty program
-    Own<AstTranslationUnit> empty = ParserDriver::parseTranslationUnit("", e, d);
+    Own<TranslationUnit> empty = ParserDriver::parseTranslationUnit("", e, d);
 
     EXPECT_TRUE(empty->getProgram()->getTypes().empty());
     EXPECT_TRUE(empty->getProgram()->getRelations().empty());
 
     // check something simple
-    Own<AstTranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
             R"(
                    .type Node <: symbol
                    .decl e ( a : Node , b : Node )
@@ -87,16 +87,16 @@ TEST(AstProgram, Parse) {
     EXPECT_FALSE(getRelation(*prog, "n"));
 }
 
-#define TESTASTCLONEANDEQUAL(SUBTYPE, DL)                                          \
-    TEST(Ast, CloneAndEqual##SUBTYPE) {                                            \
-        ErrorReport e;                                                             \
-        DebugReport d;                                                             \
-        Own<AstTranslationUnit> tu = ParserDriver::parseTranslationUnit(DL, e, d); \
-        AstProgram& program = *tu->getProgram();                                   \
-        EXPECT_EQ(program, program);                                               \
-        Own<AstProgram> clone(program.clone());                                    \
-        EXPECT_NE(clone.get(), &program);                                          \
-        EXPECT_EQ(*clone, program);                                                \
+#define TESTASTCLONEANDEQUAL(SUBTYPE, DL)                                       \
+    TEST(Ast, CloneAndEqual##SUBTYPE) {                                         \
+        ErrorReport e;                                                          \
+        DebugReport d;                                                          \
+        Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(DL, e, d); \
+        Program& program = *tu->getProgram();                                   \
+        EXPECT_EQ(program, program);                                            \
+        Own<Program> clone(program.clone());                                    \
+        EXPECT_NE(clone.get(), &program);                                       \
+        EXPECT_EQ(*clone, program);                                             \
     }
 
 TESTASTCLONEANDEQUAL(Program,
@@ -195,11 +195,11 @@ TESTASTCLONEANDEQUAL(RelationCopies,
             )");
 
 /** test removeClause, addRelation and removeRelation */
-TEST(AstProgram, RemoveClause) {
-    auto atom = mk<AstAtom>("B");
-    atom->addArgument(mk<AstVariable>("x"));
-    auto sum = mk<AstAggregator>(AggregateOp::SUM, mk<AstVariable>("x"));
-    VecOwn<AstLiteral> body;
+TEST(Program, RemoveClause) {
+    auto atom = mk<Atom>("B");
+    atom->addArgument(mk<Variable>("x"));
+    auto sum = mk<Aggregator>(AggregateOp::SUM, mk<Variable>("x"));
+    VecOwn<Literal> body;
     body.push_back(std::move(atom));
     sum->setBody(std::move(body));
 
@@ -211,22 +211,22 @@ TEST(AstProgram, RemoveClause) {
     EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
 }
 
-TEST(AstProgram, AppendAstRelation) {
+TEST(Program, AppendRelation) {
     auto tu1 = makeATU(".decl A,B,C(x:number)");
     auto* prog1 = tu1->getProgram();
-    auto rel = mk<AstRelation>();
+    auto rel = mk<Relation>();
     rel->setQualifiedName("D");
-    rel->addAttribute(mk<AstAttribute>("x", "number"));
+    rel->addAttribute(mk<Attribute>("x", "number"));
     prog1->addRelation(std::move(rel));
     auto tu2 = makeATU(".decl A,B,C,D(x:number)");
     EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
 }
 
-TEST(AstProgram, RemoveAstRelation) {
+TEST(Program, RemoveRelation) {
     auto tu1 = makeATU(".decl A,B,C(x:number)");
     removeRelation(*tu1, "B");
     auto tu2 = makeATU(".decl A,C(x:number)");
     EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
 }
 
-}  // end namespace souffle::test
+}  // namespace souffle::ast::test

--- a/src/ast/tests/constraints_test.cpp
+++ b/src/ast/tests/constraints_test.cpp
@@ -23,14 +23,14 @@
 #include <set>
 #include <string>
 
-using namespace std;
+namespace souffle::ast {
 
-namespace souffle {
+using namespace analysis;
 
 namespace test {
 
 TEST(Constraints, Basic) {
-    using Vars = Variable<string, set_property_space<int>>;
+    using Vars = Variable<std::string, set_property_space<int>>;
 
     Vars A("A");
     Vars B("B");
@@ -60,4 +60,4 @@ TEST(Constraints, Basic) {
 }
 
 }  // end namespace test
-}  // end namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/tests/type_system_test.cpp
+++ b/src/ast/tests/type_system_test.cpp
@@ -25,13 +25,14 @@
 #include <string>
 #include <vector>
 
-namespace souffle::test {
+namespace souffle::ast::test {
+using namespace analysis;
 
 TEST(TypeSystem, Basic) {
     TypeEnvironment env;
 
-    const Type& A = env.createType<SubsetType>("A", env.getType("number"));
-    const Type& B = env.createType<SubsetType>("B", env.getType("symbol"));
+    const analysis::Type& A = env.createType<SubsetType>("A", env.getType("number"));
+    const analysis::Type& B = env.createType<SubsetType>("B", env.getType("symbol"));
 
     auto& U = env.createType<UnionType>("U", toVector(&A, &B));
 
@@ -48,12 +49,12 @@ TEST(TypeSystem, Basic) {
 TEST(TypeSystem, isNumberType) {
     TypeEnvironment env;
 
-    const Type& N = env.getType("number");
+    const analysis::Type& N = env.getType("number");
 
-    const Type& A = env.createType<SubsetType>("A", env.getType("number"));
-    const Type& B = env.createType<SubsetType>("B", env.getType("number"));
+    const analysis::Type& A = env.createType<SubsetType>("A", env.getType("number"));
+    const analysis::Type& B = env.createType<SubsetType>("B", env.getType("number"));
 
-    const Type& C = env.createType<SubsetType>("C", env.getType("symbol"));
+    const analysis::Type& C = env.createType<SubsetType>("C", env.getType("symbol"));
 
     EXPECT_TRUE(isOfKind(N, TypeAttribute::Signed));
     EXPECT_TRUE(isOfKind(A, TypeAttribute::Signed));
@@ -67,20 +68,20 @@ TEST(TypeSystem, isNumberType) {
 
     // check the union type
     {
-        const Type& U = env.createType<UnionType>("U", toVector(&A, &B));
+        const analysis::Type& U = env.createType<UnionType>("U", toVector(&A, &B));
         EXPECT_TRUE(isOfKind(U, TypeAttribute::Signed));
         EXPECT_FALSE(isOfKind(U, TypeAttribute::Symbol));
-        const Type& U2 = env.createType<UnionType>("U2", toVector(&A, &B, &C));
+        const analysis::Type& U2 = env.createType<UnionType>("U2", toVector(&A, &B, &C));
         EXPECT_FALSE(isOfKind(U2, TypeAttribute::Signed));
         EXPECT_FALSE(isOfKind(U2, TypeAttribute::Symbol));
     }
     {
-        const Type& U3 = env.createType<UnionType>("U3", toVector(&A));
+        const analysis::Type& U3 = env.createType<UnionType>("U3", toVector(&A));
         EXPECT_TRUE(isOfKind(U3, TypeAttribute::Signed));
     }
 }
 
-bool isNotSubtypeOf(const Type& a, const Type& b) {
+bool isNotSubtypeOf(const analysis::Type& a, const analysis::Type& b) {
     return !isSubtypeOf(a, b);
 }
 
@@ -89,8 +90,8 @@ TEST(TypeSystem, isSubtypeOf_Basic) {
 
     // start with the two predefined types
 
-    const Type& N = env.getType("number");
-    const Type& S = env.getType("symbol");
+    const analysis::Type& N = env.getType("number");
+    const analysis::Type& S = env.getType("symbol");
 
     EXPECT_PRED2(isSubtypeOf, N, N);
     EXPECT_PRED2(isSubtypeOf, S, S);
@@ -100,8 +101,8 @@ TEST(TypeSystem, isSubtypeOf_Basic) {
 
     // check primitive type
 
-    const Type& A = env.createType<SubsetType>("A", env.getType("number"));
-    const Type& B = env.createType<SubsetType>("B", env.getType("number"));
+    const analysis::Type& A = env.createType<SubsetType>("A", env.getType("number"));
+    const analysis::Type& B = env.createType<SubsetType>("B", env.getType("number"));
 
     EXPECT_PRED2(isSubtypeOf, A, A);
     EXPECT_PRED2(isSubtypeOf, B, B);
@@ -117,7 +118,7 @@ TEST(TypeSystem, isSubtypeOf_Basic) {
 
     // check union types
 
-    const Type& U = env.createType<UnionType>("U", toVector(&A, &B));
+    const analysis::Type& U = env.createType<UnionType>("U", toVector(&A, &B));
 
     EXPECT_PRED2(isSubtypeOf, U, U);
     EXPECT_PRED2(isSubtypeOf, A, U);
@@ -137,8 +138,8 @@ TEST(TypeSystem, isSubtypeOf_Basic) {
 TEST(TypeSystem, isSubtypeOf_Records) {
     TypeEnvironment env;
 
-    const Type& A = env.createType<SubsetType>("A", env.getType("number"));
-    const Type& B = env.createType<SubsetType>("B", env.getType("number"));
+    const analysis::Type& A = env.createType<SubsetType>("A", env.getType("number"));
+    const analysis::Type& B = env.createType<SubsetType>("B", env.getType("number"));
 
     auto& R1 = env.createType<RecordType>("R1");
     auto& R2 = env.createType<RecordType>("R2");
@@ -156,11 +157,11 @@ TEST(TypeSystem, isSubtypeOf_Records) {
 TEST(TypeSystem, GreatestCommonSubtype) {
     TypeEnvironment env;
 
-    const Type& N = env.getType("number");
+    const analysis::Type& N = env.getType("number");
 
-    const Type& A = env.createType<SubsetType>("A", env.getType("number"));
-    const Type& B = env.createType<SubsetType>("B", env.getType("number"));
-    const Type& C = env.createType<SubsetType>("C", env.getType("symbol"));
+    const analysis::Type& A = env.createType<SubsetType>("A", env.getType("number"));
+    const analysis::Type& B = env.createType<SubsetType>("B", env.getType("number"));
+    const analysis::Type& C = env.createType<SubsetType>("C", env.getType("symbol"));
 
     EXPECT_EQ("{number}", toString(getGreatestCommonSubtypes(N, N)));
 
@@ -211,7 +212,7 @@ TEST(TypeSystem, GreatestCommonSubtype) {
     EXPECT_EQ("{R}", toString(getGreatestCommonSubtypes(U, R, N)));
     EXPECT_EQ("{R}", toString(getGreatestCommonSubtypes(S, R, N)));
 
-    R.setElements(toVector(static_cast<const Type*>(&U)));  // R = U = S
+    R.setElements(toVector(static_cast<const analysis::Type*>(&U)));  // R = U = S
 
     EXPECT_EQ("{U}", toString(getGreatestCommonSubtypes(U, R)));
     EXPECT_EQ("{S}", toString(getGreatestCommonSubtypes(S, R)));
@@ -219,7 +220,7 @@ TEST(TypeSystem, GreatestCommonSubtype) {
     EXPECT_EQ("{U}", toString(getGreatestCommonSubtypes(U, R, N)));
     EXPECT_EQ("{S}", toString(getGreatestCommonSubtypes(S, R, N)));
 
-    R.setElements(toVector(static_cast<const Type*>(&U), static_cast<const Type*>(&S)));
+    R.setElements(toVector(static_cast<const analysis::Type*>(&U), static_cast<const analysis::Type*>(&S)));
 
     EXPECT_EQ("{U}", toString(getGreatestCommonSubtypes(U, R)));
     EXPECT_EQ("{S}", toString(getGreatestCommonSubtypes(S, R)));
@@ -262,7 +263,7 @@ TEST(TypeSystem, EquivTypes) {
     TypeEnvironment env;
 
     auto& A = env.createType<SubsetType>("A", env.getType("number"));
-    auto& U = env.createType<UnionType>("U", toVector(dynamic_cast<const Type*>(&A)));
+    auto& U = env.createType<UnionType>("U", toVector(dynamic_cast<const analysis::Type*>(&A)));
 
     EXPECT_TRUE(areEquivalentTypes(A, U));
 }
@@ -276,4 +277,4 @@ TEST(TypeSystem, AlgebraicDataType) {
     EXPECT_EQ("{A}", toString(getGreatestCommonSubtypes(A, A)));
 }
 
-}  // namespace souffle::test
+}  // namespace souffle::ast::test

--- a/src/ast/transform/ADTtoRecords.h
+++ b/src/ast/transform/ADTtoRecords.h
@@ -23,9 +23,9 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-class ADTtoRecordsTransformer : public AstTransformer {
+class ADTtoRecordsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "ADTtoRecords";
@@ -36,7 +36,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/AddNullariesToAtomlessAggregates.h
+++ b/src/ast/transform/AddNullariesToAtomlessAggregates.h
@@ -25,13 +25,13 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to add artificial nullary atom (+Tautology())
  * to aggregate bodies that have no atoms.
  */
-class AddNullariesToAtomlessAggregatesTransformer : public AstTransformer {
+class AddNullariesToAtomlessAggregatesTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "AddNullariesToAtomlessAggregatesTransformer";
@@ -42,7 +42,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ComponentChecker.cpp
+++ b/src/ast/transform/ComponentChecker.cpp
@@ -34,28 +34,28 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool AstComponentChecker::transform(AstTranslationUnit& translationUnit) {
-    AstProgram& program = *translationUnit.getProgram();
-    ComponentLookup& componentLookup = *translationUnit.getAnalysis<ComponentLookup>();
+bool ComponentChecker::transform(TranslationUnit& translationUnit) {
+    Program& program = *translationUnit.getProgram();
+    analysis::ComponentLookup& componentLookup = *translationUnit.getAnalysis<analysis::ComponentLookup>();
     ErrorReport& report = translationUnit.getErrorReport();
     checkComponents(report, program, componentLookup);
     checkComponentNamespaces(report, program);
     return false;
 }
 
-const AstComponent* AstComponentChecker::checkComponentNameReference(ErrorReport& report,
-        const AstComponent* enclosingComponent, const ComponentLookup& componentLookup,
-        const std::string& name, const SrcLocation& loc, const TypeBinding& binding) {
-    const AstQualifiedName& forwarded = binding.find(name);
+const Component* ComponentChecker::checkComponentNameReference(ErrorReport& report,
+        const Component* enclosingComponent, const analysis::ComponentLookup& componentLookup,
+        const std::string& name, const SrcLocation& loc, const analysis::TypeBinding& binding) {
+    const QualifiedName& forwarded = binding.find(name);
     if (!forwarded.empty()) {
         // for forwarded types we do not check anything, because we do not know
         // what the actual type will be
         return nullptr;
     }
 
-    const AstComponent* c = componentLookup.getComponent(enclosingComponent, name, binding);
+    const Component* c = componentLookup.getComponent(enclosingComponent, name, binding);
     if (c == nullptr) {
         report.addError("Referencing undefined component " + name, loc);
         return nullptr;
@@ -64,11 +64,11 @@ const AstComponent* AstComponentChecker::checkComponentNameReference(ErrorReport
     return c;
 }
 
-void AstComponentChecker::checkComponentReference(ErrorReport& report, const AstComponent* enclosingComponent,
-        const ComponentLookup& componentLookup, const AstComponentType& type, const SrcLocation& loc,
-        const TypeBinding& binding) {
+void ComponentChecker::checkComponentReference(ErrorReport& report, const Component* enclosingComponent,
+        const analysis::ComponentLookup& componentLookup, const ast::ComponentType& type,
+        const SrcLocation& loc, const analysis::TypeBinding& binding) {
     // check whether targeted component exists
-    const AstComponent* c = checkComponentNameReference(
+    const Component* c = checkComponentNameReference(
             report, enclosingComponent, componentLookup, type.getName(), loc, binding);
     if (c == nullptr) {
         return;
@@ -80,8 +80,9 @@ void AstComponentChecker::checkComponentReference(ErrorReport& report, const Ast
     }
 }
 
-void AstComponentChecker::checkComponentInit(ErrorReport& report, const AstComponent* enclosingComponent,
-        const ComponentLookup& componentLookup, const AstComponentInit& init, const TypeBinding& binding) {
+void ComponentChecker::checkComponentInit(ErrorReport& report, const Component* enclosingComponent,
+        const analysis::ComponentLookup& componentLookup, const ComponentInit& init,
+        const analysis::TypeBinding& binding) {
     checkComponentReference(
             report, enclosingComponent, componentLookup, *init.getComponentType(), init.getSrcLoc(), binding);
 
@@ -96,8 +97,9 @@ void AstComponentChecker::checkComponentInit(ErrorReport& report, const AstCompo
     //}
 }
 
-void AstComponentChecker::checkComponent(ErrorReport& report, const AstComponent* enclosingComponent,
-        const ComponentLookup& componentLookup, const AstComponent& component, const TypeBinding& binding) {
+void ComponentChecker::checkComponent(ErrorReport& report, const Component* enclosingComponent,
+        const analysis::ComponentLookup& componentLookup, const Component& component,
+        const analysis::TypeBinding& binding) {
     // -- inheritance --
 
     // Update type binding:
@@ -107,8 +109,8 @@ void AstComponentChecker::checkComponent(ErrorReport& report, const AstComponent
     // Type parameter for us here is unknown type that will be bound at the template
     // instantiation time.
     auto parentTypeParameters = component.getComponentType()->getTypeParameters();
-    std::vector<AstQualifiedName> actualParams(parentTypeParameters.size(), "<type parameter>");
-    TypeBinding activeBinding = binding.extend(parentTypeParameters, actualParams);
+    std::vector<QualifiedName> actualParams(parentTypeParameters.size(), "<type parameter>");
+    analysis::TypeBinding activeBinding = binding.extend(parentTypeParameters, actualParams);
 
     // check parents of component
     for (const auto& cur : component.getBaseComponents()) {
@@ -126,8 +128,8 @@ void AstComponentChecker::checkComponent(ErrorReport& report, const AstComponent
     }
 
     // get all parents
-    std::set<const AstComponent*> parents;
-    std::function<void(const AstComponent&)> collectParents = [&](const AstComponent& cur) {
+    std::set<const Component*> parents;
+    std::function<void(const Component&)> collectParents = [&](const Component& cur) {
         for (const auto& base : cur.getBaseComponents()) {
             auto c = componentLookup.getComponent(enclosingComponent, base->getName(), binding);
             if (c == nullptr) {
@@ -141,7 +143,7 @@ void AstComponentChecker::checkComponent(ErrorReport& report, const AstComponent
     collectParents(component);
 
     // check overrides
-    for (const AstRelation* relation : component.getRelations()) {
+    for (const Relation* relation : component.getRelations()) {
         if (component.getOverridden().count(relation->getQualifiedName().getQualifiers()[0]) != 0u) {
             report.addError("Override of non-inherited relation " +
                                     relation->getQualifiedName().getQualifiers()[0] + " in component " +
@@ -149,8 +151,8 @@ void AstComponentChecker::checkComponent(ErrorReport& report, const AstComponent
                     component.getSrcLoc());
         }
     }
-    for (const AstComponent* parent : parents) {
-        for (const AstRelation* relation : parent->getRelations()) {
+    for (const Component* parent : parents) {
+        for (const Relation* relation : parent->getRelations()) {
             if ((component.getOverridden().count(relation->getQualifiedName().getQualifiers()[0]) != 0u) &&
                     !relation->hasQualifier(RelationQualifier::OVERRIDABLE)) {
                 report.addError("Override of non-overridable relation " +
@@ -181,22 +183,22 @@ void AstComponentChecker::checkComponent(ErrorReport& report, const AstComponent
     }
 }
 
-void AstComponentChecker::checkComponents(
-        ErrorReport& report, const AstProgram& program, const ComponentLookup& componentLookup) {
-    for (AstComponent* cur : program.getComponents()) {
-        checkComponent(report, nullptr, componentLookup, *cur, TypeBinding());
+void ComponentChecker::checkComponents(
+        ErrorReport& report, const Program& program, const analysis::ComponentLookup& componentLookup) {
+    for (Component* cur : program.getComponents()) {
+        checkComponent(report, nullptr, componentLookup, *cur, analysis::TypeBinding());
     }
 
-    for (AstComponentInit* cur : program.getComponentInstantiations()) {
-        checkComponentInit(report, nullptr, componentLookup, *cur, TypeBinding());
+    for (ComponentInit* cur : program.getComponentInstantiations()) {
+        checkComponentInit(report, nullptr, componentLookup, *cur, analysis::TypeBinding());
     }
 }
 
 // Check that component names are disjoint from type and relation names.
-void AstComponentChecker::checkComponentNamespaces(ErrorReport& report, const AstProgram& program) {
+void ComponentChecker::checkComponentNamespaces(ErrorReport& report, const Program& program) {
     std::map<std::string, SrcLocation> names;
 
-    // Type and relation name error reporting performed by the AstSemanticChecker instead
+    // Type and relation name error reporting performed by the SemanticChecker instead
 
     // Find all names and report redeclarations as we go.
     for (const auto& type : program.getTypes()) {
@@ -232,4 +234,4 @@ void AstComponentChecker::checkComponentNamespaces(ErrorReport& report, const As
         }
     }
 }
-}  // namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ComponentChecker.h
+++ b/src/ast/transform/ComponentChecker.h
@@ -45,19 +45,19 @@ private:
     bool transform(TranslationUnit& translationUnit) override;
 
     static const Component* checkComponentNameReference(ErrorReport& report,
-            const Component* enclosingComponent, const analysis::ComponentLookup& componentLookup,
+            const Component* enclosingComponent, const analysis::ComponentLookupAnalysis& componentLookup,
             const std::string& name, const SrcLocation& loc, const analysis::TypeBinding& binding);
     static void checkComponentReference(ErrorReport& report, const Component* enclosingComponent,
-            const analysis::ComponentLookup& componentLookup, const ast::ComponentType& type,
+            const analysis::ComponentLookupAnalysis& componentLookup, const ast::ComponentType& type,
             const SrcLocation& loc, const analysis::TypeBinding& binding);
     static void checkComponentInit(ErrorReport& report, const Component* enclosingComponent,
-            const analysis::ComponentLookup& componentLookup, const ComponentInit& init,
+            const analysis::ComponentLookupAnalysis& componentLookup, const ComponentInit& init,
             const analysis::TypeBinding& binding);
     static void checkComponent(ErrorReport& report, const Component* enclosingComponent,
-            const analysis::ComponentLookup& componentLookup, const Component& component,
+            const analysis::ComponentLookupAnalysis& componentLookup, const Component& component,
             const analysis::TypeBinding& binding);
-    static void checkComponents(
-            ErrorReport& report, const Program& program, const analysis::ComponentLookup& componentLookup);
+    static void checkComponents(ErrorReport& report, const Program& program,
+            const analysis::ComponentLookupAnalysis& componentLookup);
     static void checkComponentNamespaces(ErrorReport& report, const Program& program);
 };
 

--- a/src/ast/transform/ComponentChecker.h
+++ b/src/ast/transform/ComponentChecker.h
@@ -27,37 +27,38 @@
 #include "reports/ErrorReport.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-class AstComponentChecker : public AstTransformer {
+class ComponentChecker : public Transformer {
 public:
-    ~AstComponentChecker() override = default;
+    ~ComponentChecker() override = default;
 
     std::string getName() const override {
-        return "AstComponentChecker";
+        return "ComponentChecker";
     }
 
-    AstComponentChecker* clone() const override {
-        return new AstComponentChecker();
+    ComponentChecker* clone() const override {
+        return new ComponentChecker();
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
-    static const AstComponent* checkComponentNameReference(ErrorReport& report,
-            const AstComponent* enclosingComponent, const ComponentLookup& componentLookup,
-            const std::string& name, const SrcLocation& loc, const TypeBinding& binding);
-    static void checkComponentReference(ErrorReport& report, const AstComponent* enclosingComponent,
-            const ComponentLookup& componentLookup, const AstComponentType& type, const SrcLocation& loc,
-            const TypeBinding& binding);
-    static void checkComponentInit(ErrorReport& report, const AstComponent* enclosingComponent,
-            const ComponentLookup& componentLookup, const AstComponentInit& init, const TypeBinding& binding);
-    static void checkComponent(ErrorReport& report, const AstComponent* enclosingComponent,
-            const ComponentLookup& componentLookup, const AstComponent& component,
-            const TypeBinding& binding);
+    static const Component* checkComponentNameReference(ErrorReport& report,
+            const Component* enclosingComponent, const analysis::ComponentLookup& componentLookup,
+            const std::string& name, const SrcLocation& loc, const analysis::TypeBinding& binding);
+    static void checkComponentReference(ErrorReport& report, const Component* enclosingComponent,
+            const analysis::ComponentLookup& componentLookup, const ast::ComponentType& type,
+            const SrcLocation& loc, const analysis::TypeBinding& binding);
+    static void checkComponentInit(ErrorReport& report, const Component* enclosingComponent,
+            const analysis::ComponentLookup& componentLookup, const ComponentInit& init,
+            const analysis::TypeBinding& binding);
+    static void checkComponent(ErrorReport& report, const Component* enclosingComponent,
+            const analysis::ComponentLookup& componentLookup, const Component& component,
+            const analysis::TypeBinding& binding);
     static void checkComponents(
-            ErrorReport& report, const AstProgram& program, const ComponentLookup& componentLookup);
-    static void checkComponentNamespaces(ErrorReport& report, const AstProgram& program);
+            ErrorReport& report, const Program& program, const analysis::ComponentLookup& componentLookup);
+    static void checkComponentNamespaces(ErrorReport& report, const Program& program);
 };
 
-}  // namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ComponentInstantiation.cpp
+++ b/src/ast/transform/ComponentInstantiation.cpp
@@ -45,6 +45,8 @@
 
 namespace souffle::ast::transform {
 
+using namespace analysis;
+
 namespace {
 
 static const unsigned int MAX_INSTANTIATION_DEPTH = 1000;
@@ -120,16 +122,16 @@ struct ComponentContent {
  * by this init statement enclosed within the given scope.
  */
 ComponentContent getInstantiatedContent(Program& program, const ComponentInit& componentInit,
-        const Component* enclosingComponent, const analysis::ComponentLookup& componentLookup,
+        const Component* enclosingComponent, const ComponentLookupAnalysis& componentLookup,
         std::vector<Own<Clause>>& orphans, ErrorReport& report,
-        const analysis::TypeBinding& binding = analysis::TypeBinding(),
+        const TypeBinding& binding = analysis::TypeBinding(),
         unsigned int maxDepth = MAX_INSTANTIATION_DEPTH);
 
 /**
  * Collects clones of all the content in the given component and its base components.
  */
-void collectContent(Program& program, const Component& component, const analysis::TypeBinding& binding,
-        const Component* enclosingComponent, const analysis::ComponentLookup& componentLookup,
+void collectContent(Program& program, const Component& component, const TypeBinding& binding,
+        const Component* enclosingComponent, const ComponentLookupAnalysis& componentLookup,
         ComponentContent& res, std::vector<Own<Clause>>& orphans, const std::set<std::string>& overridden,
         ErrorReport& report, unsigned int maxInstantiationDepth) {
     // start with relations and clauses of the base components
@@ -141,7 +143,7 @@ void collectContent(Program& program, const Component& component, const analysis
             const auto& actualParams = base->getTypeParameters();
 
             // update type binding
-            analysis::TypeBinding activeBinding = binding.extend(formalParams, actualParams);
+            TypeBinding activeBinding = binding.extend(formalParams, actualParams);
 
             for (const auto& cur : comp->getInstantiations()) {
                 // instantiate sub-component
@@ -268,8 +270,8 @@ void collectContent(Program& program, const Component& component, const analysis
 }
 
 ComponentContent getInstantiatedContent(Program& program, const ComponentInit& componentInit,
-        const Component* enclosingComponent, const analysis::ComponentLookup& componentLookup,
-        std::vector<Own<Clause>>& orphans, ErrorReport& report, const analysis::TypeBinding& binding,
+        const Component* enclosingComponent, const ComponentLookupAnalysis& componentLookup,
+        std::vector<Own<Clause>>& orphans, ErrorReport& report, const TypeBinding& binding,
         unsigned int maxDepth) {
     // start with an empty list
     ComponentContent res;
@@ -290,7 +292,7 @@ ComponentContent getInstantiatedContent(Program& program, const ComponentInit& c
     // update type biding
     const auto& formalParams = component->getComponentType()->getTypeParameters();
     const auto& actualParams = componentInit.getComponentType()->getTypeParameters();
-    analysis::TypeBinding activeBinding = binding.extend(formalParams, actualParams);
+    TypeBinding activeBinding = binding.extend(formalParams, actualParams);
 
     // instantiated nested components
     for (const auto& cur : component->getInstantiations()) {
@@ -433,7 +435,7 @@ bool ComponentInstantiationTransformer::transform(TranslationUnit& translationUn
 
     Program& program = *translationUnit.getProgram();
 
-    auto* componentLookup = translationUnit.getAnalysis<analysis::ComponentLookup>();
+    auto* componentLookup = translationUnit.getAnalysis<ComponentLookupAnalysis>();
 
     for (const auto& cur : program.instantiations) {
         std::vector<Own<Clause>> orphans;

--- a/src/ast/transform/ComponentInstantiation.h
+++ b/src/ast/transform/ComponentInstantiation.h
@@ -18,9 +18,9 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-class ComponentInstantiationTransformer : public AstTransformer {
+class ComponentInstantiationTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "ComponentInstantiationTransformer";
@@ -31,7 +31,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/Conditional.h
+++ b/src/ast/transform/Conditional.h
@@ -29,20 +29,20 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformer that executes a sub-transformer iff a condition holds
  */
 class ConditionalTransformer : public MetaTransformer {
 public:
-    ConditionalTransformer(std::function<bool()> cond, Own<AstTransformer> transformer)
+    ConditionalTransformer(std::function<bool()> cond, Own<Transformer> transformer)
             : condition(std::move(cond)), transformer(std::move(transformer)) {}
 
-    ConditionalTransformer(bool cond, Own<AstTransformer> transformer)
+    ConditionalTransformer(bool cond, Own<Transformer> transformer)
             : condition([=]() { return cond; }), transformer(std::move(transformer)) {}
 
-    std::vector<AstTransformer*> getSubtransformers() const override {
+    std::vector<Transformer*> getSubtransformers() const override {
         return {transformer.get()};
     }
 
@@ -79,11 +79,11 @@ public:
 
 private:
     std::function<bool()> condition;
-    Own<AstTransformer> transformer;
+    Own<Transformer> transformer;
 
-    bool transform(AstTranslationUnit& translationUnit) override {
+    bool transform(TranslationUnit& translationUnit) override {
         return condition() ? applySubtransformer(translationUnit, transformer.get()) : false;
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/DebugReporter.cpp
+++ b/src/ast/transform/DebugReporter.cpp
@@ -21,9 +21,9 @@
 #include "reports/DebugReport.h"
 #include <chrono>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool DebugReporter::transform(AstTranslationUnit& translationUnit) {
+bool DebugReporter::transform(TranslationUnit& translationUnit) {
     translationUnit.getDebugReport().startSection();
     auto datalogSpecOriginal = pprint(*translationUnit.getProgram());
     auto start = std::chrono::high_resolution_clock::now();
@@ -40,9 +40,9 @@ bool DebugReporter::transform(AstTranslationUnit& translationUnit) {
     return changed;
 }
 
-void DebugReporter::generateDebugReport(AstTranslationUnit& tu, const std::string& preTransformDatalog) {
+void DebugReporter::generateDebugReport(TranslationUnit& tu, const std::string& preTransformDatalog) {
     tu.getDebugReport().addCodeSection(
             "dl", "Datalog", "souffle", preTransformDatalog, pprint(*tu.getProgram()));
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/DebugReporter.h
+++ b/src/ast/transform/DebugReporter.h
@@ -27,7 +27,7 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass which wraps another transformation pass and generates
@@ -36,10 +36,9 @@ namespace souffle {
  */
 class DebugReporter : public MetaTransformer {
 public:
-    DebugReporter(Own<AstTransformer> wrappedTransformer)
-            : wrappedTransformer(std::move(wrappedTransformer)) {}
+    DebugReporter(Own<Transformer> wrappedTransformer) : wrappedTransformer(std::move(wrappedTransformer)) {}
 
-    std::vector<AstTransformer*> getSubtransformers() const override {
+    std::vector<Transformer*> getSubtransformers() const override {
         return {wrappedTransformer.get()};
     }
 
@@ -69,11 +68,11 @@ public:
     }
 
 private:
-    Own<AstTransformer> wrappedTransformer;
+    Own<Transformer> wrappedTransformer;
 
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
-    void generateDebugReport(AstTranslationUnit& tu, const std::string& preTransformDatalog);
+    void generateDebugReport(TranslationUnit& tu, const std::string& preTransformDatalog);
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ExecutionPlanChecker.cpp
+++ b/src/ast/transform/ExecutionPlanChecker.cpp
@@ -31,17 +31,17 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool AstExecutionPlanChecker::transform(AstTranslationUnit& translationUnit) {
-    auto* relationSchedule = translationUnit.getAnalysis<RelationScheduleAnalysis>();
-    auto* recursiveClauses = translationUnit.getAnalysis<RecursiveClausesAnalysis>();
+bool ExecutionPlanChecker::transform(TranslationUnit& translationUnit) {
+    auto* relationSchedule = translationUnit.getAnalysis<analysis::RelationScheduleAnalysis>();
+    auto* recursiveClauses = translationUnit.getAnalysis<analysis::RecursiveClausesAnalysis>();
     auto&& report = translationUnit.getErrorReport();
 
-    for (const RelationScheduleAnalysisStep& step : relationSchedule->schedule()) {
-        const std::set<const AstRelation*>& scc = step.computed();
-        for (const AstRelation* rel : scc) {
-            for (const AstClause* clause : getClauses(*translationUnit.getProgram(), *rel)) {
+    for (const analysis::RelationScheduleAnalysisStep& step : relationSchedule->schedule()) {
+        const std::set<const Relation*>& scc = step.computed();
+        for (const Relation* rel : scc) {
+            for (const Clause* clause : getClauses(*translationUnit.getProgram(), *rel)) {
                 if (!recursiveClauses->recursive(clause)) {
                     continue;
                 }
@@ -49,7 +49,7 @@ bool AstExecutionPlanChecker::transform(AstTranslationUnit& translationUnit) {
                     continue;
                 }
                 int version = 0;
-                for (const auto* atom : getBodyLiterals<AstAtom>(*clause)) {
+                for (const auto* atom : getBodyLiterals<Atom>(*clause)) {
                     if (scc.count(getAtomRelation(atom, translationUnit.getProgram())) != 0u) {
                         version++;
                     }
@@ -77,4 +77,4 @@ bool AstExecutionPlanChecker::transform(AstTranslationUnit& translationUnit) {
     return false;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ExecutionPlanChecker.h
+++ b/src/ast/transform/ExecutionPlanChecker.h
@@ -20,20 +20,20 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-class AstExecutionPlanChecker : public AstTransformer {
+class ExecutionPlanChecker : public Transformer {
 public:
     std::string getName() const override {
-        return "AstExecutionPlanChecker";
+        return "ExecutionPlanChecker";
     }
 
-    AstExecutionPlanChecker* clone() const override {
-        return new AstExecutionPlanChecker();
+    ExecutionPlanChecker* clone() const override {
+        return new ExecutionPlanChecker();
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/Fixpoint.h
+++ b/src/ast/transform/Fixpoint.h
@@ -28,14 +28,14 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformer that repeatedly executes a sub-transformer until no changes are made
  */
 class FixpointTransformer : public MetaTransformer {
 public:
-    FixpointTransformer(Own<AstTransformer> transformer) : transformer(std::move(transformer)) {}
+    FixpointTransformer(Own<Transformer> transformer) : transformer(std::move(transformer)) {}
 
     void setDebugReport() override {
         if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
@@ -45,7 +45,7 @@ public:
         }
     }
 
-    std::vector<AstTransformer*> getSubtransformers() const override {
+    std::vector<Transformer*> getSubtransformers() const override {
         return {transformer.get()};
     }
 
@@ -73,8 +73,8 @@ public:
     }
 
 private:
-    Own<AstTransformer> transformer;
-    bool transform(AstTranslationUnit& translationUnit) override {
+    Own<Transformer> transformer;
+    bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
         while (applySubtransformer(translationUnit, transformer.get())) {
             changed = true;
@@ -83,4 +83,4 @@ private:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/FoldAnonymousRecords.h
+++ b/src/ast/transform/FoldAnonymousRecords.h
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass that removes (binary) constraints on the anonymous records.
@@ -45,7 +45,7 @@ namespace souffle {
  * E.g. A = [a, b], A = [c, d]
  * Thus it should be called in conjunction with ResolveAnonymousRecordAliases.
  */
-class FoldAnonymousRecords : public AstTransformer {
+class FoldAnonymousRecords : public Transformer {
 public:
     std::string getName() const override {
         return "FoldAnonymousRecords";
@@ -56,7 +56,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
     /**
      * Process a single clause.
@@ -64,7 +64,7 @@ private:
      * @parem clause Clause to be processed.
      * @param newClauses a destination for the newly produced clauses.
      */
-    void transformClause(const AstClause& clause, VecOwn<AstClause>& newClauses);
+    void transformClause(const Clause& clause, VecOwn<Clause>& newClauses);
 
     /**
      * Expand constraint on records position-wise.
@@ -74,20 +74,20 @@ private:
      * [x, y, z] != [a, b, c] => vector(x != a, x != b, z != c)
      *
      * Procedure assumes that argument has a valid operation,
-     * that children are of type AstRecordInit and that the size
+     * that children are of type RecordInit and that the size
      * of both sides is the same
      */
-    VecOwn<AstLiteral> expandRecordBinaryConstraint(const AstBinaryConstraint&);
+    VecOwn<Literal> expandRecordBinaryConstraint(const BinaryConstraint&);
 
     /**
      * Determine if the clause contains at least one binary constraint which can be expanded.
      */
-    bool containsValidRecordConstraint(const AstClause&);
+    bool containsValidRecordConstraint(const Clause&);
 
     /**
      * Determine if binary constraint can be expanded.
      */
-    bool isValidRecordConstraint(const AstLiteral* literal);
+    bool isValidRecordConstraint(const Literal* literal);
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/GroundedTermsChecker.cpp
+++ b/src/ast/transform/GroundedTermsChecker.cpp
@@ -30,17 +30,17 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-void GroundedTermsChecker::verify(AstTranslationUnit& translationUnit) {
+void GroundedTermsChecker::verify(TranslationUnit& translationUnit) {
     auto&& program = *translationUnit.getProgram();
     auto&& report = translationUnit.getErrorReport();
 
     // -- check grounded variables and records --
-    visitDepthFirst(program.getClauses(), [&](const AstClause& clause) {
+    visitDepthFirst(program.getClauses(), [&](const Clause& clause) {
         if (isFact(clause)) return;  // only interested in rules
 
-        auto isGrounded = getGroundedTerms(translationUnit, clause);
+        auto isGrounded = analysis::getGroundedTerms(translationUnit, clause);
 
         std::set<std::string> reportedVars;
         // all terms in head need to be grounded
@@ -51,14 +51,14 @@ void GroundedTermsChecker::verify(AstTranslationUnit& translationUnit) {
         }
 
         // all records need to be grounded
-        visitDepthFirst(clause, [&](const AstRecordInit& record) {
+        visitDepthFirst(clause, [&](const RecordInit& record) {
             if (!isGrounded[&record]) {
                 report.addError("Ungrounded record", record.getSrcLoc());
             }
         });
 
         // All sums need to be grounded
-        visitDepthFirst(clause, [&](const AstBranchInit& adt) {
+        visitDepthFirst(clause, [&](const BranchInit& adt) {
             if (!isGrounded[&adt]) {
                 report.addError("Ungrounded ADT branch", adt.getSrcLoc());
             }
@@ -66,4 +66,4 @@ void GroundedTermsChecker::verify(AstTranslationUnit& translationUnit) {
     });
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/GroundedTermsChecker.h
+++ b/src/ast/transform/GroundedTermsChecker.h
@@ -20,26 +20,26 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-class GroundedTermsChecker : public AstTransformer {
+class GroundedTermsChecker : public Transformer {
 public:
     std::string getName() const override {
         return "GroundedTermsChecker";
     }
 
     // `apply` but doesn't immediately bail if any errors are found.
-    void verify(AstTranslationUnit& translationUnit);
+    void verify(TranslationUnit& translationUnit);
 
     GroundedTermsChecker* clone() const override {
         return new GroundedTermsChecker();
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override {
+    bool transform(TranslationUnit& translationUnit) override {
         verify(translationUnit);
         return false;
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/IOAttributes.h
+++ b/src/ast/transform/IOAttributes.h
@@ -74,7 +74,7 @@ private:
     bool setAttributeParams(TranslationUnit& translationUnit) {
         bool changed = false;
         Program* program = translationUnit.getProgram();
-        auto auxArityAnalysis = translationUnit.getAnalysis<analysis::AuxiliaryArity>();
+        auto auxArityAnalysis = translationUnit.getAnalysis<analysis::AuxiliaryArityAnalysis>();
 
         for (Directive* io : program->getDirectives()) {
             if (io->getType() == ast::DirectiveType::limitsize) {
@@ -126,7 +126,7 @@ private:
             }
 
             if (Global::config().has("provenance")) {
-                auto auxArityAnalysis = translationUnit.getAnalysis<analysis::AuxiliaryArity>();
+                auto auxArityAnalysis = translationUnit.getAnalysis<analysis::AuxiliaryArityAnalysis>();
                 std::vector<std::string> originalAttributeNames(
                         attributeNames.begin(), attributeNames.end() - auxArityAnalysis->getArity(rel));
                 io->addDirective("attributeNames", toString(join(originalAttributeNames, delimiter)));
@@ -141,7 +141,7 @@ private:
     bool setAttributeTypes(TranslationUnit& translationUnit) {
         bool changed = false;
         Program* program = translationUnit.getProgram();
-        auto auxArityAnalysis = translationUnit.getAnalysis<analysis::AuxiliaryArity>();
+        auto auxArityAnalysis = translationUnit.getAnalysis<analysis::AuxiliaryArityAnalysis>();
         auto typeEnv =
                 &translationUnit.getAnalysis<analysis::TypeEnvironmentAnalysis>()->getTypeEnvironment();
 

--- a/src/ast/transform/IODefaults.h
+++ b/src/ast/transform/IODefaults.h
@@ -27,12 +27,12 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to set defaults for IO operations.
  */
-class IODefaultsTransformer : public AstTransformer {
+class IODefaultsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "IODefaultsTransformer";
@@ -43,7 +43,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override {
+    bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
 
         changed |= setDefaults(translationUnit);
@@ -65,13 +65,13 @@ private:
      * @param translationUnit
      * @return true if any changes were made
      */
-    bool setDefaults(AstTranslationUnit& translationUnit) {
+    bool setDefaults(TranslationUnit& translationUnit) {
         bool changed = false;
-        AstProgram* program = translationUnit.getProgram();
-        for (AstDirective* io : program->getDirectives()) {
+        Program* program = translationUnit.getProgram();
+        for (Directive* io : program->getDirectives()) {
             // Don't do anything for a directive which
             // is not an I/O directive
-            if (io->getType() == AstDirectiveType::limitsize) continue;
+            if (io->getType() == ast::DirectiveType::limitsize) continue;
 
             // Set a default IO of file
             if (!io->hasDirective("IO")) {
@@ -87,14 +87,14 @@ private:
 
             // Set the operation type (input/output/printsize)
             if (!io->hasDirective("operation")) {
-                if (io->getType() == AstDirectiveType::input) {
+                if (io->getType() == ast::DirectiveType::input) {
                     io->addDirective("operation", "input");
                     changed = true;
                     // Configure input directory
                     if (Global::config().has("fact-dir")) {
                         io->addDirective("fact-dir", Global::config().get("fact-dir"));
                     }
-                } else if (io->getType() == AstDirectiveType::output) {
+                } else if (io->getType() == ast::DirectiveType::output) {
                     io->addDirective("operation", "output");
                     changed = true;
                     // Configure output directory
@@ -106,7 +106,7 @@ private:
                             io->addDirective("output-dir", Global::config().get("output-dir"));
                         }
                     }
-                } else if (io->getType() == AstDirectiveType::printsize) {
+                } else if (io->getType() == ast::DirectiveType::printsize) {
                     io->addDirective("operation", "printsize");
                     io->addDirective("IO", "stdoutprintsize");
                     changed = true;
@@ -122,9 +122,9 @@ private:
      *
      * @return Valid relation name from the concatenated qualified name.
      */
-    std::string getRelationName(const AstDirective* node) {
+    std::string getRelationName(const Directive* node) {
         return toString(join(node->getQualifiedName().getQualifiers(), "."));
     }
 };
 
-}  // namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/InlineRelations.h
+++ b/src/ast/transform/InlineRelations.h
@@ -20,12 +20,12 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to inline marked relations
  */
-class InlineRelationsTransformer : public AstTransformer {
+class InlineRelationsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "InlineRelationsTransformer";
@@ -36,7 +36,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/MagicSet.cpp
+++ b/src/ast/transform/MagicSet.cpp
@@ -61,7 +61,7 @@ typedef MagicSetTransformer::LabelDatabaseTransformer::PositiveLabellingTransfor
 
 std::set<QualifiedName> MagicSetTransformer::getIgnoredRelations(const TranslationUnit& tu) {
     const auto& program = *tu.getProgram();
-    const auto& ioTypes = *tu.getAnalysis<analysis::IOType>();
+    const auto& ioTypes = *tu.getAnalysis<analysis::IOTypeAnalysis>();
 
     std::set<QualifiedName> relationsToIgnore;
 
@@ -200,7 +200,7 @@ bool NormaliseDatabaseTransformer::transform(TranslationUnit& translationUnit) {
 
 bool NormaliseDatabaseTransformer::partitionIO(TranslationUnit& translationUnit) {
     auto& program = *translationUnit.getProgram();
-    const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOType>();
+    const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
 
     // Get all relations that are both input and output
     std::set<QualifiedName> relationsToSplit;
@@ -268,7 +268,7 @@ bool NormaliseDatabaseTransformer::partitionIO(TranslationUnit& translationUnit)
 
 bool NormaliseDatabaseTransformer::extractIDB(TranslationUnit& translationUnit) {
     auto& program = *translationUnit.getProgram();
-    const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOType>();
+    const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
 
     // Helper method to check if an input relation has no associated rules
     auto isStrictlyEDB = [&](const Relation* rel) {
@@ -355,7 +355,7 @@ bool NormaliseDatabaseTransformer::querifyOutputRelations(TranslationUnit& trans
     };
 
     // Get all output relations that need to be normalised
-    const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOType>();
+    const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
     std::set<QualifiedName> outputRelationNames;
     for (auto* rel : program.getRelations()) {
         if ((ioTypes.isOutput(rel) || ioTypes.isPrintSize(rel)) && !isStrictlyOutput(rel)) {
@@ -617,7 +617,7 @@ Own<Clause> AdornDatabaseTransformer::adornClause(const Clause* clause, const st
 
 bool AdornDatabaseTransformer::transform(TranslationUnit& translationUnit) {
     auto& program = *translationUnit.getProgram();
-    const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOType>();
+    const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
 
     relationsToIgnore = getIgnoredRelations(translationUnit);
 

--- a/src/ast/transform/MagicSet.h
+++ b/src/ast/transform/MagicSet.h
@@ -34,7 +34,7 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Magic Set Transformation.
@@ -65,18 +65,18 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& tu) override {
+    bool transform(TranslationUnit& tu) override {
         return shouldRun(tu) ? PipelineTransformer::transform(tu) : false;
     }
 
     /** Determines whether any part of the MST should be run. */
-    static bool shouldRun(const AstTranslationUnit& tu);
+    static bool shouldRun(const TranslationUnit& tu);
 
     /**
      * Gets set of relations to ignore during the MST process.
      * Ignored relations are relations that should not be copied or altered beyond normalisation.
      */
-    static std::set<AstQualifiedName> getIgnoredRelations(const AstTranslationUnit& tu);
+    static std::set<QualifiedName> getIgnoredRelations(const TranslationUnit& tu);
 };
 
 /**
@@ -86,7 +86,7 @@ private:
  *  - Normalises all arguments and constraints
  * Prerequisite for adornment.
  */
-class MagicSetTransformer::NormaliseDatabaseTransformer : public AstTransformer {
+class MagicSetTransformer::NormaliseDatabaseTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "NormaliseDatabaseTransformer";
@@ -97,19 +97,19 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
     /**
      * Partitions the input and output relations.
      * Program will no longer have relations that are both input and output.
      */
-    static bool partitionIO(AstTranslationUnit& translationUnit);
+    static bool partitionIO(TranslationUnit& translationUnit);
 
     /**
      * Separates the IDB from the EDB, so that they are disjoint.
      * Program will no longer have input relations that appear as the head of clauses.
      */
-    static bool extractIDB(AstTranslationUnit& translationUnit);
+    static bool extractIDB(TranslationUnit& translationUnit);
 
     /**
      * Extracts output relations into separate simple query relations,
@@ -118,7 +118,7 @@ private:
      *      (1) have exactly one rule defining them
      *      (2) do not appear in other rules
      */
-    static bool querifyOutputRelations(AstTranslationUnit& translationUnit);
+    static bool querifyOutputRelations(TranslationUnit& translationUnit);
 
     /**
      * Normalise all arguments within each clause.
@@ -126,7 +126,7 @@ private:
      *      (1) a variable, or
      *      (2) the RHS of a `<var> = <arg>` constraint
      */
-    static bool normaliseArguments(AstTranslationUnit& translationUnit);
+    static bool normaliseArguments(TranslationUnit& translationUnit);
 };
 
 /**
@@ -151,7 +151,7 @@ public:
 
 private:
     /** Check if a relation is negatively labelled. */
-    static bool isNegativelyLabelled(const AstQualifiedName& name);
+    static bool isNegativelyLabelled(const QualifiedName& name);
 };
 
 /**
@@ -159,7 +159,7 @@ private:
  * Separates out negated appearances of relations from the main SCC graph, preventing them from affecting
  * stratification once magic dependencies are added.
  */
-class MagicSetTransformer::LabelDatabaseTransformer::NegativeLabellingTransformer : public AstTransformer {
+class MagicSetTransformer::LabelDatabaseTransformer::NegativeLabellingTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "NegativeLabellingTransformer";
@@ -170,10 +170,10 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
     /** Provide a unique name for negatively-labelled relations. */
-    static AstQualifiedName getNegativeLabel(const AstQualifiedName& name);
+    static QualifiedName getNegativeLabel(const QualifiedName& name);
 };
 
 /**
@@ -182,7 +182,7 @@ private:
  * affecting stratification after magic.
  * Note: Negative labelling must have been run first.
  */
-class MagicSetTransformer::LabelDatabaseTransformer::PositiveLabellingTransformer : public AstTransformer {
+class MagicSetTransformer::LabelDatabaseTransformer::PositiveLabellingTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "PositiveLabellingTransformer";
@@ -193,10 +193,10 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
     /** Provide a unique name for a positively labelled relation copy. */
-    static AstQualifiedName getPositiveLabel(const AstQualifiedName& name, size_t count);
+    static QualifiedName getPositiveLabel(const QualifiedName& name, size_t count);
 };
 
 /**
@@ -204,7 +204,7 @@ private:
  * Adorns the rules of a database with variable flow and binding information.
  * Prerequisite for the magic set transformation.
  */
-class MagicSetTransformer::AdornDatabaseTransformer : public AstTransformer {
+class MagicSetTransformer::AdornDatabaseTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "AdornDatabaseTransformer";
@@ -215,23 +215,22 @@ public:
     }
 
 private:
-    using adorned_predicate = std::pair<AstQualifiedName, std::string>;
+    using adorned_predicate = std::pair<QualifiedName, std::string>;
 
     std::set<adorned_predicate> headAdornmentsToDo;
-    std::set<AstQualifiedName> headAdornmentsSeen;
+    std::set<QualifiedName> headAdornmentsSeen;
 
-    VecOwn<AstClause> adornedClauses;
-    VecOwn<AstClause> redundantClauses;
-    std::set<AstQualifiedName> relationsToIgnore;
+    VecOwn<Clause> adornedClauses;
+    VecOwn<Clause> redundantClauses;
+    std::set<QualifiedName> relationsToIgnore;
 
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
     /** Get the unique identifier corresponding to an adorned predicate. */
-    static AstQualifiedName getAdornmentID(
-            const AstQualifiedName& relName, const std::string& adornmentMarker);
+    static QualifiedName getAdornmentID(const QualifiedName& relName, const std::string& adornmentMarker);
 
     /** Add an adornment to the ToDo queue if it hasn't been processed before. */
-    void queueAdornment(const AstQualifiedName& relName, const std::string& adornmentMarker) {
+    void queueAdornment(const QualifiedName& relName, const std::string& adornmentMarker) {
         auto adornmentID = getAdornmentID(relName, adornmentMarker);
         if (!contains(headAdornmentsSeen, adornmentID)) {
             headAdornmentsToDo.insert(std::make_pair(relName, adornmentMarker));
@@ -253,7 +252,7 @@ private:
     }
 
     /** Returns the adorned version of a clause. */
-    Own<AstClause> adornClause(const AstClause* clause, const std::string& adornmentMarker);
+    Own<Clause> adornClause(const Clause* clause, const std::string& adornmentMarker);
 };
 
 /**
@@ -261,7 +260,7 @@ private:
  * Creates all magic rules and relations based on the preceding adornment, and adds them into rules as needed.
  * Assumes that Normalisation, Labelling, and Adornment have all been performed.
  */
-class MagicSetTransformer::MagicSetCoreTransformer : public AstTransformer {
+class MagicSetTransformer::MagicSetCoreTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "MagicSetCoreTransformer";
@@ -272,30 +271,30 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
     /** Gets a unique magic identifier for a given adorned relation name */
-    static AstQualifiedName getMagicName(const AstQualifiedName& name);
+    static QualifiedName getMagicName(const QualifiedName& name);
 
     /** Checks if a given relation name is adorned */
-    static bool isAdorned(const AstQualifiedName& name);
+    static bool isAdorned(const QualifiedName& name);
 
     /** Retrieves an adornment encoded in a given relation name */
-    static std::string getAdornment(const AstQualifiedName& name);
+    static std::string getAdornment(const QualifiedName& name);
 
     /** Get all potentially-binding equality constraints in a clause */
-    static std::vector<const AstBinaryConstraint*> getBindingEqualityConstraints(const AstClause* clause);
+    static std::vector<const BinaryConstraint*> getBindingEqualityConstraints(const Clause* clause);
 
     /** Get the closure of the given set of variables under appearance in the given eq constraints */
     static void addRelevantVariables(
-            std::set<std::string>& variables, const std::vector<const AstBinaryConstraint*> eqConstraints);
+            std::set<std::string>& variables, const std::vector<const BinaryConstraint*> eqConstraints);
 
     /** Creates the magic atom associatd with the given (rel, adornment) pair */
-    static Own<AstAtom> createMagicAtom(const AstAtom* atom);
+    static Own<Atom> createMagicAtom(const Atom* atom);
 
     /** Creates the magic clause centred around the given magic atom */
-    static Own<AstClause> createMagicClause(const AstAtom* atom, const VecOwn<AstAtom>& constrainingAtoms,
-            const std::vector<const AstBinaryConstraint*> eqConstraints);
+    static Own<Clause> createMagicClause(const Atom* atom, const VecOwn<Atom>& constrainingAtoms,
+            const std::vector<const BinaryConstraint*> eqConstraints);
 };
 
-}  // namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/MaterializeAggregationQueries.h
+++ b/src/ast/transform/MaterializeAggregationQueries.h
@@ -22,13 +22,13 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to create artificial relations for bodies of
  * aggregation functions consisting of more than a single atom.
  */
-class MaterializeAggregationQueriesTransformer : public AstTransformer {
+class MaterializeAggregationQueriesTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "MaterializeAggregationQueriesTransformer";
@@ -41,14 +41,14 @@ public:
      * @param program the program to be processed
      * @return whether the program was modified
      */
-    static bool materializeAggregationQueries(AstTranslationUnit& translationUnit);
+    static bool materializeAggregationQueries(TranslationUnit& translationUnit);
 
     MaterializeAggregationQueriesTransformer* clone() const override {
         return new MaterializeAggregationQueriesTransformer();
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override {
+    bool transform(TranslationUnit& translationUnit) override {
         return materializeAggregationQueries(translationUnit);
     }
 
@@ -56,7 +56,7 @@ private:
      * A test determining whether the body of a given aggregation needs to be
      * 'outlined' into an independent relation or can be kept inline.
      */
-    static bool needsMaterializedRelation(const AstAggregator& agg);
+    static bool needsMaterializedRelation(const Aggregator& agg);
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/MaterializeSingletonAggregation.h
+++ b/src/ast/transform/MaterializeSingletonAggregation.h
@@ -24,13 +24,13 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Replaces literals containing single-valued aggregates with
  * a synthesised relation
  */
-class MaterializeSingletonAggregationTransformer : public AstTransformer {
+class MaterializeSingletonAggregationTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "MaterializeSingletonAggregationTransformer";
@@ -41,23 +41,23 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
     /**
      * Determines whether an aggregate is single-valued,
      * ie the aggregate does not depend on the outer scope.
      */
-    static bool isSingleValued(const AstAggregator& agg, const AstClause& clause);
+    static bool isSingleValued(const Aggregator& agg, const Clause& clause);
     /**
      * findUniqueVariableName returns a variable name that hasn't appeared
      * in the given clause.
      */
-    static std::string findUniqueVariableName(const AstClause& clause);
+    static std::string findUniqueVariableName(const Clause& clause);
     /**
      * findUniqueAggregateRelationName returns a synthesised aggregate
      * relation name that hasn't appeared
      * in the given clause.
      */
-    static std::string findUniqueAggregateRelationName(const AstProgram& program);
+    static std::string findUniqueAggregateRelationName(const Program& program);
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/Meta.cpp
+++ b/src/ast/transform/Meta.cpp
@@ -19,9 +19,9 @@
 #include <chrono>
 #include <iostream>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool MetaTransformer::applySubtransformer(AstTranslationUnit& translationUnit, AstTransformer* transformer) {
+bool MetaTransformer::applySubtransformer(TranslationUnit& translationUnit, Transformer* transformer) {
     auto start = std::chrono::high_resolution_clock::now();
     bool changed = transformer->apply(translationUnit);
     auto end = std::chrono::high_resolution_clock::now();
@@ -35,4 +35,4 @@ bool MetaTransformer::applySubtransformer(AstTranslationUnit& translationUnit, A
     return changed;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/Meta.h
+++ b/src/ast/transform/Meta.h
@@ -22,18 +22,18 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformer that coordinates other sub-transformations
  */
-class MetaTransformer : public AstTransformer {
+class MetaTransformer : public Transformer {
 protected:
     bool verbose = false;
 
 public:
     /* Get subtransformers */
-    virtual std::vector<AstTransformer*> getSubtransformers() const = 0;
+    virtual std::vector<Transformer*> getSubtransformers() const = 0;
 
     /* Enable the debug-report for all sub-transformations */
     virtual void setDebugReport() = 0;
@@ -45,9 +45,9 @@ public:
     virtual void disableTransformers(const std::set<std::string>& transforms) = 0;
 
     /* Apply a nested transformer */
-    bool applySubtransformer(AstTranslationUnit& translationUnit, AstTransformer* transformer);
+    bool applySubtransformer(TranslationUnit& translationUnit, Transformer* transformer);
 
     MetaTransformer* clone() const override = 0;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/MinimiseProgram.cpp
+++ b/src/ast/transform/MinimiseProgram.cpp
@@ -40,7 +40,9 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
+
+using namespace analysis;
 
 bool MinimiseProgramTransformer::existsValidPermutation(const NormalisedClause& left,
         const NormalisedClause& right, const std::vector<std::vector<unsigned int>>& permutationMatrix) {
@@ -232,21 +234,21 @@ bool MinimiseProgramTransformer::areBijectivelyEquivalent(
     return existsValidPermutation(left, right, permutationMatrix);
 }
 
-bool MinimiseProgramTransformer::reduceLocallyEquivalentClauses(AstTranslationUnit& translationUnit) {
-    AstProgram& program = *translationUnit.getProgram();
-    const auto& normalisations = *translationUnit.getAnalysis<ClauseNormalisationAnalysis>();
+bool MinimiseProgramTransformer::reduceLocallyEquivalentClauses(TranslationUnit& translationUnit) {
+    Program& program = *translationUnit.getProgram();
+    const auto& normalisations = *translationUnit.getAnalysis<analysis::ClauseNormalisationAnalysis>();
 
-    std::vector<AstClause*> clausesToDelete;
+    std::vector<Clause*> clausesToDelete;
 
     // split up each relation's rules into equivalence classes
     // TODO (azreika): consider turning this into an ast analysis instead
-    for (AstRelation* rel : program.getRelations()) {
-        std::vector<std::vector<AstClause*>> equivalenceClasses;
+    for (Relation* rel : program.getRelations()) {
+        std::vector<std::vector<Clause*>> equivalenceClasses;
 
-        for (AstClause* clause : getClauses(program, *rel)) {
+        for (Clause* clause : getClauses(program, *rel)) {
             bool added = false;
 
-            for (std::vector<AstClause*>& eqClass : equivalenceClasses) {
+            for (std::vector<Clause*>& eqClass : equivalenceClasses) {
                 const auto& normedRep = normalisations.getNormalisation(eqClass[0]);
                 const auto& normedClause = normalisations.getNormalisation(clause);
                 if (areBijectivelyEquivalent(normedRep, normedClause)) {
@@ -260,7 +262,7 @@ bool MinimiseProgramTransformer::reduceLocallyEquivalentClauses(AstTranslationUn
 
             if (!added) {
                 // clause does not belong to any existing equivalence class, so keep it
-                std::vector<AstClause*> clauseToAdd = {clause};
+                std::vector<Clause*> clauseToAdd = {clause};
                 equivalenceClasses.push_back(clauseToAdd);
             }
         }
@@ -275,27 +277,27 @@ bool MinimiseProgramTransformer::reduceLocallyEquivalentClauses(AstTranslationUn
     return !clausesToDelete.empty();
 }
 
-bool MinimiseProgramTransformer::reduceSingletonRelations(AstTranslationUnit& translationUnit) {
+bool MinimiseProgramTransformer::reduceSingletonRelations(TranslationUnit& translationUnit) {
     // Note: This reduction is particularly useful in conjunction with the
     // body-partitioning transformation
-    AstProgram& program = *translationUnit.getProgram();
-    const auto& ioTypes = *translationUnit.getAnalysis<IOType>();
-    const auto& normalisations = *translationUnit.getAnalysis<ClauseNormalisationAnalysis>();
+    Program& program = *translationUnit.getProgram();
+    const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOType>();
+    const auto& normalisations = *translationUnit.getAnalysis<analysis::ClauseNormalisationAnalysis>();
 
     // Find all singleton relations to consider
-    std::vector<AstClause*> singletonRelationClauses;
-    for (AstRelation* rel : program.getRelations()) {
+    std::vector<Clause*> singletonRelationClauses;
+    for (Relation* rel : program.getRelations()) {
         if (!ioTypes.isIO(rel) && getClauses(program, *rel).size() == 1) {
-            AstClause* clause = getClauses(program, *rel)[0];
+            Clause* clause = getClauses(program, *rel)[0];
             singletonRelationClauses.push_back(clause);
         }
     }
 
     // Keep track of clauses found to be redundant
-    std::set<const AstClause*> redundantClauses;
+    std::set<const Clause*> redundantClauses;
 
     // Keep track of canonical relation name for each redundant clause
-    std::map<AstQualifiedName, AstQualifiedName> canonicalName;
+    std::map<QualifiedName, QualifiedName> canonicalName;
 
     // Check pairwise equivalence of each singleton relation
     for (size_t i = 0; i < singletonRelationClauses.size(); i++) {
@@ -312,8 +314,8 @@ bool MinimiseProgramTransformer::reduceSingletonRelations(AstTranslationUnit& tr
             const auto& normedFirst = normalisations.getNormalisation(first);
             const auto& normedSecond = normalisations.getNormalisation(second);
             if (areBijectivelyEquivalent(normedFirst, normedSecond)) {
-                AstQualifiedName firstName = first->getHead()->getQualifiedName();
-                AstQualifiedName secondName = second->getHead()->getQualifiedName();
+                QualifiedName firstName = first->getHead()->getQualifiedName();
+                QualifiedName secondName = second->getHead()->getQualifiedName();
                 redundantClauses.insert(second);
                 canonicalName.insert(std::pair(secondName, firstName));
             }
@@ -323,23 +325,23 @@ bool MinimiseProgramTransformer::reduceSingletonRelations(AstTranslationUnit& tr
     // Remove redundant relation definitions
     for (const auto* clause : redundantClauses) {
         auto relName = clause->getHead()->getQualifiedName();
-        AstRelation* rel = getRelation(program, relName);
+        Relation* rel = getRelation(program, relName);
         assert(rel != nullptr && "relation does not exist in program");
         removeRelation(translationUnit, relName);
     }
 
     // Replace each redundant relation appearance with its canonical name
-    struct replaceRedundantRelations : public AstNodeMapper {
-        const std::map<AstQualifiedName, AstQualifiedName>& canonicalName;
+    struct replaceRedundantRelations : public NodeMapper {
+        const std::map<QualifiedName, QualifiedName>& canonicalName;
 
-        replaceRedundantRelations(const std::map<AstQualifiedName, AstQualifiedName>& canonicalName)
+        replaceRedundantRelations(const std::map<QualifiedName, QualifiedName>& canonicalName)
                 : canonicalName(canonicalName) {}
 
-        Own<AstNode> operator()(Own<AstNode> node) const override {
+        Own<Node> operator()(Own<Node> node) const override {
             // Remove appearances from children nodes
             node->apply(*this);
 
-            if (auto* atom = dynamic_cast<AstAtom*>(node.get())) {
+            if (auto* atom = dynamic_cast<Atom*>(node.get())) {
                 auto pos = canonicalName.find(atom->getQualifiedName());
                 if (pos != canonicalName.end()) {
                     auto newAtom = souffle::clone(atom);
@@ -358,9 +360,9 @@ bool MinimiseProgramTransformer::reduceSingletonRelations(AstTranslationUnit& tr
     return !canonicalName.empty();
 }
 
-bool MinimiseProgramTransformer::removeRedundantClauses(AstTranslationUnit& translationUnit) {
+bool MinimiseProgramTransformer::removeRedundantClauses(TranslationUnit& translationUnit) {
     auto& program = *translationUnit.getProgram();
-    auto isRedundant = [&](const AstClause* clause) {
+    auto isRedundant = [&](const Clause* clause) {
         const auto* head = clause->getHead();
         for (const auto* lit : clause->getBodyLiterals()) {
             if (*head == *lit) {
@@ -370,7 +372,7 @@ bool MinimiseProgramTransformer::removeRedundantClauses(AstTranslationUnit& tran
         return false;
     };
 
-    std::set<Own<AstClause>> clausesToRemove;
+    std::set<Own<Clause>> clausesToRemove;
     for (const auto* clause : program.getClauses()) {
         if (isRedundant(clause)) {
             clausesToRemove.insert(souffle::clone(clause));
@@ -383,10 +385,10 @@ bool MinimiseProgramTransformer::removeRedundantClauses(AstTranslationUnit& tran
     return !clausesToRemove.empty();
 }
 
-bool MinimiseProgramTransformer::reduceClauseBodies(AstTranslationUnit& translationUnit) {
+bool MinimiseProgramTransformer::reduceClauseBodies(TranslationUnit& translationUnit) {
     auto& program = *translationUnit.getProgram();
-    std::set<Own<AstClause>> clausesToAdd;
-    std::set<Own<AstClause>> clausesToRemove;
+    std::set<Own<Clause>> clausesToAdd;
+    std::set<Own<Clause>> clausesToRemove;
 
     for (const auto* clause : program.getClauses()) {
         auto bodyLiterals = clause->getBodyLiterals();
@@ -401,7 +403,7 @@ bool MinimiseProgramTransformer::reduceClauseBodies(AstTranslationUnit& translat
         }
 
         if (!redundantPositions.empty()) {
-            auto minimisedClause = mk<AstClause>();
+            auto minimisedClause = mk<Clause>();
             minimisedClause->setHead(souffle::clone(clause->getHead()));
             for (size_t i = 0; i < bodyLiterals.size(); i++) {
                 if (!contains(redundantPositions, i)) {
@@ -423,7 +425,7 @@ bool MinimiseProgramTransformer::reduceClauseBodies(AstTranslationUnit& translat
     return !clausesToAdd.empty();
 }
 
-bool MinimiseProgramTransformer::transform(AstTranslationUnit& translationUnit) {
+bool MinimiseProgramTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
     changed |= reduceClauseBodies(translationUnit);
     if (changed) translationUnit.invalidateAnalyses();
@@ -435,4 +437,4 @@ bool MinimiseProgramTransformer::transform(AstTranslationUnit& translationUnit) 
     return changed;
 }
 
-}  // namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/MinimiseProgram.cpp
+++ b/src/ast/transform/MinimiseProgram.cpp
@@ -281,7 +281,7 @@ bool MinimiseProgramTransformer::reduceSingletonRelations(TranslationUnit& trans
     // Note: This reduction is particularly useful in conjunction with the
     // body-partitioning transformation
     Program& program = *translationUnit.getProgram();
-    const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOType>();
+    const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
     const auto& normalisations = *translationUnit.getAnalysis<analysis::ClauseNormalisationAnalysis>();
 
     // Find all singleton relations to consider

--- a/src/ast/transform/MinimiseProgram.h
+++ b/src/ast/transform/MinimiseProgram.h
@@ -22,35 +22,37 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to remove equivalent rules.
  */
-class MinimiseProgramTransformer : public AstTransformer {
+class MinimiseProgramTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "MinimiseProgramTransformer";
     }
 
     // Check whether two normalised clause representations are equivalent.
-    static bool areBijectivelyEquivalent(const NormalisedClause& left, const NormalisedClause& right);
+    static bool areBijectivelyEquivalent(
+            const analysis::NormalisedClause& left, const analysis::NormalisedClause& right);
 
     MinimiseProgramTransformer* clone() const override {
         return new MinimiseProgramTransformer();
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
     /** -- Bijective Equivalence Helper Methods -- */
 
     // Check whether a valid variable mapping exists for the given permutation.
-    static bool isValidPermutation(const NormalisedClause& left, const NormalisedClause& right,
-            const std::vector<unsigned int>& permutation);
+    static bool isValidPermutation(const analysis::NormalisedClause& left,
+            const analysis::NormalisedClause& right, const std::vector<unsigned int>& permutation);
 
     // Checks whether a permutation encoded in the given matrix has a valid corresponding variable mapping.
-    static bool existsValidPermutation(const NormalisedClause& left, const NormalisedClause& right,
+    static bool existsValidPermutation(const analysis::NormalisedClause& left,
+            const analysis::NormalisedClause& right,
             const std::vector<std::vector<unsigned int>>& permutationMatrix);
 
     /** -- Sub-Transformations -- */
@@ -60,17 +62,17 @@ private:
      * A clause is locally-redundant if there is another clause within the same relation
      * that computes the same set of tuples.
      */
-    static bool reduceLocallyEquivalentClauses(AstTranslationUnit& translationUnit);
+    static bool reduceLocallyEquivalentClauses(TranslationUnit& translationUnit);
 
     /**
      * Remove clauses that are only satisfied if they are already satisfied.
      */
-    static bool removeRedundantClauses(AstTranslationUnit& translationUnit);
+    static bool removeRedundantClauses(TranslationUnit& translationUnit);
 
     /**
      * Remove redundant literals within a clause.
      */
-    static bool reduceClauseBodies(AstTranslationUnit& translationUnit);
+    static bool reduceClauseBodies(TranslationUnit& translationUnit);
 
     /**
      * Removes redundant singleton relations.
@@ -78,7 +80,7 @@ private:
      * if there exists another singleton relation that computes the same set of tuples.
      * @return true iff the program was changed
      */
-    static bool reduceSingletonRelations(AstTranslationUnit& translationUnit);
+    static bool reduceSingletonRelations(TranslationUnit& translationUnit);
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/NameUnnamedVariables.cpp
+++ b/src/ast/transform/NameUnnamedVariables.cpp
@@ -27,32 +27,32 @@
 #include <ostream>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool NameUnnamedVariablesTransformer::transform(AstTranslationUnit& translationUnit) {
+bool NameUnnamedVariablesTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
     static constexpr const char* boundPrefix = "+underscore";
     static size_t underscoreCount = 0;
 
-    struct nameVariables : public AstNodeMapper {
+    struct nameVariables : public NodeMapper {
         mutable bool changed = false;
         nameVariables() = default;
 
-        Own<AstNode> operator()(Own<AstNode> node) const override {
-            if (isA<AstUnnamedVariable>(node.get())) {
+        Own<Node> operator()(Own<Node> node) const override {
+            if (isA<UnnamedVariable>(node.get())) {
                 changed = true;
                 std::stringstream name;
                 name << boundPrefix << "_" << underscoreCount++;
-                return mk<AstVariable>(name.str());
+                return mk<ast::Variable>(name.str());
             }
             node->apply(*this);
             return node;
         }
     };
 
-    AstProgram& program = *translationUnit.getProgram();
-    for (AstRelation* rel : program.getRelations()) {
-        for (AstClause* clause : getClauses(program, *rel)) {
+    Program& program = *translationUnit.getProgram();
+    for (Relation* rel : program.getRelations()) {
+        for (Clause* clause : getClauses(program, *rel)) {
             nameVariables update;
             clause->apply(update);
             changed |= update.changed;
@@ -62,4 +62,4 @@ bool NameUnnamedVariablesTransformer::transform(AstTranslationUnit& translationU
     return changed;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/NameUnnamedVariables.h
+++ b/src/ast/transform/NameUnnamedVariables.h
@@ -22,14 +22,14 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to replace unnamed variables
  * with singletons.
  * E.g.: a() :- b(_). -> a() :- b(x).
  */
-class NameUnnamedVariablesTransformer : public AstTransformer {
+class NameUnnamedVariablesTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "NameUnnamedVariablesTransformer";
@@ -40,7 +40,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/NormaliseConstraints.h
+++ b/src/ast/transform/NormaliseConstraints.h
@@ -21,13 +21,13 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to normalise constraints.
  * E.g.: a(x) :- b(x, 1). -> a(x) :- b(x, tmp0), tmp0=1.
  */
-class NormaliseConstraintsTransformer : public AstTransformer {
+class NormaliseConstraintsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "NormaliseConstraintsTransformer";
@@ -38,7 +38,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/Null.h
+++ b/src/ast/transform/Null.h
@@ -23,19 +23,19 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformer that does absolutely nothing
  */
 class NullTransformer : public MetaTransformer {
 private:
-    bool transform(AstTranslationUnit& /* translationUnit */) override {
+    bool transform(TranslationUnit& /* translationUnit */) override {
         return false;
     }
 
 public:
-    std::vector<AstTransformer*> getSubtransformers() const override {
+    std::vector<Transformer*> getSubtransformers() const override {
         return {};
     }
 
@@ -54,4 +54,4 @@ public:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/PartitionBodyLiterals.h
+++ b/src/ast/transform/PartitionBodyLiterals.h
@@ -25,7 +25,7 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to move literals into new clauses
@@ -35,7 +35,7 @@ namespace souffle {
  *      - newrel1() :- c(y), d(y).
  *      - newrel2() :- e(z).
  */
-class PartitionBodyLiteralsTransformer : public AstTransformer {
+class PartitionBodyLiteralsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "PartitionBodyLiteralsTransformer";
@@ -46,7 +46,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/Pipeline.h
+++ b/src/ast/transform/Pipeline.h
@@ -30,7 +30,7 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformer that holds an arbitrary number of sub-transformations
@@ -39,15 +39,15 @@ class PipelineTransformer : public MetaTransformer {
 public:
     template <typename... Args>
     PipelineTransformer(Args... args) {
-        Own<AstTransformer> tmp[] = {std::move(args)...};
+        Own<Transformer> tmp[] = {std::move(args)...};
         for (auto& cur : tmp) {
             pipeline.push_back(std::move(cur));
         }
     }
 
-    PipelineTransformer(VecOwn<AstTransformer> pipeline) : pipeline(std::move(pipeline)) {}
+    PipelineTransformer(VecOwn<Transformer> pipeline) : pipeline(std::move(pipeline)) {}
 
-    std::vector<AstTransformer*> getSubtransformers() const override {
+    std::vector<Transformer*> getSubtransformers() const override {
         return toPtrVector(pipeline);
     }
 
@@ -85,7 +85,7 @@ public:
     }
 
     PipelineTransformer* clone() const override {
-        VecOwn<AstTransformer> transformers;
+        VecOwn<Transformer> transformers;
         for (const auto& transformer : pipeline) {
             transformers.push_back(souffle::clone(transformer));
         }
@@ -93,8 +93,8 @@ public:
     }
 
 protected:
-    VecOwn<AstTransformer> pipeline;
-    bool transform(AstTranslationUnit& translationUnit) override {
+    VecOwn<Transformer> pipeline;
+    bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
         for (auto& transformer : pipeline) {
             changed |= applySubtransformer(translationUnit, transformer.get());
@@ -103,4 +103,4 @@ protected:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/PolymorphicObjects.h
+++ b/src/ast/transform/PolymorphicObjects.h
@@ -21,14 +21,14 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to determine instances of polymorphic object
  * objects = Functors (plus, minus...) ∪ binary constraints (>, ≥ ...) ∪ aggregation ∪ numeric constants
  */
 
-class PolymorphicObjectsTransformer : public AstTransformer {
+class PolymorphicObjectsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "PolymorphicObjectsTransformer";
@@ -39,7 +39,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/PragmaChecker.cpp
+++ b/src/ast/transform/PragmaChecker.cpp
@@ -23,13 +23,13 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
-bool AstPragmaChecker::transform(AstTranslationUnit& translationUnit) {
+namespace souffle::ast::transform {
+bool PragmaChecker::transform(TranslationUnit& translationUnit) {
     bool changed = false;
-    AstProgram* program = translationUnit.getProgram();
+    Program* program = translationUnit.getProgram();
 
     // Take in pragma options from the datalog file
-    visitDepthFirst(*program, [&](const AstPragma& pragma) {
+    visitDepthFirst(*program, [&](const Pragma& pragma) {
         std::pair<std::string, std::string> kvp = pragma.getkvp();
 
         // Command line options take precedence
@@ -41,4 +41,4 @@ bool AstPragmaChecker::transform(AstTranslationUnit& translationUnit) {
 
     return changed;
 }
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/PragmaChecker.h
+++ b/src/ast/transform/PragmaChecker.h
@@ -20,20 +20,20 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-class AstPragmaChecker : public AstTransformer {
+class PragmaChecker : public Transformer {
 public:
     std::string getName() const override {
-        return "AstPragmaChecker";
+        return "PragmaChecker";
     }
 
-    AstPragmaChecker* clone() const override {
-        return new AstPragmaChecker();
+    PragmaChecker* clone() const override {
+        return new PragmaChecker();
     }
 
 private:
-    bool transform(AstTranslationUnit&) override;
+    bool transform(TranslationUnit&) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/Provenance.h
+++ b/src/ast/transform/Provenance.h
@@ -20,12 +20,12 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to add provenance information
  */
-class ProvenanceTransformer : public AstTransformer {
+class ProvenanceTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "ProvenanceTransformer";
@@ -36,8 +36,8 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
-    bool transformMaxHeight(AstTranslationUnit& translationUnit);
+    bool transform(TranslationUnit& translationUnit) override;
+    bool transformMaxHeight(TranslationUnit& translationUnit);
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ReduceExistentials.cpp
+++ b/src/ast/transform/ReduceExistentials.cpp
@@ -39,15 +39,15 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUnit) {
-    AstProgram& program = *translationUnit.getProgram();
+bool ReduceExistentialsTransformer::transform(TranslationUnit& translationUnit) {
+    Program& program = *translationUnit.getProgram();
 
     // Checks whether an atom is of the form a(_,_,...,_)
-    auto isExistentialAtom = [&](const AstAtom& atom) {
-        for (AstArgument* arg : atom.getArguments()) {
-            if (!isA<AstUnnamedVariable>(arg)) {
+    auto isExistentialAtom = [&](const Atom& atom) {
+        for (Argument* arg : atom.getArguments()) {
+            if (!isA<UnnamedVariable>(arg)) {
                 return false;
             }
         }
@@ -59,26 +59,26 @@ bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUni
     // - An edge (a,b) exists iff a uses b "non-existentially" in one of its *recursive* clauses
     // This way, a relation can be transformed into an existential form
     // if and only if all its predecessors can also be transformed.
-    Graph<AstQualifiedName> relationGraph = Graph<AstQualifiedName>();
+    Graph<QualifiedName> relationGraph = Graph<QualifiedName>();
 
     // Add in the nodes
-    for (AstRelation* relation : program.getRelations()) {
+    for (Relation* relation : program.getRelations()) {
         relationGraph.insert(relation->getQualifiedName());
     }
 
     // Keep track of all relations that cannot be transformed
-    std::set<AstQualifiedName> minimalIrreducibleRelations;
+    std::set<QualifiedName> minimalIrreducibleRelations;
 
-    auto* ioType = translationUnit.getAnalysis<IOType>();
+    auto* ioType = translationUnit.getAnalysis<analysis::IOType>();
 
-    for (AstRelation* relation : program.getRelations()) {
+    for (Relation* relation : program.getRelations()) {
         // No I/O relations can be transformed
         if (ioType->isIO(relation)) {
             minimalIrreducibleRelations.insert(relation->getQualifiedName());
         }
-        for (AstClause* clause : getClauses(program, *relation)) {
+        for (Clause* clause : getClauses(program, *relation)) {
             bool recursive = isRecursiveClause(*clause);
-            visitDepthFirst(*clause, [&](const AstAtom& atom) {
+            visitDepthFirst(*clause, [&](const Atom& atom) {
                 if (atom.getQualifiedName() == clause->getHead()->getQualifiedName()) {
                     return;
                 }
@@ -99,23 +99,23 @@ bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUni
 
     // TODO (see issue #564): Don't transform relations appearing in aggregators
     //                        due to aggregator issues with unnamed variables.
-    visitDepthFirst(program, [&](const AstAggregator& aggr) {
-        visitDepthFirst(aggr,
-                [&](const AstAtom& atom) { minimalIrreducibleRelations.insert(atom.getQualifiedName()); });
+    visitDepthFirst(program, [&](const Aggregator& aggr) {
+        visitDepthFirst(
+                aggr, [&](const Atom& atom) { minimalIrreducibleRelations.insert(atom.getQualifiedName()); });
     });
 
     // Run a DFS from each 'bad' source
     // A node is reachable in a DFS from an irreducible node if and only if it is
     // also an irreducible node
-    std::set<AstQualifiedName> irreducibleRelations;
-    for (AstQualifiedName relationName : minimalIrreducibleRelations) {
+    std::set<QualifiedName> irreducibleRelations;
+    for (QualifiedName relationName : minimalIrreducibleRelations) {
         relationGraph.visitDepthFirst(
-                relationName, [&](const AstQualifiedName& subRel) { irreducibleRelations.insert(subRel); });
+                relationName, [&](const QualifiedName& subRel) { irreducibleRelations.insert(subRel); });
     }
 
     // All other relations are necessarily existential
-    std::set<AstQualifiedName> existentialRelations;
-    for (AstRelation* relation : program.getRelations()) {
+    std::set<QualifiedName> existentialRelations;
+    for (Relation* relation : program.getRelations()) {
         if (!getClauses(program, *relation).empty() && relation->getArity() != 0 &&
                 irreducibleRelations.find(relation->getQualifiedName()) == irreducibleRelations.end()) {
             existentialRelations.insert(relation->getQualifiedName());
@@ -123,13 +123,13 @@ bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUni
     }
 
     // Reduce the existential relations
-    for (AstQualifiedName relationName : existentialRelations) {
-        AstRelation* originalRelation = getRelation(program, relationName);
+    for (QualifiedName relationName : existentialRelations) {
+        Relation* originalRelation = getRelation(program, relationName);
 
         std::stringstream newRelationName;
         newRelationName << "+?exists_" << relationName;
 
-        auto newRelation = mk<AstRelation>();
+        auto newRelation = mk<Relation>();
         newRelation->setQualifiedName(newRelationName.str());
         newRelation->setSrcLoc(originalRelation->getSrcLoc());
 
@@ -139,16 +139,16 @@ bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUni
         }
 
         // Keep all non-recursive clauses
-        for (AstClause* clause : getClauses(program, *originalRelation)) {
+        for (Clause* clause : getClauses(program, *originalRelation)) {
             if (!isRecursiveClause(*clause)) {
-                auto newClause = mk<AstClause>();
+                auto newClause = mk<Clause>();
 
                 newClause->setSrcLoc(clause->getSrcLoc());
-                if (const AstExecutionPlan* plan = clause->getExecutionPlan()) {
+                if (const ExecutionPlan* plan = clause->getExecutionPlan()) {
                     newClause->setExecutionPlan(souffle::clone(plan));
                 }
-                newClause->setHead(mk<AstAtom>(newRelationName.str()));
-                for (AstLiteral* lit : clause->getBodyLiterals()) {
+                newClause->setHead(mk<Atom>(newRelationName.str()));
+                for (Literal* lit : clause->getBodyLiterals()) {
                     newClause->addToBody(souffle::clone(lit));
                 }
 
@@ -161,23 +161,23 @@ bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUni
 
     // Mapper that renames the occurrences of marked relations with their existential
     // counterparts
-    struct renameExistentials : public AstNodeMapper {
-        const std::set<AstQualifiedName>& relations;
+    struct renameExistentials : public NodeMapper {
+        const std::set<QualifiedName>& relations;
 
-        renameExistentials(std::set<AstQualifiedName>& relations) : relations(relations) {}
+        renameExistentials(std::set<QualifiedName>& relations) : relations(relations) {}
 
-        Own<AstNode> operator()(Own<AstNode> node) const override {
-            if (auto* clause = dynamic_cast<AstClause*>(node.get())) {
+        Own<Node> operator()(Own<Node> node) const override {
+            if (auto* clause = dynamic_cast<Clause*>(node.get())) {
                 if (relations.find(clause->getHead()->getQualifiedName()) != relations.end()) {
                     // Clause is going to be removed, so don't rename it
                     return node;
                 }
-            } else if (auto* atom = dynamic_cast<AstAtom*>(node.get())) {
+            } else if (auto* atom = dynamic_cast<Atom*>(node.get())) {
                 if (relations.find(atom->getQualifiedName()) != relations.end()) {
                     // Relation is now existential, so rename it
                     std::stringstream newName;
                     newName << "+?exists_" << atom->getQualifiedName();
-                    return mk<AstAtom>(newName.str());
+                    return mk<Atom>(newName.str());
                 }
             }
             node->apply(*this);
@@ -192,4 +192,4 @@ bool ReduceExistentialsTransformer::transform(AstTranslationUnit& translationUni
     return changed;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ReduceExistentials.cpp
+++ b/src/ast/transform/ReduceExistentials.cpp
@@ -69,7 +69,7 @@ bool ReduceExistentialsTransformer::transform(TranslationUnit& translationUnit) 
     // Keep track of all relations that cannot be transformed
     std::set<QualifiedName> minimalIrreducibleRelations;
 
-    auto* ioType = translationUnit.getAnalysis<analysis::IOType>();
+    auto* ioType = translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
 
     for (Relation* relation : program.getRelations()) {
         // No I/O relations can be transformed

--- a/src/ast/transform/ReduceExistentials.h
+++ b/src/ast/transform/ReduceExistentials.h
@@ -21,13 +21,13 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to reduce unnecessary computation for
  * relations that only appear in the form A(_,...,_).
  */
-class ReduceExistentialsTransformer : public AstTransformer {
+class ReduceExistentialsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "ReduceExistentialsTransformer";
@@ -38,7 +38,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/RemoveBooleanConstraints.h
+++ b/src/ast/transform/RemoveBooleanConstraints.h
@@ -18,13 +18,13 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to remove constant boolean constraints
  * Should be called after any transformation that may generate boolean constraints
  */
-class RemoveBooleanConstraintsTransformer : public AstTransformer {
+class RemoveBooleanConstraintsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "RemoveBooleanConstraintsTransformer";
@@ -35,7 +35,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/RemoveEmptyRelations.cpp
+++ b/src/ast/transform/RemoveEmptyRelations.cpp
@@ -31,12 +31,12 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool RemoveEmptyRelationsTransformer::removeEmptyRelations(AstTranslationUnit& translationUnit) {
-    AstProgram& program = *translationUnit.getProgram();
-    auto* ioTypes = translationUnit.getAnalysis<IOType>();
-    std::set<AstQualifiedName> emptyRelations;
+bool RemoveEmptyRelationsTransformer::removeEmptyRelations(TranslationUnit& translationUnit) {
+    Program& program = *translationUnit.getProgram();
+    auto* ioTypes = translationUnit.getAnalysis<analysis::IOType>();
+    std::set<QualifiedName> emptyRelations;
     bool changed = false;
     for (auto rel : program.getRelations()) {
         if (!getClauses(program, *rel).empty() || ioTypes->isInput(rel)) {
@@ -45,9 +45,9 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelations(AstTranslationUnit& t
         emptyRelations.insert(rel->getQualifiedName());
 
         bool usedInAggregate = false;
-        visitDepthFirst(program, [&](const AstAggregator& agg) {
+        visitDepthFirst(program, [&](const Aggregator& agg) {
             for (const auto lit : agg.getBodyLiterals()) {
-                visitDepthFirst(*lit, [&](const AstAtom& atom) {
+                visitDepthFirst(*lit, [&](const Atom& atom) {
                     if (getAtomRelation(&atom, &program) == rel) {
                         usedInAggregate = true;
                     }
@@ -69,8 +69,8 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelations(AstTranslationUnit& t
 }
 
 bool RemoveEmptyRelationsTransformer::removeEmptyRelationUses(
-        AstTranslationUnit& translationUnit, const AstQualifiedName& emptyRelationName) {
-    AstProgram& program = *translationUnit.getProgram();
+        TranslationUnit& translationUnit, const QualifiedName& emptyRelationName) {
+    Program& program = *translationUnit.getProgram();
     bool changed = false;
 
     //
@@ -78,16 +78,16 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelationUses(
     // (2) drop negations of empty relations
     //
     // get all clauses
-    std::vector<const AstClause*> clauses;
-    visitDepthFirst(program, [&](const AstClause& cur) { clauses.push_back(&cur); });
+    std::vector<const Clause*> clauses;
+    visitDepthFirst(program, [&](const Clause& cur) { clauses.push_back(&cur); });
 
     // clean all clauses
-    for (const AstClause* cl : clauses) {
+    for (const Clause* cl : clauses) {
         // check for an atom whose relation is the empty relation
 
         bool removed = false;
-        for (AstLiteral* lit : cl->getBodyLiterals()) {
-            if (auto* arg = dynamic_cast<AstAtom*>(lit)) {
+        for (Literal* lit : cl->getBodyLiterals()) {
+            if (auto* arg = dynamic_cast<Atom*>(lit)) {
                 if (arg->getQualifiedName() == emptyRelationName) {
                     program.removeClause(cl);
                     removed = true;
@@ -101,8 +101,8 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelationUses(
             // check whether a negation with empty relations exists
 
             bool rewrite = false;
-            for (AstLiteral* lit : cl->getBodyLiterals()) {
-                if (auto* neg = dynamic_cast<AstNegation*>(lit)) {
+            for (Literal* lit : cl->getBodyLiterals()) {
+                if (auto* neg = dynamic_cast<Negation*>(lit)) {
                     if (neg->getAtom()->getQualifiedName() == emptyRelationName) {
                         rewrite = true;
                         break;
@@ -113,10 +113,10 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelationUses(
             if (rewrite) {
                 // clone clause without negation for empty relations
 
-                auto res = Own<AstClause>(cloneHead(cl));
+                auto res = Own<Clause>(cloneHead(cl));
 
-                for (AstLiteral* lit : cl->getBodyLiterals()) {
-                    if (auto* neg = dynamic_cast<AstNegation*>(lit)) {
+                for (Literal* lit : cl->getBodyLiterals()) {
+                    if (auto* neg = dynamic_cast<Negation*>(lit)) {
                         if (neg->getAtom()->getQualifiedName() != emptyRelationName) {
                             res->addToBody(souffle::clone(lit));
                         }
@@ -135,4 +135,4 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelationUses(
     return changed;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/RemoveEmptyRelations.cpp
+++ b/src/ast/transform/RemoveEmptyRelations.cpp
@@ -35,7 +35,7 @@ namespace souffle::ast::transform {
 
 bool RemoveEmptyRelationsTransformer::removeEmptyRelations(TranslationUnit& translationUnit) {
     Program& program = *translationUnit.getProgram();
-    auto* ioTypes = translationUnit.getAnalysis<analysis::IOType>();
+    auto* ioTypes = translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
     std::set<QualifiedName> emptyRelations;
     bool changed = false;
     for (auto rel : program.getRelations()) {

--- a/src/ast/transform/RemoveEmptyRelations.h
+++ b/src/ast/transform/RemoveEmptyRelations.h
@@ -19,12 +19,12 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to remove all empty relations and rules that use empty relations.
  */
-class RemoveEmptyRelationsTransformer : public AstTransformer {
+class RemoveEmptyRelationsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "RemoveEmptyRelationsTransformer";
@@ -36,14 +36,14 @@ public:
      * @param translationUnit the program to be processed
      * @return whether the program was modified
      */
-    static bool removeEmptyRelations(AstTranslationUnit& translationUnit);
+    static bool removeEmptyRelations(TranslationUnit& translationUnit);
 
     RemoveEmptyRelationsTransformer* clone() const override {
         return new RemoveEmptyRelationsTransformer();
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override {
+    bool transform(TranslationUnit& translationUnit) override {
         return removeEmptyRelations(translationUnit);
     }
 
@@ -54,8 +54,7 @@ private:
      * @param emptyRelation relation that is empty
      * @return whether the program was modified
      */
-    static bool removeEmptyRelationUses(
-            AstTranslationUnit& translationUnit, const AstQualifiedName& emptyRelation);
+    static bool removeEmptyRelationUses(TranslationUnit& translationUnit, const QualifiedName& emptyRelation);
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/RemoveRedundantRelations.cpp
+++ b/src/ast/transform/RemoveRedundantRelations.cpp
@@ -19,13 +19,12 @@
 #include "ast/utility/Utils.h"
 #include <set>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool RemoveRedundantRelationsTransformer::transform(AstTranslationUnit& translationUnit) {
+bool RemoveRedundantRelationsTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
-    auto* redundantRelationsAnalysis = translationUnit.getAnalysis<RedundantRelationsAnalysis>();
-    const std::set<const AstRelation*>& redundantRelations =
-            redundantRelationsAnalysis->getRedundantRelations();
+    auto* redundantRelationsAnalysis = translationUnit.getAnalysis<analysis::RedundantRelationsAnalysis>();
+    const std::set<const Relation*>& redundantRelations = redundantRelationsAnalysis->getRedundantRelations();
     if (!redundantRelations.empty()) {
         for (auto rel : redundantRelations) {
             removeRelation(translationUnit, rel->getQualifiedName());
@@ -35,4 +34,4 @@ bool RemoveRedundantRelationsTransformer::transform(AstTranslationUnit& translat
     return changed;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/RemoveRedundantRelations.h
+++ b/src/ast/transform/RemoveRedundantRelations.h
@@ -18,12 +18,12 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to remove relations which are redundant (do not contribute to output).
  */
-class RemoveRedundantRelationsTransformer : public AstTransformer {
+class RemoveRedundantRelationsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "RemoveRedundantRelationsTransformer";
@@ -34,7 +34,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/RemoveRedundantSums.h
+++ b/src/ast/transform/RemoveRedundantSums.h
@@ -18,7 +18,7 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to remove expressions of the form
@@ -26,7 +26,7 @@ namespace souffle {
  * k * count : { ... }
  * where k is a constant.
  */
-class RemoveRedundantSumsTransformer : public AstTransformer {
+class RemoveRedundantSumsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "RemoveRedundantSumsTransformer";
@@ -37,7 +37,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/RemoveRelationCopies.cpp
+++ b/src/ast/transform/RemoveRelationCopies.cpp
@@ -41,7 +41,7 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(TranslationUnit& tran
     // collect aliases
     alias_map isDirectAliasOf;
 
-    auto* ioType = translationUnit.getAnalysis<analysis::IOType>();
+    auto* ioType = translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
 
     Program& program = *translationUnit.getProgram();
 

--- a/src/ast/transform/RemoveRelationCopies.cpp
+++ b/src/ast/transform/RemoveRelationCopies.cpp
@@ -33,27 +33,27 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool RemoveRelationCopiesTransformer::removeRelationCopies(AstTranslationUnit& translationUnit) {
-    using alias_map = std::map<AstQualifiedName, AstQualifiedName>;
+bool RemoveRelationCopiesTransformer::removeRelationCopies(TranslationUnit& translationUnit) {
+    using alias_map = std::map<QualifiedName, QualifiedName>;
 
     // collect aliases
     alias_map isDirectAliasOf;
 
-    auto* ioType = translationUnit.getAnalysis<IOType>();
+    auto* ioType = translationUnit.getAnalysis<analysis::IOType>();
 
-    AstProgram& program = *translationUnit.getProgram();
+    Program& program = *translationUnit.getProgram();
 
     // search for relations only defined by a single rule ..
-    for (AstRelation* rel : program.getRelations()) {
+    for (Relation* rel : program.getRelations()) {
         const auto& clauses = getClauses(program, *rel);
         if (!ioType->isIO(rel) && clauses.size() == 1u) {
             // .. of shape r(x,y,..) :- s(x,y,..)
-            AstClause* cl = clauses[0];
-            std::vector<AstAtom*> bodyAtoms = getBodyLiterals<AstAtom>(*cl);
+            Clause* cl = clauses[0];
+            std::vector<Atom*> bodyAtoms = getBodyLiterals<Atom>(*cl);
             if (!isFact(*cl) && cl->getBodyLiterals().size() == 1u && bodyAtoms.size() == 1u) {
-                AstAtom* atom = bodyAtoms[0];
+                Atom* atom = bodyAtoms[0];
                 if (equal_targets(cl->getHead()->getArguments(), atom->getArguments())) {
                     // Requirements:
                     // 1) (checked) It is a rule with exactly one body.
@@ -71,9 +71,9 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(AstTranslationUnit& t
                         const auto cur = args.back();
                         args.pop_back();
 
-                        if (auto var = dynamic_cast<const AstVariable*>(cur)) {
+                        if (auto var = dynamic_cast<const ast::Variable*>(cur)) {
                             onlyDistinctHeadVars &= headVars.insert(var->getName()).second;
-                        } else if (auto init = dynamic_cast<const AstRecordInit*>(cur)) {
+                        } else if (auto init = dynamic_cast<const RecordInit*>(cur)) {
                             // records are decomposed and their arguments are checked
                             for (auto rec_arg : init->getArguments()) {
                                 args.push_back(rec_arg);
@@ -97,12 +97,12 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(AstTranslationUnit& t
     alias_map isAliasOf;
 
     // track any copy cycles; cyclic rules are effectively empty
-    std::set<AstQualifiedName> cycle_reps;
+    std::set<QualifiedName> cycle_reps;
 
-    for (std::pair<AstQualifiedName, AstQualifiedName> cur : isDirectAliasOf) {
+    for (std::pair<QualifiedName, QualifiedName> cur : isDirectAliasOf) {
         // compute replacement
 
-        std::set<AstQualifiedName> visited;
+        std::set<QualifiedName> visited;
         visited.insert(cur.first);
         visited.insert(cur.second);
 
@@ -123,10 +123,10 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(AstTranslationUnit& t
     }
 
     // replace usage of relations according to alias map
-    visitDepthFirst(program, [&](const AstAtom& atom) {
+    visitDepthFirst(program, [&](const Atom& atom) {
         auto pos = isAliasOf.find(atom.getQualifiedName());
         if (pos != isAliasOf.end()) {
-            const_cast<AstAtom&>(atom).setQualifiedName(pos->second);
+            const_cast<Atom&>(atom).setQualifiedName(pos->second);
         }
     });
 
@@ -148,4 +148,4 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(AstTranslationUnit& t
     return true;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/RemoveRelationCopies.h
+++ b/src/ast/transform/RemoveRelationCopies.h
@@ -18,7 +18,7 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to replaces copy of relations by their origin.
@@ -28,7 +28,7 @@ namespace souffle {
  *
  * and no other clause, all occurrences of r will be replaced by s.
  */
-class RemoveRelationCopiesTransformer : public AstTransformer {
+class RemoveRelationCopiesTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "RemoveRelationCopiesTransformer";
@@ -40,16 +40,16 @@ public:
      * @param program the program to be processed
      * @return whether the program was modified
      */
-    static bool removeRelationCopies(AstTranslationUnit& translationUnit);
+    static bool removeRelationCopies(TranslationUnit& translationUnit);
 
     RemoveRelationCopiesTransformer* clone() const override {
         return new RemoveRelationCopiesTransformer();
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override {
+    bool transform(TranslationUnit& translationUnit) override {
         return removeRelationCopies(translationUnit);
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/RemoveTypecasts.cpp
+++ b/src/ast/transform/RemoveTypecasts.cpp
@@ -22,18 +22,18 @@
 #include "souffle/utility/MiscUtil.h"
 #include <memory>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool RemoveTypecastsTransformer::transform(AstTranslationUnit& translationUnit) {
-    struct TypecastRemover : public AstNodeMapper {
+bool RemoveTypecastsTransformer::transform(TranslationUnit& translationUnit) {
+    struct TypecastRemover : public NodeMapper {
         mutable bool changed{false};
 
-        Own<AstNode> operator()(Own<AstNode> node) const override {
+        Own<Node> operator()(Own<Node> node) const override {
             // remove sub-typecasts first
             node->apply(*this);
 
             // if current node is a typecast, replace with the value directly
-            if (auto* cast = dynamic_cast<AstTypeCast*>(node.get())) {
+            if (auto* cast = dynamic_cast<ast::TypeCast*>(node.get())) {
                 changed = true;
                 return souffle::clone(cast->getValue());
             }
@@ -49,4 +49,4 @@ bool RemoveTypecastsTransformer::transform(AstTranslationUnit& translationUnit) 
     return update.changed;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/RemoveTypecasts.h
+++ b/src/ast/transform/RemoveTypecasts.h
@@ -20,14 +20,14 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation to remove typecasts.
  */
-class RemoveTypecastsTransformer : public AstTransformer {
+class RemoveTypecastsTransformer : public Transformer {
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
 public:
     std::string getName() const override {
@@ -39,4 +39,4 @@ public:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ReorderLiterals.h
+++ b/src/ast/transform/ReorderLiterals.h
@@ -22,9 +22,10 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
-
+namespace souffle::ast {
 class BindingStore;
+}
+namespace souffle::ast::transform {
 
 /**
  * Type for SIPS functions
@@ -32,12 +33,12 @@ class BindingStore;
  * @param bindingStore a store of currently bound variables
  * @return the index of the best atom to choose based on some SIPS-specific cost metric
  */
-using sips_t = std::function<unsigned int(std::vector<AstAtom*>, const BindingStore&)>;
+using sips_t = std::function<unsigned int(std::vector<Atom*>, const BindingStore&)>;
 
 /**
  * Transformation pass to reorder body literals.
  */
-class ReorderLiteralsTransformer : public AstTransformer {
+class ReorderLiteralsTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "ReorderLiteralsTransformer";
@@ -56,10 +57,10 @@ public:
      * @param clause clause to reorder
      * @return nullptr if no change, otherwise a new reordered clause
      */
-    static AstClause* reorderClauseWithSips(sips_t sipsFunction, const AstClause* clause);
+    static Clause* reorderClauseWithSips(sips_t sipsFunction, const Clause* clause);
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
     /**
      * Determines the new ordering of a clause after the given SIPS is applied.
@@ -67,7 +68,7 @@ private:
      * @param clause clause to reorder
      * @return the vector of new positions; v[i] = j iff atom j moves to pos i
      */
-    static std::vector<unsigned int> getOrderingAfterSIPS(sips_t sipsFunction, const AstClause* clause);
+    static std::vector<unsigned int> getOrderingAfterSIPS(sips_t sipsFunction, const Clause* clause);
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ReplaceSingletonVariables.cpp
+++ b/src/ast/transform/ReplaceSingletonVariables.cpp
@@ -29,23 +29,23 @@
 #include <set>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool ReplaceSingletonVariablesTransformer::transform(AstTranslationUnit& translationUnit) {
+bool ReplaceSingletonVariablesTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
 
-    AstProgram& program = *translationUnit.getProgram();
+    Program& program = *translationUnit.getProgram();
 
     // Node-mapper to replace a set of singletons with unnamed variables
-    struct replaceSingletons : public AstNodeMapper {
+    struct replaceSingletons : public NodeMapper {
         std::set<std::string>& singletons;
 
         replaceSingletons(std::set<std::string>& singletons) : singletons(singletons) {}
 
-        Own<AstNode> operator()(Own<AstNode> node) const override {
-            if (auto* var = dynamic_cast<AstVariable*>(node.get())) {
+        Own<Node> operator()(Own<Node> node) const override {
+            if (auto* var = dynamic_cast<ast::Variable*>(node.get())) {
                 if (singletons.find(var->getName()) != singletons.end()) {
-                    return mk<AstUnnamedVariable>();
+                    return mk<UnnamedVariable>();
                 }
             }
             node->apply(*this);
@@ -53,12 +53,12 @@ bool ReplaceSingletonVariablesTransformer::transform(AstTranslationUnit& transla
         }
     };
 
-    for (AstRelation* rel : program.getRelations()) {
-        for (AstClause* clause : getClauses(program, *rel)) {
+    for (Relation* rel : program.getRelations()) {
+        for (Clause* clause : getClauses(program, *rel)) {
             std::set<std::string> nonsingletons;
             std::set<std::string> vars;
 
-            visitDepthFirst(*clause, [&](const AstVariable& var) {
+            visitDepthFirst(*clause, [&](const ast::Variable& var) {
                 const std::string& name = var.getName();
                 if (vars.find(name) != vars.end()) {
                     // Variable seen before, so not a singleton variable
@@ -73,14 +73,14 @@ bool ReplaceSingletonVariablesTransformer::transform(AstTranslationUnit& transla
             // Don't unname singleton variables occurring in records.
             // TODO (azreika): remove this check once issue #420 is fixed
             std::set<std::string> recordVars;
-            visitDepthFirst(*clause, [&](const AstRecordInit& rec) {
-                visitDepthFirst(rec, [&](const AstVariable& var) { ignoredVars.insert(var.getName()); });
+            visitDepthFirst(*clause, [&](const RecordInit& rec) {
+                visitDepthFirst(rec, [&](const ast::Variable& var) { ignoredVars.insert(var.getName()); });
             });
 
             // Don't unname singleton variables occuring in constraints.
             std::set<std::string> constraintVars;
-            visitDepthFirst(*clause, [&](const AstConstraint& cons) {
-                visitDepthFirst(cons, [&](const AstVariable& var) { ignoredVars.insert(var.getName()); });
+            visitDepthFirst(*clause, [&](const Constraint& cons) {
+                visitDepthFirst(cons, [&](const ast::Variable& var) { ignoredVars.insert(var.getName()); });
             });
 
             std::set<std::string> singletons;
@@ -101,4 +101,4 @@ bool ReplaceSingletonVariablesTransformer::transform(AstTranslationUnit& transla
     return changed;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ReplaceSingletonVariables.h
+++ b/src/ast/transform/ReplaceSingletonVariables.h
@@ -18,14 +18,14 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to replace singleton variables
  * with unnamed variables.
  * E.g.: a() :- b(x). -> a() :- b(_).
  */
-class ReplaceSingletonVariablesTransformer : public AstTransformer {
+class ReplaceSingletonVariablesTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "ReplaceSingletonVariablesTransformer";
@@ -36,7 +36,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ResolveAliases.cpp
+++ b/src/ast/transform/ResolveAliases.cpp
@@ -48,19 +48,19 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 namespace {
 
 /**
  * A utility class for the unification process required to eliminate aliases.
  * A substitution maps variables to terms and can be applied as a transformation
- * to AstArguments.
+ * to Arguments.
  */
 class Substitution {
     // map type used for internally storing var->term mappings
     //      - note: variables are identified by their names
-    using map_t = std::map<std::string, Own<AstArgument>>;
+    using map_t = std::map<std::string, Own<Argument>>;
 
     // the mapping of variables to terms
     map_t varToTerm;
@@ -70,7 +70,7 @@ public:
 
     Substitution() = default;
 
-    Substitution(const std::string& var, const AstArgument* arg) {
+    Substitution(const std::string& var, const Argument* arg) {
         varToTerm.insert(std::make_pair(var, souffle::clone(arg)));
     }
 
@@ -83,18 +83,18 @@ public:
      * @param node the node to be transformed
      * @return a pointer to the modified or replaced node
      */
-    Own<AstNode> operator()(Own<AstNode> node) const {
+    Own<Node> operator()(Own<Node> node) const {
         // create a substitution mapper
-        struct M : public AstNodeMapper {
+        struct M : public NodeMapper {
             const map_t& map;
 
             M(const map_t& map) : map(map) {}
 
-            using AstNodeMapper::operator();
+            using NodeMapper::operator();
 
-            Own<AstNode> operator()(Own<AstNode> node) const override {
+            Own<Node> operator()(Own<Node> node) const override {
                 // see whether it is a variable to be substituted
-                if (auto var = dynamic_cast<AstVariable*>(node.get())) {
+                if (auto var = dynamic_cast<ast::Variable*>(node.get())) {
                     auto pos = map.find(var->getName());
                     if (pos != map.end()) {
                         return souffle::clone(pos->second);
@@ -116,7 +116,7 @@ public:
      */
     template <typename T>
     Own<T> operator()(Own<T> node) const {
-        Own<AstNode> resPtr = (*this)(Own<AstNode>(node.release()));
+        Own<Node> resPtr = (*this)(Own<Node>(node.release()));
         assert(isA<T>(resPtr.get()) && "Invalid node type mapping.");
         return Own<T>(dynamic_cast<T*>(resPtr.release()));
     }
@@ -147,7 +147,7 @@ public:
     void print(std::ostream& out) const {
         out << "{"
             << join(varToTerm, ",",
-                       [](std::ostream& out, const std::pair<const std::string, Own<AstArgument>>& cur) {
+                       [](std::ostream& out, const std::pair<const std::string, Own<Argument>>& cur) {
                            out << cur.first << " -> " << *cur.second;
                        })
             << "}";
@@ -160,20 +160,19 @@ public:
 };
 
 /**
- * An equality constraint between two AstArguments utilised by the unification
+ * An equality constraint between two Arguments utilised by the unification
  * algorithm required by the alias resolution.
  */
 class Equation {
 public:
     // the two terms to be equivalent
-    Own<AstArgument> lhs;
-    Own<AstArgument> rhs;
+    Own<Argument> lhs;
+    Own<Argument> rhs;
 
-    Equation(const AstArgument& lhs, const AstArgument& rhs)
+    Equation(const Argument& lhs, const Argument& rhs)
             : lhs(souffle::clone(&lhs)), rhs(souffle::clone(&rhs)) {}
 
-    Equation(const AstArgument* lhs, const AstArgument* rhs)
-            : lhs(souffle::clone(lhs)), rhs(souffle::clone(rhs)) {}
+    Equation(const Argument* lhs, const Argument* rhs) : lhs(souffle::clone(lhs)), rhs(souffle::clone(rhs)) {}
 
     Equation(const Equation& other) : lhs(souffle::clone(other.lhs)), rhs(souffle::clone(other.rhs)) {}
 
@@ -204,34 +203,34 @@ public:
 
 }  // namespace
 
-Own<AstClause> ResolveAliasesTransformer::resolveAliases(const AstClause& clause) {
+Own<Clause> ResolveAliasesTransformer::resolveAliases(const Clause& clause) {
     // -- utilities --
 
     // tests whether something is a variable
-    auto isVar = [&](const AstArgument& arg) { return isA<AstVariable>(&arg); };
+    auto isVar = [&](const Argument& arg) { return isA<ast::Variable>(&arg); };
 
     // tests whether something is a record
-    auto isRec = [&](const AstArgument& arg) { return isA<AstRecordInit>(&arg); };
+    auto isRec = [&](const Argument& arg) { return isA<RecordInit>(&arg); };
 
     // tests whether a value `a` occurs in a term `b`
-    auto occurs = [](const AstArgument& a, const AstArgument& b) {
+    auto occurs = [](const Argument& a, const Argument& b) {
         bool res = false;
-        visitDepthFirst(b, [&](const AstArgument& arg) { res = (res || (arg == a)); });
+        visitDepthFirst(b, [&](const Argument& arg) { res = (res || (arg == a)); });
         return res;
     };
 
     // variables appearing as functorless arguments in atoms or records should not
     // be resolved
     std::set<std::string> baseGroundedVariables;
-    for (const auto* atom : getBodyLiterals<AstAtom>(clause)) {
-        for (const AstArgument* arg : atom->getArguments()) {
-            if (const auto* var = dynamic_cast<const AstVariable*>(arg)) {
+    for (const auto* atom : getBodyLiterals<Atom>(clause)) {
+        for (const Argument* arg : atom->getArguments()) {
+            if (const auto* var = dynamic_cast<const ast::Variable*>(arg)) {
                 baseGroundedVariables.insert(var->getName());
             }
         }
-        visitDepthFirst(*atom, [&](const AstRecordInit& rec) {
-            for (const AstArgument* arg : rec.getArguments()) {
-                if (const auto* var = dynamic_cast<const AstVariable*>(arg)) {
+        visitDepthFirst(*atom, [&](const RecordInit& rec) {
+            for (const Argument* arg : rec.getArguments()) {
+                if (const auto* var = dynamic_cast<const ast::Variable*>(arg)) {
                     baseGroundedVariables.insert(var->getName());
                 }
             }
@@ -240,7 +239,7 @@ Own<AstClause> ResolveAliasesTransformer::resolveAliases(const AstClause& clause
 
     // I) extract equations
     std::vector<Equation> equations;
-    visitDepthFirst(clause, [&](const AstBinaryConstraint& constraint) {
+    visitDepthFirst(clause, [&](const BinaryConstraint& constraint) {
         if (isEqConstraint(constraint.getOperator())) {
             equations.push_back(Equation(constraint.getLHS(), constraint.getRHS()));
         }
@@ -250,7 +249,7 @@ Own<AstClause> ResolveAliasesTransformer::resolveAliases(const AstClause& clause
     Substitution substitution;
 
     // a utility for processing newly identified mappings
-    auto newMapping = [&](const std::string& var, const AstArgument* term) {
+    auto newMapping = [&](const std::string& var, const Argument* term) {
         // found a new substitution
         Substitution newMapping(var, term);
 
@@ -269,8 +268,8 @@ Own<AstClause> ResolveAliasesTransformer::resolveAliases(const AstClause& clause
         equations.pop_back();
 
         // shortcuts for left/right
-        const AstArgument& lhs = *equation.lhs;
-        const AstArgument& rhs = *equation.rhs;
+        const Argument& lhs = *equation.lhs;
+        const Argument& rhs = *equation.rhs;
 
         // #1:  t = t   => skip
         if (lhs == rhs) {
@@ -280,8 +279,8 @@ Own<AstClause> ResolveAliasesTransformer::resolveAliases(const AstClause& clause
         // #2:  [..] = [..]  => decompose
         if (isRec(lhs) && isRec(rhs)) {
             // get arguments
-            const auto& lhs_args = static_cast<const AstRecordInit&>(lhs).getArguments();
-            const auto& rhs_args = static_cast<const AstRecordInit&>(rhs).getArguments();
+            const auto& lhs_args = static_cast<const RecordInit&>(lhs).getArguments();
+            const auto& rhs_args = static_cast<const RecordInit&>(rhs).getArguments();
 
             // make sure sizes are identical
             assert(lhs_args.size() == rhs_args.size() && "Record lengths not equal");
@@ -301,7 +300,7 @@ Own<AstClause> ResolveAliasesTransformer::resolveAliases(const AstClause& clause
 
         // #4:  v = w    => add mapping
         if (isVar(lhs) && isVar(rhs)) {
-            auto& var = static_cast<const AstVariable&>(lhs);
+            auto& var = static_cast<const ast::Variable&>(lhs);
             newMapping(var.getName(), &rhs);
             continue;
         }
@@ -316,8 +315,8 @@ Own<AstClause> ResolveAliasesTransformer::resolveAliases(const AstClause& clause
         assert(isVar(lhs));
 
         // therefore, we have v = t
-        const auto& v = static_cast<const AstVariable&>(lhs);
-        const AstArgument& t = rhs;
+        const auto& v = static_cast<const ast::Variable&>(lhs);
+        const Argument& t = rhs;
 
         // #6:  v occurs in t   => skip
         if (occurs(v, t)) {
@@ -346,12 +345,12 @@ Own<AstClause> ResolveAliasesTransformer::resolveAliases(const AstClause& clause
     return substitution(souffle::clone(&clause));
 }
 
-Own<AstClause> ResolveAliasesTransformer::removeTrivialEquality(const AstClause& clause) {
-    Own<AstClause> res(cloneHead(&clause));
+Own<Clause> ResolveAliasesTransformer::removeTrivialEquality(const Clause& clause) {
+    Own<Clause> res(cloneHead(&clause));
 
     // add all literals, except filtering out t = t constraints
-    for (AstLiteral* literal : clause.getBodyLiterals()) {
-        if (auto* constraint = dynamic_cast<AstBinaryConstraint*>(literal)) {
+    for (Literal* literal : clause.getBodyLiterals()) {
+        if (auto* constraint = dynamic_cast<BinaryConstraint*>(literal)) {
             // TODO: don't filter out `FEQ` constraints, since `x = x` can fail when `x` is a NaN
             if (isEqConstraint(constraint->getOperator())) {
                 if (*constraint->getLHS() == *constraint->getRHS()) {
@@ -367,62 +366,62 @@ Own<AstClause> ResolveAliasesTransformer::removeTrivialEquality(const AstClause&
     return res;
 }
 
-Own<AstClause> ResolveAliasesTransformer::removeComplexTermsInAtoms(const AstClause& clause) {
-    Own<AstClause> res(clause.clone());
+Own<Clause> ResolveAliasesTransformer::removeComplexTermsInAtoms(const Clause& clause) {
+    Own<Clause> res(clause.clone());
 
     // get list of atoms
-    std::vector<AstAtom*> atoms = getBodyLiterals<AstAtom>(*res);
+    std::vector<Atom*> atoms = getBodyLiterals<Atom>(*res);
 
     // find all functors in atoms
-    std::vector<const AstArgument*> terms;
-    for (const AstAtom* atom : atoms) {
-        for (const AstArgument* arg : atom->getArguments()) {
+    std::vector<const Argument*> terms;
+    for (const Atom* atom : atoms) {
+        for (const Argument* arg : atom->getArguments()) {
             // ignore if not a functor
-            if (!isA<AstFunctor>(arg)) {
+            if (!isA<Functor>(arg)) {
                 continue;
             }
 
             // add this functor if not seen yet
-            if (!any_of(terms, [&](const AstArgument* cur) { return *cur == *arg; })) {
+            if (!any_of(terms, [&](const Argument* cur) { return *cur == *arg; })) {
                 terms.push_back(arg);
             }
         }
     }
 
     // find all functors in records too
-    visitDepthFirst(atoms, [&](const AstRecordInit& rec) {
-        for (const AstArgument* arg : rec.getArguments()) {
+    visitDepthFirst(atoms, [&](const RecordInit& rec) {
+        for (const Argument* arg : rec.getArguments()) {
             // ignore if not a functor
-            if (!isA<AstFunctor>(arg)) {
+            if (!isA<Functor>(arg)) {
                 continue;
             }
 
             // add this functor if not seen yet
-            if (!any_of(terms, [&](const AstArgument* cur) { return *cur == *arg; })) {
+            if (!any_of(terms, [&](const Argument* cur) { return *cur == *arg; })) {
                 terms.push_back(arg);
             }
         }
     });
 
     // substitute them with new variables (a real map would compare pointers)
-    using substitution_map = std::vector<std::pair<Own<AstArgument>, Own<AstVariable>>>;
+    using substitution_map = std::vector<std::pair<Own<Argument>, Own<ast::Variable>>>;
     substitution_map termToVar;
 
     static int varCounter = 0;
-    for (const AstArgument* arg : terms) {
+    for (const Argument* arg : terms) {
         // create a new mapping for this term
         auto term = souffle::clone(arg);
-        auto newVariable = mk<AstVariable>(" _tmp_" + toString(varCounter++));
+        auto newVariable = mk<ast::Variable>(" _tmp_" + toString(varCounter++));
         termToVar.push_back(std::make_pair(std::move(term), std::move(newVariable)));
     }
 
     // apply mapping to replace the terms with the variables
-    struct Update : public AstNodeMapper {
+    struct Update : public NodeMapper {
         const substitution_map& map;
 
         Update(const substitution_map& map) : map(map) {}
 
-        Own<AstNode> operator()(Own<AstNode> node) const override {
+        Own<Node> operator()(Own<Node> node) const override {
             // check whether node needs to be replaced
             for (const auto& pair : map) {
                 auto& term = pair.first;
@@ -441,7 +440,7 @@ Own<AstClause> ResolveAliasesTransformer::removeComplexTermsInAtoms(const AstCla
 
     // update atoms
     Update update(termToVar);
-    for (AstAtom* atom : atoms) {
+    for (Atom* atom : atoms) {
         atom->apply(update);
     }
 
@@ -450,37 +449,37 @@ Own<AstClause> ResolveAliasesTransformer::removeComplexTermsInAtoms(const AstCla
         auto& term = pair.first;
         auto& variable = pair.second;
 
-        res->addToBody(mk<AstBinaryConstraint>(
-                BinaryConstraintOp::EQ, souffle::clone(variable), souffle::clone(term)));
+        res->addToBody(
+                mk<BinaryConstraint>(BinaryConstraintOp::EQ, souffle::clone(variable), souffle::clone(term)));
     }
 
     return res;
 }
 
-bool ResolveAliasesTransformer::transform(AstTranslationUnit& translationUnit) {
+bool ResolveAliasesTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
-    AstProgram& program = *translationUnit.getProgram();
+    Program& program = *translationUnit.getProgram();
 
     // get all clauses
-    std::vector<const AstClause*> clauses;
-    visitDepthFirst(program, [&](const AstRelation& rel) {
+    std::vector<const Clause*> clauses;
+    visitDepthFirst(program, [&](const Relation& rel) {
         for (const auto& clause : getClauses(program, rel)) {
             clauses.push_back(clause);
         }
     });
 
     // clean all clauses
-    for (const AstClause* clause : clauses) {
+    for (const Clause* clause : clauses) {
         // -- Step 1 --
         // get rid of aliases
-        Own<AstClause> noAlias = resolveAliases(*clause);
+        Own<Clause> noAlias = resolveAliases(*clause);
 
         // clean up equalities
-        Own<AstClause> cleaned = removeTrivialEquality(*noAlias);
+        Own<Clause> cleaned = removeTrivialEquality(*noAlias);
 
         // -- Step 2 --
         // restore simple terms in atoms
-        Own<AstClause> normalised = removeComplexTermsInAtoms(*cleaned);
+        Own<Clause> normalised = removeComplexTermsInAtoms(*cleaned);
 
         // swap if changed
         if (*normalised != *clause) {
@@ -493,4 +492,4 @@ bool ResolveAliasesTransformer::transform(AstTranslationUnit& translationUnit) {
     return changed;
 }
 
-}  // namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ResolveAliases.h
+++ b/src/ast/transform/ResolveAliases.h
@@ -21,14 +21,14 @@
 #include <memory>
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to eliminate grounded aliases.
  * e.g. resolve: a(r) , r = [x,y]       => a(x,y)
  * e.g. resolve: a(x) , !b(y) , y = x   => a(x) , !b(x)
  */
-class ResolveAliasesTransformer : public AstTransformer {
+class ResolveAliasesTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "ResolveAliasesTransformer";
@@ -41,7 +41,7 @@ public:
      * @param clause the clause to be processed
      * @return a modified clone of the processed clause
      */
-    static Own<AstClause> resolveAliases(const AstClause& clause);
+    static Own<Clause> resolveAliases(const Clause& clause);
 
     /**
      * Removes trivial equalities of the form t = t from the given clause.
@@ -49,7 +49,7 @@ public:
      * @param clause the clause to be processed
      * @return a modified clone of the given clause
      */
-    static Own<AstClause> removeTrivialEquality(const AstClause& clause);
+    static Own<Clause> removeTrivialEquality(const Clause& clause);
 
     /**
      * Removes complex terms in atoms, replacing them with constrained variables.
@@ -57,14 +57,14 @@ public:
      * @param clause the clause to be processed
      * @return a modified clone of the processed clause
      */
-    static Own<AstClause> removeComplexTermsInAtoms(const AstClause& clause);
+    static Own<Clause> removeComplexTermsInAtoms(const Clause& clause);
 
     ResolveAliasesTransformer* clone() const override {
         return new ResolveAliasesTransformer();
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ResolveAnonymousRecordAliases.cpp
+++ b/src/ast/transform/ResolveAnonymousRecordAliases.cpp
@@ -37,7 +37,7 @@
 
 namespace souffle::ast::transform {
 
-std::map<std::string, const RecordInit*> ResolveAnonymousRecordAliases::findVariablesRecordMapping(
+std::map<std::string, const RecordInit*> ResolveAnonymousRecordAliasesTransformer::findVariablesRecordMapping(
         TranslationUnit& tu, const Clause& clause) {
     std::map<std::string, const RecordInit*> variableRecordMap;
 
@@ -92,7 +92,7 @@ std::map<std::string, const RecordInit*> ResolveAnonymousRecordAliases::findVari
     return variableRecordMap;
 }
 
-bool ResolveAnonymousRecordAliases::replaceNamedVariables(TranslationUnit& tu, Clause& clause) {
+bool ResolveAnonymousRecordAliasesTransformer::replaceNamedVariables(TranslationUnit& tu, Clause& clause) {
     struct ReplaceVariables : public NodeMapper {
         std::map<std::string, const RecordInit*> varToRecordMap;
 
@@ -122,7 +122,7 @@ bool ResolveAnonymousRecordAliases::replaceNamedVariables(TranslationUnit& tu, C
     return changed;
 }
 
-bool ResolveAnonymousRecordAliases::replaceUnnamedVariable(Clause& clause) {
+bool ResolveAnonymousRecordAliasesTransformer::replaceUnnamedVariable(Clause& clause) {
     struct ReplaceUnnamed : public NodeMapper {
         mutable bool changed{false};
         ReplaceUnnamed() = default;
@@ -154,7 +154,7 @@ bool ResolveAnonymousRecordAliases::replaceUnnamedVariable(Clause& clause) {
     return update.changed;
 }
 
-bool ResolveAnonymousRecordAliases::transform(TranslationUnit& translationUnit) {
+bool ResolveAnonymousRecordAliasesTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
     for (auto* clause : translationUnit.getProgram()->getClauses()) {
         changed |= replaceNamedVariables(translationUnit, *clause);

--- a/src/ast/transform/ResolveAnonymousRecordAliases.cpp
+++ b/src/ast/transform/ResolveAnonymousRecordAliases.cpp
@@ -35,20 +35,20 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-std::map<std::string, const AstRecordInit*> ResolveAnonymousRecordAliases::findVariablesRecordMapping(
-        AstTranslationUnit& tu, const AstClause& clause) {
-    std::map<std::string, const AstRecordInit*> variableRecordMap;
+std::map<std::string, const RecordInit*> ResolveAnonymousRecordAliases::findVariablesRecordMapping(
+        TranslationUnit& tu, const Clause& clause) {
+    std::map<std::string, const RecordInit*> variableRecordMap;
 
-    auto isVariable = [](AstNode* node) -> bool { return isA<AstVariable>(node); };
-    auto isRecord = [](AstNode* node) -> bool { return isA<AstRecordInit>(node); };
+    auto isVariable = [](Node* node) -> bool { return isA<ast::Variable>(node); };
+    auto isRecord = [](Node* node) -> bool { return isA<RecordInit>(node); };
 
-    auto& typeAnalysis = *tu.getAnalysis<TypeAnalysis>();
-    auto groundedTerms = getGroundedTerms(tu, clause);
+    auto& typeAnalysis = *tu.getAnalysis<analysis::TypeAnalysis>();
+    auto groundedTerms = analysis::getGroundedTerms(tu, clause);
 
     for (auto* literal : clause.getBodyLiterals()) {
-        if (auto constraint = dynamic_cast<AstBinaryConstraint*>(literal)) {
+        if (auto constraint = dynamic_cast<BinaryConstraint*>(literal)) {
             if (!isEqConstraint(constraint->getOperator())) {
                 continue;
             }
@@ -71,7 +71,7 @@ std::map<std::string, const AstRecordInit*> ResolveAnonymousRecordAliases::findV
                 continue;
             }
 
-            auto* variable = static_cast<AstVariable*>(isVariable(left) ? left : right);
+            auto* variable = static_cast<ast::Variable*>(isVariable(left) ? left : right);
             const auto& variableName = variable->getName();
 
             if (!groundedTerms.find(variable)->second) {
@@ -83,7 +83,7 @@ std::map<std::string, const AstRecordInit*> ResolveAnonymousRecordAliases::findV
                 continue;
             }
 
-            auto* record = static_cast<AstRecordInit*>(isRecord(left) ? left : right);
+            auto* record = static_cast<RecordInit*>(isRecord(left) ? left : right);
 
             variableRecordMap.insert({variableName, record});
         }
@@ -92,15 +92,15 @@ std::map<std::string, const AstRecordInit*> ResolveAnonymousRecordAliases::findV
     return variableRecordMap;
 }
 
-bool ResolveAnonymousRecordAliases::replaceNamedVariables(AstTranslationUnit& tu, AstClause& clause) {
-    struct ReplaceVariables : public AstNodeMapper {
-        std::map<std::string, const AstRecordInit*> varToRecordMap;
+bool ResolveAnonymousRecordAliases::replaceNamedVariables(TranslationUnit& tu, Clause& clause) {
+    struct ReplaceVariables : public NodeMapper {
+        std::map<std::string, const RecordInit*> varToRecordMap;
 
-        ReplaceVariables(std::map<std::string, const AstRecordInit*> varToRecordMap)
+        ReplaceVariables(std::map<std::string, const RecordInit*> varToRecordMap)
                 : varToRecordMap(std::move(varToRecordMap)){};
 
-        Own<AstNode> operator()(Own<AstNode> node) const override {
-            if (auto variable = dynamic_cast<AstVariable*>(node.get())) {
+        Own<Node> operator()(Own<Node> node) const override {
+            if (auto variable = dynamic_cast<ast::Variable*>(node.get())) {
                 auto iteratorToRecord = varToRecordMap.find(variable->getName());
                 if (iteratorToRecord != varToRecordMap.end()) {
                     return souffle::clone(iteratorToRecord->second);
@@ -122,23 +122,23 @@ bool ResolveAnonymousRecordAliases::replaceNamedVariables(AstTranslationUnit& tu
     return changed;
 }
 
-bool ResolveAnonymousRecordAliases::replaceUnnamedVariable(AstClause& clause) {
-    struct ReplaceUnnamed : public AstNodeMapper {
+bool ResolveAnonymousRecordAliases::replaceUnnamedVariable(Clause& clause) {
+    struct ReplaceUnnamed : public NodeMapper {
         mutable bool changed{false};
         ReplaceUnnamed() = default;
 
-        Own<AstNode> operator()(Own<AstNode> node) const override {
-            auto isUnnamed = [](AstNode* node) -> bool { return isA<AstUnnamedVariable>(node); };
-            auto isRecord = [](AstNode* node) -> bool { return isA<AstRecordInit>(node); };
+        Own<Node> operator()(Own<Node> node) const override {
+            auto isUnnamed = [](Node* node) -> bool { return isA<UnnamedVariable>(node); };
+            auto isRecord = [](Node* node) -> bool { return isA<RecordInit>(node); };
 
-            if (auto constraint = dynamic_cast<AstBinaryConstraint*>(node.get())) {
+            if (auto constraint = dynamic_cast<BinaryConstraint*>(node.get())) {
                 auto left = constraint->getLHS();
                 auto right = constraint->getRHS();
                 bool hasUnnamed = isUnnamed(left) || isUnnamed(right);
                 bool hasRecord = isRecord(left) || isRecord(right);
                 auto op = constraint->getOperator();
                 if (hasUnnamed && hasRecord && isEqConstraint(op)) {
-                    return mk<AstBooleanConstraint>(true);
+                    return mk<BooleanConstraint>(true);
                 }
             }
 
@@ -154,7 +154,7 @@ bool ResolveAnonymousRecordAliases::replaceUnnamedVariable(AstClause& clause) {
     return update.changed;
 }
 
-bool ResolveAnonymousRecordAliases::transform(AstTranslationUnit& translationUnit) {
+bool ResolveAnonymousRecordAliases::transform(TranslationUnit& translationUnit) {
     bool changed = false;
     for (auto* clause : translationUnit.getProgram()->getClauses()) {
         changed |= replaceNamedVariables(translationUnit, *clause);
@@ -164,4 +164,4 @@ bool ResolveAnonymousRecordAliases::transform(AstTranslationUnit& translationUni
     return changed;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ResolveAnonymousRecordAliases.h
+++ b/src/ast/transform/ResolveAnonymousRecordAliases.h
@@ -21,7 +21,7 @@
 #include <map>
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformer resolving aliases for anonymous records.
@@ -32,7 +32,7 @@ namespace souffle {
  *
  * The transformer is to be called in conjunction with FoldAnonymousRecords.
  **/
-class ResolveAnonymousRecordAliases : public AstTransformer {
+class ResolveAnonymousRecordAliases : public Transformer {
 public:
     std::string getName() const override {
         return "ResolveAnonymousRecordAliases";
@@ -43,25 +43,24 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 
     /**
      * Use mapping found by findVariablesRecordMapping to substitute
      * a records for each variable that operates on records.
      **/
-    bool replaceNamedVariables(AstTranslationUnit&, AstClause&);
+    bool replaceNamedVariables(TranslationUnit&, Clause&);
 
     /**
      * For each variable equal to some anonymous record,
      * assign a value of that record.
      **/
-    std::map<std::string, const AstRecordInit*> findVariablesRecordMapping(
-            AstTranslationUnit&, const AstClause&);
+    std::map<std::string, const RecordInit*> findVariablesRecordMapping(TranslationUnit&, const Clause&);
 
     /**
      * For unnamed variables, replace each equation _ op record with true.
      **/
-    bool replaceUnnamedVariable(AstClause&);
+    bool replaceUnnamedVariable(Clause&);
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/ResolveAnonymousRecordAliases.h
+++ b/src/ast/transform/ResolveAnonymousRecordAliases.h
@@ -32,14 +32,14 @@ namespace souffle::ast::transform {
  *
  * The transformer is to be called in conjunction with FoldAnonymousRecords.
  **/
-class ResolveAnonymousRecordAliases : public Transformer {
+class ResolveAnonymousRecordAliasesTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "ResolveAnonymousRecordAliases";
     }
 
-    ResolveAnonymousRecordAliases* clone() const override {
-        return new ResolveAnonymousRecordAliases();
+    ResolveAnonymousRecordAliasesTransformer* clone() const override {
+        return new ResolveAnonymousRecordAliasesTransformer();
     }
 
 private:

--- a/src/ast/transform/SemanticChecker.cpp
+++ b/src/ast/transform/SemanticChecker.cpp
@@ -101,7 +101,7 @@ struct SemanticCheckerImpl {
     SemanticCheckerImpl(TranslationUnit& tu);
 
 private:
-    const IOType& ioTypes = *tu.getAnalysis<IOType>();
+    const IOTypeAnalysis& ioTypes = *tu.getAnalysis<IOTypeAnalysis>();
     const PrecedenceGraphAnalysis& precedenceGraph = *tu.getAnalysis<PrecedenceGraphAnalysis>();
     const RecursiveClausesAnalysis& recursiveClauses = *tu.getAnalysis<RecursiveClausesAnalysis>();
     const TypeEnvironmentAnalysis& typeEnvAnalysis = *tu.getAnalysis<TypeEnvironmentAnalysis>();

--- a/src/ast/transform/SemanticChecker.h
+++ b/src/ast/transform/SemanticChecker.h
@@ -20,22 +20,22 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-class AstSemanticChecker : public AstTransformer {
+class SemanticChecker : public Transformer {
 public:
-    ~AstSemanticChecker() override = default;
+    ~SemanticChecker() override = default;
 
     std::string getName() const override {
-        return "AstSemanticChecker";
+        return "SemanticChecker";
     }
 
-    AstSemanticChecker* clone() const override {
-        return new AstSemanticChecker();
+    SemanticChecker* clone() const override {
+        return new SemanticChecker();
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/Transformer.cpp
+++ b/src/ast/transform/Transformer.cpp
@@ -18,9 +18,9 @@
 #include "ast/TranslationUnit.h"
 #include "reports/ErrorReport.h"
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool AstTransformer::apply(AstTranslationUnit& translationUnit) {
+bool Transformer::apply(TranslationUnit& translationUnit) {
     // invoke the transformation
     bool changed = transform(translationUnit);
 
@@ -34,4 +34,4 @@ bool AstTransformer::apply(AstTranslationUnit& translationUnit) {
     return changed;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/Transformer.h
+++ b/src/ast/transform/Transformer.h
@@ -19,20 +19,20 @@
 #include "ast/TranslationUnit.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-class AstTransformer {
+class Transformer {
 private:
-    virtual bool transform(AstTranslationUnit& translationUnit) = 0;
+    virtual bool transform(TranslationUnit& translationUnit) = 0;
 
 public:
-    virtual ~AstTransformer() = default;
+    virtual ~Transformer() = default;
 
-    bool apply(AstTranslationUnit& translationUnit);
+    bool apply(TranslationUnit& translationUnit);
 
     virtual std::string getName() const = 0;
 
-    virtual AstTransformer* clone() const = 0;
+    virtual Transformer* clone() const = 0;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/UniqueAggregationVariables.cpp
+++ b/src/ast/transform/UniqueAggregationVariables.cpp
@@ -23,14 +23,14 @@
 #include <set>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool UniqueAggregationVariablesTransformer::transform(AstTranslationUnit& translationUnit) {
+bool UniqueAggregationVariablesTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
 
     // make variables in aggregates unique
     int aggNumber = 0;
-    visitDepthFirstPostOrder(*translationUnit.getProgram(), [&](const AstAggregator& agg) {
+    visitDepthFirstPostOrder(*translationUnit.getProgram(), [&](const Aggregator& agg) {
         // only applicable for aggregates with target expression
         if (agg.getTargetExpression() == nullptr) {
             return;
@@ -39,15 +39,15 @@ bool UniqueAggregationVariablesTransformer::transform(AstTranslationUnit& transl
         // get all variables in the target expression
         std::set<std::string> names;
         visitDepthFirst(
-                *agg.getTargetExpression(), [&](const AstVariable& var) { names.insert(var.getName()); });
+                *agg.getTargetExpression(), [&](const ast::Variable& var) { names.insert(var.getName()); });
 
         // rename them
-        visitDepthFirst(agg, [&](const AstVariable& var) {
+        visitDepthFirst(agg, [&](const ast::Variable& var) {
             auto pos = names.find(var.getName());
             if (pos == names.end()) {
                 return;
             }
-            const_cast<AstVariable&>(var).setName(" " + var.getName() + toString(aggNumber));
+            const_cast<ast::Variable&>(var).setName(" " + var.getName() + toString(aggNumber));
             changed = true;
         });
 
@@ -57,4 +57,4 @@ bool UniqueAggregationVariablesTransformer::transform(AstTranslationUnit& transl
     return changed;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/UniqueAggregationVariables.h
+++ b/src/ast/transform/UniqueAggregationVariables.h
@@ -18,12 +18,12 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation pass to rename aggregation variables to make them unique.
  */
-class UniqueAggregationVariablesTransformer : public AstTransformer {
+class UniqueAggregationVariablesTransformer : public Transformer {
 public:
     std::string getName() const override {
         return "UniqueAggregationVariablesTransformer";
@@ -34,7 +34,7 @@ public:
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/UserDefinedFunctors.cpp
+++ b/src/ast/transform/UserDefinedFunctors.cpp
@@ -25,23 +25,22 @@
 #include <memory>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
-bool AstUserDefinedFunctorsTransformer::transform(AstTranslationUnit& translationUnit) {
-    struct UserFunctorRewriter : public AstNodeMapper {
+bool UserDefinedFunctorsTransformer::transform(TranslationUnit& translationUnit) {
+    struct UserFunctorRewriter : public NodeMapper {
         mutable bool changed{false};
-        const AstProgram& program;
+        const Program& program;
         ErrorReport& report;
 
-        UserFunctorRewriter(const AstProgram& program, ErrorReport& report)
-                : program(program), report(report){};
+        UserFunctorRewriter(const Program& program, ErrorReport& report) : program(program), report(report){};
 
-        Own<AstNode> operator()(Own<AstNode> node) const override {
+        Own<Node> operator()(Own<Node> node) const override {
             node->apply(*this);
 
-            if (auto* userFunctor = dynamic_cast<AstUserDefinedFunctor*>(node.get())) {
-                const AstFunctorDeclaration* functorDeclaration =
-                        getIf(program.getFunctorDeclarations(), [&](const AstFunctorDeclaration* current) {
+            if (auto* userFunctor = dynamic_cast<UserDefinedFunctor*>(node.get())) {
+                const FunctorDeclaration* functorDeclaration =
+                        getIf(program.getFunctorDeclarations(), [&](const FunctorDeclaration* current) {
                             return current->getName() == userFunctor->getName();
                         });
 
@@ -71,4 +70,4 @@ bool AstUserDefinedFunctorsTransformer::transform(AstTranslationUnit& translatio
     return update.changed;
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/UserDefinedFunctors.h
+++ b/src/ast/transform/UserDefinedFunctors.h
@@ -21,24 +21,24 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformation that passes the type information from user functors
  * declaration to functors instances
  */
-class AstUserDefinedFunctorsTransformer : public AstTransformer {
+class UserDefinedFunctorsTransformer : public Transformer {
 public:
     std::string getName() const override {
-        return "AstUserDefinedFunctorsTransformer";
+        return "UserDefinedFunctorsTransformer";
     }
 
-    AstUserDefinedFunctorsTransformer* clone() const override {
-        return new AstUserDefinedFunctorsTransformer();
+    UserDefinedFunctorsTransformer* clone() const override {
+        return new UserDefinedFunctorsTransformer();
     }
 
 private:
-    bool transform(AstTranslationUnit& translationUnit) override;
+    bool transform(TranslationUnit& translationUnit) override;
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/transform/While.h
+++ b/src/ast/transform/While.h
@@ -27,20 +27,20 @@
 #include <utility>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast::transform {
 
 /**
  * Transformer that repeatedly executes a sub-transformer while a condition is met
  */
 class WhileTransformer : public MetaTransformer {
 public:
-    WhileTransformer(std::function<bool()> cond, Own<AstTransformer> transformer)
+    WhileTransformer(std::function<bool()> cond, Own<Transformer> transformer)
             : condition(std::move(cond)), transformer(std::move(transformer)) {}
 
-    WhileTransformer(bool cond, Own<AstTransformer> transformer)
+    WhileTransformer(bool cond, Own<Transformer> transformer)
             : condition([=]() { return cond; }), transformer(std::move(transformer)) {}
 
-    std::vector<AstTransformer*> getSubtransformers() const override {
+    std::vector<Transformer*> getSubtransformers() const override {
         return {transformer.get()};
     }
     void setDebugReport() override {
@@ -76,9 +76,9 @@ public:
 
 private:
     std::function<bool()> condition;
-    Own<AstTransformer> transformer;
+    Own<Transformer> transformer;
 
-    bool transform(AstTranslationUnit& translationUnit) override {
+    bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
         while (condition()) {
             changed |= applySubtransformer(translationUnit, transformer.get());
@@ -87,4 +87,4 @@ private:
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast::transform

--- a/src/ast/utility/BindingStore.h
+++ b/src/ast/utility/BindingStore.h
@@ -26,11 +26,11 @@
 #include <set>
 #include <string>
 
-namespace souffle {
+namespace souffle::ast {
 
 class BindingStore {
 public:
-    BindingStore(const AstClause* clause);
+    BindingStore(const Clause* clause);
 
     /**
      * Mark the given variable as strongly bound.
@@ -59,10 +59,10 @@ public:
     }
 
     /** Check if an argument is bound */
-    bool isBound(const AstArgument* arg) const;
+    bool isBound(const Argument* arg) const;
 
     /** Counts the number of bound arguments in the given atom */
-    size_t numBoundArguments(const AstAtom* atom) const;
+    size_t numBoundArguments(const Atom* atom) const;
 
 private:
     // Helper types to represent a disjunction of several dependency sets
@@ -85,10 +85,10 @@ private:
     }
 
     /** Add binding dependencies formed on lhs by a <lhs> = <rhs> equality constraint. */
-    void processEqualityBindings(const AstArgument* lhs, const AstArgument* rhs);
+    void processEqualityBindings(const Argument* lhs, const Argument* rhs);
 
     /** Generate all binding dependencies implied by the constraints within a given clause. */
-    void generateBindingDependencies(const AstClause* clause);
+    void generateBindingDependencies(const Clause* clause);
 
     /** Reduce a conjunctive set of dependencies based on the current bound variable set. */
     ConjBindingSet reduceDependency(const ConjBindingSet& origDependency);
@@ -100,4 +100,4 @@ private:
     bool reduceDependencies();
 };
 
-}  // namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/utility/LambdaNodeMapper.h
+++ b/src/ast/utility/LambdaNodeMapper.h
@@ -20,21 +20,21 @@
 #include <memory>
 #include <utility>
 
-namespace souffle {
+namespace souffle::ast {
 
 namespace detail {
 
 /**
- * A special AstNodeMapper wrapping a lambda conducting node transformations.
+ * A special NodeMapper wrapping a lambda conducting node transformations.
  */
 template <typename Lambda>
-class LambdaNodeMapper : public AstNodeMapper {
+class LambdaNodeMapper : public NodeMapper {
     const Lambda& lambda;
 
 public:
     LambdaNodeMapper(const Lambda& lambda) : lambda(lambda) {}
 
-    Own<AstNode> operator()(Own<AstNode> node) const override {
+    Own<Node> operator()(Own<Node> node) const override {
         return lambda(std::move(node));
     }
 };
@@ -48,4 +48,4 @@ detail::LambdaNodeMapper<Lambda> makeLambdaAstMapper(const Lambda& lambda) {
     return detail::LambdaNodeMapper<Lambda>(lambda);
 }
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/utility/NodeMapper.h
+++ b/src/ast/utility/NodeMapper.h
@@ -21,15 +21,15 @@
 #include <cassert>
 #include <memory>
 
-namespace souffle {
-class AstNode;
+namespace souffle::ast {
+class Node;
 
 /**
  * An abstract class for manipulating AST Nodes by substitution
  */
-class AstNodeMapper {
+class NodeMapper {
 public:
-    virtual ~AstNodeMapper() = default;
+    virtual ~NodeMapper() = default;
 
     /**
      * Abstract replacement method for a node.
@@ -38,17 +38,17 @@ public:
      * will be destroyed by the mapper and the returned node
      * will become owned by the caller.
      */
-    virtual Own<AstNode> operator()(Own<AstNode> node) const = 0;
+    virtual Own<Node> operator()(Own<Node> node) const = 0;
 
     /**
      * Wrapper for any subclass of the AST node hierarchy performing type casts.
      */
     template <typename T>
     Own<T> operator()(Own<T> node) const {
-        Own<AstNode> resPtr = (*this)(Own<AstNode>(static_cast<AstNode*>(node.release())));
+        Own<Node> resPtr = (*this)(Own<Node>(static_cast<Node*>(node.release())));
         assert(isA<T>(resPtr.get()) && "Invalid target node!");
         return Own<T>(dynamic_cast<T*>(resPtr.release()));
     }
 };
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast/utility/Utils.h
+++ b/src/ast/utility/Utils.h
@@ -23,24 +23,26 @@
 #include <string>
 #include <vector>
 
-namespace souffle {
+namespace souffle::ast {
 
 // some forward declarations
-class AstAtom;
-class AstClause;
-class AstConstraint;
-class AstFunctorDeclaration;
-class AstIntrinsicFunctor;
-class AstLiteral;
-class AstNode;
-class AstProgram;
-class AstQualifiedName;
-class AstRelation;
-class AstTranslationUnit;
-class AstType;
-class AstVariable;
-class AstRecordInit;
+class Atom;
+class Clause;
+class Constraint;
+class FunctorDeclaration;
+class IntrinsicFunctor;
+class Literal;
+class Node;
+class Program;
+class QualifiedName;
+class Relation;
+class TranslationUnit;
+class Type;
+class Variable;
+class RecordInit;
+namespace analysis {
 class TypeAnalysis;
+}
 
 // ---------------------------------------------------------------
 //                      General Utilities
@@ -49,7 +51,7 @@ class TypeAnalysis;
 // Deliberately wraps `toString` in order to assure `pprint` works for
 // all AST nodes during debugging. If `toString` were to be used, only
 // the specific instanciations would be available at runtime.
-std::string pprint(const AstNode& node);
+std::string pprint(const Node& node);
 
 /**
  * Obtains a list of all variables referenced within the AST rooted
@@ -58,7 +60,7 @@ std::string pprint(const AstNode& node);
  * @param root the root of the AST to be searched
  * @return a list of all variables referenced within
  */
-std::vector<const AstVariable*> getVariables(const AstNode& root);
+std::vector<const Variable*> getVariables(const Node& root);
 
 /**
  * Obtains a list of all records referenced within the AST rooted
@@ -67,7 +69,7 @@ std::vector<const AstVariable*> getVariables(const AstNode& root);
  * @param root the root of the AST to be searched
  * @return a list of all records referenced within
  */
-std::vector<const AstRecordInit*> getRecords(const AstNode& root);
+std::vector<const RecordInit*> getRecords(const Node& root);
 
 /**
  * Returns literals of a particular type in the body of a clause.
@@ -93,7 +95,7 @@ std::vector<T*> getBodyLiterals(const C& clause) {
  * @param name the name of the relation to search for
  * @return vector of clauses describing the relation with the given name
  */
-std::vector<AstClause*> getClauses(const AstProgram& program, const AstQualifiedName& relationName);
+std::vector<Clause*> getClauses(const Program& program, const QualifiedName& relationName);
 
 /**
  * Returns a vector of clauses in the program describing the given relation.
@@ -102,7 +104,7 @@ std::vector<AstClause*> getClauses(const AstProgram& program, const AstQualified
  * @param rel the relation to search for
  * @return vector of clauses describing the given relation
  */
-std::vector<AstClause*> getClauses(const AstProgram& program, const AstRelation& rel);
+std::vector<Clause*> getClauses(const Program& program, const Relation& rel);
 
 /**
  * Returns the relation with the given name in the program.
@@ -111,7 +113,7 @@ std::vector<AstClause*> getClauses(const AstProgram& program, const AstRelation&
  * @param name the name of the relation to search for
  * @return the relation if it exists; nullptr otherwise
  */
-AstRelation* getRelation(const AstProgram& program, const AstQualifiedName& name);
+Relation* getRelation(const Program& program, const QualifiedName& name);
 
 /**
  * Remove relation and all its clauses from the program.
@@ -119,7 +121,7 @@ AstRelation* getRelation(const AstProgram& program, const AstQualifiedName& name
  * @param tu the translation unit
  * @param name the name of the relation to delete
  */
-void removeRelation(AstTranslationUnit& tu, const AstQualifiedName& name);
+void removeRelation(TranslationUnit& tu, const QualifiedName& name);
 
 /**
  * Removes the set of clauses with the given relation name.
@@ -127,7 +129,7 @@ void removeRelation(AstTranslationUnit& tu, const AstQualifiedName& name);
  * @param tu the translation unit
  * @param name the name of the relation to search for
  */
-void removeRelationClauses(AstTranslationUnit& tu, const AstQualifiedName& name);
+void removeRelationClauses(TranslationUnit& tu, const QualifiedName& name);
 
 /**
  * Removes the set of IOs with the given relation name.
@@ -135,7 +137,7 @@ void removeRelationClauses(AstTranslationUnit& tu, const AstQualifiedName& name)
  * @param tu the translation unit
  * @param name the name of the relation to search for
  */
-void removeRelationIOs(AstTranslationUnit& tu, const AstQualifiedName& name);
+void removeRelationIOs(TranslationUnit& tu, const QualifiedName& name);
 
 /**
  * Returns the relation referenced by the given atom.
@@ -143,7 +145,7 @@ void removeRelationIOs(AstTranslationUnit& tu, const AstQualifiedName& name);
  * @param program the program containing the relations
  * @return relation referenced by the atom
  */
-const AstRelation* getAtomRelation(const AstAtom* atom, const AstProgram* program);
+const Relation* getAtomRelation(const Atom* atom, const Program* program);
 
 /**
  * Returns the relation referenced by the head of the given clause.
@@ -151,7 +153,7 @@ const AstRelation* getAtomRelation(const AstAtom* atom, const AstProgram* progra
  * @param program the program containing the relations
  * @return relation referenced by the clause head
  */
-const AstRelation* getHeadRelation(const AstClause* clause, const AstProgram* program);
+const Relation* getHeadRelation(const Clause* clause, const Program* program);
 
 /**
  * Returns the relations referenced in the body of the given clause.
@@ -159,7 +161,7 @@ const AstRelation* getHeadRelation(const AstClause* clause, const AstProgram* pr
  * @param program the program containing the relations
  * @return relation referenced in the clause body
  */
-std::set<const AstRelation*> getBodyRelations(const AstClause* clause, const AstProgram* program);
+std::set<const Relation*> getBodyRelations(const Clause* clause, const Program* program);
 
 /**
  * Returns the index of a clause within its relation, ignoring facts.
@@ -168,7 +170,7 @@ std::set<const AstRelation*> getBodyRelations(const AstClause* clause, const Ast
  * @param clause the clause to get the index of
  * @return the index of the clause ignoring facts; 0 for facts
  */
-size_t getClauseNum(const AstProgram* program, const AstClause* clause);
+size_t getClauseNum(const Program* program, const Clause* clause);
 
 /**
  * Returns whether the given relation has any clauses which contain a negation of a specific relation.
@@ -177,8 +179,8 @@ size_t getClauseNum(const AstProgram* program, const AstClause* clause);
  * @param program the program containing the relations
  * @param foundLiteral set to the negation literal that was found
  */
-bool hasClauseWithNegatedRelation(const AstRelation* relation, const AstRelation* negRelation,
-        const AstProgram* program, const AstLiteral*& foundLiteral);
+bool hasClauseWithNegatedRelation(const Relation* relation, const Relation* negRelation,
+        const Program* program, const Literal*& foundLiteral);
 
 /**
  * Returns whether the given relation has any clauses which contain an aggregation over of a specific
@@ -188,40 +190,40 @@ bool hasClauseWithNegatedRelation(const AstRelation* relation, const AstRelation
  * @param program the program containing the relations
  * @param foundLiteral set to the literal found in an aggregation
  */
-bool hasClauseWithAggregatedRelation(const AstRelation* relation, const AstRelation* aggRelation,
-        const AstProgram* program, const AstLiteral*& foundLiteral);
+bool hasClauseWithAggregatedRelation(const Relation* relation, const Relation* aggRelation,
+        const Program* program, const Literal*& foundLiteral);
 
 /**
  * Returns whether the given clause is recursive.
  * @param clause the clause to check
  * @return true iff the clause is recursive
  */
-bool isRecursiveClause(const AstClause& clause);
+bool isRecursiveClause(const Clause& clause);
 
 /**
  * Returns whether the given clause is a fact
  * @return true iff the clause is a fact
  */
-bool isFact(const AstClause& clause);
+bool isFact(const Clause& clause);
 
 /**
  * Returns whether the given clause is a rule
  * @return true iff the clause is a rule
  */
-bool isRule(const AstClause& clause);
+bool isRule(const Clause& clause);
 
 /**
  * Returns whether the given atom is a propositon
  * @return true iff the atom has no arguments
  */
-bool isProposition(const AstAtom* atom);
+bool isProposition(const Atom* atom);
 
 /**
  * Returns a clause which contains head of the given clause
  * @param clause the clause which head to be cloned
  * @return pointer to clause which has head cloned from given clause
  */
-AstClause* cloneHead(const AstClause* clause);
+Clause* cloneHead(const Clause* clause);
 
 /**
  * Reorders the atoms of a clause to be in the given order.
@@ -233,19 +235,19 @@ AstClause* cloneHead(const AstClause* clause);
  * @param clause clause to reorder atoms in
  * @param newOrder new order of atoms; atoms[i] = atoms[newOrder[i]]
  */
-AstClause* reorderAtoms(const AstClause* clause, const std::vector<unsigned int>& newOrder);
+Clause* reorderAtoms(const Clause* clause, const std::vector<unsigned int>& newOrder);
 
 /**
  * Negate an ast constraint
  *
  * @param constraint constraint that will be negated
  */
-void negateConstraintInPlace(AstConstraint& constraint);
+void negateConstraintInPlace(Constraint& constraint);
 
 /**
  * Pick valid overloads for a functor, sorted by some measure of "preference".
  */
-IntrinsicFunctors validOverloads(const TypeAnalysis&, const AstIntrinsicFunctor&);
+IntrinsicFunctors validOverloads(const analysis::TypeAnalysis&, const IntrinsicFunctor&);
 
 /**
  * Rename all atoms hat appear in a node to a given name.
@@ -253,6 +255,6 @@ IntrinsicFunctors validOverloads(const TypeAnalysis&, const AstIntrinsicFunctor&
  * @param oldToNew map from old atom names to new atom names
  * @return true if the node was changed
  */
-bool renameAtoms(AstNode& node, const std::map<AstQualifiedName, AstQualifiedName>& oldToNew);
+bool renameAtoms(Node& node, const std::map<QualifiedName, QualifiedName>& oldToNew);
 
-}  // end of namespace souffle
+}  // namespace souffle::ast

--- a/src/ast2ram/AstToRamTranslator.cpp
+++ b/src/ast2ram/AstToRamTranslator.cpp
@@ -1482,7 +1482,7 @@ Own<RamStatement> AstToRamTranslator::makeNegationSubproofSubroutine(const ast::
 /** translates the given datalog program into an equivalent RAM program  */
 void AstToRamTranslator::translateProgram(const ast::TranslationUnit& translationUnit) {
     // obtain IO Type of relations
-    ioType = translationUnit.getAnalysis<ast::analysis::IOType>();
+    ioType = translationUnit.getAnalysis<ast::analysis::IOTypeAnalysis>();
 
     // obtain type environment from analysis
     typeEnv = &translationUnit.getAnalysis<ast::analysis::TypeEnvironmentAnalysis>()->getTypeEnvironment();
@@ -1501,7 +1501,7 @@ void AstToRamTranslator::translateProgram(const ast::TranslationUnit& translatio
             translationUnit.getAnalysis<ast::analysis::RelationScheduleAnalysis>()->schedule();
 
     // get auxiliary arity analysis
-    auxArityAnalysis = translationUnit.getAnalysis<ast::analysis::AuxiliaryArity>();
+    auxArityAnalysis = translationUnit.getAnalysis<ast::analysis::AuxiliaryArityAnalysis>();
 
     // handle the case of an empty SCC graph
     if (sccGraph.getNumberOfSCCs() == 0) return;

--- a/src/ast2ram/AstToRamTranslator.h
+++ b/src/ast2ram/AstToRamTranslator.h
@@ -78,7 +78,7 @@ private:
     const ast::analysis::TypeEnvironment* typeEnv = nullptr;
 
     /** IO Type */
-    const ast::analysis::IOType* ioType = nullptr;
+    const ast::analysis::IOTypeAnalysis* ioType = nullptr;
 
     /** RAM program */
     Own<RamStatement> ramMain;
@@ -93,7 +93,7 @@ private:
     SymbolTable symbolTable;
 
     /** Auxiliary Arity Analysis */
-    const ast::analysis::AuxiliaryArity* auxArityAnalysis = nullptr;
+    const ast::analysis::AuxiliaryArityAnalysis* auxArityAnalysis = nullptr;
 
     /**
      * Concrete attribute
@@ -365,7 +365,7 @@ private:
         Own<RamOperation> filterByConstraints(size_t level, const std::vector<ast::Argument*>& args,
                 Own<RamOperation> op, bool constrainByFunctors = true);
 
-        const ast::analysis::AuxiliaryArity* auxArityAnalysis;
+        const ast::analysis::AuxiliaryArityAnalysis* auxArityAnalysis;
 
     public:
         ClauseTranslator(AstToRamTranslator& translator)

--- a/src/ast2ram/AstToRamTranslator.h
+++ b/src/ast2ram/AstToRamTranslator.h
@@ -68,17 +68,17 @@ public:
     AstToRamTranslator() = default;
 
     /** translates AST to translation unit  */
-    Own<RamTranslationUnit> translateUnit(AstTranslationUnit& tu);
+    Own<RamTranslationUnit> translateUnit(ast::TranslationUnit& tu);
 
 private:
     /** AST program */
-    const AstProgram* program = nullptr;
+    const ast::Program* program = nullptr;
 
     /** Type environment */
-    const TypeEnvironment* typeEnv = nullptr;
+    const ast::analysis::TypeEnvironment* typeEnv = nullptr;
 
     /** IO Type */
-    const IOType* ioType = nullptr;
+    const ast::analysis::IOType* ioType = nullptr;
 
     /** RAM program */
     Own<RamStatement> ramMain;
@@ -93,7 +93,7 @@ private:
     SymbolTable symbolTable;
 
     /** Auxiliary Arity Analysis */
-    const AuxiliaryArity* auxArityAnalysis = nullptr;
+    const ast::analysis::AuxiliaryArity* auxArityAnalysis = nullptr;
 
     /**
      * Concrete attribute
@@ -159,15 +159,15 @@ private:
          * The type mapping record init expressions to their definition points,
          * hence the point where they get grounded/bound.
          */
-        using record_definition_map = std::map<const AstRecordInit*, Location>;
+        using record_definition_map = std::map<const ast::RecordInit*, Location>;
 
         /**
-         * A map from generative `AstArgument`s to storage locations. Note,
-         * since in this case AstArgument are indexed by their values (not their
+         * A map from generative `ast::Argument`s to storage locations. Note,
+         * since in this case ast::Argument are indexed by their values (not their
          * address) no standard map can be utilized.
          * (By-value indexing induces an ad-hoc form of CSE.)
          */
-        using generator_location_map = std::vector<std::pair<const AstArgument*, Location>>;
+        using generator_location_map = std::vector<std::pair<const ast::Argument*, Location>>;
 
         /** The index of variable accesses */
         variable_reference_map var_references;
@@ -181,21 +181,21 @@ private:
     public:
         // -- variables --
 
-        void addVarReference(const AstVariable& var, const Location& l) {
+        void addVarReference(const ast::Variable& var, const Location& l) {
             std::set<Location>& locs = var_references[var.getName()];
             locs.insert(l);
         }
 
         void addVarReference(
-                const AstVariable& var, int ident, int pos, Own<RamRelationReference> rel = nullptr) {
+                const ast::Variable& var, int ident, int pos, Own<RamRelationReference> rel = nullptr) {
             addVarReference(var, Location({ident, pos, std::move(rel)}));
         }
 
-        bool isDefined(const AstVariable& var) const {
+        bool isDefined(const ast::Variable& var) const {
             return var_references.find(var.getName()) != var_references.end();
         }
 
-        const Location& getDefinitionPoint(const AstVariable& var) const {
+        const Location& getDefinitionPoint(const ast::Variable& var) const {
             auto pos = var_references.find(var.getName());
             assert(pos != var_references.end() && "Undefined variable referenced!");
             return *pos->second.begin();
@@ -209,16 +209,16 @@ private:
 
         // - definition -
 
-        void setRecordDefinition(const AstRecordInit& init, const Location& l) {
+        void setRecordDefinition(const ast::RecordInit& init, const Location& l) {
             record_definitions[&init] = l;
         }
 
         void setRecordDefinition(
-                const AstRecordInit& init, int ident, int pos, Own<RamRelationReference> rel = nullptr) {
+                const ast::RecordInit& init, int ident, int pos, Own<RamRelationReference> rel = nullptr) {
             setRecordDefinition(init, Location({ident, pos, std::move(rel)}));
         }
 
-        const Location& getDefinitionPoint(const AstRecordInit& init) const {
+        const Location& getDefinitionPoint(const ast::RecordInit& init) const {
             auto pos = record_definitions.find(&init);
             if (pos != record_definitions.end()) {
                 return pos->second;
@@ -229,11 +229,11 @@ private:
 
         // -- generators (aggregates & some functors) --
 
-        void setGeneratorLoc(const AstArgument& agg, const Location& loc) {
+        void setGeneratorLoc(const ast::Argument& agg, const Location& loc) {
             arg_generator_locations.push_back(std::make_pair(&agg, loc));
         }
 
-        const Location& getGeneratorLoc(const AstArgument& arg) const {
+        const Location& getGeneratorLoc(const ast::Argument& arg) const {
             // search list
             for (const auto& cur : arg_generator_locations) {
                 if (*cur.first == arg) {
@@ -284,69 +284,70 @@ private:
     static Own<RamTupleElement> makeRamTupleElement(const Location& loc);
 
     /** determine the auxiliary for relations */
-    size_t getEvaluationArity(const AstAtom* atom) const;
+    size_t getEvaluationArity(const ast::Atom* atom) const;
 
     /**
      * assigns names to unnamed variables such that enclosing
      * constructs may be cloned without losing the variable-identity
      */
-    void nameUnnamedVariables(AstClause* clause);
+    void nameUnnamedVariables(ast::Clause* clause);
 
     /** converts the given relation identifier into a relation name */
-    std::string getRelationName(const AstQualifiedName& id) {
+    std::string getRelationName(const ast::QualifiedName& id) {
         return toString(join(id.getQualifiers(), "."));
     }
 
     /** translate AST directives to RAM directives */
     // TODO (b-scholz): revisit / refactor
-    void translateDirectives(std::map<std::string, std::string>& directives, const AstRelation* rel);
+    void translateDirectives(std::map<std::string, std::string>& directives, const ast::Relation* rel);
 
     // TODO (b-scholz): revisit / refactor so that only one directive is translated
-    std::vector<std::map<std::string, std::string>> getInputDirectives(const AstRelation* rel);
+    std::vector<std::map<std::string, std::string>> getInputDirectives(const ast::Relation* rel);
 
     // TODO (b-scholz): revisit / refactor so that only one directive is translated
-    std::vector<std::map<std::string, std::string>> getOutputDirectives(const AstRelation* rel);
+    std::vector<std::map<std::string, std::string>> getOutputDirectives(const ast::Relation* rel);
 
     /** create a reference to a RAM relation */
     Own<RamRelationReference> createRelationReference(const std::string name);
 
     /** a utility to translate atoms to relations */
-    Own<RamRelationReference> translateRelation(const AstAtom* atom);
+    Own<RamRelationReference> translateRelation(const ast::Atom* atom);
 
     /** translate an AST relation to a RAM relation */
     Own<RamRelationReference> translateRelation(
-            const AstRelation* rel, const std::string relationNamePrefix = "");
+            const ast::Relation* rel, const std::string relationNamePrefix = "");
 
     /** translate a temporary `delta` relation to a RAM relation for semi-naive evaluation */
-    Own<RamRelationReference> translateDeltaRelation(const AstRelation* rel);
+    Own<RamRelationReference> translateDeltaRelation(const ast::Relation* rel);
 
     /** translate a temporary `new` relation to a RAM relation for semi-naive evaluation */
-    Own<RamRelationReference> translateNewRelation(const AstRelation* rel);
+    Own<RamRelationReference> translateNewRelation(const ast::Relation* rel);
 
     /** translate an AST argument to a RAM value */
-    Own<RamExpression> translateValue(const AstArgument* arg, const ValueIndex& index);
+    Own<RamExpression> translateValue(const ast::Argument* arg, const ValueIndex& index);
 
     /** translate an AST constraint to a RAM condition */
-    Own<RamCondition> translateConstraint(const AstLiteral* arg, const ValueIndex& index);
+    Own<RamCondition> translateConstraint(const ast::Literal* arg, const ValueIndex& index);
 
     /** translate AST clause to RAM code */
     class ClauseTranslator {
         // index nested variables and records
-        using arg_list = std::vector<AstArgument*>;
+        using arg_list = std::vector<ast::Argument*>;
 
-        std::vector<const AstArgument*> generators;
+        std::vector<const ast::Argument*> generators;
 
         // the order of processed operations
-        std::vector<const AstNode*> op_nesting;
+        std::vector<const ast::Node*> op_nesting;
 
-        Own<AstClause> getReorderedClause(const AstClause& clause, const int version) const;
+        Own<ast::Clause> getReorderedClause(const ast::Clause& clause, const int version) const;
 
-        arg_list* getArgList(const AstNode* curNode, std::map<const AstNode*, Own<arg_list>>& nodeArgs) const;
+        arg_list* getArgList(
+                const ast::Node* curNode, std::map<const ast::Node*, Own<arg_list>>& nodeArgs) const;
 
-        void indexValues(const AstNode* curNode, std::map<const AstNode*, Own<arg_list>>& nodeArgs,
+        void indexValues(const ast::Node* curNode, std::map<const ast::Node*, Own<arg_list>>& nodeArgs,
                 std::map<const arg_list*, int>& arg_level, RamRelationReference* relation);
 
-        void createValueIndex(const AstClause& clause);
+        void createValueIndex(const ast::Clause& clause);
 
     protected:
         AstToRamTranslator& translator;
@@ -357,27 +358,27 @@ private:
         // current nesting level
         int level = 0;
 
-        virtual Own<RamOperation> createOperation(const AstClause& clause);
-        virtual Own<RamCondition> createCondition(const AstClause& originalClause);
+        virtual Own<RamOperation> createOperation(const ast::Clause& clause);
+        virtual Own<RamCondition> createCondition(const ast::Clause& originalClause);
 
         /** translate RAM code for a constant value */
-        Own<RamOperation> filterByConstraints(size_t level, const std::vector<AstArgument*>& args,
+        Own<RamOperation> filterByConstraints(size_t level, const std::vector<ast::Argument*>& args,
                 Own<RamOperation> op, bool constrainByFunctors = true);
 
-        const AuxiliaryArity* auxArityAnalysis;
+        const ast::analysis::AuxiliaryArity* auxArityAnalysis;
 
     public:
         ClauseTranslator(AstToRamTranslator& translator)
                 : translator(translator), auxArityAnalysis(translator.auxArityAnalysis) {}
 
         Own<RamStatement> translateClause(
-                const AstClause& clause, const AstClause& originalClause, const int version = 0);
+                const ast::Clause& clause, const ast::Clause& originalClause, const int version = 0);
     };
 
     class ProvenanceClauseTranslator : public ClauseTranslator {
     protected:
-        Own<RamOperation> createOperation(const AstClause& clause) override;
-        Own<RamCondition> createCondition(const AstClause& originalClause) override;
+        Own<RamOperation> createOperation(const ast::Clause& clause) override;
+        Own<RamCondition> createCondition(const ast::Clause& originalClause) override;
 
     public:
         ProvenanceClauseTranslator(AstToRamTranslator& translator) : ClauseTranslator(translator) {}
@@ -391,19 +392,19 @@ private:
     /**
      *  Get ram representation of constant.
      */
-    RamDomain getConstantRamRepresentation(const AstConstant& constant) {
-        if (auto strConstant = dynamic_cast<const AstStringConstant*>(&constant)) {
+    RamDomain getConstantRamRepresentation(const ast::Constant& constant) {
+        if (auto strConstant = dynamic_cast<const ast::StringConstant*>(&constant)) {
             return getSymbolTable().lookup(strConstant->getConstant());
-        } else if (isA<AstNilConstant>(&constant)) {
+        } else if (isA<ast::NilConstant>(&constant)) {
             return 0;
-        } else if (auto* numConstant = dynamic_cast<const AstNumericConstant*>(&constant)) {
+        } else if (auto* numConstant = dynamic_cast<const ast::NumericConstant*>(&constant)) {
             assert(numConstant->getType().has_value());
             switch (*numConstant->getType()) {
-                case AstNumericConstant::Type::Int:
+                case ast::NumericConstant::Type::Int:
                     return RamSignedFromString(numConstant->getConstant(), nullptr, 0);
-                case AstNumericConstant::Type::Uint:
+                case ast::NumericConstant::Type::Uint:
                     return RamUnsignedFromString(numConstant->getConstant(), nullptr, 0);
-                case AstNumericConstant::Type::Float: return RamFloatFromString(numConstant->getConstant());
+                case ast::NumericConstant::Type::Float: return RamFloatFromString(numConstant->getConstant());
             }
         }
 
@@ -411,7 +412,7 @@ private:
     }
 
     /** translate RAM code for a constant value */
-    Own<RamExpression> translateConstant(AstConstant const& c);
+    Own<RamExpression> translateConstant(ast::Constant const& c);
 
     /**
      * translate RAM code for the non-recursive clauses of the given relation.
@@ -419,23 +420,23 @@ private:
      * @return a corresponding statement or null if there are no non-recursive clauses.
      */
     Own<RamStatement> translateNonRecursiveRelation(
-            const AstRelation& rel, const RecursiveClausesAnalysis* recursiveClauses);
+            const ast::Relation& rel, const ast::analysis::RecursiveClausesAnalysis* recursiveClauses);
 
     /** translate RAM code for recursive relations in a strongly-connected component */
-    Own<RamStatement> translateRecursiveRelation(
-            const std::set<const AstRelation*>& scc, const RecursiveClausesAnalysis* recursiveClauses);
+    Own<RamStatement> translateRecursiveRelation(const std::set<const ast::Relation*>& scc,
+            const ast::analysis::RecursiveClausesAnalysis* recursiveClauses);
 
     /** translate RAM code for subroutine to get subproofs */
-    Own<RamStatement> makeSubproofSubroutine(const AstClause& clause);
+    Own<RamStatement> makeSubproofSubroutine(const ast::Clause& clause);
 
     /** translate RAM code for subroutine to get subproofs */
-    Own<RamStatement> makeSubproofSubroutineOpt(const AstClause& clause);
+    Own<RamStatement> makeSubproofSubroutineOpt(const ast::Clause& clause);
 
     /** translate RAM code for subroutine to get subproofs for non-existence of a tuple */
-    Own<RamStatement> makeNegationSubproofSubroutine(const AstClause& clause);
+    Own<RamStatement> makeNegationSubproofSubroutine(const ast::Clause& clause);
 
     /** translate AST to RAM Program */
-    void translateProgram(const AstTranslationUnit& translationUnit);
+    void translateProgram(const ast::TranslationUnit& translationUnit);
 };
 
 }  // end of namespace souffle

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -481,7 +481,7 @@ int main(int argc, char** argv) {
             mk<ast::transform::UniqueAggregationVariablesTransformer>(),
             mk<ast::transform::UserDefinedFunctorsTransformer>(),
             mk<ast::transform::FixpointTransformer>(mk<ast::transform::PipelineTransformer>(
-                    mk<ast::transform::ResolveAnonymousRecordAliases>(),
+                    mk<ast::transform::ResolveAnonymousRecordAliasesTransformer>(),
                     mk<ast::transform::FoldAnonymousRecords>())),
             mk<ast::transform::PolymorphicObjectsTransformer>(), mk<ast::transform::SemanticChecker>(),
             mk<ast::transform::ADTtoRecordsTransformer>(),

--- a/src/parser/ParserDriver.cpp
+++ b/src/parser/ParserDriver.cpp
@@ -47,9 +47,9 @@ extern void yyset_in(FILE* in_str, yyscan_t scanner);
 
 namespace souffle {
 
-Own<AstTranslationUnit> ParserDriver::parse(
+Own<ast::TranslationUnit> ParserDriver::parse(
         const std::string& filename, FILE* in, ErrorReport& errorReport, DebugReport& debugReport) {
-    translationUnit = mk<AstTranslationUnit>(mk<AstProgram>(), errorReport, debugReport);
+    translationUnit = mk<ast::TranslationUnit>(mk<ast::Program>(), errorReport, debugReport);
     yyscan_t scanner;
     scanner_data data;
     data.yyfilename = filename;
@@ -64,9 +64,9 @@ Own<AstTranslationUnit> ParserDriver::parse(
     return std::move(translationUnit);
 }
 
-Own<AstTranslationUnit> ParserDriver::parse(
+Own<ast::TranslationUnit> ParserDriver::parse(
         const std::string& code, ErrorReport& errorReport, DebugReport& debugReport) {
-    translationUnit = mk<AstTranslationUnit>(mk<AstProgram>(), errorReport, debugReport);
+    translationUnit = mk<ast::TranslationUnit>(mk<ast::Program>(), errorReport, debugReport);
 
     scanner_data data;
     data.yyfilename = "<in-memory>";
@@ -81,27 +81,27 @@ Own<AstTranslationUnit> ParserDriver::parse(
     return std::move(translationUnit);
 }
 
-Own<AstTranslationUnit> ParserDriver::parseTranslationUnit(
+Own<ast::TranslationUnit> ParserDriver::parseTranslationUnit(
         const std::string& filename, FILE* in, ErrorReport& errorReport, DebugReport& debugReport) {
     ParserDriver parser;
     return parser.parse(filename, in, errorReport, debugReport);
 }
 
-Own<AstTranslationUnit> ParserDriver::parseTranslationUnit(
+Own<ast::TranslationUnit> ParserDriver::parseTranslationUnit(
         const std::string& code, ErrorReport& errorReport, DebugReport& debugReport) {
     ParserDriver parser;
     return parser.parse(code, errorReport, debugReport);
 }
 
-void ParserDriver::addPragma(Own<AstPragma> p) {
+void ParserDriver::addPragma(Own<ast::Pragma> p) {
     translationUnit->getProgram()->addPragma(std::move(p));
 }
 
-void ParserDriver::addFunctorDeclaration(Own<AstFunctorDeclaration> f) {
+void ParserDriver::addFunctorDeclaration(Own<ast::FunctorDeclaration> f) {
     const std::string& name = f->getName();
-    const AstFunctorDeclaration* existingFunctorDecl =
+    const ast::FunctorDeclaration* existingFunctorDecl =
             getIf(translationUnit->getProgram()->getFunctorDeclarations(),
-                    [&](const AstFunctorDeclaration* current) { return current->getName() == name; });
+                    [&](const ast::FunctorDeclaration* current) { return current->getName() == name; });
     if (existingFunctorDecl != nullptr) {
         Diagnostic err(Diagnostic::Type::ERROR,
                 DiagnosticMessage("Redefinition of functor " + toString(name), f->getSrcLoc()),
@@ -112,9 +112,9 @@ void ParserDriver::addFunctorDeclaration(Own<AstFunctorDeclaration> f) {
     }
 }
 
-void ParserDriver::addRelation(Own<AstRelation> r) {
+void ParserDriver::addRelation(Own<ast::Relation> r) {
     const auto& name = r->getQualifiedName();
-    if (AstRelation* prev = getRelation(*translationUnit->getProgram(), name)) {
+    if (ast::Relation* prev = getRelation(*translationUnit->getProgram(), name)) {
         Diagnostic err(Diagnostic::Type::ERROR,
                 DiagnosticMessage("Redefinition of relation " + toString(name), r->getSrcLoc()),
                 {DiagnosticMessage("Previous definition", prev->getSrcLoc())});
@@ -124,11 +124,11 @@ void ParserDriver::addRelation(Own<AstRelation> r) {
     }
 }
 
-void ParserDriver::addDirective(Own<AstDirective> directive) {
-    if (directive->getType() == AstDirectiveType::printsize) {
+void ParserDriver::addDirective(Own<ast::Directive> directive) {
+    if (directive->getType() == ast::DirectiveType::printsize) {
         for (const auto& cur : translationUnit->getProgram()->getDirectives()) {
             if (cur->getQualifiedName() == directive->getQualifiedName() &&
-                    cur->getType() == AstDirectiveType::printsize) {
+                    cur->getType() == ast::DirectiveType::printsize) {
                 Diagnostic err(Diagnostic::Type::ERROR,
                         DiagnosticMessage("Redefinition of printsize directives for relation " +
                                                   toString(directive->getQualifiedName()),
@@ -138,10 +138,10 @@ void ParserDriver::addDirective(Own<AstDirective> directive) {
                 return;
             }
         }
-    } else if (directive->getType() == AstDirectiveType::limitsize) {
+    } else if (directive->getType() == ast::DirectiveType::limitsize) {
         for (const auto& cur : translationUnit->getProgram()->getDirectives()) {
             if (cur->getQualifiedName() == directive->getQualifiedName() &&
-                    cur->getType() == AstDirectiveType::limitsize) {
+                    cur->getType() == ast::DirectiveType::limitsize) {
                 Diagnostic err(Diagnostic::Type::ERROR,
                         DiagnosticMessage("Redefinition of limitsize directives for relation " +
                                                   toString(directive->getQualifiedName()),
@@ -155,10 +155,10 @@ void ParserDriver::addDirective(Own<AstDirective> directive) {
     translationUnit->getProgram()->addDirective(std::move(directive));
 }
 
-void ParserDriver::addType(Own<AstType> type) {
+void ParserDriver::addType(Own<ast::Type> type) {
     const auto& name = type->getQualifiedName();
     auto* existingType = getIf(translationUnit->getProgram()->getTypes(),
-            [&](const AstType* current) { return current->getQualifiedName() == name; });
+            [&](const ast::Type* current) { return current->getQualifiedName() == name; });
     if (existingType != nullptr) {
         Diagnostic err(Diagnostic::Type::ERROR,
                 DiagnosticMessage("Redefinition of type " + toString(name), type->getSrcLoc()),
@@ -169,27 +169,28 @@ void ParserDriver::addType(Own<AstType> type) {
     }
 }
 
-void ParserDriver::addClause(Own<AstClause> c) {
+void ParserDriver::addClause(Own<ast::Clause> c) {
     translationUnit->getProgram()->addClause(std::move(c));
 }
-void ParserDriver::addComponent(Own<AstComponent> c) {
+void ParserDriver::addComponent(Own<ast::Component> c) {
     translationUnit->getProgram()->addComponent(std::move(c));
 }
-void ParserDriver::addInstantiation(Own<AstComponentInit> ci) {
+void ParserDriver::addInstantiation(Own<ast::ComponentInit> ci) {
     translationUnit->getProgram()->addInstantiation(std::move(ci));
 }
 
-void ParserDriver::addIoFromDeprecatedTag(AstRelation& rel) {
+void ParserDriver::addIoFromDeprecatedTag(ast::Relation& rel) {
     if (rel.hasQualifier(RelationQualifier::INPUT)) {
-        addDirective(mk<AstDirective>(AstDirectiveType::input, rel.getQualifiedName(), rel.getSrcLoc()));
+        addDirective(mk<ast::Directive>(ast::DirectiveType::input, rel.getQualifiedName(), rel.getSrcLoc()));
     }
 
     if (rel.hasQualifier(RelationQualifier::OUTPUT)) {
-        addDirective(mk<AstDirective>(AstDirectiveType::output, rel.getQualifiedName(), rel.getSrcLoc()));
+        addDirective(mk<ast::Directive>(ast::DirectiveType::output, rel.getQualifiedName(), rel.getSrcLoc()));
     }
 
     if (rel.hasQualifier(RelationQualifier::PRINTSIZE)) {
-        addDirective(mk<AstDirective>(AstDirectiveType::printsize, rel.getQualifiedName(), rel.getSrcLoc()));
+        addDirective(
+                mk<ast::Directive>(ast::DirectiveType::printsize, rel.getQualifiedName(), rel.getSrcLoc()));
     }
 }
 
@@ -221,12 +222,12 @@ std::set<RelationTag> ParserDriver::addTag(RelationTag tag, std::vector<Relation
     return tags;
 }
 
-Own<AstSubsetType> ParserDriver::mkDeprecatedSubType(
-        AstQualifiedName name, AstQualifiedName baseTypeName, SrcLocation loc) {
+Own<ast::SubsetType> ParserDriver::mkDeprecatedSubType(
+        ast::QualifiedName name, ast::QualifiedName baseTypeName, SrcLocation loc) {
     if (!Global::config().has("legacy")) {
         warning(loc, "Deprecated type declaration used");
     }
-    return mk<AstSubsetType>(std::move(name), std::move(baseTypeName), std::move(loc));
+    return mk<ast::SubsetType>(std::move(name), std::move(baseTypeName), std::move(loc));
 }
 
 void ParserDriver::warning(const SrcLocation& loc, const std::string& msg) {

--- a/src/parser/ParserDriver.h
+++ b/src/parser/ParserDriver.h
@@ -52,19 +52,20 @@ class ParserDriver {
 public:
     virtual ~ParserDriver() = default;
 
-    Own<AstTranslationUnit> translationUnit;
+    Own<ast::TranslationUnit> translationUnit;
 
-    void addRelation(Own<AstRelation> r);
-    void addFunctorDeclaration(Own<AstFunctorDeclaration> f);
-    void addDirective(Own<AstDirective> d);
-    void addType(Own<AstType> type);
-    void addClause(Own<AstClause> c);
-    void addComponent(Own<AstComponent> c);
-    void addInstantiation(Own<AstComponentInit> ci);
-    void addPragma(Own<AstPragma> p);
+    void addRelation(Own<ast::Relation> r);
+    void addFunctorDeclaration(Own<ast::FunctorDeclaration> f);
+    void addDirective(Own<ast::Directive> d);
+    void addType(Own<ast::Type> type);
+    void addClause(Own<ast::Clause> c);
+    void addComponent(Own<ast::Component> c);
+    void addInstantiation(Own<ast::ComponentInit> ci);
+    void addPragma(Own<ast::Pragma> p);
 
-    void addIoFromDeprecatedTag(AstRelation& r);
-    Own<AstSubsetType> mkDeprecatedSubType(AstQualifiedName name, AstQualifiedName attr, SrcLocation loc);
+    void addIoFromDeprecatedTag(ast::Relation& r);
+    Own<ast::SubsetType> mkDeprecatedSubType(
+            ast::QualifiedName name, ast::QualifiedName attr, SrcLocation loc);
 
     std::set<RelationTag> addReprTag(RelationTag tag, SrcLocation tagLoc, std::set<RelationTag> tags);
     std::set<RelationTag> addDeprecatedTag(RelationTag tag, SrcLocation tagLoc, std::set<RelationTag> tags);
@@ -74,13 +75,13 @@ public:
 
     bool trace_scanning = false;
 
-    Own<AstTranslationUnit> parse(
+    Own<ast::TranslationUnit> parse(
             const std::string& filename, FILE* in, ErrorReport& errorReport, DebugReport& debugReport);
-    Own<AstTranslationUnit> parse(
+    Own<ast::TranslationUnit> parse(
             const std::string& code, ErrorReport& errorReport, DebugReport& debugReport);
-    static Own<AstTranslationUnit> parseTranslationUnit(
+    static Own<ast::TranslationUnit> parseTranslationUnit(
             const std::string& filename, FILE* in, ErrorReport& errorReport, DebugReport& debugReport);
-    static Own<AstTranslationUnit> parseTranslationUnit(
+    static Own<ast::TranslationUnit> parseTranslationUnit(
             const std::string& code, ErrorReport& errorReport, DebugReport& debugReport);
 
     void warning(const SrcLocation& loc, const std::string& msg);

--- a/src/parser/ParserUtils.cpp
+++ b/src/parser/ParserUtils.cpp
@@ -87,12 +87,12 @@ void RuleBody::disjunct(RuleBody other) {
     }
 }
 
-VecOwn<AstClause> RuleBody::toClauseBodies() const {
+VecOwn<ast::Clause> RuleBody::toClauseBodies() const {
     // collect clause results
-    VecOwn<AstClause> bodies;
+    VecOwn<ast::Clause> bodies;
     for (const clause& cur : dnf) {
-        bodies.push_back(mk<AstClause>());
-        AstClause& clause = *bodies.back();
+        bodies.push_back(mk<ast::Clause>());
+        ast::Clause& clause = *bodies.back();
 
         for (const literal& lit : cur) {
             // extract literal
@@ -100,11 +100,11 @@ VecOwn<AstClause> RuleBody::toClauseBodies() const {
             // negate if necessary
             if (lit.negated) {
                 // negate
-                if (auto* atom = dynamic_cast<AstAtom*>(&*base)) {
+                if (auto* atom = dynamic_cast<ast::Atom*>(&*base)) {
                     base.release();
-                    base = mk<AstNegation>(Own<AstAtom>(atom));
+                    base = mk<ast::Negation>(Own<ast::Atom>(atom));
                     base->setSrcLoc(atom->getSrcLoc());
-                } else if (auto* cstr = dynamic_cast<AstConstraint*>(&*base)) {
+                } else if (auto* cstr = dynamic_cast<ast::Constraint*>(&*base)) {
                     negateConstraintInPlace(*cstr);
                 }
             }
@@ -130,14 +130,14 @@ RuleBody RuleBody::getFalse() {
     return RuleBody();
 }
 
-RuleBody RuleBody::atom(Own<AstAtom> atom) {
+RuleBody RuleBody::atom(Own<ast::Atom> atom) {
     RuleBody body;
     body.dnf.push_back(clause());
     body.dnf.back().emplace_back(literal{false, std::move(atom)});
     return body;
 }
 
-RuleBody RuleBody::constraint(Own<AstConstraint> constraint) {
+RuleBody RuleBody::constraint(Own<ast::Constraint> constraint) {
     RuleBody body;
     body.dnf.push_back(clause());
     body.dnf.back().emplace_back(literal{false, std::move(constraint)});

--- a/src/parser/ParserUtils.h
+++ b/src/parser/ParserUtils.h
@@ -27,7 +27,6 @@
 
 namespace souffle {
 
-class AstConstraint;
 class RuleBody {
 public:
     RuleBody() = default;
@@ -40,7 +39,7 @@ public:
 
     void disjunct(RuleBody other);
 
-    VecOwn<AstClause> toClauseBodies() const;
+    VecOwn<ast::Clause> toClauseBodies() const;
 
     // -- factory functions --
 
@@ -48,22 +47,22 @@ public:
 
     static RuleBody getFalse();
 
-    static RuleBody atom(Own<AstAtom> atom);
+    static RuleBody atom(Own<ast::Atom> atom);
 
-    static RuleBody constraint(Own<AstConstraint> constraint);
+    static RuleBody constraint(Own<ast::Constraint> constraint);
 
     friend std::ostream& operator<<(std::ostream& out, const RuleBody& body);
 
 private:
     // a struct to represent literals
     struct literal {
-        literal(bool negated, Own<AstLiteral> atom) : negated(negated), atom(std::move(atom)) {}
+        literal(bool negated, Own<ast::Literal> atom) : negated(negated), atom(std::move(atom)) {}
 
         // whether this literal is negated or not
         bool negated;
 
         // the atom referenced by tis literal
-        Own<AstLiteral> atom;
+        Own<ast::Literal> atom;
 
         literal clone() const {
             return literal(negated, souffle::clone(atom));

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -306,57 +306,57 @@
 %token L_NOT                     "lnot"
 
 /* -- Non-Terminal Types -- */
-%type <Mov<RuleBody>>                        aggregate_body
-%type <AggregateOp>                          aggregate_func
-%type <Mov<Own<AstArgument>>>                arg
-%type <Mov<VecOwn<AstArgument>>>             arg_list
-%type <Mov<Own<AstAtom>>>                    atom
-%type <Mov<VecOwn<AstAttribute>>>            attributes_list
-%type <Mov<RuleBody>>                        body
-%type <Mov<Own<AstComponentType>>>           comp_type
-%type <Mov<Own<AstComponentInit>>>           comp_init
-%type <Mov<Own<AstComponent>>>               component
-%type <Mov<Own<AstComponent>>>               component_body
-%type <Mov<Own<AstComponent>>>               component_head
-%type <Mov<RuleBody>>                        conjunction
-%type <Mov<Own<AstConstraint>>>              constraint
-%type <Mov<RuleBody>>                        disjunction
-%type <Mov<Own<AstExecutionOrder>>>          exec_order
-%type <Mov<Own<AstExecutionPlan>>>           exec_plan
-%type <Mov<Own<AstExecutionPlan>>>           exec_plan_list
-%type <Mov<Own<AstClause>>>                  fact
-%type <Mov<std::vector<TypeAttribute>>>      functor_arg_type_list
-%type <Mov<std::string>>                     functor_built_in
-%type <Mov<Own<AstFunctorDeclaration>>>      functor_decl
-%type <Mov<VecOwn<AstAtom>>>                 head
-%type <Mov<AstQualifiedName>>                identifier
-%type <Mov<VecOwn<AstDirective>>>                   directive_list
-%type <Mov<VecOwn<AstDirective>>>                   directive_head
-%type <AstDirectiveType>                            directive_head_decl
-%type <Mov<VecOwn<AstDirective>>>                   relation_directive_list
-%type <Mov<std::string>>                     kvp_value
-%type <Mov<VecOwn<AstArgument>>>             non_empty_arg_list
-%type <Mov<Own<AstAttribute>>>               attribute
-%type <Mov<VecOwn<AstAttribute>>>            non_empty_attributes
-%type <Mov<AstExecutionOrder::ExecOrder>>    non_empty_exec_order_list
-%type <Mov<std::vector<TypeAttribute>>>      non_empty_functor_arg_type_list
+%type <Mov<RuleBody>>                          aggregate_body
+%type <AggregateOp>                            aggregate_func
+%type <Mov<Own<ast::Argument>>>                arg
+%type <Mov<VecOwn<ast::Argument>>>             arg_list
+%type <Mov<Own<ast::Atom>>>                    atom
+%type <Mov<VecOwn<ast::Attribute>>>            attributes_list
+%type <Mov<RuleBody>>                          body
+%type <Mov<Own<ast::ComponentType>>>           comp_type
+%type <Mov<Own<ast::ComponentInit>>>           comp_init
+%type <Mov<Own<ast::Component>>>               component
+%type <Mov<Own<ast::Component>>>               component_body
+%type <Mov<Own<ast::Component>>>               component_head
+%type <Mov<RuleBody>>                          conjunction
+%type <Mov<Own<ast::Constraint>>>              constraint
+%type <Mov<RuleBody>>                          disjunction
+%type <Mov<Own<ast::ExecutionOrder>>>          exec_order
+%type <Mov<Own<ast::ExecutionPlan>>>           exec_plan
+%type <Mov<Own<ast::ExecutionPlan>>>           exec_plan_list
+%type <Mov<Own<ast::Clause>>>                  fact
+%type <Mov<std::vector<TypeAttribute>>>        functor_arg_type_list
+%type <Mov<std::string>>                       functor_built_in
+%type <Mov<Own<ast::FunctorDeclaration>>>      functor_decl
+%type <Mov<VecOwn<ast::Atom>>>                 head
+%type <Mov<ast::QualifiedName>>                identifier
+%type <Mov<VecOwn<ast::Directive>>>            directive_list
+%type <Mov<VecOwn<ast::Directive>>>            directive_head
+%type <ast::DirectiveType>                     directive_head_decl
+%type <Mov<VecOwn<ast::Directive>>>            relation_directive_list
+%type <Mov<std::string>>                       kvp_value
+%type <Mov<VecOwn<ast::Argument>>>             non_empty_arg_list
+%type <Mov<Own<ast::Attribute>>>               attribute
+%type <Mov<VecOwn<ast::Attribute>>>            non_empty_attributes
+%type <Mov<ast::ExecutionOrder::ExecOrder>>    non_empty_exec_order_list
+%type <Mov<std::vector<TypeAttribute>>>        non_empty_functor_arg_type_list
 %type <Mov<std::vector<std::pair
-            <std::string, std::string>>>>    non_empty_key_value_pairs
-%type <Mov<VecOwn<AstRelation>>>             non_empty_relation_list
-%type <Mov<Own<AstPragma>>>                  pragma
-%type <TypeAttribute>                        predefined_type
-%type <Mov<VecOwn<AstAttribute>>>            record_type_list
-%type <Mov<VecOwn<AstRelation>>>             relation_decl
-%type <std::set<RelationTag>>                relation_tags
-%type <Mov<VecOwn<AstClause>>>               rule
-%type <Mov<VecOwn<AstClause>>>               rule_def
-%type <Mov<RuleBody>>                        term
-%type <Mov<Own<AstType>>>                    type
-%type <Mov<std::vector<AstQualifiedName>>>   type_params
-%type <Mov<std::vector<AstQualifiedName>>>   type_param_list
-%type <Mov<std::vector<AstQualifiedName>>>   union_type_list
-%type <Mov<VecOwn<AstBranchDeclaration>>>    sum_branch_list
-%type <Mov<Own<AstBranchDeclaration>>>       sum_branch
+            <std::string, std::string>>>>      non_empty_key_value_pairs
+%type <Mov<VecOwn<ast::Relation>>>             non_empty_relation_list
+%type <Mov<Own<ast::Pragma>>>                  pragma
+%type <TypeAttribute>                          predefined_type
+%type <Mov<VecOwn<ast::Attribute>>>            record_type_list
+%type <Mov<VecOwn<ast::Relation>>>             relation_decl
+%type <std::set<RelationTag>>                  relation_tags
+%type <Mov<VecOwn<ast::Clause>>>               rule
+%type <Mov<VecOwn<ast::Clause>>>               rule_def
+%type <Mov<RuleBody>>                          term
+%type <Mov<Own<ast::Type>>>                    type
+%type <Mov<std::vector<ast::QualifiedName>>>   type_params
+%type <Mov<std::vector<ast::QualifiedName>>>   type_param_list
+%type <Mov<std::vector<ast::QualifiedName>>>   union_type_list
+%type <Mov<VecOwn<ast::BranchDeclaration>>>    sum_branch_list
+%type <Mov<Own<ast::BranchDeclaration>>>       sum_branch
 
 /* -- Operator precedence -- */
 %left L_OR
@@ -416,10 +416,10 @@ identifier
 
 /* Type declarations */
 type
-  : TYPE IDENT SUBTYPE IDENT             { $$ = mk<AstSubsetType>($2, $4, @$); }
-  | TYPE IDENT EQUALS  union_type_list   { $$ = mk<AstUnionType>($2, $4, @$); }
-  | TYPE IDENT EQUALS  record_type_list  { $$ = mk<AstRecordType>($2, $4, @$); }
-  | TYPE IDENT EQUALS  sum_branch_list   { $$ = mk<AstAlgebraicDataType>($2, $4, @$); }
+  : TYPE IDENT SUBTYPE IDENT             { $$ = mk<ast::SubsetType>($2, $4, @$); }
+  | TYPE IDENT EQUALS  union_type_list   { $$ = mk<ast::UnionType>($2, $4, @$); }
+  | TYPE IDENT EQUALS  record_type_list  { $$ = mk<ast::RecordType>($2, $4, @$); }
+  | TYPE IDENT EQUALS  sum_branch_list   { $$ = mk<ast::AlgebraicDataType>($2, $4, @$); }
     /* deprecated subset type forms */
   | NUMBER_TYPE IDENT { $$ = driver.mkDeprecatedSubType($IDENT, "number", @$); }
   | SYMBOL_TYPE IDENT { $$ = driver.mkDeprecatedSubType($IDENT, "symbol", @$); }
@@ -439,9 +439,9 @@ sum_branch_list
 
 sum_branch
   : IDENT[name] LBRACE RBRACE
-    { $$ = mk<AstBranchDeclaration>($name, VecOwn<AstAttribute>{}, @$); }
+    { $$ = mk<ast::BranchDeclaration>($name, VecOwn<ast::Attribute>{}, @$); }
   | IDENT[name] LBRACE non_empty_attributes[attributes] RBRACE
-    { $$ = mk<AstBranchDeclaration>($name, $attributes, @$); }
+    { $$ = mk<ast::BranchDeclaration>($name, $attributes, @$); }
   ;
 
 /**
@@ -473,8 +473,8 @@ relation_decl
 
 /* List of relation names to declare */
 non_empty_relation_list
-  :                               IDENT {          $$.push_back(mk<AstRelation>($1, @1)); }
-  | non_empty_relation_list COMMA IDENT { $$ = $1; $$.push_back(mk<AstRelation>($3, @3)); }
+  :                               IDENT {          $$.push_back(mk<ast::Relation>($1, @1)); }
+  | non_empty_relation_list COMMA IDENT { $$ = $1; $$.push_back(mk<ast::Relation>($3, @3)); }
   ;
 
 /* Attribute definition of a relation */
@@ -495,7 +495,7 @@ non_empty_attributes
   ;
 
 attribute
-  : IDENT[name] COLON identifier[type] { $$ = mk<AstAttribute>($name, $type, @type); }
+  : IDENT[name] COLON identifier[type] { $$ = mk<ast::Attribute>($name, $type, @type); }
   ;
 
 /* Relation tags */
@@ -520,7 +520,7 @@ relation_tags
  */
 
 /* Fact */
-fact : atom DOT { $$ = mk<AstClause>($atom, Mov<VecOwn<AstLiteral>> {}, nullptr, @$); };
+fact : atom DOT { $$ = mk<ast::Clause>($atom, Mov<VecOwn<ast::Literal>> {}, nullptr, @$); };
 
 /* Rule */
 rule
@@ -577,8 +577,8 @@ exec_plan : PLAN exec_plan_list { $$ = $exec_plan_list; };
 /* Rule execution plan list */
 exec_plan_list
   : NUMBER COLON exec_order {
-        $$ = mk<AstExecutionPlan>();
-        $$->setOrderFor(RamSignedFromString($NUMBER), Own<AstExecutionOrder>($exec_order));
+        $$ = mk<ast::ExecutionPlan>();
+        $$->setOrderFor(RamSignedFromString($NUMBER), Own<ast::ExecutionOrder>($exec_order));
     }
   | exec_plan_list[curr_list] COMMA NUMBER COLON exec_order {
         $$ = $curr_list;
@@ -588,8 +588,8 @@ exec_plan_list
 
 /* Rule execution order */
 exec_order
-  : LPAREN RPAREN                           { $$ = mk<AstExecutionOrder>(AstExecutionOrder::ExecOrder(), @$); }
-  | LPAREN non_empty_exec_order_list RPAREN { $$ = mk<AstExecutionOrder>($2, @$); }
+  : LPAREN RPAREN                           { $$ = mk<ast::ExecutionOrder>(ast::ExecutionOrder::ExecOrder(), @$); }
+  | LPAREN non_empty_exec_order_list RPAREN { $$ = mk<ast::ExecutionOrder>($2, @$); }
   ;
 non_empty_exec_order_list
   :                                 NUMBER {          $$.push_back(RamUnsignedFromString($NUMBER)); }
@@ -609,27 +609,27 @@ term
   ;
 
 /* Rule body atom */
-atom : identifier LPAREN arg_list RPAREN { $$ = mk<AstAtom>($identifier, $arg_list, @$); };
+atom : identifier LPAREN arg_list RPAREN { $$ = mk<ast::Atom>($identifier, $arg_list, @$); };
 
 /* Rule literal constraints */
 constraint
     /* binary infix constraints */
-  : arg LT      arg { $$ = mk<AstBinaryConstraint>(BinaryConstraintOp::LT, $1, $3, @$); }
-  | arg GT      arg { $$ = mk<AstBinaryConstraint>(BinaryConstraintOp::GT, $1, $3, @$); }
-  | arg LE      arg { $$ = mk<AstBinaryConstraint>(BinaryConstraintOp::LE, $1, $3, @$); }
-  | arg GE      arg { $$ = mk<AstBinaryConstraint>(BinaryConstraintOp::GE, $1, $3, @$); }
-  | arg EQUALS  arg { $$ = mk<AstBinaryConstraint>(BinaryConstraintOp::EQ, $1, $3, @$); }
-  | arg NE      arg { $$ = mk<AstBinaryConstraint>(BinaryConstraintOp::NE, $1, $3, @$); }
+  : arg LT      arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::LT, $1, $3, @$); }
+  | arg GT      arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::GT, $1, $3, @$); }
+  | arg LE      arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::LE, $1, $3, @$); }
+  | arg GE      arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::GE, $1, $3, @$); }
+  | arg EQUALS  arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::EQ, $1, $3, @$); }
+  | arg NE      arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::NE, $1, $3, @$); }
 
     /* binary prefix constraints */
   | TMATCH    LPAREN arg[a0] COMMA arg[a1] RPAREN
-    { $$ = mk<AstBinaryConstraint>(BinaryConstraintOp::MATCH   , $a0, $a1, @$); }
+    { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::MATCH   , $a0, $a1, @$); }
   | TCONTAINS LPAREN arg[a0] COMMA arg[a1] RPAREN
-    { $$ = mk<AstBinaryConstraint>(BinaryConstraintOp::CONTAINS, $a0, $a1, @$); }
+    { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::CONTAINS, $a0, $a1, @$); }
 
     /* zero-arity constraints */
-  | TRUE  { $$ = mk<AstBooleanConstraint>(true , @$); }
-  | FALSE { $$ = mk<AstBooleanConstraint>(false, @$); }
+  | TRUE  { $$ = mk<ast::BooleanConstraint>(true , @$); }
+  | FALSE { $$ = mk<ast::BooleanConstraint>(false, @$); }
   ;
 
 /* Argument list */
@@ -641,34 +641,34 @@ non_empty_arg_list
 
 /* Atom argument */
 arg
-  : STRING      { $$ = mk<AstStringConstant >($STRING, @$); }
-  | FLOAT       { $$ = mk<AstNumericConstant>($FLOAT, AstNumericConstant::Type::Float, @$); }
+  : STRING      { $$ = mk<ast::StringConstant >($STRING, @$); }
+  | FLOAT       { $$ = mk<ast::NumericConstant>($FLOAT, ast::NumericConstant::Type::Float, @$); }
   | UNSIGNED    {
       auto&& n = $UNSIGNED; // drop the last character (`u`)
-      $$ = mk<AstNumericConstant>(n.substr(0, n.size() - 1), AstNumericConstant::Type::Uint, @$);
+      $$ = mk<ast::NumericConstant>(n.substr(0, n.size() - 1), ast::NumericConstant::Type::Uint, @$);
     }
-  | NUMBER      { $$ = mk<AstNumericConstant>($NUMBER, @$); }
-  | UNDERSCORE  { $$ = mk<AstUnnamedVariable>(@$); }
-  | DOLLAR      { $$ = mk<AstCounter        >(@$); }
-  | IDENT       { $$ = mk<AstVariable       >($IDENT, @$); }
-  | NIL         { $$ = mk<AstNilConstant    >(@$); }
+  | NUMBER      { $$ = mk<ast::NumericConstant>($NUMBER, @$); }
+  | UNDERSCORE  { $$ = mk<ast::UnnamedVariable>(@$); }
+  | DOLLAR      { $$ = mk<ast::Counter        >(@$); }
+  | IDENT       { $$ = mk<ast::Variable       >($IDENT, @$); }
+  | NIL         { $$ = mk<ast::NilConstant    >(@$); }
 
   /* TODO (azreika): in next version: prepend records with identifiers */
-  | LBRACKET arg_list RBRACKET { $$ = mk<AstRecordInit>($arg_list, @$); }
+  | LBRACKET arg_list RBRACKET { $$ = mk<ast::RecordInit>($arg_list, @$); }
 
   // Branch of adt
-  | DOLLAR IDENT[branch] LPAREN arg_list RPAREN { $$ = mk<AstBranchInit>($branch, $arg_list, @$); }
-  | DOLLAR IDENT[branch]                        { $$ = mk<AstBranchInit>($branch, VecOwn<AstArgument>{}, @$); }
+  | DOLLAR IDENT[branch] LPAREN arg_list RPAREN { $$ = mk<ast::BranchInit>($branch, $arg_list, @$); }
+  | DOLLAR IDENT[branch]                        { $$ = mk<ast::BranchInit>($branch, VecOwn<ast::Argument>{}, @$); }
 
   |     LPAREN arg                  RPAREN { $$ = $2; }
-  | AS  LPAREN arg COMMA identifier RPAREN { $$ = mk<AstTypeCast>($3, $identifier, @$); }
+  | AS  LPAREN arg COMMA identifier RPAREN { $$ = mk<ast::TypeCast>($3, $identifier, @$); }
 
-  | AT IDENT         LPAREN arg_list RPAREN { $$ = mk<AstUserDefinedFunctor>($IDENT, *$arg_list, @$); }
-  | functor_built_in LPAREN arg_list RPAREN { $$ = mk<AstIntrinsicFunctor>($functor_built_in, *$arg_list, @$); }
+  | AT IDENT         LPAREN arg_list RPAREN { $$ = mk<ast::UserDefinedFunctor>($IDENT, *$arg_list, @$); }
+  | functor_built_in LPAREN arg_list RPAREN { $$ = mk<ast::IntrinsicFunctor>($functor_built_in, *$arg_list, @$); }
 
     /* some aggregates have the same name as functors */
   | aggregate_func LPAREN arg[first] COMMA non_empty_arg_list[rest] RPAREN {
-        VecOwn<AstArgument> arg_list = $rest;
+        VecOwn<ast::Argument> arg_list = $rest;
         arg_list.insert(arg_list.begin(), $first);
 
         auto agg_2_func = [](AggregateOp op) -> char const* {
@@ -684,10 +684,10 @@ arg
         };
 
         if (auto* func_op = agg_2_func($aggregate_func)) {
-          $$ = mk<AstIntrinsicFunctor>(func_op, std::move(arg_list), @$);
+          $$ = mk<ast::IntrinsicFunctor>(func_op, std::move(arg_list), @$);
         } else {
           driver.error(@$, "aggregate operation has no functor equivalent");
-          $$ = mk<AstUnnamedVariable>(@$);
+          $$ = mk<ast::UnnamedVariable>(@$);
         }
     }
 
@@ -696,32 +696,32 @@ arg
   | MINUS arg[nested_arg] %prec NEG {
         // If we have a constant that is not already negated we just negate the constant value.
         auto nested_arg = *$nested_arg;
-        const auto* asNumeric = dynamic_cast<const AstNumericConstant*>(&*nested_arg);
+        const auto* asNumeric = dynamic_cast<const ast::NumericConstant*>(&*nested_arg);
         if (asNumeric && !isPrefix("-", asNumeric->getConstant())) {
-            $$ = mk<AstNumericConstant>("-" + asNumeric->getConstant(), asNumeric->getType(), @nested_arg);
+            $$ = mk<ast::NumericConstant>("-" + asNumeric->getConstant(), asNumeric->getType(), @nested_arg);
         } else { // Otherwise, create a functor.
-            $$ = mk<AstIntrinsicFunctor>(@$, FUNCTOR_INTRINSIC_PREFIX_NEGATE_NAME, std::move(nested_arg));
+            $$ = mk<ast::IntrinsicFunctor>(@$, FUNCTOR_INTRINSIC_PREFIX_NEGATE_NAME, std::move(nested_arg));
         }
     }
-  | BW_NOT  arg { $$ = mk<AstIntrinsicFunctor>(@$, "~", $2); }
-  | L_NOT   arg { $$ = mk<AstIntrinsicFunctor>(@$, "!", $2); }
+  | BW_NOT  arg { $$ = mk<ast::IntrinsicFunctor>(@$, "~", $2); }
+  | L_NOT   arg { $$ = mk<ast::IntrinsicFunctor>(@$, "!", $2); }
 
     /* binary infix functors */
-  | arg PLUS                arg { $$ = mk<AstIntrinsicFunctor>(@$, "+"  , $1, $3); }
-  | arg MINUS               arg { $$ = mk<AstIntrinsicFunctor>(@$, "-"  , $1, $3); }
-  | arg STAR                arg { $$ = mk<AstIntrinsicFunctor>(@$, "*"  , $1, $3); }
-  | arg SLASH               arg { $$ = mk<AstIntrinsicFunctor>(@$, "/"  , $1, $3); }
-  | arg PERCENT             arg { $$ = mk<AstIntrinsicFunctor>(@$, "%"  , $1, $3); }
-  | arg CARET               arg { $$ = mk<AstIntrinsicFunctor>(@$, "**" , $1, $3); }
-  | arg L_AND               arg { $$ = mk<AstIntrinsicFunctor>(@$, "&&" , $1, $3); }
-  | arg L_OR                arg { $$ = mk<AstIntrinsicFunctor>(@$, "||" , $1, $3); }
-  | arg L_XOR               arg { $$ = mk<AstIntrinsicFunctor>(@$, "^^" , $1, $3); }
-  | arg BW_AND              arg { $$ = mk<AstIntrinsicFunctor>(@$, "&"  , $1, $3); }
-  | arg BW_OR               arg { $$ = mk<AstIntrinsicFunctor>(@$, "|"  , $1, $3); }
-  | arg BW_XOR              arg { $$ = mk<AstIntrinsicFunctor>(@$, "^"  , $1, $3); }
-  | arg BW_SHIFT_L          arg { $$ = mk<AstIntrinsicFunctor>(@$, "<<" , $1, $3); }
-  | arg BW_SHIFT_R          arg { $$ = mk<AstIntrinsicFunctor>(@$, ">>" , $1, $3); }
-  | arg BW_SHIFT_R_UNSIGNED arg { $$ = mk<AstIntrinsicFunctor>(@$, ">>>", $1, $3); }
+  | arg PLUS                arg { $$ = mk<ast::IntrinsicFunctor>(@$, "+"  , $1, $3); }
+  | arg MINUS               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "-"  , $1, $3); }
+  | arg STAR                arg { $$ = mk<ast::IntrinsicFunctor>(@$, "*"  , $1, $3); }
+  | arg SLASH               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "/"  , $1, $3); }
+  | arg PERCENT             arg { $$ = mk<ast::IntrinsicFunctor>(@$, "%"  , $1, $3); }
+  | arg CARET               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "**" , $1, $3); }
+  | arg L_AND               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "&&" , $1, $3); }
+  | arg L_OR                arg { $$ = mk<ast::IntrinsicFunctor>(@$, "||" , $1, $3); }
+  | arg L_XOR               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "^^" , $1, $3); }
+  | arg BW_AND              arg { $$ = mk<ast::IntrinsicFunctor>(@$, "&"  , $1, $3); }
+  | arg BW_OR               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "|"  , $1, $3); }
+  | arg BW_XOR              arg { $$ = mk<ast::IntrinsicFunctor>(@$, "^"  , $1, $3); }
+  | arg BW_SHIFT_L          arg { $$ = mk<ast::IntrinsicFunctor>(@$, "<<" , $1, $3); }
+  | arg BW_SHIFT_R          arg { $$ = mk<ast::IntrinsicFunctor>(@$, ">>" , $1, $3); }
+  | arg BW_SHIFT_R_UNSIGNED arg { $$ = mk<ast::IntrinsicFunctor>(@$, ">>>", $1, $3); }
 
     /* -- aggregators -- */
   | aggregate_func arg_list COLON aggregate_body {
@@ -738,8 +738,8 @@ arg
         }
 
         auto expr = $arg_list.empty() ? nullptr : std::move($arg_list[0]);
-        auto body = (bodies.size() == 1) ? clone(bodies[0]->getBodyLiterals()) : VecOwn<AstLiteral> {};
-        $$ = mk<AstAggregator>($aggregate_func, std::move(expr), std::move(body), @$);
+        auto body = (bodies.size() == 1) ? clone(bodies[0]->getBodyLiterals()) : VecOwn<ast::Literal> {};
+        $$ = mk<ast::Aggregator>($aggregate_func, std::move(expr), std::move(body), @$);
     }
   ;
 
@@ -785,13 +785,13 @@ component
 
 /* Component head */
 component_head
-  : COMPONENT             comp_type { $$ = mk<AstComponent>();  $$->setComponentType($comp_type); }
+  : COMPONENT             comp_type { $$ = mk<ast::Component>();  $$->setComponentType($comp_type); }
   | component_head COLON  comp_type { $$ = $1;                  $$->addBaseComponent($comp_type); }
   | component_head COMMA  comp_type { $$ = $1;                  $$->addBaseComponent($comp_type); }
   ;
 
 /* Component type */
-comp_type : IDENT type_params { $$ = mk<AstComponentType>($IDENT, $type_params, @$); };
+comp_type : IDENT type_params { $$ = mk<ast::ComponentType>($IDENT, $type_params, @$); };
 
 /* Component type parameters */
 type_params
@@ -807,7 +807,7 @@ type_param_list
 
 /* Component body */
 component_body
-  : %empty                        { $$ = mk<AstComponent>(); }
+  : %empty                        { $$ = mk<ast::Component>(); }
   | component_body directive_head { $$ = $1; for (auto&& x : $2) $$->addDirective(std::move(x)); }
   | component_body rule           { $$ = $1; for (auto&& x : $2) $$->addClause(std::move(x)); }
   | component_body fact           { $$ = $1; $$->addClause       ($2); }
@@ -825,7 +825,7 @@ component_body
   ;
 
 /* Component initialisation */
-comp_init : INSTANTIATE IDENT EQUALS comp_type { $$ = mk<AstComponentInit>($IDENT, $comp_type, @$); };
+comp_init : INSTANTIATE IDENT EQUALS comp_type { $$ = mk<ast::ComponentInit>($IDENT, $comp_type, @$); };
 
 /**
  * User-Defined Functors
@@ -834,9 +834,9 @@ comp_init : INSTANTIATE IDENT EQUALS comp_type { $$ = mk<AstComponentInit>($IDEN
 /* Functor declaration */
 functor_decl
   : FUNCTOR IDENT LPAREN functor_arg_type_list[args] RPAREN COLON predefined_type
-    { $$ = mk<AstFunctorDeclaration>($IDENT, $args, $predefined_type, false, @$); }
+    { $$ = mk<ast::FunctorDeclaration>($IDENT, $args, $predefined_type, false, @$); }
   | FUNCTOR IDENT LPAREN functor_arg_type_list[args] RPAREN COLON predefined_type STATEFUL
-    { $$ = mk<AstFunctorDeclaration>($IDENT, $args, $predefined_type, true, @$); }
+    { $$ = mk<ast::FunctorDeclaration>($IDENT, $args, $predefined_type, true, @$); }
   ;
 
 /* Functor argument list type */
@@ -869,8 +869,8 @@ predefined_type
 
 /* Pragma directives */
 pragma
-  : PRAGMA STRING[key   ] STRING[value] { $$ = mk<AstPragma>($key   , $value, @$); }
-  | PRAGMA STRING[option]               { $$ = mk<AstPragma>($option, ""    , @$); }
+  : PRAGMA STRING[key   ] STRING[value] { $$ = mk<ast::Pragma>($key   , $value, @$); }
+  | PRAGMA STRING[option]               { $$ = mk<ast::Pragma>($option, ""    , @$); }
   ;
 
 /* io directives */
@@ -885,10 +885,10 @@ directive_head
   ;
 
 directive_head_decl
-  : INPUT_DECL      { $$ = AstDirectiveType::input;      }
-  | OUTPUT_DECL     { $$ = AstDirectiveType::output;     }
-  | PRINTSIZE_DECL  { $$ = AstDirectiveType::printsize;  }
-  | LIMITSIZE_DECL  { $$ = AstDirectiveType::limitsize;  }
+  : INPUT_DECL      { $$ = ast::DirectiveType::input;      }
+  | OUTPUT_DECL     { $$ = ast::DirectiveType::output;     }
+  | PRINTSIZE_DECL  { $$ = ast::DirectiveType::printsize;  }
+  | LIMITSIZE_DECL  { $$ = ast::DirectiveType::limitsize;  }
   ;
 
 /* IO directive list */
@@ -906,10 +906,10 @@ directive_list
   ;
 
 /* IO relation list */
-/* use a dummy `AstDirectiveType` for now. `directive_head` will replace it */
+/* use a dummy `ast::DirectiveType` for now. `directive_head` will replace it */
 relation_directive_list
-  :                         identifier {          $$.push_back(mk<AstDirective>(AstDirectiveType::input, $1, @1)); }
-  | relation_directive_list COMMA  identifier { $$ = $1; $$.push_back(mk<AstDirective>(AstDirectiveType::input, $3, @3)); }
+  :                         identifier {          $$.push_back(mk<ast::Directive>(ast::DirectiveType::input, $1, @1)); }
+  | relation_directive_list COMMA  identifier { $$ = $1; $$.push_back(mk<ast::Directive>(ast::DirectiveType::input, $3, @3)); }
   ;
 
 /* Key-value pairs */


### PR DESCRIPTION
 * Add ast namespace to the structures in src/ast
 * Add ast::analysis namespace to the structures in src/ast/analysis
 * Add ast::transform namespace to the structures in src/ast/transform
 * Rename AstThing to ast::Thing
 * Standardise ast analysis and transformer naming (note that some things in ast::analysis are related to analysis but are not actually analyses themselves, so names are still of the form `DescriptionAnalysis` rather than relying on the namespace to show their purpose.

Note that since this was mostly an automated change, there is scope for improvement in cpp files with `using` rather than always including the namespace specifier. Despite this, for the most part the new notation is more concise.