### PR TITLE
Optimise ADTs' encoding

### DIFF
--- a/src/ast/transform/ADTtoRecords.h
+++ b/src/ast/transform/ADTtoRecords.h
@@ -12,7 +12,10 @@
  *
  * Defines the desugaring of ADTs to records.
  *
- * Each record has a form [branch_id, [arguments]].
+ * Each record has one of two possible forms:
+ * - [branch_id, argument]    if a branch takes a single argument.
+ * - [branch_id, [arguments]] otherwise
+ *
  * Branch ID is given by a lexicographical ordering of branches within an ADT.
  *
  ***********************************************************************/

--- a/src/include/souffle/io/ReadStream.h
+++ b/src/include/souffle/io/ReadStream.h
@@ -220,11 +220,18 @@ protected:
 
         consumeChar(source, ')', pos);
 
-        RamDomain branchValue = recordTable.pack(branchArgs.data(), branchArgs.size());
-
         if (charactersRead != nullptr) {
             *charactersRead = pos - initial_position;
         }
+
+        // Store branch either as [branch_id, [arguments]] or [branch_id, argument].
+        RamDomain branchValue = [&]() -> RamDomain {
+            if (branchArgs.size() != 1) {
+                return recordTable.pack(branchArgs.data(), branchArgs.size());
+            } else {
+                return branchArgs[0];
+            }
+        }();
 
         return recordTable.pack(toVector<RamDomain>(branchIdx, branchValue).data(), 2);
     }


### PR DESCRIPTION
### Optimise ADTs' encoding for a branch with a single argument.
Encode a branch with a single argument as `[branch_id, argument]` instead of `[branch_id, [argument]]`

After ADTs' reduction each record will have one of two possible forms:
 - `[branch_id, argument]`         if a branch takes a single argument.
 - `[branch_id, [arguments...]]` otherwise