### PR TITLE
Remove unnecessary getters from translation unit

### DIFF
--- a/src/ast/TranslationUnit.h
+++ b/src/ast/TranslationUnit.h
@@ -89,11 +89,6 @@ public:
         return errorReport;
     }
 
-    /** Return error report */
-    const ErrorReport& getErrorReport() const {
-        return errorReport;
-    }
-
     /** Destroy all cached analyses of translation unit */
     void invalidateAnalyses() {
         analyses.clear();
@@ -101,11 +96,6 @@ public:
 
     /** Return debug report */
     DebugReport& getDebugReport() {
-        return debugReport;
-    }
-
-    /** Return debug report */
-    const DebugReport& getDebugReport() const {
         return debugReport;
     }
 


### PR DESCRIPTION
Translation unit has const versions of Debug/Error report that are not used. 