### PR TITLE
Remove unused pragmas

### DIFF
--- a/src/include/souffle/CompiledOptions.h
+++ b/src/include/souffle/CompiledOptions.h
@@ -18,10 +18,10 @@
 #pragma once
 
 #include <cstdio>
+#include <cstdlib>
 #include <iostream>
 #include <string>
 #include <getopt.h>
-#include <stdlib.h>
 #include <sys/stat.h>
 
 namespace souffle {
@@ -124,19 +124,11 @@ public:
         std::string fact_dir = input_dir;
         std::string out_dir = output_dir;
 
-// avoid warning due to Solaris getopt.h
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wwrite-strings"
-#endif  // __GNUC__
         // long options
         option longOptions[] = {{"facts", true, nullptr, 'F'}, {"output", true, nullptr, 'D'},
                 {"profile", true, nullptr, 'p'}, {"jobs", true, nullptr, 'j'}, {"index", true, nullptr, 'i'},
                 // the terminal option -- needs to be null
                 {nullptr, false, nullptr, 0}};
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif  // __GNUC__
 
         // check whether all options are fine
         bool ok = true;

--- a/src/include/souffle/io/SerialisationStream.h
+++ b/src/include/souffle/io/SerialisationStream.h
@@ -18,14 +18,7 @@
 
 #include "souffle/RamTypes.h"
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4244)
-#endif  // _MSC_VER
 #include "souffle/utility/json11.h"
-#ifdef _MSC_VER
-#pragma warning(default : 4244)
-#endif  // _MSC_VER
-
 #include <cassert>
 #include <cstddef>
 #include <map>

--- a/src/include/souffle/profile/ProfileDatabase.h
+++ b/src/include/souffle/profile/ProfileDatabase.h
@@ -2,15 +2,7 @@
 
 #include "souffle/utility/ContainerUtil.h"
 #include "souffle/utility/MiscUtil.h"
-
-#ifdef _MSC_VER
-#pragma warning(disable : 4244)
-#endif  // _MSC_VER
 #include "souffle/utility/json11.h"
-#ifdef _MSC_VER
-#pragma warning(default : 4244)
-#endif  // _MSC_VER
-
 #include <cassert>
 #include <chrono>
 #include <cstddef>

--- a/src/include/souffle/utility/MiscUtil.h
+++ b/src/include/souffle/utility/MiscUtil.h
@@ -16,14 +16,7 @@
 
 #pragma once
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4127)
-#endif  // _MSC_VER
 #include "tinyformat.h"
-#ifdef _MSC_VER
-#pragma warning(default : 4127)
-#endif  // _MSC_VER
-
 #include <cassert>
 #include <chrono>
 #include <cstdlib>

--- a/src/include/souffle/utility/json11.h
+++ b/src/include/souffle/utility/json11.h
@@ -66,6 +66,7 @@
 #include <vector>
 
 #ifdef _MSC_VER
+#pragma warning(disable : 4244)
 #if _MSC_VER <= 1800  // VS 2013
 #ifndef noexcept
 #define noexcept throw()
@@ -1103,5 +1104,9 @@ inline std::vector<Json> parse_multi(const std::string& in, std::string::size_ty
     }
     return json_vec;
 }
+
+#ifdef _MSC_VER
+#pragma warning(default : 4244)
+#endif  // _MSC_VER
 
 }  // namespace json11

--- a/src/include/souffle/utility/tinyformat.h
+++ b/src/include/souffle/utility/tinyformat.h
@@ -179,6 +179,10 @@ namespace tfm = tinyformat;
 #   define TINYFORMAT_HIDDEN
 #endif
 
+#ifdef _MSC_VER
+#pragma warning(disable : 4127)
+#endif  // _MSC_VER
+
 namespace tinyformat {
 
 //------------------------------------------------------------------------------
@@ -1141,6 +1145,10 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_FUNCS)
 
 
 } // namespace tinyformat
+
+#ifdef _MSC_VER
+#pragma warning(default : 4127)
+#endif  // _MSC_VER
 
 #endif // TINYFORMAT_H_INCLUDED
 


### PR DESCRIPTION
Some old pragmas to help with different compilers are no longer relevant (and possibly never were). This PR fixes that, and also refactors some newer pragmas.