### PR TITLE
Refactor getProgram() in ast::TranslationUnit

### DIFF
--- a/src/ast/TranslationUnit.h
+++ b/src/ast/TranslationUnit.h
@@ -75,13 +75,9 @@ public:
     }
 
     /** Return the program */
-    Program* getProgram() {
-        return program.get();
-    }
-
-    /** Return the program */
-    const Program* getProgram() const {
-        return program.get();
+    Program& getProgram() const {
+        assert(program && "NULL program");
+        return *program.get();
     }
 
     /** Return error report */

--- a/src/ast/analysis/AuxArity.h
+++ b/src/ast/analysis/AuxArity.h
@@ -36,7 +36,7 @@ public:
     AuxiliaryArityAnalysis() : Analysis(name) {}
 
     void run(const TranslationUnit& translationUnit) override {
-        program = translationUnit.getProgram();
+        program = &translationUnit.getProgram();
     }
 
     /**

--- a/src/ast/analysis/ClauseNormalisation.cpp
+++ b/src/ast/analysis/ClauseNormalisation.cpp
@@ -158,7 +158,7 @@ std::string NormalisedClause::normaliseArgument(const Argument* arg) {
 }
 
 void ClauseNormalisationAnalysis::run(const TranslationUnit& translationUnit) {
-    const auto& program = *translationUnit.getProgram();
+    const auto& program = translationUnit.getProgram();
     for (const auto* clause : program.getClauses()) {
         assert(!contains(normalisations, clause) && "clause already processed");
         normalisations[clause] = NormalisedClause(clause);

--- a/src/ast/analysis/ComponentLookup.cpp
+++ b/src/ast/analysis/ComponentLookup.cpp
@@ -25,12 +25,12 @@
 namespace souffle::ast::analysis {
 
 void ComponentLookupAnalysis::run(const TranslationUnit& translationUnit) {
-    const Program* program = translationUnit.getProgram();
-    for (Component* component : program->getComponents()) {
+    Program& program = translationUnit.getProgram();
+    for (Component* component : program.getComponents()) {
         globalScopeComponents.insert(component);
         enclosingComponent[component] = nullptr;
     }
-    visitDepthFirst(*program, [&](const Component& cur) {
+    visitDepthFirst(program, [&](const Component& cur) {
         nestedComponents[&cur];
         for (Component* nestedComponent : cur.getComponents()) {
             nestedComponents[&cur].insert(nestedComponent);

--- a/src/ast/analysis/IOType.cpp
+++ b/src/ast/analysis/IOType.cpp
@@ -30,7 +30,7 @@
 namespace souffle::ast::analysis {
 
 void IOTypeAnalysis::run(const TranslationUnit& translationUnit) {
-    const Program& program = *translationUnit.getProgram();
+    const Program& program = translationUnit.getProgram();
     visitDepthFirst(program, [&](const Directive& directive) {
         auto* relation = getRelation(program, directive.getQualifiedName());
         if (relation == nullptr) {

--- a/src/ast/analysis/PrecedenceGraph.cpp
+++ b/src/ast/analysis/PrecedenceGraph.cpp
@@ -36,7 +36,7 @@ namespace souffle::ast::analysis {
 
 void PrecedenceGraphAnalysis::run(const TranslationUnit& translationUnit) {
     /* Get relations */
-    const auto& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     const auto& relationDetail = *translationUnit.getAnalysis<RelationDetailCacheAnalysis>();
 
     for (const auto* r : program.getRelations()) {

--- a/src/ast/analysis/RecursiveClauses.cpp
+++ b/src/ast/analysis/RecursiveClauses.cpp
@@ -35,7 +35,8 @@
 namespace souffle::ast::analysis {
 
 void RecursiveClausesAnalysis::run(const TranslationUnit& translationUnit) {
-    visitDepthFirst(*translationUnit.getProgram(), [&](const Clause& clause) {
+    Program& program = translationUnit.getProgram();
+    visitDepthFirst(program, [&](const Clause& clause) {
         if (computeIsRecursive(clause, translationUnit)) {
             recursiveClauses.insert(&clause);
         }
@@ -49,7 +50,7 @@ void RecursiveClausesAnalysis::print(std::ostream& os) const {
 bool RecursiveClausesAnalysis::computeIsRecursive(
         const Clause& clause, const TranslationUnit& translationUnit) const {
     const auto& relationDetail = *translationUnit.getAnalysis<RelationDetailCacheAnalysis>();
-    const Program& program = *translationUnit.getProgram();
+    const Program& program = translationUnit.getProgram();
 
     // we want to reach the atom of the head through the body
     const Relation* trg = getHeadRelation(&clause, &program);

--- a/src/ast/analysis/RedundantRelations.cpp
+++ b/src/ast/analysis/RedundantRelations.cpp
@@ -36,8 +36,9 @@ void RedundantRelationsAnalysis::run(const TranslationUnit& translationUnit) {
     std::set<const Relation*> work;
     std::set<const Relation*> notRedundant;
     auto* ioType = translationUnit.getAnalysis<IOTypeAnalysis>();
+    Program& program = translationUnit.getProgram();
 
-    const std::vector<Relation*>& relations = translationUnit.getProgram()->getRelations();
+    const std::vector<Relation*>& relations = program.getRelations();
     /* Add all output relations to the work set */
     for (const Relation* r : relations) {
         if (ioType->isOutput(r)) {

--- a/src/ast/analysis/RelationDetailCache.cpp
+++ b/src/ast/analysis/RelationDetailCache.cpp
@@ -31,7 +31,7 @@
 namespace souffle::ast::analysis {
 
 void RelationDetailCacheAnalysis::run(const TranslationUnit& translationUnit) {
-    const auto& program = *translationUnit.getProgram();
+    const auto& program = translationUnit.getProgram();
     for (auto* rel : program.getRelations()) {
         nameToRelation[rel->getQualifiedName()] = rel;
         nameToClauses[rel->getQualifiedName()] = std::set<Clause*>();

--- a/src/ast/analysis/SCCGraph.cpp
+++ b/src/ast/analysis/SCCGraph.cpp
@@ -42,7 +42,8 @@ void SCCGraphAnalysis::run(const TranslationUnit& translationUnit) {
     successors.clear();
 
     /* Compute SCC */
-    std::vector<Relation*> relations = translationUnit.getProgram()->getRelations();
+    Program& program = translationUnit.getProgram();
+    std::vector<Relation*> relations = program.getRelations();
     size_t counter = 0;
     size_t numSCCs = 0;
     std::stack<const Relation*> S;

--- a/src/ast/analysis/SumTypeBranches.cpp
+++ b/src/ast/analysis/SumTypeBranches.cpp
@@ -30,7 +30,8 @@ namespace souffle::ast::analysis {
 void SumTypeBranchesAnalysis::run(const TranslationUnit& tu) {
     const TypeEnvironment& env = tu.getAnalysis<TypeEnvironmentAnalysis>()->getTypeEnvironment();
 
-    visitDepthFirst(tu.getProgram()->getTypes(), [&](const ast::AlgebraicDataType& adt) {
+    Program& program = tu.getProgram();
+    visitDepthFirst(program.getTypes(), [&](const ast::AlgebraicDataType& adt) {
         auto typeName = adt.getQualifiedName();
         if (!env.isType(typeName)) return;
 

--- a/src/ast/analysis/Type.cpp
+++ b/src/ast/analysis/Type.cpp
@@ -564,7 +564,7 @@ public:
 private:
     const TranslationUnit& tu;
     const TypeEnvironment& typeEnv = tu.getAnalysis<TypeEnvironmentAnalysis>()->getTypeEnvironment();
-    const Program& program = *tu.getProgram();
+    const Program& program = tu.getProgram();
     const SumTypeBranchesAnalysis& sumTypesBranches = *tu.getAnalysis<SumTypeBranchesAnalysis>();
 
     // Sinks = {head} ∪ {negated atoms}
@@ -821,7 +821,8 @@ void TypeAnalysis::run(const TranslationUnit& translationUnit) {
     }
 
     // Analyse types, clause by clause.
-    for (const Clause* clause : translationUnit.getProgram()->getClauses()) {
+    const Program& program = translationUnit.getProgram();
+    for (const Clause* clause : program.getClauses()) {
         auto clauseArgumentTypes = analyseTypes(translationUnit, *clause, debugStream);
         argumentTypes.insert(clauseArgumentTypes.begin(), clauseArgumentTypes.end());
 

--- a/src/ast/analysis/TypeEnvironment.cpp
+++ b/src/ast/analysis/TypeEnvironment.cpp
@@ -112,7 +112,7 @@ std::map<QualifiedName, std::set<QualifiedName>> analysePrimitiveTypesInUnion(
 }  // namespace
 
 void TypeEnvironmentAnalysis::run(const TranslationUnit& translationUnit) {
-    const Program& program = *translationUnit.getProgram();
+    const Program& program = translationUnit.getProgram();
 
     auto rawProgramTypes = program.getTypes();
     Graph<QualifiedName> typeDependencyGraph{createTypeDependencyGraph(rawProgramTypes)};

--- a/src/ast/tests/ast_print_test.cpp
+++ b/src/ast/tests/ast_print_test.cpp
@@ -51,7 +51,7 @@ inline Own<TranslationUnit> makeATU(std::string program = ".decl A,B,C(x:number)
 
 inline Own<TranslationUnit> makePrintedATU(Own<TranslationUnit>& tu) {
     std::stringstream ss;
-    ss << *tu->getProgram();
+    ss << tu->getProgram();
     return makeATU(ss.str());
 }
 
@@ -67,9 +67,9 @@ TEST(AstPrint, NilConstant) {
     auto testArgument = mk<NilConstant>();
 
     auto tu1 = makeATU();
-    tu1->getProgram()->addClause(makeClauseA(std::move(testArgument)));
+    tu1->getProgram().addClause(makeClauseA(std::move(testArgument)));
     auto tu2 = makePrintedATU(tu1);
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 TEST(AstPrint, NumberConstant) {
@@ -78,9 +78,9 @@ TEST(AstPrint, NumberConstant) {
     EXPECT_EQ(testArgument, testArgument);
 
     auto tu1 = makeATU();
-    tu1->getProgram()->addClause(makeClauseA(std::move(testArgument)));
+    tu1->getProgram().addClause(makeClauseA(std::move(testArgument)));
     auto tu2 = makePrintedATU(tu1);
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 TEST(AstPrint, StringConstant) {
@@ -89,36 +89,36 @@ TEST(AstPrint, StringConstant) {
     auto testArgument = mk<StringConstant>("test string");
 
     auto tu1 = ParserDriver::parseTranslationUnit(".decl A,B,C(x:number)", e, d);
-    tu1->getProgram()->addClause(makeClauseA(std::move(testArgument)));
+    tu1->getProgram().addClause(makeClauseA(std::move(testArgument)));
     auto tu2 = makePrintedATU(tu1);
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 TEST(AstPrint, Variable) {
     auto testArgument = mk<Variable>("testVar");
 
     auto tu1 = makeATU();
-    tu1->getProgram()->addClause(makeClauseA(std::move(testArgument)));
+    tu1->getProgram().addClause(makeClauseA(std::move(testArgument)));
     auto tu2 = makePrintedATU(tu1);
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 TEST(AstPrint, UnnamedVariable) {
     auto testArgument = mk<UnnamedVariable>();
 
     auto tu1 = makeATU();
-    tu1->getProgram()->addClause(makeClauseA(std::move(testArgument)));
+    tu1->getProgram().addClause(makeClauseA(std::move(testArgument)));
     auto tu2 = makePrintedATU(tu1);
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 TEST(AstPrint, Counter) {
     auto testArgument = mk<Counter>();
 
     auto tu1 = makeATU();
-    tu1->getProgram()->addClause(makeClauseA(std::move(testArgument)));
+    tu1->getProgram().addClause(makeClauseA(std::move(testArgument)));
     auto tu2 = makePrintedATU(tu1);
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 TEST(AstPrint, AggregatorMin) {
@@ -132,10 +132,10 @@ TEST(AstPrint, AggregatorMin) {
     min->setBody(std::move(body));
 
     auto tu1 = makeATU();
-    auto* prog1 = tu1->getProgram();
-    prog1->addClause(makeClauseA(std::move(min)));
+    auto& prog1 = tu1->getProgram();
+    prog1.addClause(makeClauseA(std::move(min)));
     auto tu2 = makePrintedATU(tu1);
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 TEST(AstPrint, AggregatorMax) {
@@ -148,10 +148,10 @@ TEST(AstPrint, AggregatorMax) {
     max->setBody(std::move(body));
 
     auto tu1 = makeATU();
-    auto* prog1 = tu1->getProgram();
-    prog1->addClause(makeClauseA(std::move(max)));
+    auto& prog1 = tu1->getProgram();
+    prog1.addClause(makeClauseA(std::move(max)));
     auto tu2 = makePrintedATU(tu1);
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 TEST(AstPrint, AggregatorCount) {
@@ -164,10 +164,10 @@ TEST(AstPrint, AggregatorCount) {
     count->setBody(std::move(body));
 
     auto tu1 = makeATU();
-    auto* prog1 = tu1->getProgram();
-    prog1->addClause(makeClauseA(std::move(count)));
+    auto& prog1 = tu1->getProgram();
+    prog1.addClause(makeClauseA(std::move(count)));
     auto tu2 = makePrintedATU(tu1);
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 TEST(AstPrint, AggregatorSum) {
@@ -180,10 +180,10 @@ TEST(AstPrint, AggregatorSum) {
     sum->setBody(std::move(body));
 
     auto tu1 = makeATU();
-    auto* prog1 = tu1->getProgram();
-    prog1->addClause(makeClauseA(std::move(sum)));
+    auto& prog1 = tu1->getProgram();
+    prog1.addClause(makeClauseA(std::move(sum)));
     auto tu2 = makePrintedATU(tu1);
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 }  // namespace souffle::ast::test

--- a/src/ast/tests/ast_program_test.cpp
+++ b/src/ast/tests/ast_program_test.cpp
@@ -61,8 +61,8 @@ TEST(Program, Parse) {
     // check the empty program
     Own<TranslationUnit> empty = ParserDriver::parseTranslationUnit("", e, d);
 
-    EXPECT_TRUE(empty->getProgram()->getTypes().empty());
-    EXPECT_TRUE(empty->getProgram()->getRelations().empty());
+    EXPECT_TRUE(empty->getProgram().getTypes().empty());
+    EXPECT_TRUE(empty->getProgram().getRelations().empty());
 
     // check something simple
     Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
@@ -76,15 +76,15 @@ TEST(Program, Parse) {
             )",
             e, d);
 
-    auto* prog = tu->getProgram();
-    std::cout << *prog << "\n";
+    auto& prog = tu->getProgram();
+    std::cout << prog << "\n";
 
-    EXPECT_EQ(1, prog->getTypes().size());
-    EXPECT_EQ(2, prog->getRelations().size());
+    EXPECT_EQ(1, prog.getTypes().size());
+    EXPECT_EQ(2, prog.getRelations().size());
 
-    EXPECT_TRUE(getRelation(*prog, "e"));
-    EXPECT_TRUE(getRelation(*prog, "r"));
-    EXPECT_FALSE(getRelation(*prog, "n"));
+    EXPECT_TRUE(getRelation(prog, "e"));
+    EXPECT_TRUE(getRelation(prog, "r"));
+    EXPECT_FALSE(getRelation(prog, "n"));
 }
 
 #define TESTASTCLONEANDEQUAL(SUBTYPE, DL)                                       \
@@ -92,7 +92,7 @@ TEST(Program, Parse) {
         ErrorReport e;                                                          \
         DebugReport d;                                                          \
         Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(DL, e, d); \
-        Program& program = *tu->getProgram();                                   \
+        Program& program = tu->getProgram();                                    \
         EXPECT_EQ(program, program);                                            \
         Own<Program> clone(program.clone());                                    \
         EXPECT_NE(clone.get(), &program);                                       \
@@ -206,27 +206,27 @@ TEST(Program, RemoveClause) {
     auto tu1 = makeATU(".decl A,B(x:number) \n A(sum x : B(x)).");
     auto clause = makeClause("A", std::move(sum));
 
-    tu1->getProgram()->removeClause(clause.get());
+    tu1->getProgram().removeClause(clause.get());
     auto tu2 = makeATU(".decl A,B(x:number)");
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 TEST(Program, AppendRelation) {
     auto tu1 = makeATU(".decl A,B,C(x:number)");
-    auto* prog1 = tu1->getProgram();
+    auto& prog1 = tu1->getProgram();
     auto rel = mk<Relation>();
     rel->setQualifiedName("D");
     rel->addAttribute(mk<Attribute>("x", "number"));
-    prog1->addRelation(std::move(rel));
+    prog1.addRelation(std::move(rel));
     auto tu2 = makeATU(".decl A,B,C,D(x:number)");
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 TEST(Program, RemoveRelation) {
     auto tu1 = makeATU(".decl A,B,C(x:number)");
     removeRelation(*tu1, "B");
     auto tu2 = makeATU(".decl A,C(x:number)");
-    EXPECT_EQ(*tu1->getProgram(), *tu2->getProgram());
+    EXPECT_EQ(tu1->getProgram(), tu2->getProgram());
 }
 
 }  // namespace souffle::ast::test

--- a/src/ast/tests/ast_transformers_test.cpp
+++ b/src/ast/tests/ast_transformers_test.cpp
@@ -56,7 +56,7 @@ TEST(Transformers, GroundTermPropagation) {
             )",
             errorReport, debugReport);
 
-    Program& program = *tu->getProgram();
+    Program& program = tu->getProgram();
 
     // check types in clauses
     Clause* a = getClauses(program, "p")[0];
@@ -87,7 +87,7 @@ TEST(Transformers, GroundTermPropagation2) {
            )",
             errorReport, debugReport);
 
-    Program& program = *tu->getProgram();
+    Program& program = tu->getProgram();
 
     // check types in clauses
     Clause* a = getClauses(program, "p")[0];
@@ -114,7 +114,7 @@ TEST(Transformers, ResolveGroundedAliases) {
             )",
             errorReport, debugReport);
 
-    Program& program = *tu->getProgram();
+    Program& program = tu->getProgram();
 
     EXPECT_EQ("p(a,b) :- \n   p(x,y),\n   r = [x,y],\n   s = r,\n   s = [w,v],\n   [w,v] = [a,b].",
             toString(*getClauses(program, "p")[0]));
@@ -137,7 +137,7 @@ TEST(Transformers, ResolveAliasesWithTermsInAtoms) {
             )",
             errorReport, debugReport);
 
-    Program& program = *tu->getProgram();
+    Program& program = tu->getProgram();
 
     EXPECT_EQ("p(x,c) :- \n   p(x,b),\n   p(b,c),\n   c = (b+1),\n   x = (c+2).",
             toString(*getClauses(program, "p")[0]));
@@ -183,7 +183,7 @@ TEST(Transformers, RemoveRelationCopies) {
             )",
             errorReport, debugReport);
 
-    Program& program = *tu->getProgram();
+    Program& program = tu->getProgram();
 
     EXPECT_EQ(4, program.getRelations().size());
 
@@ -229,7 +229,7 @@ TEST(Transformers, RemoveRelationCopiesOutput) {
             )",
             errorReport, debugReport);
 
-    Program& program = *tu->getProgram();
+    Program& program = tu->getProgram();
 
     EXPECT_EQ(4, program.getRelations().size());
 
@@ -263,7 +263,7 @@ TEST(Transformers, CheckClausalEquivalence) {
             )",
             errorReport, debugReport);
 
-    const auto& program = *tu->getProgram();
+    const auto& program = tu->getProgram();
 
     // Resolve aliases to remove trivial equalities
     mk<ResolveAliasesTransformer>()->apply(*tu);
@@ -363,7 +363,7 @@ TEST(Transformers, CheckAggregatorEquivalence) {
             )",
             errorReport, debugReport);
 
-    const auto& program = *tu->getProgram();
+    const auto& program = tu->getProgram();
     mk<MinimiseProgramTransformer>()->apply(*tu);
 
     // A, B, C, D should still be the relations
@@ -417,7 +417,7 @@ TEST(Transformers, RemoveClauseRedundancies) {
             )",
             errorReport, debugReport);
 
-    const auto& program = *tu->getProgram();
+    const auto& program = tu->getProgram();
 
     // Invoking the `RemoveRelationCopiesTransformer` to create some extra redundancy
     // In particular: The relation `c` will be replaced with `b` throughout, creating
@@ -491,7 +491,7 @@ TEST(Transformers, MagicSetComprehensive) {
             )",
             e, d);
 
-    auto& program = *tu->getProgram();
+    auto& program = tu->getProgram();
 
     // Test helpers
     auto mappifyRelations = [&](const Program& program) {

--- a/src/ast/tests/ast_utils_test.cpp
+++ b/src/ast/tests/ast_utils_test.cpp
@@ -86,7 +86,7 @@ TEST(AstUtils, Grounded) {
     TranslationUnit tu{std::move(program), errReport, dbgReport};
 
     // obtain groundness
-    auto isGrounded = analysis::getGroundedTerms(tu, *tu.getProgram()->getClauses()[0]);
+    auto isGrounded = analysis::getGroundedTerms(tu, *tu.getProgram().getClauses()[0]);
 
     auto args = head->getArguments();
     // check selected sub-terms
@@ -111,7 +111,7 @@ TEST(AstUtils, GroundedRecords) {
             )",
             e, d);
 
-    Program& program = *tu->getProgram();
+    Program& program = tu->getProgram();
 
     Clause* clause = getClauses(program, "s")[0];
 
@@ -144,7 +144,7 @@ TEST(AstUtils, ReorderClauseAtoms) {
             )",
             e, d);
 
-    Program& program = *tu->getProgram();
+    Program& program = tu->getProgram();
     EXPECT_EQ(5, program.getRelations().size());
 
     Relation* a = getRelation(program, "a");

--- a/src/ast/transform/ADTtoRecords.cpp
+++ b/src/ast/transform/ADTtoRecords.cpp
@@ -97,7 +97,7 @@ bool ADTtoRecordsTransformer::transform(TranslationUnit& tu) {
     };
 
     ADTsFuneral mapper(tu);
-    tu.getProgram()->apply(mapper);
+    tu.getProgram().apply(mapper);
     return mapper.changed;
 }
 

--- a/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
+++ b/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
@@ -33,7 +33,7 @@ namespace souffle::ast::transform {
 
 bool AddNullariesToAtomlessAggregatesTransformer::transform(TranslationUnit& translationUnit) {
     bool changed{false};
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     visitDepthFirst(program, [&](const Aggregator& agg) {
         bool seenAtom{false};
         for (const auto& literal : agg.getBodyLiterals()) {

--- a/src/ast/transform/ComponentChecker.cpp
+++ b/src/ast/transform/ComponentChecker.cpp
@@ -39,7 +39,7 @@ namespace souffle::ast::transform {
 using namespace analysis;
 
 bool ComponentChecker::transform(TranslationUnit& translationUnit) {
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     ComponentLookupAnalysis& componentLookup = *translationUnit.getAnalysis<ComponentLookupAnalysis>();
     ErrorReport& report = translationUnit.getErrorReport();
     checkComponents(report, program, componentLookup);

--- a/src/ast/transform/ComponentInstantiation.cpp
+++ b/src/ast/transform/ComponentInstantiation.cpp
@@ -433,7 +433,7 @@ ComponentContent getInstantiatedContent(Program& program, const ComponentInit& c
 bool ComponentInstantiationTransformer::transform(TranslationUnit& translationUnit) {
     // TODO: Do this without being a friend class of Program
 
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     auto* componentLookup = translationUnit.getAnalysis<ComponentLookupAnalysis>();
 

--- a/src/ast/transform/DebugReporter.cpp
+++ b/src/ast/transform/DebugReporter.cpp
@@ -25,7 +25,7 @@ namespace souffle::ast::transform {
 
 bool DebugReporter::transform(TranslationUnit& translationUnit) {
     translationUnit.getDebugReport().startSection();
-    auto datalogSpecOriginal = pprint(*translationUnit.getProgram());
+    auto datalogSpecOriginal = pprint(translationUnit.getProgram());
     auto start = std::chrono::high_resolution_clock::now();
     bool changed = applySubtransformer(translationUnit, wrappedTransformer.get());
     auto end = std::chrono::high_resolution_clock::now();
@@ -42,7 +42,7 @@ bool DebugReporter::transform(TranslationUnit& translationUnit) {
 
 void DebugReporter::generateDebugReport(TranslationUnit& tu, const std::string& preTransformDatalog) {
     tu.getDebugReport().addCodeSection(
-            "dl", "Datalog", "souffle", preTransformDatalog, pprint(*tu.getProgram()));
+            "dl", "Datalog", "souffle", preTransformDatalog, pprint(tu.getProgram()));
 }
 
 }  // namespace souffle::ast::transform

--- a/src/ast/transform/ExecutionPlanChecker.cpp
+++ b/src/ast/transform/ExecutionPlanChecker.cpp
@@ -38,10 +38,11 @@ bool ExecutionPlanChecker::transform(TranslationUnit& translationUnit) {
     auto* recursiveClauses = translationUnit.getAnalysis<analysis::RecursiveClausesAnalysis>();
     auto&& report = translationUnit.getErrorReport();
 
+    Program& program = translationUnit.getProgram();
     for (const analysis::RelationScheduleAnalysisStep& step : relationSchedule->schedule()) {
         const std::set<const Relation*>& scc = step.computed();
         for (const Relation* rel : scc) {
-            for (const Clause* clause : getClauses(*translationUnit.getProgram(), *rel)) {
+            for (const Clause* clause : getClauses(program, *rel)) {
                 if (!recursiveClauses->recursive(clause)) {
                     continue;
                 }
@@ -50,7 +51,7 @@ bool ExecutionPlanChecker::transform(TranslationUnit& translationUnit) {
                 }
                 int version = 0;
                 for (const auto* atom : getBodyLiterals<Atom>(*clause)) {
-                    if (scc.count(getAtomRelation(atom, translationUnit.getProgram())) != 0u) {
+                    if (scc.count(getAtomRelation(atom, &program)) != 0u) {
                         version++;
                     }
                 }

--- a/src/ast/transform/FoldAnonymousRecords.cpp
+++ b/src/ast/transform/FoldAnonymousRecords.cpp
@@ -159,7 +159,7 @@ void FoldAnonymousRecords::transformClause(const Clause& clause, VecOwn<Clause>&
 
 bool FoldAnonymousRecords::transform(TranslationUnit& translationUnit) {
     bool changed = false;
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     VecOwn<Clause> newClauses;
 

--- a/src/ast/transform/GroundedTermsChecker.cpp
+++ b/src/ast/transform/GroundedTermsChecker.cpp
@@ -33,7 +33,7 @@
 namespace souffle::ast::transform {
 
 void GroundedTermsChecker::verify(TranslationUnit& translationUnit) {
-    auto&& program = *translationUnit.getProgram();
+    auto&& program = translationUnit.getProgram();
     auto&& report = translationUnit.getErrorReport();
 
     // -- check grounded variables and records --

--- a/src/ast/transform/IOAttributes.h
+++ b/src/ast/transform/IOAttributes.h
@@ -73,14 +73,14 @@ private:
 
     bool setAttributeParams(TranslationUnit& translationUnit) {
         bool changed = false;
-        Program* program = translationUnit.getProgram();
+        Program& program = translationUnit.getProgram();
         auto auxArityAnalysis = translationUnit.getAnalysis<analysis::AuxiliaryArityAnalysis>();
 
-        for (Directive* io : program->getDirectives()) {
+        for (Directive* io : program.getDirectives()) {
             if (io->getType() == ast::DirectiveType::limitsize) {
                 continue;
             }
-            Relation* rel = getRelation(*translationUnit.getProgram(), io->getQualifiedName());
+            Relation* rel = getRelation(program, io->getQualifiedName());
             // Prepare type system information.
             std::vector<std::string> attributesParams;
 
@@ -106,15 +106,15 @@ private:
 
     bool setAttributeNames(TranslationUnit& translationUnit) {
         bool changed = false;
-        Program* program = translationUnit.getProgram();
-        for (Directive* io : program->getDirectives()) {
+        Program& program = translationUnit.getProgram();
+        for (Directive* io : program.getDirectives()) {
             if (io->getType() == ast::DirectiveType::limitsize) {
                 continue;
             }
             if (io->hasDirective("attributeNames")) {
                 continue;
             }
-            Relation* rel = getRelation(*translationUnit.getProgram(), io->getQualifiedName());
+            Relation* rel = getRelation(program, io->getQualifiedName());
             std::string delimiter("\t");
             if (io->hasDirective("delimiter")) {
                 delimiter = io->getDirective("delimiter");
@@ -140,13 +140,13 @@ private:
 
     bool setAttributeTypes(TranslationUnit& translationUnit) {
         bool changed = false;
-        Program* program = translationUnit.getProgram();
+        Program& program = translationUnit.getProgram();
         auto auxArityAnalysis = translationUnit.getAnalysis<analysis::AuxiliaryArityAnalysis>();
         auto typeEnv =
                 &translationUnit.getAnalysis<analysis::TypeEnvironmentAnalysis>()->getTypeEnvironment();
 
-        for (Directive* io : program->getDirectives()) {
-            Relation* rel = getRelation(*translationUnit.getProgram(), io->getQualifiedName());
+        for (Directive* io : program.getDirectives()) {
+            Relation* rel = getRelation(program, io->getQualifiedName());
             // Prepare type system information.
             std::vector<std::string> attributesTypes;
 
@@ -193,7 +193,7 @@ private:
             return sumTypesInfo;
         }
 
-        Program& program = *translationUnit.getProgram();
+        Program& program = translationUnit.getProgram();
         auto& typeEnv =
                 translationUnit.getAnalysis<analysis::TypeEnvironmentAnalysis>()->getTypeEnvironment();
 
@@ -235,14 +235,14 @@ private:
             return ramRecordTypes;
         }
 
-        Program* program = translationUnit.getProgram();
+        Program& program = translationUnit.getProgram();
         auto typeEnv =
                 &translationUnit.getAnalysis<analysis::TypeEnvironmentAnalysis>()->getTypeEnvironment();
         std::vector<std::string> elementTypes;
         std::map<std::string, json11::Json> records;
 
         // Iterate over all record types in the program populating the records map.
-        for (auto* astType : program->getTypes()) {
+        for (auto* astType : program.getTypes()) {
             const auto& type = typeEnv->getType(*astType);
             if (isA<analysis::RecordType>(type)) {
                 elementTypes.clear();
@@ -268,12 +268,12 @@ private:
             return ramRecordParams;
         }
 
-        Program* program = translationUnit.getProgram();
+        Program& program = translationUnit.getProgram();
         std::vector<std::string> elementParams;
         std::map<std::string, json11::Json> records;
 
         // Iterate over all record types in the program populating the records map.
-        for (auto* astType : program->getTypes()) {
+        for (auto* astType : program.getTypes()) {
             if (isA<ast::RecordType>(astType)) {
                 elementParams.clear();
 

--- a/src/ast/transform/IODefaults.h
+++ b/src/ast/transform/IODefaults.h
@@ -67,8 +67,8 @@ private:
      */
     bool setDefaults(TranslationUnit& translationUnit) {
         bool changed = false;
-        Program* program = translationUnit.getProgram();
-        for (Directive* io : program->getDirectives()) {
+        Program& program = translationUnit.getProgram();
+        for (Directive* io : program.getDirectives()) {
             // Don't do anything for a directive which
             // is not an I/O directive
             if (io->getType() == ast::DirectiveType::limitsize) continue;

--- a/src/ast/transform/InlineRelations.cpp
+++ b/src/ast/transform/InlineRelations.cpp
@@ -991,7 +991,7 @@ std::vector<Clause*> getInlinedClause(Program& program, const Clause& clause) {
 
 bool InlineRelationsTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     // Replace constants in the head of inlined clauses with (constrained) variables.
     // This is done to simplify atom unification, particularly when negations are involved.

--- a/src/ast/transform/MagicSet.cpp
+++ b/src/ast/transform/MagicSet.cpp
@@ -60,7 +60,7 @@ typedef MagicSetTransformer::LabelDatabaseTransformer::PositiveLabellingTransfor
         PositiveLabellingTransformer;
 
 std::set<QualifiedName> MagicSetTransformer::getIgnoredRelations(const TranslationUnit& tu) {
-    const auto& program = *tu.getProgram();
+    Program& program = tu.getProgram();
     const auto& ioTypes = *tu.getAnalysis<analysis::IOTypeAnalysis>();
 
     std::set<QualifiedName> relationsToIgnore;
@@ -168,7 +168,7 @@ std::set<QualifiedName> MagicSetTransformer::getIgnoredRelations(const Translati
 }
 
 bool MagicSetTransformer::shouldRun(const TranslationUnit& tu) {
-    const auto& program = *tu.getProgram();
+    const Program& program = tu.getProgram();
     if (Global::config().has("magic-transform")) return true;
     for (const auto* rel : program.getRelations()) {
         if (rel->hasQualifier(RelationQualifier::MAGIC)) return true;
@@ -199,7 +199,7 @@ bool NormaliseDatabaseTransformer::transform(TranslationUnit& translationUnit) {
 }
 
 bool NormaliseDatabaseTransformer::partitionIO(TranslationUnit& translationUnit) {
-    auto& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
 
     // Get all relations that are both input and output
@@ -267,7 +267,7 @@ bool NormaliseDatabaseTransformer::partitionIO(TranslationUnit& translationUnit)
 }
 
 bool NormaliseDatabaseTransformer::extractIDB(TranslationUnit& translationUnit) {
-    auto& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
 
     // Helper method to check if an input relation has no associated rules
@@ -330,7 +330,7 @@ bool NormaliseDatabaseTransformer::extractIDB(TranslationUnit& translationUnit) 
 }
 
 bool NormaliseDatabaseTransformer::querifyOutputRelations(TranslationUnit& translationUnit) {
-    auto& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     // Helper method to check if a relation is a single-rule output query
     auto isStrictlyOutput = [&](const Relation* rel) {
@@ -404,7 +404,7 @@ bool NormaliseDatabaseTransformer::querifyOutputRelations(TranslationUnit& trans
 }
 
 bool NormaliseDatabaseTransformer::normaliseArguments(TranslationUnit& translationUnit) {
-    auto& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     // Replace all non-variable-arguments nested inside the node with named variables
     // Also, keeps track of constraints to add to keep the clause semantically equivalent
@@ -616,7 +616,7 @@ Own<Clause> AdornDatabaseTransformer::adornClause(const Clause* clause, const st
 }
 
 bool AdornDatabaseTransformer::transform(TranslationUnit& translationUnit) {
-    auto& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
 
     relationsToIgnore = getIgnoredRelations(translationUnit);
@@ -689,7 +689,7 @@ bool LabelDatabaseTransformer::isNegativelyLabelled(const QualifiedName& name) {
 
 bool NegativeLabellingTransformer::transform(TranslationUnit& translationUnit) {
     const auto& sccGraph = *translationUnit.getAnalysis<analysis::SCCGraphAnalysis>();
-    auto& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     std::set<QualifiedName> relationsToLabel;
     std::set<Own<Clause>> clausesToAdd;
@@ -754,7 +754,7 @@ bool NegativeLabellingTransformer::transform(TranslationUnit& translationUnit) {
 }
 
 bool PositiveLabellingTransformer::transform(TranslationUnit& translationUnit) {
-    auto& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     const auto& sccGraph = *translationUnit.getAnalysis<analysis::SCCGraphAnalysis>();
     const auto& precedenceGraph = translationUnit.getAnalysis<analysis::PrecedenceGraphAnalysis>()->graph();
     auto ignoredRelations = getIgnoredRelations(translationUnit);
@@ -1036,7 +1036,7 @@ std::vector<const BinaryConstraint*> MagicSetCoreTransformer::getBindingEquality
 }
 
 bool MagicSetCoreTransformer::transform(TranslationUnit& translationUnit) {
-    auto& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     std::set<Own<Clause>> clausesToRemove;
     std::set<Own<Clause>> clausesToAdd;
 

--- a/src/ast/transform/MaterializeAggregationQueries.cpp
+++ b/src/ast/transform/MaterializeAggregationQueries.cpp
@@ -49,7 +49,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
         TranslationUnit& translationUnit) {
     bool changed = false;
 
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     // if an aggregator has a body consisting of more than an atom => create new relation
     int counter = 0;

--- a/src/ast/transform/MaterializeSingletonAggregation.cpp
+++ b/src/ast/transform/MaterializeSingletonAggregation.cpp
@@ -63,7 +63,7 @@ std::string MaterializeSingletonAggregationTransformer::findUniqueAggregateRelat
 }
 
 bool MaterializeSingletonAggregationTransformer::transform(TranslationUnit& translationUnit) {
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     std::set<std::pair<Aggregator*, Clause*>> pairs;
     // collect references to clause / aggregate pairs
     visitDepthFirst(program, [&](const Clause& clause) {

--- a/src/ast/transform/MinimiseProgram.cpp
+++ b/src/ast/transform/MinimiseProgram.cpp
@@ -235,7 +235,7 @@ bool MinimiseProgramTransformer::areBijectivelyEquivalent(
 }
 
 bool MinimiseProgramTransformer::reduceLocallyEquivalentClauses(TranslationUnit& translationUnit) {
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     const auto& normalisations = *translationUnit.getAnalysis<analysis::ClauseNormalisationAnalysis>();
 
     std::vector<Clause*> clausesToDelete;
@@ -280,7 +280,7 @@ bool MinimiseProgramTransformer::reduceLocallyEquivalentClauses(TranslationUnit&
 bool MinimiseProgramTransformer::reduceSingletonRelations(TranslationUnit& translationUnit) {
     // Note: This reduction is particularly useful in conjunction with the
     // body-partitioning transformation
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     const auto& ioTypes = *translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
     const auto& normalisations = *translationUnit.getAnalysis<analysis::ClauseNormalisationAnalysis>();
 
@@ -361,7 +361,7 @@ bool MinimiseProgramTransformer::reduceSingletonRelations(TranslationUnit& trans
 }
 
 bool MinimiseProgramTransformer::removeRedundantClauses(TranslationUnit& translationUnit) {
-    auto& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     auto isRedundant = [&](const Clause* clause) {
         const auto* head = clause->getHead();
         for (const auto* lit : clause->getBodyLiterals()) {
@@ -386,7 +386,7 @@ bool MinimiseProgramTransformer::removeRedundantClauses(TranslationUnit& transla
 }
 
 bool MinimiseProgramTransformer::reduceClauseBodies(TranslationUnit& translationUnit) {
-    auto& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     std::set<Own<Clause>> clausesToAdd;
     std::set<Own<Clause>> clausesToRemove;
 

--- a/src/ast/transform/NameUnnamedVariables.cpp
+++ b/src/ast/transform/NameUnnamedVariables.cpp
@@ -50,7 +50,7 @@ bool NameUnnamedVariablesTransformer::transform(TranslationUnit& translationUnit
         }
     };
 
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     for (Relation* rel : program.getRelations()) {
         for (Clause* clause : getClauses(program, *rel)) {
             nameVariables update;

--- a/src/ast/transform/NormaliseConstraints.cpp
+++ b/src/ast/transform/NormaliseConstraints.cpp
@@ -45,7 +45,7 @@ bool NormaliseConstraintsTransformer::transform(TranslationUnit& translationUnit
     // prepended by + to avoid conflict with user-defined variables
     static constexpr const char* boundPrefix = "+abdul";
 
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     /* Create a node mapper that recursively replaces all constants and underscores
      * with named variables.

--- a/src/ast/transform/PartitionBodyLiterals.cpp
+++ b/src/ast/transform/PartitionBodyLiterals.cpp
@@ -36,7 +36,7 @@ namespace souffle::ast::transform {
 
 bool PartitionBodyLiteralsTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     /* Process:
      * Go through each clause and construct a variable dependency graph G.

--- a/src/ast/transform/PolymorphicObjects.cpp
+++ b/src/ast/transform/PolymorphicObjects.cpp
@@ -149,7 +149,7 @@ bool PolymorphicObjectsTransformer::transform(TranslationUnit& translationUnit) 
     };
     const TypeAnalysis& typeAnalysis = *translationUnit.getAnalysis<analysis::TypeAnalysis>();
     TypeRewriter update(typeAnalysis, translationUnit.getErrorReport());
-    translationUnit.getProgram()->apply(update);
+    translationUnit.getProgram().apply(update);
     return update.changed;
 }
 

--- a/src/ast/transform/PragmaChecker.cpp
+++ b/src/ast/transform/PragmaChecker.cpp
@@ -26,10 +26,10 @@
 namespace souffle::ast::transform {
 bool PragmaChecker::transform(TranslationUnit& translationUnit) {
     bool changed = false;
-    Program* program = translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     // Take in pragma options from the datalog file
-    visitDepthFirst(*program, [&](const Pragma& pragma) {
+    visitDepthFirst(program, [&](const Pragma& pragma) {
         std::pair<std::string, std::string> kvp = pragma.getkvp();
 
         // Command line options take precedence

--- a/src/ast/transform/ReduceExistentials.cpp
+++ b/src/ast/transform/ReduceExistentials.cpp
@@ -42,7 +42,7 @@
 namespace souffle::ast::transform {
 
 bool ReduceExistentialsTransformer::transform(TranslationUnit& translationUnit) {
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     // Checks whether an atom is of the form a(_,_,...,_)
     auto isExistentialAtom = [&](const Atom& atom) {

--- a/src/ast/transform/RemoveBooleanConstraints.cpp
+++ b/src/ast/transform/RemoveBooleanConstraints.cpp
@@ -36,7 +36,7 @@
 namespace souffle::ast::transform {
 
 bool RemoveBooleanConstraintsTransformer::transform(TranslationUnit& translationUnit) {
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     // If any boolean constraints exist, they will be removed
     bool changed = false;

--- a/src/ast/transform/RemoveEmptyRelations.cpp
+++ b/src/ast/transform/RemoveEmptyRelations.cpp
@@ -34,7 +34,7 @@
 namespace souffle::ast::transform {
 
 bool RemoveEmptyRelationsTransformer::removeEmptyRelations(TranslationUnit& translationUnit) {
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     auto* ioTypes = translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
     std::set<QualifiedName> emptyRelations;
     bool changed = false;
@@ -70,7 +70,7 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelations(TranslationUnit& tran
 
 bool RemoveEmptyRelationsTransformer::removeEmptyRelationUses(
         TranslationUnit& translationUnit, const QualifiedName& emptyRelationName) {
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
     bool changed = false;
 
     //

--- a/src/ast/transform/RemoveRedundantSums.cpp
+++ b/src/ast/transform/RemoveRedundantSums.cpp
@@ -68,7 +68,8 @@ bool RemoveRedundantSumsTransformer::transform(TranslationUnit& translationUnit)
     };
 
     ReplaceSumWithCount update;
-    translationUnit.getProgram()->apply(update);
+    Program& program = translationUnit.getProgram();
+    program.apply(update);
     return update.changed;
 }
 

--- a/src/ast/transform/RemoveRelationCopies.cpp
+++ b/src/ast/transform/RemoveRelationCopies.cpp
@@ -43,7 +43,7 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(TranslationUnit& tran
 
     auto* ioType = translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
 
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     // search for relations only defined by a single rule ..
     for (Relation* rel : program.getRelations()) {

--- a/src/ast/transform/RemoveTypecasts.cpp
+++ b/src/ast/transform/RemoveTypecasts.cpp
@@ -44,7 +44,8 @@ bool RemoveTypecastsTransformer::transform(TranslationUnit& translationUnit) {
     };
 
     TypecastRemover update;
-    translationUnit.getProgram()->apply(update);
+    Program& program = translationUnit.getProgram();
+    program.apply(update);
 
     return update.changed;
 }

--- a/src/ast/transform/ReorderLiterals.cpp
+++ b/src/ast/transform/ReorderLiterals.cpp
@@ -82,7 +82,7 @@ Clause* ReorderLiteralsTransformer::reorderClauseWithSips(const SipsMetric& sips
 
 bool ReorderLiteralsTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     // --- SIPS-based static reordering ---
     // ordering is based on the given SIPS

--- a/src/ast/transform/ReplaceSingletonVariables.cpp
+++ b/src/ast/transform/ReplaceSingletonVariables.cpp
@@ -34,7 +34,7 @@ namespace souffle::ast::transform {
 bool ReplaceSingletonVariablesTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
 
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     // Node-mapper to replace a set of singletons with unnamed variables
     struct replaceSingletons : public NodeMapper {

--- a/src/ast/transform/ResolveAliases.cpp
+++ b/src/ast/transform/ResolveAliases.cpp
@@ -458,7 +458,7 @@ Own<Clause> ResolveAliasesTransformer::removeComplexTermsInAtoms(const Clause& c
 
 bool ResolveAliasesTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
-    Program& program = *translationUnit.getProgram();
+    Program& program = translationUnit.getProgram();
 
     // get all clauses
     std::vector<const Clause*> clauses;

--- a/src/ast/transform/ResolveAnonymousRecordAliases.cpp
+++ b/src/ast/transform/ResolveAnonymousRecordAliases.cpp
@@ -156,7 +156,8 @@ bool ResolveAnonymousRecordAliasesTransformer::replaceUnnamedVariable(Clause& cl
 
 bool ResolveAnonymousRecordAliasesTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
-    for (auto* clause : translationUnit.getProgram()->getClauses()) {
+    Program& program = translationUnit.getProgram();
+    for (auto* clause : program.getClauses()) {
         changed |= replaceNamedVariables(translationUnit, *clause);
         changed |= replaceUnnamedVariable(*clause);
     }

--- a/src/ast/transform/SemanticChecker.cpp
+++ b/src/ast/transform/SemanticChecker.cpp
@@ -109,7 +109,7 @@ private:
     const SumTypeBranchesAnalysis& sumTypesBranches = *tu.getAnalysis<SumTypeBranchesAnalysis>();
 
     const TypeEnvironment& typeEnv = typeEnvAnalysis.getTypeEnvironment();
-    const Program& program = *tu.getProgram();
+    const Program& program = tu.getProgram();
     ErrorReport& report = tu.getErrorReport();
 
     void checkAtom(const Atom& atom);
@@ -150,7 +150,8 @@ public:
 
     /** Analyse types, clause by clause */
     void run() {
-        for (auto* clause : tu.getProgram()->getClauses()) {
+        const Program& program = tu.getProgram();
+        for (auto* clause : program.getClauses()) {
             visitDepthFirstPreOrder(*clause, *this);
         }
     }
@@ -160,7 +161,7 @@ private:
     ErrorReport& report = tu.getErrorReport();
     const TypeAnalysis& typeAnalysis = *tu.getAnalysis<TypeAnalysis>();
     const TypeEnvironment& typeEnv = tu.getAnalysis<TypeEnvironmentAnalysis>()->getTypeEnvironment();
-    const Program& program = *tu.getProgram();
+    const Program& program = tu.getProgram();
 
     void visitAtom(const Atom& atom) override;
     void visitVariable(const ast::Variable& var) override;
@@ -402,7 +403,7 @@ bool SemanticCheckerImpl::isDependent(const Clause& agg1, const Clause& agg2) {
 
 void SemanticCheckerImpl::checkAggregator(const Aggregator& aggregator) {
     auto& report = tu.getErrorReport();
-    auto& program = *tu.getProgram();
+    const Program& program = tu.getProgram();
     Clause dummyClauseAggregator;
 
     visitDepthFirst(program, [&](const Literal& parentLiteral) {

--- a/src/ast/transform/UniqueAggregationVariables.cpp
+++ b/src/ast/transform/UniqueAggregationVariables.cpp
@@ -30,7 +30,8 @@ bool UniqueAggregationVariablesTransformer::transform(TranslationUnit& translati
 
     // make variables in aggregates unique
     int aggNumber = 0;
-    visitDepthFirstPostOrder(*translationUnit.getProgram(), [&](const Aggregator& agg) {
+    Program& program = translationUnit.getProgram();
+    visitDepthFirstPostOrder(program, [&](const Aggregator& agg) {
         // only applicable for aggregates with target expression
         if (agg.getTargetExpression() == nullptr) {
             return;

--- a/src/ast/transform/UserDefinedFunctors.cpp
+++ b/src/ast/transform/UserDefinedFunctors.cpp
@@ -65,8 +65,9 @@ bool UserDefinedFunctorsTransformer::transform(TranslationUnit& translationUnit)
             return node;
         }
     };
-    UserFunctorRewriter update(*translationUnit.getProgram(), translationUnit.getErrorReport());
-    translationUnit.getProgram()->apply(update);
+    Program& program = translationUnit.getProgram();
+    UserFunctorRewriter update(program, translationUnit.getErrorReport());
+    program.apply(update);
     return update.changed;
 }
 

--- a/src/ast/utility/Utils.cpp
+++ b/src/ast/utility/Utils.cpp
@@ -96,22 +96,24 @@ Relation* getRelation(const Program& program, const QualifiedName& name) {
 }
 
 void removeRelation(TranslationUnit& tu, const QualifiedName& name) {
-    if (getRelation(*tu.getProgram(), name) != nullptr) {
+    Program& program = tu.getProgram();
+    if (getRelation(program, name) != nullptr) {
         removeRelationClauses(tu, name);
         removeRelationIOs(tu, name);
-        tu.getProgram()->removeRelationDecl(name);
+        program.removeRelationDecl(name);
     }
 }
 
 void removeRelationClauses(TranslationUnit& tu, const QualifiedName& name) {
+    Program& program = tu.getProgram();
     const auto& relDetail = *tu.getAnalysis<analysis::RelationDetailCacheAnalysis>();
     for (const auto* clause : relDetail.getClauses(name)) {
-        tu.getProgram()->removeClause(clause);
+        program.removeClause(clause);
     }
 }
 
 void removeRelationIOs(TranslationUnit& tu, const QualifiedName& name) {
-    auto& program = *tu.getProgram();
+    Program& program = tu.getProgram();
     for (const auto* directive : getDirectives(program, name)) {
         program.removeDirective(directive);
     }

--- a/src/ast2ram/AstToRamTranslator.cpp
+++ b/src/ast2ram/AstToRamTranslator.cpp
@@ -1670,7 +1670,7 @@ void AstToRamTranslator::translateProgram(const ast::TranslationUnit& translatio
 
 Own<ram::TranslationUnit> AstToRamTranslator::translateUnit(ast::TranslationUnit& tu) {
     auto ram_start = std::chrono::high_resolution_clock::now();
-    program = tu.getProgram();
+    program = &tu.getProgram();
 
     translateProgram(tu);
     SymbolTable& symTab = getSymbolTable();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -556,7 +556,7 @@ int main(int argc, char** argv) {
     if (Global::config().has("show")) {
         // Output the transformed datalog and return
         if (Global::config().get("show") == "transformed-datalog") {
-            std::cout << *astTranslationUnit->getProgram() << std::endl;
+            std::cout << astTranslationUnit->getProgram() << std::endl;
             return 0;
         }
 

--- a/src/parser/ParserDriver.cpp
+++ b/src/parser/ParserDriver.cpp
@@ -94,39 +94,42 @@ Own<ast::TranslationUnit> ParserDriver::parseTranslationUnit(
 }
 
 void ParserDriver::addPragma(Own<ast::Pragma> p) {
-    translationUnit->getProgram()->addPragma(std::move(p));
+    ast::Program& program = translationUnit->getProgram();
+    program.addPragma(std::move(p));
 }
 
 void ParserDriver::addFunctorDeclaration(Own<ast::FunctorDeclaration> f) {
     const std::string& name = f->getName();
-    const ast::FunctorDeclaration* existingFunctorDecl =
-            getIf(translationUnit->getProgram()->getFunctorDeclarations(),
-                    [&](const ast::FunctorDeclaration* current) { return current->getName() == name; });
+    ast::Program& program = translationUnit->getProgram();
+    const ast::FunctorDeclaration* existingFunctorDecl = getIf(program.getFunctorDeclarations(),
+            [&](const ast::FunctorDeclaration* current) { return current->getName() == name; });
     if (existingFunctorDecl != nullptr) {
         Diagnostic err(Diagnostic::Type::ERROR,
                 DiagnosticMessage("Redefinition of functor " + toString(name), f->getSrcLoc()),
                 {DiagnosticMessage("Previous definition", existingFunctorDecl->getSrcLoc())});
         translationUnit->getErrorReport().addDiagnostic(err);
     } else {
-        translationUnit->getProgram()->addFunctorDeclaration(std::move(f));
+        program.addFunctorDeclaration(std::move(f));
     }
 }
 
 void ParserDriver::addRelation(Own<ast::Relation> r) {
     const auto& name = r->getQualifiedName();
-    if (ast::Relation* prev = getRelation(*translationUnit->getProgram(), name)) {
+    ast::Program& program = translationUnit->getProgram();
+    if (ast::Relation* prev = getRelation(program, name)) {
         Diagnostic err(Diagnostic::Type::ERROR,
                 DiagnosticMessage("Redefinition of relation " + toString(name), r->getSrcLoc()),
                 {DiagnosticMessage("Previous definition", prev->getSrcLoc())});
         translationUnit->getErrorReport().addDiagnostic(err);
     } else {
-        translationUnit->getProgram()->addRelation(std::move(r));
+        program.addRelation(std::move(r));
     }
 }
 
 void ParserDriver::addDirective(Own<ast::Directive> directive) {
+    ast::Program& program = translationUnit->getProgram();
     if (directive->getType() == ast::DirectiveType::printsize) {
-        for (const auto& cur : translationUnit->getProgram()->getDirectives()) {
+        for (const auto& cur : program.getDirectives()) {
             if (cur->getQualifiedName() == directive->getQualifiedName() &&
                     cur->getType() == ast::DirectiveType::printsize) {
                 Diagnostic err(Diagnostic::Type::ERROR,
@@ -139,7 +142,7 @@ void ParserDriver::addDirective(Own<ast::Directive> directive) {
             }
         }
     } else if (directive->getType() == ast::DirectiveType::limitsize) {
-        for (const auto& cur : translationUnit->getProgram()->getDirectives()) {
+        for (const auto& cur : program.getDirectives()) {
             if (cur->getQualifiedName() == directive->getQualifiedName() &&
                     cur->getType() == ast::DirectiveType::limitsize) {
                 Diagnostic err(Diagnostic::Type::ERROR,
@@ -152,12 +155,13 @@ void ParserDriver::addDirective(Own<ast::Directive> directive) {
             }
         }
     }
-    translationUnit->getProgram()->addDirective(std::move(directive));
+    program.addDirective(std::move(directive));
 }
 
 void ParserDriver::addType(Own<ast::Type> type) {
+    ast::Program& program = translationUnit->getProgram();
     const auto& name = type->getQualifiedName();
-    auto* existingType = getIf(translationUnit->getProgram()->getTypes(),
+    auto* existingType = getIf(program.getTypes(),
             [&](const ast::Type* current) { return current->getQualifiedName() == name; });
     if (existingType != nullptr) {
         Diagnostic err(Diagnostic::Type::ERROR,
@@ -165,18 +169,21 @@ void ParserDriver::addType(Own<ast::Type> type) {
                 {DiagnosticMessage("Previous definition", existingType->getSrcLoc())});
         translationUnit->getErrorReport().addDiagnostic(err);
     } else {
-        translationUnit->getProgram()->addType(std::move(type));
+        program.addType(std::move(type));
     }
 }
 
 void ParserDriver::addClause(Own<ast::Clause> c) {
-    translationUnit->getProgram()->addClause(std::move(c));
+    ast::Program& program = translationUnit->getProgram();
+    program.addClause(std::move(c));
 }
 void ParserDriver::addComponent(Own<ast::Component> c) {
-    translationUnit->getProgram()->addComponent(std::move(c));
+    ast::Program& program = translationUnit->getProgram();
+    program.addComponent(std::move(c));
 }
 void ParserDriver::addInstantiation(Own<ast::ComponentInit> ci) {
-    translationUnit->getProgram()->addInstantiation(std::move(ci));
+    ast::Program& program = translationUnit->getProgram();
+    program.addInstantiation(std::move(ci));
 }
 
 void ParserDriver::addIoFromDeprecatedTag(ast::Relation& rel) {


### PR DESCRIPTION
The ast::TranslationUnit has two pointer versions of the getProgram() getter. 

This change uniforms the access for getProgram() returning an alias rather than a pointer. 