### PR TITLE
Class SipsMetric had a missing virtual destructor

### DIFF
--- a/src/ast/utility/SipsMetric.h
+++ b/src/ast/utility/SipsMetric.h
@@ -34,6 +34,8 @@ class Clause;
  */
 class SipsMetric {
 public:
+    virtual ~SipsMetric() = default;
+
     /**
      * Determines the new ordering of a clause after the SIPS is applied.
      * @param clause clause to reorder


### PR DESCRIPTION
Adds a missing virtual destructor in class SipsMetric.