### PR TITLE
Added new translator SIPS, toggleable via pragma

### DIFF
--- a/src/ast/transform/ReorderLiterals.cpp
+++ b/src/ast/transform/ReorderLiterals.cpp
@@ -36,29 +36,6 @@
 
 namespace souffle::ast::transform {
 
-std::unique_ptr<SipsMetric> ReorderLiteralsTransformer::getSipsFunction(
-        const std::string& sipsChosen, const TranslationUnit& tu) {
-    if (sipsChosen == "strict")
-        return std::make_unique<StrictSips>();
-    else if (sipsChosen == "all-bound")
-        return std::make_unique<AllBoundSips>();
-    else if (sipsChosen == "naive")
-        return std::make_unique<NaiveSips>();
-    else if (sipsChosen == "max-bound")
-        return std::make_unique<MaxBoundSips>();
-    else if (sipsChosen == "max-ratio")
-        return std::make_unique<MaxRatioSips>();
-    else if (sipsChosen == "least-free")
-        return std::make_unique<LeastFreeSips>();
-    else if (sipsChosen == "least-free-vars")
-        return std::make_unique<LeastFreeVarsSips>();
-    else if (sipsChosen == "profile-use")
-        return std::make_unique<ProfileUseSips>(*tu.getAnalysis<analysis::ProfileUseAnalysis>());
-
-    // default is all-bound
-    return getSipsFunction("all-bound", tu);
-}
-
 Clause* ReorderLiteralsTransformer::reorderClauseWithSips(const SipsMetric& sips, const Clause* clause) {
     // ignore clauses with fixed execution plans
     if (clause->getExecutionPlan() != nullptr) {
@@ -92,7 +69,7 @@ bool ReorderLiteralsTransformer::transform(TranslationUnit& translationUnit) {
     if (Global::config().has("SIPS")) {
         sipsChosen = Global::config().get("SIPS");
     }
-    auto sipsFunction = getSipsFunction(sipsChosen, translationUnit);
+    auto sipsFunction = SipsMetric::create(sipsChosen, translationUnit);
 
     // literal reordering is a rule-local transformation
     std::vector<Clause*> clausesToRemove;
@@ -114,7 +91,7 @@ bool ReorderLiteralsTransformer::transform(TranslationUnit& translationUnit) {
     // --- profile-guided reordering ---
     if (Global::config().has("profile-use")) {
         // parse supplied profile information
-        auto profilerSips = getSipsFunction("profiler", translationUnit);
+        auto profilerSips = SipsMetric::create("profiler", translationUnit);
 
         // change the ordering of literals within clauses
         std::vector<Clause*> clausesToRemove;

--- a/src/ast/transform/ReorderLiterals.h
+++ b/src/ast/transform/ReorderLiterals.h
@@ -41,10 +41,6 @@ public:
         return new ReorderLiteralsTransformer();
     }
 
-    /** Returns a SIPS cost evaluator based on the SIPS option provided. */
-    static std::unique_ptr<SipsMetric> getSipsFunction(
-            const std::string& sipsChosen, const TranslationUnit& tu);
-
     /**
      * Reorder the clause based on a given SIPS function.
      * @param sipsFunction SIPS metric to use

--- a/src/ast/utility/SipsMetric.cpp
+++ b/src/ast/utility/SipsMetric.cpp
@@ -278,6 +278,32 @@ std::vector<double> DeltaSips::evaluateCosts(
     return cost;
 }
 
+std::vector<double> InputSips::evaluateCosts(
+        const std::vector<Atom*> atoms, const BindingStore& bindingStore) const {
+    // Goal: prioritise (1) all-bound, (2) input, then (3) rest
+    std::vector<double> cost;
+    for (const auto* atom : atoms) {
+        if (atom == nullptr) {
+            cost.push_back(std::numeric_limits<double>::max());
+            continue;
+        }
+
+        const auto& relName = atom->getQualifiedName();
+        int arity = atom->getArity();
+        int numBound = bindingStore.numBoundArguments(atom);
+        if (arity == numBound) {
+            // prioritise all-bound
+            cost.push_back(0);
+        } else if (ioTypes.isInput(relDetail.getRelation(relName))) {
+            // then input
+            cost.push_back(1);
+        } else {
+            cost.push_back(2);
+        }
+    }
+    return cost;
+}
+
 std::vector<double> DeltaInputSips::evaluateCosts(
         const std::vector<Atom*> atoms, const BindingStore& bindingStore) const {
     // Goal: prioritise (1) all-bound, (2) deltas, (3) input, then (4) rest

--- a/src/ast/utility/SipsMetric.cpp
+++ b/src/ast/utility/SipsMetric.cpp
@@ -17,6 +17,7 @@
 #include "ast/utility/SipsMetric.h"
 #include "ast/Clause.h"
 #include "ast/Variable.h"
+#include "ast/TranslationUnit.h"
 #include "ast/analysis/IOType.h"
 #include "ast/analysis/ProfileUse.h"
 #include "ast/analysis/RelationDetailCache.h"
@@ -55,6 +56,29 @@ std::vector<unsigned int> SipsMetric::getReordering(const Clause* clause) const 
     }
 
     return newOrder;
+}
+
+/** Create a SIPS metric based on a given heuristic. */
+std::unique_ptr<SipsMetric> SipsMetric::create(const std::string& heuristic, const TranslationUnit& tu) {
+    if (heuristic == "strict")
+        return std::make_unique<StrictSips>();
+    else if (heuristic == "all-bound")
+        return std::make_unique<AllBoundSips>();
+    else if (heuristic == "naive")
+        return std::make_unique<NaiveSips>();
+    else if (heuristic == "max-bound")
+        return std::make_unique<MaxBoundSips>();
+    else if (heuristic == "max-ratio")
+        return std::make_unique<MaxRatioSips>();
+    else if (heuristic == "least-free")
+        return std::make_unique<LeastFreeSips>();
+    else if (heuristic == "least-free-vars")
+        return std::make_unique<LeastFreeVarsSips>();
+    else if (heuristic == "profile-use")
+        return std::make_unique<ProfileUseSips>(*tu.getAnalysis<analysis::ProfileUseAnalysis>());
+
+    // default is all-bound
+    return create("all-bound", tu);
 }
 
 std::vector<double> StrictSips::evaluateCosts(

--- a/src/ast/utility/SipsMetric.cpp
+++ b/src/ast/utility/SipsMetric.cpp
@@ -16,8 +16,8 @@
 
 #include "ast/utility/SipsMetric.h"
 #include "ast/Clause.h"
-#include "ast/Variable.h"
 #include "ast/TranslationUnit.h"
+#include "ast/Variable.h"
 #include "ast/analysis/IOType.h"
 #include "ast/analysis/ProfileUse.h"
 #include "ast/analysis/RelationDetailCache.h"
@@ -76,6 +76,14 @@ std::unique_ptr<SipsMetric> SipsMetric::create(const std::string& heuristic, con
         return std::make_unique<LeastFreeVarsSips>();
     else if (heuristic == "profile-use")
         return std::make_unique<ProfileUseSips>(*tu.getAnalysis<analysis::ProfileUseAnalysis>());
+    else if (heuristic == "delta")
+        return std::make_unique<DeltaSips>();
+    else if (heuristic == "input")
+        return std::make_unique<InputSips>(*tu.getAnalysis<analysis::RelationDetailCacheAnalysis>(),
+                *tu.getAnalysis<analysis::IOTypeAnalysis>());
+    else if (heuristic == "delta-input")
+        return std::make_unique<DeltaInputSips>(*tu.getAnalysis<analysis::RelationDetailCacheAnalysis>(),
+                *tu.getAnalysis<analysis::IOTypeAnalysis>());
 
     // default is all-bound
     return create("all-bound", tu);

--- a/src/ast/utility/SipsMetric.h
+++ b/src/ast/utility/SipsMetric.h
@@ -157,6 +157,21 @@ protected:
             const std::vector<Atom*> atoms, const BindingStore& bindingStore) const override;
 };
 
+/** Goal: prioritise (1) all-bound, then (2) input, and then (3) left-most */
+class InputSips : public SipsMetric {
+public:
+    InputSips(const analysis::RelationDetailCacheAnalysis& relDetail, const analysis::IOTypeAnalysis& ioTypes)
+            : relDetail(relDetail), ioTypes(ioTypes) {}
+
+protected:
+    std::vector<double> evaluateCosts(
+            const std::vector<Atom*> atoms, const BindingStore& bindingStore) const override;
+
+private:
+    const analysis::RelationDetailCacheAnalysis& relDetail;
+    const analysis::IOTypeAnalysis& ioTypes;
+};
+
 /** Goal: prioritise (1) all-bound, then (2) deltas, then (3) input, and then (4) left-most */
 class DeltaInputSips : public SipsMetric {
 public:

--- a/src/ast/utility/SipsMetric.h
+++ b/src/ast/utility/SipsMetric.h
@@ -19,8 +19,10 @@
 #include <vector>
 
 namespace souffle::ast::analysis {
+class IOTypeAnalysis;
 class ProfileUseAnalysis;
-}
+class RelationDetailCacheAnalysis;
+}  // namespace souffle::ast::analysis
 namespace souffle::ast {
 
 class Atom;
@@ -138,6 +140,32 @@ protected:
 
 private:
     const analysis::ProfileUseAnalysis& profileUse;
+};
+
+/** Goal: prioritise (1) all-bound, then (2) deltas, and then (3) left-most */
+class DeltaSips : public SipsMetric {
+public:
+    DeltaSips() = default;
+
+protected:
+    std::vector<double> evaluateCosts(
+            const std::vector<Atom*> atoms, const BindingStore& bindingStore) const override;
+};
+
+/** Goal: prioritise (1) all-bound, then (2) deltas, then (3) input, and then (4) left-most */
+class DeltaInputSips : public SipsMetric {
+public:
+    DeltaInputSips(
+            const analysis::RelationDetailCacheAnalysis& relDetail, const analysis::IOTypeAnalysis& ioTypes)
+            : relDetail(relDetail), ioTypes(ioTypes) {}
+
+protected:
+    std::vector<double> evaluateCosts(
+            const std::vector<Atom*> atoms, const BindingStore& bindingStore) const override;
+
+private:
+    const analysis::RelationDetailCacheAnalysis& relDetail;
+    const analysis::IOTypeAnalysis& ioTypes;
 };
 
 };  // namespace souffle::ast

--- a/src/ast/utility/SipsMetric.h
+++ b/src/ast/utility/SipsMetric.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 namespace souffle::ast::analysis {
@@ -28,6 +29,7 @@ namespace souffle::ast {
 class Atom;
 class BindingStore;
 class Clause;
+class TranslationUnit;
 
 /**
  * Class for SIPS cost-metric functions
@@ -44,6 +46,9 @@ public:
      * @return the vector of new positions; v[i] = j iff atom j moves to pos i
      */
     std::vector<unsigned int> getReordering(const Clause* clause) const;
+
+    /** Create a SIPS metric based on a given heuristic. */
+    static std::unique_ptr<SipsMetric> create(const std::string& heuristic, const TranslationUnit& tu);
 
 protected:
     /**

--- a/src/ast/utility/Utils.cpp
+++ b/src/ast/utility/Utils.cpp
@@ -238,6 +238,14 @@ bool isProposition(const Atom* atom) {
     return atom->getArguments().empty();
 }
 
+bool isDeltaRelation(const QualifiedName& name) {
+    const auto& qualifiers = name.getQualifiers();
+    if (qualifiers.empty()) {
+        return false;
+    }
+    return isPrefix("@delta_", qualifiers[0]);
+}
+
 Clause* cloneHead(const Clause* clause) {
     auto* clone = new Clause();
     clone->setSrcLoc(clause->getSrcLoc());

--- a/src/ast/utility/Utils.h
+++ b/src/ast/utility/Utils.h
@@ -219,6 +219,12 @@ bool isRule(const Clause& clause);
 bool isProposition(const Atom* atom);
 
 /**
+ * Returns whether the given atom is a delta relation
+ * @return true iff the atom is a delta relation
+ */
+bool isDeltaRelation(const QualifiedName& name);
+
+/**
  * Returns a clause which contains head of the given clause
  * @param clause the clause which head to be cloned
  * @return pointer to clause which has head cloned from given clause

--- a/src/ast2ram/AstToRamTranslator.h
+++ b/src/ast2ram/AstToRamTranslator.h
@@ -33,7 +33,6 @@
 #include "ast/Variable.h"
 #include "ast/analysis/AuxArity.h"
 #include "ast/analysis/IOType.h"
-#include "ast/analysis/RelationDetailCache.h"
 #include "ast/analysis/RecursiveClauses.h"
 #include "ast/analysis/TypeSystem.h"
 #include "ast/utility/SipsMetric.h"
@@ -82,9 +81,6 @@ private:
     /** IO Type */
     const ast::analysis::IOTypeAnalysis* ioType = nullptr;
 
-    /** Relation Detail */
-    const ast::analysis::RelationDetailCacheAnalysis* relDetail = nullptr;
-
     /** RAM program */
     Own<ram::Statement> ramMain;
 
@@ -99,6 +95,9 @@ private:
 
     /** Auxiliary Arity Analysis */
     const ast::analysis::AuxiliaryArityAnalysis* auxArityAnalysis = nullptr;
+
+    /** SIPS metric for reordering */
+    Own<ast::SipsMetric> sips;
 
     /**
      * Concrete attribute
@@ -345,9 +344,6 @@ private:
         std::vector<const ast::Node*> op_nesting;
 
         Own<ast::Clause> getReorderedClause(const ast::Clause& clause, const int version) const;
-
-        // get the appropraite sips function
-        std::unique_ptr<ast::SipsMetric> getSipsFunction() const;
 
         arg_list* getArgList(
                 const ast::Node* curNode, std::map<const ast::Node*, Own<arg_list>>& nodeArgs) const;

--- a/src/ast2ram/AstToRamTranslator.h
+++ b/src/ast2ram/AstToRamTranslator.h
@@ -33,6 +33,7 @@
 #include "ast/Variable.h"
 #include "ast/analysis/AuxArity.h"
 #include "ast/analysis/IOType.h"
+#include "ast/analysis/RelationDetailCache.h"
 #include "ast/analysis/RecursiveClauses.h"
 #include "ast/analysis/TypeSystem.h"
 #include "ast/utility/SipsMetric.h"
@@ -80,6 +81,9 @@ private:
 
     /** IO Type */
     const ast::analysis::IOTypeAnalysis* ioType = nullptr;
+
+    /** Relation Detail */
+    const ast::analysis::RelationDetailCacheAnalysis* relDetail = nullptr;
 
     /** RAM program */
     Own<ram::Statement> ramMain;
@@ -341,6 +345,9 @@ private:
         std::vector<const ast::Node*> op_nesting;
 
         Own<ast::Clause> getReorderedClause(const ast::Clause& clause, const int version) const;
+
+        // get the appropraite sips function
+        std::unique_ptr<ast::SipsMetric> getSipsFunction() const;
 
         arg_list* getArgList(
                 const ast::Node* curNode, std::map<const ast::Node*, Own<arg_list>>& nodeArgs) const;


### PR DESCRIPTION
Added three new SIPS:
* Delta SIPS (option: 'delta') - prioritises all-bound, then delta relations
* Input SIPS (option: 'input') - prioritises all-bound, then input relations
* Delta-Input SIPS (option: 'delta-input') - prioritises all-bound, then delta, then input relations

All are toggleable using the `--pragma` command-line option (or `.pragma` declarative in Souffle) with key `"RamSIPS"`

E.g. to use the Delta SIPS, either use `--pragma="RamSIPS:delta"` on the command-line, or `.pragma "RamSIPS:delta"` in a Souffle program.

Default heuristics is still `all-bound`, which is more or less guaranteed to always be better than or equal to the original program.

Also refactored SIPS metric class slightly to make it a lot more accessible and independent of the `ReorderLiteralsTransformer` class.