### PR TITLE
add missing casts for indirect relations comparators.

### DIFF
--- a/src/synthesiser/Relation.cpp
+++ b/src/synthesiser/Relation.cpp
@@ -556,6 +556,7 @@ std::string IndirectRelation::getTypeName() {
 void IndirectRelation::generateTypeStruct(std::ostream& out) {
     size_t arity = getArity();
     const auto& inds = getIndices();
+    auto types = relation.getAttributeTypes();
     size_t numIndexes = inds.size();
     std::map<MinIndexSelection::LexOrder, int> indexToNumMap;
 
@@ -577,6 +578,17 @@ void IndirectRelation::generateTypeStruct(std::ostream& out) {
             indexToNumMap[getMinIndexSelection().getAllOrders()[i]] = i;
         }
 
+        std::vector<std::string> typecasts;
+        typecasts.reserve(types.size());
+
+        for (auto type : types) {
+            switch (type[0]) {
+                case 'f': typecasts.push_back("ramBitCast<RamFloat>"); break;
+                case 'u': typecasts.push_back("ramBitCast<RamUnsigned>"); break;
+                default: typecasts.push_back("ramBitCast<RamSigned>");
+            }
+        }
+
         std::string comparator = "t_comparator_" + std::to_string(i);
 
         out << "struct " << comparator << "{\n";
@@ -584,8 +596,10 @@ void IndirectRelation::generateTypeStruct(std::ostream& out) {
         out << "  return ";
         std::function<void(size_t)> gencmp = [&](size_t i) {
             size_t attrib = ind[i];
-            out << "((*a)[" << attrib << "] < (*b)[" << attrib << "]) ? -1 : (((*a)[" << attrib << "] > (*b)["
-                << attrib << "]) ? 1 :(";
+            const auto& typecast = typecasts[attrib];
+            out << "(" << typecast << "((*a)[" << attrib << "]) <" << typecast << " ((*b)[" << attrib
+                << "])) ? -1 : ((" << typecast << "((*a)[" << attrib << "]) > " << typecast << "((*b)["
+                << attrib << "])) ? 1 :(";
             if (i + 1 < ind.size()) {
                 gencmp(i + 1);
             } else {
@@ -599,9 +613,11 @@ void IndirectRelation::generateTypeStruct(std::ostream& out) {
         out << "  return ";
         std::function<void(size_t)> genless = [&](size_t i) {
             size_t attrib = ind[i];
-            out << " (*a)[" << attrib << "] < (*b)[" << attrib << "]";
+            const auto& typecast = typecasts[attrib];
+            out << typecast << " ((*a)[" << attrib << "]) < " << typecast << "((*b)[" << attrib << "])";
             if (i + 1 < ind.size()) {
-                out << "|| ((*a)[" << attrib << "] == (*b)[" << attrib << "] && (";
+                out << "|| (" << typecast << "((*a)[" << attrib << "]) == " << typecast << "((*b)[" << attrib
+                    << "]) && (";
                 genless(i + 1);
                 out << "))";
             }
@@ -612,7 +628,8 @@ void IndirectRelation::generateTypeStruct(std::ostream& out) {
         out << "return ";
         std::function<void(size_t)> geneq = [&](size_t i) {
             size_t attrib = ind[i];
-            out << "(*a)[" << attrib << "] == (*b)[" << attrib << "]";
+            const auto& typecast = typecasts[attrib];
+            out << typecast << "((*a)[" << attrib << "]) == " << typecast << "((*b)[" << attrib << "])";
             if (i + 1 < ind.size()) {
                 out << "&&";
                 geneq(i + 1);


### PR DESCRIPTION
It looks like cast were not being added to indirect relations the same way they are added to direct relations. This would cause erroneous behavior for some Datalog programs that contain relations with many fields. For example:
```
.decl instruction(ea:unsigned, size:unsigned, prefix:symbol, opcode:symbol, op1:unsigned, op2:unsigned, op3:unsigned)

.decl invalid(ea:unsigned,ea2:unsigned)
.output invalid

.decl must_fallthrough(ea:unsigned,ea2:unsigned)
must_fallthrough(1,2).

instruction(1,5,"","JMP",0,0,0).
instruction(2,5,"","PUSH",0,0,0).

invalid(EA,Not_code):-
    must_fallthrough(EA,Not_code),
    !instruction(Not_code,_,_,_,_,_,_).
```
was producing  the pair `invalid(1,2)` when using the `-c` flag. But no pairs should be generated at all.
This behavior did not manifest if `instruction` had fewer fields. I guess because there is a threshold between relation and indirect relation?

It would be good to add a regression test. The snippet above could do the job but maybe it is better to add one that exercises the three comparator functions? Let me know if you want me to put it somewhere.