### PR TITLE
Removed size initialisation for cost metric vector.

### DIFF
--- a/src/ast/utility/SipsMetric.cpp
+++ b/src/ast/utility/SipsMetric.cpp
@@ -92,7 +92,7 @@ std::unique_ptr<SipsMetric> SipsMetric::create(const std::string& heuristic, con
 std::vector<double> StrictSips::evaluateCosts(
         const std::vector<Atom*> atoms, const BindingStore& /* bindingStore */) const {
     // Goal: Always choose the left-most atom
-    std::vector<double> cost(atoms.size());
+    std::vector<double> cost;
     for (const auto* atom : atoms) {
         cost.push_back(atom == nullptr ? std::numeric_limits<double>::max() : 0);
     }


### PR DESCRIPTION
This only affected the new `strict` SIPS metric. General SIPS tests are still being run offline.