### PR TITLE
Fix type clash

### DIFF
--- a/src/interpreter/Node.h
+++ b/src/interpreter/Node.h
@@ -44,7 +44,7 @@ class Node;
 
 namespace interpreter {
 class ViewContext;
-class RelationWrapper;
+struct RelationWrapper;
 
 // clang-format off
 


### PR DESCRIPTION
Currently, RelationWrapper is defined as struct but a forward reference uses it as a class. This may lead to linker issues in some C++ compilers. 