### PR TITLE
More clean-up of Ast2Ram translator code

### DIFF
--- a/src/ast2ram/AstToRamTranslator.cpp
+++ b/src/ast2ram/AstToRamTranslator.cpp
@@ -55,6 +55,7 @@
 #include "ast/utility/Utils.h"
 #include "ast/utility/Visitor.h"
 #include "ast2ram/ClauseTranslator.h"
+#include "ast2ram/Location.h"
 #include "ast2ram/ProvenanceClauseTranslator.h"
 #include "ast2ram/ValueIndex.h"
 #include "parser/SrcLocation.h"

--- a/src/ast2ram/ClauseTranslator.cpp
+++ b/src/ast2ram/ClauseTranslator.cpp
@@ -26,6 +26,7 @@
 #include "ast/transform/ReorderLiterals.h"
 #include "ast/utility/Utils.h"
 #include "ast/utility/Visitor.h"
+#include "ast2ram/AstToRamTranslator.h"
 #include "ast2ram/Location.h"
 #include "ast2ram/ValueIndex.h"
 #include "ram/Aggregate.h"

--- a/src/ast2ram/ClauseTranslator.cpp
+++ b/src/ast2ram/ClauseTranslator.cpp
@@ -384,7 +384,7 @@ Own<ast::Clause> ClauseTranslator::getReorderedClause(const ast::Clause& clause,
 
 ClauseTranslator::arg_list* ClauseTranslator::getArgList(
         const ast::Node* curNode, std::map<const ast::Node*, Own<arg_list>>& nodeArgs) const {
-    if (nodeArgs.count(curNode) == 0u) {
+    if (!contains(nodeArgs, curNode)) {
         if (auto rec = dynamic_cast<const ast::RecordInit*>(curNode)) {
             nodeArgs[curNode] = mk<arg_list>(rec->getArguments());
         } else if (auto atom = dynamic_cast<const ast::Atom*>(curNode)) {
@@ -431,9 +431,7 @@ void ClauseTranslator::indexValues(const ast::Node* curNode,
 /** index values in rule */
 void ClauseTranslator::createValueIndex(const ast::Clause& clause) {
     for (const auto* atom : ast::getBodyLiterals<ast::Atom>(clause)) {
-        // std::map<const arg_list*, int> arg_level;
         std::map<const ast::Node*, Own<arg_list>> nodeArgs;
-
         std::map<const arg_list*, int> arg_level;
         nodeArgs[atom] = mk<arg_list>(atom->getArguments());
         // the atom is obtained at the current level

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -67,8 +67,8 @@ private:
 
     Own<ast::Clause> getReorderedClause(const ast::Clause& clause, const int version) const;
 
-    void indexValues(const ast::Node* curNode, const std::vector<ast::Argument*>& curNodeArgs, std::map<const ast::Node*, int>& nodeLevel,
-            ram::RelationReference* relation);
+    void indexValues(const ast::Node* curNode, const std::vector<ast::Argument*>& curNodeArgs,
+            std::map<const ast::Node*, int>& nodeLevel, ram::RelationReference* relation);
 
     void createValueIndex(const ast::Clause& clause);
 };

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "ast2ram/AstToRamTranslator.h"
-#include "ast2ram/ValueIndex.h"
 #include <map>
 #include <vector>
 
@@ -39,6 +38,8 @@ class RelationReference;
 
 namespace souffle::ast2ram {
 
+class ValueIndex;
+
 class ClauseTranslator {
 public:
     ClauseTranslator(AstToRamTranslator& translator)
@@ -50,6 +51,7 @@ public:
 protected:
     AstToRamTranslator& translator;
 
+    // value index to keep track of references in the loop nest
     Own<ValueIndex> valueIndex = mk<ValueIndex>();
 
     // current nesting level

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -26,10 +26,6 @@ class Clause;
 class Node;
 }  // namespace souffle::ast
 
-namespace souffle::ast::analysis {
-class AuxiliaryArityAnalsyis;
-}
-
 namespace souffle::ram {
 class Operation;
 class Condition;
@@ -42,8 +38,7 @@ class ValueIndex;
 
 class ClauseTranslator {
 public:
-    ClauseTranslator(AstToRamTranslator& translator)
-            : translator(translator), auxArityAnalysis(translator.getAuxArityAnalysis()) {}
+    ClauseTranslator(AstToRamTranslator& translator) : translator(translator) {}
 
     Own<ram::Statement> translateClause(
             const ast::Clause& clause, const ast::Clause& originalClause, const int version = 0);
@@ -63,8 +58,6 @@ protected:
     /** apply constraint filters to a given operation */
     Own<ram::Operation> filterByConstraints(size_t level, const std::vector<ast::Argument*>& args,
             Own<ram::Operation> op, bool constrainByFunctors = true);
-
-    const ast::analysis::AuxiliaryArityAnalysis* auxArityAnalysis;
 
 private:
     // index nested variables and records

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -60,9 +60,6 @@ protected:
             Own<ram::Operation> op, bool constrainByFunctors = true);
 
 private:
-    // index nested variables and records
-    using arg_list = std::vector<ast::Argument*>;
-
     std::vector<const ast::Argument*> generators;
 
     // the order of processed operations
@@ -70,10 +67,8 @@ private:
 
     Own<ast::Clause> getReorderedClause(const ast::Clause& clause, const int version) const;
 
-    arg_list* getArgList(const ast::Node* curNode, std::map<const ast::Node*, Own<arg_list>>& nodeArgs) const;
-
-    void indexValues(const ast::Node* curNode, std::map<const ast::Node*, Own<arg_list>>& nodeArgs,
-            std::map<const arg_list*, int>& arg_level, ram::RelationReference* relation);
+    void indexValues(const ast::Node* curNode, const std::vector<ast::Argument*>& curNodeArgs, std::map<const ast::Node*, int>& nodeLevel,
+            ram::RelationReference* relation);
 
     void createValueIndex(const ast::Clause& clause);
 };

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -50,8 +50,7 @@ public:
 protected:
     AstToRamTranslator& translator;
 
-    // create value index
-    ValueIndex valueIndex;
+    Own<ValueIndex> valueIndex = mk<ValueIndex>();
 
     // current nesting level
     int level = 0;

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -59,7 +59,7 @@ protected:
     virtual Own<ram::Operation> createOperation(const ast::Clause& clause);
     virtual Own<ram::Condition> createCondition(const ast::Clause& originalClause);
 
-    /** translate RAM code for a constant value */
+    /** apply constraint filters to a given operation */
     Own<ram::Operation> filterByConstraints(size_t level, const std::vector<ast::Argument*>& args,
             Own<ram::Operation> op, bool constrainByFunctors = true);
 

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "ast2ram/AstToRamTranslator.h"
+#include "souffle/utility/ContainerUtil.h"
 #include <map>
 #include <vector>
 
@@ -30,10 +30,12 @@ namespace souffle::ram {
 class Operation;
 class Condition;
 class RelationReference;
+class Statement;
 }  // namespace souffle::ram
 
 namespace souffle::ast2ram {
 
+class AstToRamTranslator;
 class ValueIndex;
 
 class ClauseTranslator {

--- a/src/ast2ram/Location.h
+++ b/src/ast2ram/Location.h
@@ -24,27 +24,15 @@ class RelationReference;
 namespace souffle::ast2ram {
 
 struct Location {
-    int identifier{};
-    int element{};
-    Own<ram::RelationReference> relation{nullptr};
-
-    Location() = default;
+    const int identifier;
+    const int element;
+    const Own<const ram::RelationReference> relation;
 
     Location(int ident, int elem, Own<ram::RelationReference> rel = nullptr)
             : identifier(ident), element(elem), relation(std::move(rel)) {}
 
-    Location(const Location& l) : identifier(l.identifier), element(l.element) {
-        if (l.relation != nullptr) {
-            relation = souffle::clone(l.relation);
-        }
-    }
-
-    Location& operator=(Location other) {
-        identifier = other.identifier;
-        element = other.element;
-        relation = std::move(other.relation);
-        return *this;
-    }
+    Location(const Location& l)
+            : identifier(l.identifier), element(l.element), relation(souffle::clone(l.relation)) {}
 
     bool operator==(const Location& loc) const {
         return identifier == loc.identifier && element == loc.element;

--- a/src/ast2ram/ProvenanceClauseTranslator.cpp
+++ b/src/ast2ram/ProvenanceClauseTranslator.cpp
@@ -38,24 +38,24 @@ Own<ram::Operation> ProvenanceClauseTranslator::createOperation(const ast::Claus
     for (ast::Literal* lit : clause.getBodyLiterals()) {
         if (auto atom = dynamic_cast<ast::Atom*>(lit)) {
             for (ast::Argument* arg : atom->getArguments()) {
-                values.push_back(translator.translateValue(arg, valueIndex));
+                values.push_back(translator.translateValue(arg, *valueIndex));
             }
         } else if (auto neg = dynamic_cast<ast::ProvenanceNegation*>(lit)) {
             size_t auxiliaryArity = translator.getEvaluationArity(neg->getAtom());
             for (size_t i = 0; i < neg->getAtom()->getArguments().size() - auxiliaryArity; ++i) {
                 auto arg = neg->getAtom()->getArguments()[i];
-                values.push_back(translator.translateValue(arg, valueIndex));
+                values.push_back(translator.translateValue(arg, *valueIndex));
             }
             for (size_t i = 0; i < auxiliaryArity; ++i) {
                 values.push_back(mk<ram::SignedConstant>(-1));
             }
         } else if (auto neg = dynamic_cast<ast::Negation*>(lit)) {
             for (ast::Argument* arg : neg->getAtom()->getArguments()) {
-                values.push_back(translator.translateValue(arg, valueIndex));
+                values.push_back(translator.translateValue(arg, *valueIndex));
             }
         } else if (auto con = dynamic_cast<ast::BinaryConstraint*>(lit)) {
-            values.push_back(translator.translateValue(con->getLHS(), valueIndex));
-            values.push_back(translator.translateValue(con->getRHS(), valueIndex));
+            values.push_back(translator.translateValue(con->getLHS(), *valueIndex));
+            values.push_back(translator.translateValue(con->getRHS(), *valueIndex));
         }
     }
 

--- a/src/ast2ram/ProvenanceClauseTranslator.cpp
+++ b/src/ast2ram/ProvenanceClauseTranslator.cpp
@@ -19,6 +19,7 @@
 #include "ast/BinaryConstraint.h"
 #include "ast/Clause.h"
 #include "ast/ProvenanceNegation.h"
+#include "ast2ram/AstToRamTranslator.h"
 #include "ast2ram/ValueIndex.h"
 #include "ram/Condition.h"
 #include "ram/Relation.h"

--- a/src/ast2ram/ValueIndex.cpp
+++ b/src/ast2ram/ValueIndex.cpp
@@ -26,6 +26,9 @@
 
 namespace souffle::ast2ram {
 
+ValueIndex::ValueIndex() = default;
+ValueIndex::~ValueIndex() = default;
+
 void ValueIndex::addVarReference(const ast::Variable& var, const Location& l) {
     std::set<Location>& locs = var_references[var.getName()];
     locs.insert(l);

--- a/src/ast2ram/ValueIndex.cpp
+++ b/src/ast2ram/ValueIndex.cpp
@@ -62,7 +62,7 @@ const Location& ValueIndex::getGeneratorLoc(const ast::Argument& arg) const {
 }
 
 void ValueIndex::setRecordDefinition(const ast::RecordInit& init, const Location& l) {
-    record_definitions[&init] = l;
+    record_definitions.insert({&init, l});
 }
 
 void ValueIndex::setRecordDefinition(

--- a/src/ast2ram/ValueIndex.h
+++ b/src/ast2ram/ValueIndex.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include "ast2ram/Location.h"
 #include "souffle/utility/ContainerUtil.h"
 #include <map>
 #include <set>
@@ -35,8 +34,13 @@ class RelationReference;
 
 namespace souffle::ast2ram {
 
+struct Location;
+
 class ValueIndex {
 public:
+    ValueIndex();
+    ~ValueIndex();
+
     /**
      * The type mapping variables (referenced by their names) to the
      * locations where they are used.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -583,8 +583,7 @@ int main(int argc, char** argv) {
     // ------- execution -------------
     /* translate AST to RAM */
     debugReport.startSection();
-    Own<ram::TranslationUnit> ramTranslationUnit =
-            ast2ram::AstToRamTranslator().translateUnit(*astTranslationUnit);
+    auto ramTranslationUnit = ast2ram::AstToRamTranslator().translateUnit(*astTranslationUnit);
     debugReport.endSection("ast-to-ram", "Translate AST to RAM");
 
     // Apply RAM transforms


### PR DESCRIPTION
Another pass through the translator code to clean up the codebase. Continues off of PR #1665. This PR addresses all the comments in that PR re: style, changes up a few things for readability, and removes a bunch of unnecessary code bloat. Ast2Ram headers are also now fully independent.