### PR TITLE
ci: Set CXX to clang++ for Ubuntu Bionic Clang++ build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
       create:
         name: bionic_clang
         paths: .
-    script: docker exec souf /bin/sh -c "export CXX=g++ && .travis/init_test.sh '--enable-swig'"
+    script: docker exec souf /bin/sh -c "export CXX=clang++ && .travis/init_test.sh '--enable-swig'"
 
 # MSVC souffle-interface
   - stage: Testing


### PR DESCRIPTION
Looks like it was previously set to `g++`, making this build redundant with the other `g++` build.