### PR TITLE
Add record table getter to SouffleInterface

### DIFF
--- a/src/include/souffle/SouffleInterface.h
+++ b/src/include/souffle/SouffleInterface.h
@@ -8,7 +8,7 @@
 
 /************************************************************************
  *
- * @file CompiledSouffle.h
+ * @file SouffleInterface.h
  *
  * Main include file for generated C++ classes of Souffle
  *
@@ -152,7 +152,7 @@ public:
          * iterator_base class pointer.
          *
          */
-        Own<iterator_base> iter = nullptr;
+        std::unique_ptr<iterator_base> iter = nullptr;
 
     public:
         /**

--- a/src/include/souffle/SouffleInterface.h
+++ b/src/include/souffle/SouffleInterface.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "souffle/RamTypes.h"
+#include "souffle/RecordTable.h"
 #include "souffle/SymbolTable.h"
 #include "souffle/utility/MiscUtil.h"
 #include <algorithm>
@@ -865,6 +866,11 @@ public:
      * Get the symbol table of the program.
      */
     virtual SymbolTable& getSymbolTable() = 0;
+
+    /**
+     * Get the record table of the program.
+     */
+    virtual RecordTable& getRecordTable() = 0;
 
     /**
      * Remove all the tuples from the outputRelations, calling the purge method of each.

--- a/src/interpreter/ProgInterface.h
+++ b/src/interpreter/ProgInterface.h
@@ -208,8 +208,8 @@ private:
 class ProgInterface : public SouffleProgram {
 public:
     explicit ProgInterface(Engine& interp)
-            : prog(interp.getTranslationUnit().getProgram()), exec(interp),
-              symTable(interp.getTranslationUnit().getSymbolTable()) {
+            : prog(interp.getTranslationUnit().getProgram()), exec(interp), symTable(interp.getSymbolTable()),
+              recordTable(interp.getRecordTable()) {
         uint32_t id = 0;
 
         // Retrieve AST Relations and store them in a map
@@ -286,10 +286,15 @@ public:
         return symTable;
     }
 
+    RecordTable& getRecordTable() override {
+        return recordTable;
+    }
+
 private:
     const ram::Program& prog;
     Engine& exec;
     SymbolTable& symTable;
+    RecordTable& recordTable;
     std::vector<RelInterface*> interfaces;
 };
 

--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -2678,6 +2678,10 @@ void Synthesiser::generateCode(std::ostream& os, const std::string& id, bool& wi
     os << "return symTable;\n";
     os << "}\n";  // end of getSymbolTable() method
 
+    os << "RecordTable& getRecordTable() override {\n";
+    os << "return recordTable;\n";
+    os << "}\n";  // end of getRecordTable() method
+
     if (!prog.getSubroutines().empty()) {
         // generate subroutine adapter
         os << "void executeSubroutine(std::string name, const std::vector<RamDomain>& args, "


### PR DESCRIPTION
Also removed an unneeded dependencies from the interface and corrected the file documentation.

`souffle::Relation` also has a `getSymbolTable()` method, which seems odd. If that is actually useful, then a `getRecordTable()` method would also be useful there.