### PR TITLE
Refactor RAM

### DIFF
--- a/src/ram/AbstractExistenceCheck.h
+++ b/src/ram/AbstractExistenceCheck.h
@@ -76,16 +76,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "("
-           << join(values, ",",
-                      [](std::ostream& out, const Own<Expression>& value) {
-                          if (!value) {
-                              out << "_";
-                          } else {
-                              out << *value;
-                          }
-                      })
-           << ") ∈ " << relation;
+        os << "(" << join(values, ",") << ") ∈ " << relation;
     }
 
     bool equal(const Node& node) const override {
@@ -96,7 +87,7 @@ protected:
     /** Relation */
     std::string relation;
 
-    /** Pattern -- nullptr if undefined */
+    /** Search tuple */
     VecOwn<Expression> values;
 };
 

--- a/src/ram/AbstractLog.h
+++ b/src/ram/AbstractLog.h
@@ -63,10 +63,10 @@ protected:
     }
 
 protected:
-    /** logging statement */
+    /** Logging statement */
     Own<Statement> statement;
 
-    /** logging message */
+    /** Logging message */
     std::string message;
 };
 

--- a/src/ram/BinRelationStatement.h
+++ b/src/ram/BinRelationStatement.h
@@ -55,10 +55,10 @@ protected:
     }
 
 protected:
-    /** first relation */
+    /** First relation */
     std::string first;
 
-    /** second relation */
+    /** Second relation */
     std::string second;
 };
 

--- a/src/ram/Call.h
+++ b/src/ram/Call.h
@@ -58,7 +58,7 @@ protected:
         return name == other.name;
     }
 
-    /** name of subroutine */
+    /** Name of subroutine */
     std::string name;
 };
 

--- a/src/ram/Exit.h
+++ b/src/ram/Exit.h
@@ -74,7 +74,7 @@ protected:
         return equal_ptr(condition, other.condition);
     }
 
-    /** exit condition */
+    /** Exit condition */
     Own<Condition> condition;
 };
 

--- a/src/ram/IndexOperation.h
+++ b/src/ram/IndexOperation.h
@@ -105,8 +105,6 @@ public:
         //  const auto& attrib = getRelation().getAttributeNames();
         bool first = true;
         for (unsigned int i = 0; i < queryPattern.first.size(); ++i) {
-            // TODO: print proper upper lower/bound
-
             // early exit if no upper/lower bounds are defined
             if (isUndefValue(queryPattern.first[i].get()) && isUndefValue(queryPattern.second[i].get())) {
                 continue;

--- a/src/ram/ListStatement.h
+++ b/src/ram/ListStatement.h
@@ -69,7 +69,7 @@ protected:
     }
 
 protected:
-    /** ordered list of RAM statements */
+    /** Ordered list of RAM statements */
     VecOwn<Statement> statements;
 };
 

--- a/src/ram/LogSize.h
+++ b/src/ram/LogSize.h
@@ -57,7 +57,7 @@ protected:
         return RelationStatement::equal(other) && message == other.message;
     }
 
-    /** logging message */
+    /** Logging message */
     std::string message;
 };
 

--- a/src/ram/Loop.h
+++ b/src/ram/Loop.h
@@ -76,7 +76,7 @@ protected:
         return equal_ptr(body, other.body);
     }
 
-    /** loop body */
+    /** Loop body */
     Own<Statement> body;
 };
 

--- a/src/ram/NestedIntrinsicOperator.h
+++ b/src/ram/NestedIntrinsicOperator.h
@@ -101,7 +101,10 @@ protected:
         return TupleOperation::equal(node) && op == other.op && equal_targets(args, other.args);
     }
 
+    /* Arguments */
     VecOwn<Expression> args;
+
+    /* Operator */
     NestedIntrinsicOp op;
 };
 

--- a/src/ram/RelationStatement.h
+++ b/src/ram/RelationStatement.h
@@ -46,7 +46,7 @@ protected:
     }
 
 protected:
-    /** relation */
+    /** Relation */
     std::string relation;
 };
 


### PR DESCRIPTION
This is a small RAM refactoring update:
 1) null-pointer checks were still presented in AbstracExistenceCheck (null-pointers have been replaced by RamUndef values some time ago) 
 2) Consistent naming of attributes 
 3) Removal of old TODO

This is related to issue #462 and older RAM refactoring issues. 