### PR TITLE
Added const Qualifier for RAM state

### DIFF
--- a/src/ram/AbstractAggregate.h
+++ b/src/ram/AbstractAggregate.h
@@ -94,7 +94,7 @@ protected:
     }
 
     /** Aggregation function */
-    AggregateOp function;
+    const AggregateOp function;
 
     /** Aggregation expression */
     Own<Expression> expression;

--- a/src/ram/AbstractExistenceCheck.h
+++ b/src/ram/AbstractExistenceCheck.h
@@ -85,7 +85,7 @@ protected:
     }
 
     /** Relation */
-    std::string relation;
+    const std::string relation;
 
     /** Search tuple */
     VecOwn<Expression> values;

--- a/src/ram/AbstractLog.h
+++ b/src/ram/AbstractLog.h
@@ -67,7 +67,7 @@ protected:
     Own<Statement> statement;
 
     /** Logging message */
-    std::string message;
+    const std::string message;
 };
 
 }  // namespace souffle::ram

--- a/src/ram/BinRelationStatement.h
+++ b/src/ram/BinRelationStatement.h
@@ -56,10 +56,10 @@ protected:
 
 protected:
     /** First relation */
-    std::string first;
+    const std::string first;
 
     /** Second relation */
-    std::string second;
+    const std::string second;
 };
 
 }  // namespace souffle::ram

--- a/src/ram/Call.h
+++ b/src/ram/Call.h
@@ -59,7 +59,7 @@ protected:
     }
 
     /** Name of subroutine */
-    std::string name;
+    const std::string name;
 };
 
 }  // namespace souffle::ram

--- a/src/ram/Constraint.h
+++ b/src/ram/Constraint.h
@@ -94,7 +94,7 @@ protected:
     }
 
     /** Operator */
-    BinaryConstraintOp op;
+    const BinaryConstraintOp op;
 
     /** Left-hand side of constraint*/
     Own<Expression> lhs;

--- a/src/ram/EmptinessCheck.h
+++ b/src/ram/EmptinessCheck.h
@@ -67,7 +67,7 @@ protected:
     }
 
     /** Relation */
-    std::string relation;
+    const std::string relation;
 };
 
 }  // namespace souffle::ram

--- a/src/ram/IO.h
+++ b/src/ram/IO.h
@@ -70,7 +70,7 @@ protected:
     }
 
     /** IO directives */
-    std::map<std::string, std::string> directives;
+    const std::map<std::string, std::string> directives;
 };
 
 }  // namespace souffle::ram

--- a/src/ram/LogSize.h
+++ b/src/ram/LogSize.h
@@ -58,7 +58,7 @@ protected:
     }
 
     /** Logging message */
-    std::string message;
+    const std::string message;
 };
 
 }  // namespace souffle::ram

--- a/src/ram/NestedIntrinsicOperator.h
+++ b/src/ram/NestedIntrinsicOperator.h
@@ -105,7 +105,7 @@ protected:
     VecOwn<Expression> args;
 
     /* Operator */
-    NestedIntrinsicOp op;
+    const NestedIntrinsicOp op;
 };
 
 }  // namespace souffle::ram


### PR DESCRIPTION
I added the const qualifier to member variables in RAM classes that cannot be modified via the apply() method. 

This ensures that member variables can only be set by the constructor. 
