### PR TITLE
Refactor Interpreter

### DIFF
--- a/src/ram/utility/Utils.h
+++ b/src/ram/utility/Utils.h
@@ -88,7 +88,7 @@ inline Own<Condition> toCondition(const VecOwn<Condition>& conds) {
 }
 
 /**
- * @brief store terms of a conjunction in an array of pointers without cloning 
+ * @brief store terms of a conjunction in an array of pointers without cloning
  *
  * Convert a condition of the format C1 /\ C2 /\ ... /\ Cn
  * to a list {C1, C2, ..., Cn}.

--- a/src/ram/utility/Utils.h
+++ b/src/ram/utility/Utils.h
@@ -87,4 +87,29 @@ inline Own<Condition> toCondition(const VecOwn<Condition>& conds) {
     return result;
 }
 
+/**
+ * @brief store terms of a conjunction in an array of pointers without cloning 
+ *
+ * Convert a condition of the format C1 /\ C2 /\ ... /\ Cn
+ * to a list {C1, C2, ..., Cn}.
+ */
+inline std::vector<const ram::Condition*> findConjunctiveTerms(const ram::Condition* condition) {
+    std::vector<const ram::Condition*> conditionList;
+    std::queue<const ram::Condition*> conditionsToProcess;
+    if (condition != nullptr) {
+        conditionsToProcess.push(condition);
+        while (!conditionsToProcess.empty()) {
+            condition = conditionsToProcess.front();
+            conditionsToProcess.pop();
+            if (const auto* ramConj = dynamic_cast<const ram::Conjunction*>(condition)) {
+                conditionsToProcess.push(&ramConj->getLHS());
+                conditionsToProcess.push(&ramConj->getRHS());
+            } else {
+                conditionList.emplace_back(condition);
+            }
+        }
+    }
+    return conditionList;
+}
+
 }  // namespace souffle::ram


### PR DESCRIPTION
This is a first step to refactor the interpreter:
1) A RAM utility method has been moved to the `ram/utility/Utils.h` header file.
2) Member variables have been placed at the end of the class definition.
3) An unused method has been deleted. 
