### PR TITLE
Fix profile event output escaping

### DIFF
--- a/src/include/souffle/profile/EventProcessor.h
+++ b/src/include/souffle/profile/EventProcessor.h
@@ -103,11 +103,10 @@ private:
                 break;
             }
             ++start_pos;
-            if (str[start_pos] == 't' || str[start_pos] == '"' || str[start_pos] == '\\' ||
-                    str[start_pos] == 'n' || str[start_pos] == ';') {
-                continue;
+            if (str[start_pos] != 't' && str[start_pos] != '"' && str[start_pos] != '\\' &&
+                    str[start_pos] != 'n' && str[start_pos] != ';') {
+                str.replace(start_pos - 1, 1, "\\\\");
             }
-            str.replace(start_pos - 1, 1, "\\\\");
             ++start_pos;
         }
         return str;


### PR DESCRIPTION
The current escaping used in the profiler does not handle repeated escapes, treating the second as the start of a new potential escaped character. This PR is to fix that behaviour.

Fixes #1713 