### PR TITLE
Print infix operators correctly from AST

### DIFF
--- a/src/ast/BinaryConstraint.h
+++ b/src/ast/BinaryConstraint.h
@@ -83,7 +83,11 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << *lhs << " " << operation << " " << *rhs;
+        if (isInfixFunctorOp(operation)) {
+            os << *lhs << " " << operation << " " << *rhs;
+        } else {
+            os << operation << "(" << *lhs << ", " << *rhs << ")";
+        }
     }
 
     bool equal(const Node& node) const override {

--- a/src/include/souffle/BinaryConstraintOps.h
+++ b/src/include/souffle/BinaryConstraintOps.h
@@ -413,6 +413,21 @@ inline bool isOrderedBinaryConstraintOp(const BinaryConstraintOp op) {
 }
 
 /**
+ * Determines whether a functor should be written using infix notation (e.g. `a + b + c`)
+ * or prefix notation (e.g. `+(a,b,c)`)
+ */
+inline bool isInfixFunctorOp(const BinaryConstraintOp op) {
+    switch (op) {
+        case BinaryConstraintOp::MATCH:
+        case BinaryConstraintOp::NOT_MATCH:
+        case BinaryConstraintOp::CONTAINS:
+        case BinaryConstraintOp::NOT_CONTAINS: return false;
+
+        default: return true;
+    }
+}
+
+/**
  * Get type binary constraint operates on.
  **/
 inline std::vector<TypeAttribute> getBinaryConstraintTypes(const BinaryConstraintOp op) {


### PR DESCRIPTION
Fix output from the AST that represents match and contains.
Currently, if we start with
```prolog
A(x) :- B(x), match(x, "a.*").
```
the output looks like
```prolog
A(x) :- B(x), x match "a.*".
```
which is incorrect.
