### PR TITLE
Fix Travis CI builds

### DIFF
--- a/.travis/osx/install_withgcc.sh
+++ b/.travis/osx/install_withgcc.sh
@@ -11,10 +11,10 @@ set -x
 rm /usr/local/include/c++ || true
 
 brew unlink gcc
-brew install gcc@9
+brew install gcc@10
 # Using 'g++' will call the xcode link to clang
-export CC=gcc-9
-export CXX=g++-9
+export CC=gcc-10
+export CXX=g++-10
 
 $CXX --version
 $CC --version

--- a/src/include/souffle/datastructure/Brie.h
+++ b/src/include/souffle/datastructure/Brie.h
@@ -29,6 +29,7 @@
 #include "souffle/RamTypes.h"
 #include "souffle/utility/CacheUtil.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include "souffle/utility/span.h"
 #include <algorithm>

--- a/src/include/souffle/datastructure/PiggyList.h
+++ b/src/include/souffle/datastructure/PiggyList.h
@@ -13,7 +13,7 @@
  * Some versions of MSVC do not provide a builtin for counting leading zeroes
  * like gcc, so we have to implement it ourselves.
  */
-#if _MSC_VER < 1924
+#if defined(_MSC_VER)
 unsigned long __inline __builtin_clzll(unsigned long long value) {
     unsigned long msb = 0;
 
@@ -22,7 +22,7 @@ unsigned long __inline __builtin_clzll(unsigned long long value) {
     else
         return 64;
 }
-#endif  // _MSC_VER < 1924
+#endif  // _MSC_VER
 #endif  // _WIN32
 
 using std::size_t;

--- a/src/include/souffle/utility/MiscUtil.h
+++ b/src/include/souffle/utility/MiscUtil.h
@@ -48,7 +48,7 @@
  */
 #define __builtin_popcountll __popcnt64
 
-#if _MSC_VER < 1924
+#if defined(_MSC_VER)
 constexpr unsigned long __builtin_ctz(unsigned long value) {
     unsigned long trailing_zeroes = 0;
     while ((value = value >> 1) ^ 1) {
@@ -66,8 +66,8 @@ inline unsigned long __builtin_ctzll(unsigned long long value) {
         return 64;
     }
 }
-#endif  // _MSC_VER < 1924
-#endif
+#endif  // _MSC_VER
+#endif  // _WIN32
 
 // -------------------------------------------------------------------------------
 //                               Timing Utils


### PR DESCRIPTION
* Enable __builtin_ctzl() for more versions of MSC (this is a workaround, rather than a fix, since it will cause problems if it's ever defined)
 * Use gcc10 on travis OSX (this is now automatically installed after we install gcc9, so the workaround is to just use gcc10)