### PR TITLE
Refactoring IndexAnalysis

### DIFF
--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -78,17 +78,6 @@ bool SearchSignature::empty() const {
     return true;
 }
 
-bool SearchSignature::containsEquality() const {
-    for (auto constraint : constraints) {
-        if (constraint == AttributeConstraint::Equal) {
-            return true;
-        }
-    }
-    return false;
-}
-
-// Note: We have 0 < 1 and 0 < 2 but we cannot say that 1 < 2.
-// The reason for this is to prevent search chains such as 100->101->201 which have no valid lex-order
 bool SearchSignature::isComparable(const SearchSignature& lhs, const SearchSignature& rhs) {
     assert(lhs.arity() == rhs.arity());
     if (lhs == rhs) {
@@ -135,16 +124,6 @@ SearchSignature SearchSignature::getFullSearchSignature(size_t arity) {
     SearchSignature res(arity);
     for (size_t i = 0; i < arity; ++i) {
         res.constraints[i] = AttributeConstraint::Equal;
-    }
-    return res;
-}
-
-SearchSignature SearchSignature::getDischarged(const SearchSignature& signature) {
-    SearchSignature res = signature;  // copy original
-    for (size_t i = 0; i < res.arity(); ++i) {
-        if (res[i] == AttributeConstraint::Inequal) {
-            res[i] = AttributeConstraint::None;
-        }
     }
     return res;
 }

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -47,9 +47,9 @@ namespace souffle::ram::analysis {
 enum class AttributeConstraint { None, Equal, Inequal };
 
 /** Search Signature of a RAM Operation
- *	Inequal - The attribute has an inequality constraint i.e. 11 <= x <= 13
- *      Equal   - The attribute has an equality constraint i.e. x = 17
- *      None    - The attribute no constraint
+ *    Inequal - The attribute has an inequality constraint i.e. 11 <= x <= 13
+ *    Equal   - The attribute has an equality constraint i.e. x = 17
+ *    None    - The attribute no constraint
  * */
 class SearchSignature {
 public:

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -53,6 +53,7 @@ enum class AttributeConstraint { None, Equal, Inequal };
  * */
 class SearchSignature {
 public:
+    class Iterator;
     explicit SearchSignature(size_t arity);
     size_t arity() const;
 
@@ -82,6 +83,96 @@ public:
             }
             return seed;
         }
+    };
+
+    Iterator begin() const {
+        return Iterator(const_cast<AttributeConstraint*>(constraints.data()));
+    }
+
+    Iterator end() const {
+        return Iterator(nullptr);
+    }
+
+    class Iterator : public std::iterator<std::random_access_iterator_tag, AttributeConstraint> {
+    public:
+        using difference_type =
+                typename std::iterator<std::random_access_iterator_tag, AttributeConstraint>::difference_type;
+
+        Iterator() : it(nullptr) {}
+        Iterator(AttributeConstraint* rhs) : it(rhs) {}
+        Iterator(const Iterator& rhs) : it(rhs.it) {}
+        inline Iterator& operator=(AttributeConstraint* rhs) {
+            it = rhs;
+            return *this;
+        }
+        inline Iterator& operator=(const Iterator& rhs) {
+            it = rhs.it;
+            return *this;
+        }
+        inline Iterator& operator+=(difference_type rhs) {
+            it += rhs;
+            return *this;
+        }
+        inline Iterator& operator-=(difference_type rhs) {
+            it -= rhs;
+            return *this;
+        }
+        inline AttributeConstraint& operator*() const {
+            return *it;
+        }
+        inline AttributeConstraint operator->() const {
+            return *it;
+        }
+        inline AttributeConstraint& operator[](difference_type rhs) const {
+            return it[rhs];
+        }
+
+        inline Iterator& operator++() {
+            ++it;
+            return *this;
+        }
+        inline Iterator& operator--() {
+            --it;
+            return *this;
+        }
+
+        inline difference_type operator-(const Iterator& rhs) const {
+            return {it - rhs.it};
+        }
+        inline Iterator operator+(difference_type rhs) const {
+            return {it + rhs};
+        }
+        inline Iterator operator-(difference_type rhs) const {
+            return {it - rhs};
+        }
+        friend inline Iterator operator+(difference_type lhs, const Iterator& rhs) {
+            return {rhs.it + lhs};
+        }
+        friend inline Iterator operator-(difference_type lhs, const Iterator& rhs) {
+            return {rhs.it - lhs};
+        }
+
+        inline bool operator==(const Iterator& rhs) const {
+            return it == rhs.it;
+        }
+        inline bool operator!=(const Iterator& rhs) const {
+            return it != rhs.it;
+        }
+        inline bool operator>(const Iterator& rhs) const {
+            return it > rhs.it;
+        }
+        inline bool operator<(const Iterator& rhs) const {
+            return it < rhs.it;
+        }
+        inline bool operator>=(const Iterator& rhs) const {
+            return it >= rhs.it;
+        }
+        inline bool operator<=(const Iterator& rhs) const {
+            return it <= rhs.it;
+        }
+
+    private:
+        AttributeConstraint* it;
     };
 
 private:

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -67,8 +67,6 @@ public:
 
     bool empty() const;
 
-    static bool isComparable(const SearchSignature& lhs, const SearchSignature& rhs);
-    static bool isSubset(const SearchSignature& lhs, const SearchSignature& rhs);
     static SearchSignature getDelta(const SearchSignature& lhs, const SearchSignature& rhs);
     static SearchSignature getFullSearchSignature(size_t arity);
 
@@ -185,7 +183,7 @@ private:
     /**
      * distance function of nodes
      */
-    using DistanceMap = std::map<Node, Distance>;
+    using DistanceMap = std::unordered_map<Node, Distance>;
 
     Matchings match;
     Graph graph;
@@ -216,7 +214,7 @@ public:
     using LexOrder = std::vector<AttributeIndex>;
     using OrderCollection = std::vector<LexOrder>;
     using Chain = std::vector<SearchSignature>;
-    using ChainOrderMap = std::list<Chain>;
+    using ChainOrderMap = std::vector<Chain>;
 
     class SearchComparator {
     public:
@@ -233,9 +231,11 @@ public:
 
     /** @Brief Add new key to an Index Set */
     inline void addSearch(SearchSignature cols) {
-        if (!cols.empty()) {
-            searches.insert(cols);
+        if (cols.empty()) {
+            return;
         }
+
+        searches.insert(cols);
     }
 
     MinIndexSelection() = default;

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -46,9 +46,11 @@ namespace souffle::ram::analysis {
 
 enum class AttributeConstraint { None, Equal, Inequal };
 
-/** search signature of a RAM operation; each bit represents an attribute of a relation.
- * A one represents that the attribute has an assigned value; a zero represents that
- * no value exists (i.e. attribute is unbounded) in the search. */
+/** Search Signature of a RAM Operation
+ *	Inequal - The attribute has an inequality constraint i.e. 11 <= x <= 13
+ *      Equal   - The attribute has an equality constraint i.e. x = 17
+ *      None    - The attribute no constraint
+ * */
 class SearchSignature {
 public:
     explicit SearchSignature(size_t arity);
@@ -64,13 +66,11 @@ public:
     bool operator!=(const SearchSignature& other) const;
 
     bool empty() const;
-    bool containsEquality() const;
 
     static bool isComparable(const SearchSignature& lhs, const SearchSignature& rhs);
     static bool isSubset(const SearchSignature& lhs, const SearchSignature& rhs);
     static SearchSignature getDelta(const SearchSignature& lhs, const SearchSignature& rhs);
     static SearchSignature getFullSearchSignature(size_t arity);
-    static SearchSignature getDischarged(const SearchSignature& signature);
 
     friend std::ostream& operator<<(std::ostream& out, const SearchSignature& signature);
 
@@ -216,8 +216,6 @@ public:
     using LexOrder = std::vector<AttributeIndex>;
     using OrderCollection = std::vector<LexOrder>;
     using Chain = std::vector<SearchSignature>;
-    // A chain is a vector of SearchSignature to support inserting incomparable elements later
-    // E.g. 1 --> 2 we don't have 1 and 2 as comparable but they form a valid lex-order
     using ChainOrderMap = std::list<Chain>;
 
     class SearchComparator {
@@ -303,14 +301,14 @@ public:
         /* Print searches */
         os << "\tNumber of Searches: " << getSearches().size() << "\n";
 
-        /* print searches */
+        /* Print searches */
         for (auto& search : getSearches()) {
             os << "\t\t";
             os << search;
             os << "\n";
         }
 
-        /* print chains */
+        /* Print chains */
         for (auto& chain : getAllChains()) {
             os << join(chain, "-->") << "\n";
         }

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -85,12 +85,14 @@ public:
         }
     };
 
+    // raw ptr to begin
     Iterator begin() const {
         return Iterator(const_cast<AttributeConstraint*>(constraints.data()));
     }
 
+    // raw ptr to end
     Iterator end() const {
-        return Iterator(nullptr);
+        return Iterator(const_cast<AttributeConstraint*>(constraints.data() + constraints.size()));
     }
 
     class Iterator : public std::iterator<std::random_access_iterator_tag, AttributeConstraint> {


### PR DESCRIPTION
I did some light refactoring of the Index Analysis code.

Changes:

1. Removed some unused methods from SearchSignature.
2. Updated some out-of-date comments.
3. Added non-const STL iterators for SearchSignature and switched to some STL algorithms where possible.

I found that I can't really make super good use of these iterators in that many places since I'm often iterating through two SearchSignatures in order which is usually easier with a traditional for loop.

In any case, I hope this PR cleans things up a bit and makes SearchSignature more usable elsewhere in the codebase.

TODO in future PRs:

1. Indexed Min/Max Aggregates
2. Indexed Inequalities for Provenance
3. Refactor IndexAnalysis into separate classes