### PR TITLE
Fixed type-checker logic for binary constraints in malformed programs.

### DIFF
--- a/src/ast/transform/TypeChecker.cpp
+++ b/src/ast/transform/TypeChecker.cpp
@@ -550,7 +550,8 @@ void TypeCheckerImpl::visitBinaryConstraint(const BinaryConstraint& constraint) 
 
     // Skip checks if either side could not be fully deduced
     // The unable-to-deduce-type checker will point out the issue.
-    if (leftTypes.size() != 1 || rightTypes.size() != 1) return;
+    if (leftTypes.isAll() || leftTypes.size() != 1) return;
+    if (rightTypes.isAll() || rightTypes.size() != 1) return;
 
     // Extract types from singleton sets.
     auto& leftType = *typeAnalysis.getTypes(left).begin();

--- a/src/ast/transform/TypeChecker.cpp
+++ b/src/ast/transform/TypeChecker.cpp
@@ -548,11 +548,9 @@ void TypeCheckerImpl::visitBinaryConstraint(const BinaryConstraint& constraint) 
     auto leftTypes = typeAnalysis.getTypes(left);
     auto rightTypes = typeAnalysis.getTypes(right);
 
-    // Skip checks if either side is `Bottom` b/c it just adds noise.
+    // Skip checks if either side could not be fully deduced
     // The unable-to-deduce-type checker will point out the issue.
-    if (leftTypes.empty() || rightTypes.empty() || leftTypes.isAll() || rightTypes.isAll()) return;
-
-    assert((leftTypes.size() == 1) && (rightTypes.size() == 1));
+    if (leftTypes.size() != 1 || rightTypes.size() != 1) return;
 
     // Extract types from singleton sets.
     auto& leftType = *typeAnalysis.getTypes(left).begin();


### PR DESCRIPTION
See issue #1749 (which this fixes).

The following (single-line!) malformed program crashes with an assertion error:

```
A(x, m) :- L(x, _), m = min y : { L(x, y) }.
```

Error:
```
./src/souffle crash.dl
souffle: ast/transform/TypeChecker.cpp:555: virtual void souffle::ast::transform::TypeCheckerImpl::visitBinaryConstraint(const souffle::ast::BinaryConstraint&): Assertion `(leftTypes.size() == 1) && (rightTypes.size() == 1)' failed.
Aborted (core dumped)
```

The lack of relation declarations means the type-analysis is missing some information, but the clause itself provides enough information for partial deduction. The result is an unexpected state where the type hasn't been fully deduced, but is neither the full nor empty typeset. When checking the operands of a binary constraint, this is falsely assumed to be an impossible case. Instead, handling this should be left to the individual argument checks happening elsewhere, as with the other invalid typeset situations.