### PR TITLE
Disable frequency counter in the interpreter

### DIFF
--- a/src/interpreter/Generator.cpp
+++ b/src/interpreter/Generator.cpp
@@ -166,9 +166,6 @@ NodePtr NodeGenerator::visitNestedOperation(const ram::NestedOperation& nested) 
 }
 
 NodePtr NodeGenerator::visitTupleOperation(const ram::TupleOperation& search) {
-    if (engine.profileEnabled) {
-        return mk<TupleOperation>(I_TupleOperation, &search, visit(search.getOperation()));
-    }
     return visit(search.getOperation());
 }
 

--- a/src/interpreter/Node.h
+++ b/src/interpreter/Node.h
@@ -70,7 +70,6 @@ struct RelationWrapper;
     FOR_EACH(Expand, ExistenceCheck)\
     FOR_EACH_PROVENANCE(Expand, ProvenanceExistenceCheck)\
     Forward(Constraint)\
-    Forward(TupleOperation)\
     FOR_EACH(Expand, Scan)\
     FOR_EACH(Expand, ParallelScan)\
     FOR_EACH(Expand, IndexScan)\
@@ -555,13 +554,6 @@ public:
  */
 class Constraint : public BinaryNode {
     using BinaryNode::BinaryNode;
-};
-
-/**
- * @class TupleOperation
- */
-class TupleOperation : public UnaryNode {
-    using UnaryNode::UnaryNode;
 };
 
 /**


### PR DESCRIPTION
The frequency counter in the interpreter causes a lot of performance overhead under profiling mode.
This makes the profiler report, in particular, the execution time of the interpreter inaccurate.

This PR disables the frequency counter in the interpreter so that user can at least get accurate profiling for the execution time.
If the frequency counter is really needed, the user should go for synthesiser mode as the result should be the same.

Once the PR is merged I'll update the documentation accordingly.