### PR TITLE
Add option to explicitly enable frequency counter in profiler.

### DIFF
--- a/src/interpreter/Engine.h
+++ b/src/interpreter/Engine.h
@@ -150,6 +150,7 @@ private:
 
     /** If profile is enable in this program */
     const bool profileEnabled;
+    const bool frequencyCounterEnabled;
     /** If running a provenance program */
     const bool isProvenance;
     /** subroutines */

--- a/src/interpreter/Generator.cpp
+++ b/src/interpreter/Generator.cpp
@@ -166,7 +166,7 @@ NodePtr NodeGenerator::visitNestedOperation(const ram::NestedOperation& nested) 
 }
 
 NodePtr NodeGenerator::visitTupleOperation(const ram::TupleOperation& search) {
-    if (engine.profileEnabled) {
+    if (engine.profileEnabled && engine.frequencyCounterEnabled && !search.getProfileText().empty()) {
         return mk<TupleOperation>(I_TupleOperation, &search, visit(search.getOperation()));
     }
     return visit(search.getOperation());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -237,10 +237,11 @@ int main(int argc, char** argv) {
                 {"dl-program", 'o', "FILE", "", false,
                         "Generate C++ source code, written to <FILE>, and compile this to a "
                         "binary executable (without executing it)."},
-                {"live-profile", '\2', "", "", false, "Enable live profiling."},
+                {"live-profile", '\1', "", "", false, "Enable live profiling."},
                 {"profile", 'p', "FILE", "", false, "Enable profiling, and write profile data to <FILE>."},
                 {"profile-use", 'u', "FILE", "", false,
                         "Use profile log-file <FILE> for profile-guided optimization."},
+                {"profile-frequency", '\2', "", "", false, "Enable the frequency counter in the profiler."},
                 {"debug-report", 'r', "FILE", "", false, "Write HTML debug report to <FILE>."},
                 {"pragma", 'P', "OPTIONS", "", false, "Set pragma options."},
                 {"provenance", 't', "[ none | explain | explore ]", "", false,

--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -638,7 +638,8 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
         void visitNestedOperation(const NestedOperation& nested, std::ostream& out) override {
             visit(nested.getOperation(), out);
-            if (Global::config().has("profile") && !nested.getProfileText().empty()) {
+            if (Global::config().has("profile") && Global::config().has("profile-frequency") &&
+                    !nested.getProfileText().empty()) {
                 out << "freqs[" << synthesiser.lookupFreqIdx(nested.getProfileText()) << "]++;\n";
             }
         }
@@ -1782,7 +1783,8 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             auto arity = rel->getArity();
             assert(arity > 0 && "AstToRamTranslator failed");
             std::string after;
-            if (Global::config().has("profile") && !synthesiser.lookup(exists.getRelation())->isTemp()) {
+            if (Global::config().has("profile") && Global::config().has("profile-frequency") &&
+                    !synthesiser.lookup(exists.getRelation())->isTemp()) {
                 out << R"_((reads[)_" << synthesiser.lookupReadIdx(rel->getName()) << R"_(]++,)_";
                 after = ")";
             }

--- a/tests/profile.at
+++ b/tests/profile.at
@@ -49,7 +49,7 @@ m4_define([TEST_PROFILE_COMMAND],[
   m4_define([PROGRAM],[TESTDIR/TESTNAME.dl])
   m4_define([FACTS],[TESTDIR/facts])
   m4_define([EXPECTED_OUTPUT],["TESTDIR/out/$4.out"])
-  AT_CHECK(["$SOUFFLE" CONF -D. -p LOG_FILE -F FACTS PROGRAM 1>TESTNAME.out 2>TESTNAME.err], [0])
+  AT_CHECK(["$SOUFFLE" CONF -D. -p LOG_FILE --profile-frequency -F FACTS PROGRAM 1>TESTNAME.out 2>TESTNAME.err], [0])
   FILE_EXISTS([LOG_FILE])
   AT_CHECK(["$SOUFFLE_PROFILE" LOG_FILE -c $4 1>TESTNAME.prof0.out 2>TESTNAME.prof.err], [0])
   AT_CHECK([sed 's?[./].*$1.dl?$1.dl?g' TESTNAME.prof0.out >TESTNAME.prof.out], [0])


### PR DESCRIPTION
The frequency counter causes a lot of performance overhead under profiling mode. This makes the reported execution time inaccurate.

This PR disables the frequency counter by default so that user can at least get accurate profiling for the execution time.
If the frequency counter is desired, the user should pass `--profile-frequency` along with `--profile` to enable the counter.

Once the PR is merged I'll update the documentation accordingly.