### PR TITLE
Interpretr: make sure lower <= upper before issuing a range search.

### DIFF
--- a/src/interpreter/Index.h
+++ b/src/interpreter/Index.h
@@ -150,12 +150,14 @@ public:
     using Tuple = typename souffle::Tuple<RamDomain, Arity>;
     using iterator = typename Data::iterator;
     using Hints = typename Data::operation_hints;
+    using Comparator = comparator<Arity>;
 
     Index(Order order) : order(std::move(order)) {}
 
 protected:
     Order order;
     Data data;
+    Comparator cmp;
 
 public:
     /**
@@ -166,6 +168,7 @@ public:
     class View : public ViewWrapper {
         mutable Hints hints;
         const Data& data;
+        Comparator cmp;
 
     public:
         View(const Data& data) : data(data) {}
@@ -182,6 +185,9 @@ public:
 
         /** Obtains a pair of iterators representing the given range within this index. */
         souffle::range<iterator> range(const Tuple& low, const Tuple& high) {
+            if (cmp.less(low, high) != true) {
+                return {data.end(), data.end()};
+            }
             return {data.lower_bound(low, hints), data.upper_bound(high, hints)};
         }
     };
@@ -264,6 +270,9 @@ public:
      * Returns a pair of iterators covering elements in the range [low,high)
      */
     souffle::range<iterator> range(const Tuple& low, const Tuple& high) const {
+        if (cmp.less(low, high) != true) {
+            return {data.end(), data.end()};
+        }
         return {data.lower_bound(low), data.upper_bound(high)};
     }
 

--- a/src/interpreter/Index.h
+++ b/src/interpreter/Index.h
@@ -185,7 +185,7 @@ public:
 
         /** Obtains a pair of iterators representing the given range within this index. */
         souffle::range<iterator> range(const Tuple& low, const Tuple& high) {
-            if (cmp.less(low, high) != true) {
+            if (cmp(low, high) > 0) {
                 return {data.end(), data.end()};
             }
             return {data.lower_bound(low, hints), data.upper_bound(high, hints)};
@@ -270,7 +270,7 @@ public:
      * Returns a pair of iterators covering elements in the range [low,high)
      */
     souffle::range<iterator> range(const Tuple& low, const Tuple& high) const {
-        if (cmp.less(low, high) != true) {
+        if (cmp(low, high) > 0) {
             return {data.end(), data.end()};
         }
         return {data.lower_bound(low), data.upper_bound(high)};


### PR DESCRIPTION
With the new inequality index, it is possible to run into situations where lower search bound is larger than the higher search bound. (e.g. #1765) 
As a result, we need to make sure the lower <= upper before issuing a range search in the data structure.

The synthesiser already has this check, this PR makes up for the interpreter side.
Fix issue #1765.

