### PR TITLE
Make sed new line insertion more portable

### DIFF
--- a/tests/provenance.at
+++ b/tests/provenance.at
@@ -35,8 +35,10 @@ m4_define([TEST_PROV],[
 
   # provenance output generates a `.' after the final tuple
   # since tuple output is non-deterministic, this `.' should be decoupled from the tuple
-  sed 's/\.$/\n./' TESTNAME.out | sort > TESTNAME.out.generated
-  sed 's/\.$/\n./' EXPECTEDDIR/TESTNAME.out | sort > TESTNAME.out.expected
+  sed 's/\.$/\
+./' TESTNAME.out | sort > TESTNAME.out.generated
+  sed 's/\.$/\
+./' EXPECTEDDIR/TESTNAME.out | sort > TESTNAME.out.expected
   SAME_FILE([TESTNAME.out.generated],[TESTNAME.out.expected])
 
   # validate whether the number of generated CSV files

--- a/tests/semantic.at
+++ b/tests/semantic.at
@@ -58,16 +58,20 @@ m4_define([TEST_EVAL_JSON],[
   m4_define([EXPECTEDDIR], [TESTDIR$4])
   # invoke souffle
   AT_CHECK(["$SOUFFLE" FLAGS -D. -F FACTS PROGRAM 1>TESTNAME.out 2>TESTNAME.err], [0])
-  sed 's/\(@<:@@:>@,@:>@\)$/\n\1/' TESTNAME.out | sort > TESTNAME.out.generated
-  sed 's/\(@<:@@:>@,@:>@\)$/\n\1/' EXPECTEDDIR/TESTNAME.out | sort > TESTNAME.out.expected
+  sed 's/\(@<:@@:>@,@:>@\)$/\
+\1/' TESTNAME.out | sort > TESTNAME.out.generated
+  sed 's/\(@<:@@:>@,@:>@\)$/\
+\1/' EXPECTEDDIR/TESTNAME.out | sort > TESTNAME.out.expected
   SAME_FILE([TESTNAME.out.generated],[TESTNAME.out.expected])
 
   for i in *.json
   do
     if ls "$i" 2>&1 > /dev/null;
     then
-      sed 's/\(@<:@@:>@,@:>@\)$/\n\1/' $i | sort > $i.generated
-      sed 's/\(@<:@@:>@,@:>@\)$/\n\1/' EXPECTEDDIR/$i | sort > $i.expected
+      sed 's/\(@<:@@:>@,@:>@\)$/\
+\1/' $i | sort > $i.generated
+      sed 's/\(@<:@@:>@,@:>@\)$/\
+\1/' EXPECTEDDIR/$i | sort > $i.expected
       SAME_FILE([$i.generated],[$i.expected])
     fi
   done


### PR DESCRIPTION
Currently, json parsing tests are non-deterministic when run on OSX sed. This PR uses more portable sed syntax.