### PR TITLE
First stage of refactoring clause translator.

### DIFF
--- a/src/ast2ram/ClauseTranslator.cpp
+++ b/src/ast2ram/ClauseTranslator.cpp
@@ -262,7 +262,8 @@ Own<ram::Operation> ClauseTranslator::addGeneratorLevels(Own<ram::Operation> op)
                             break;
                         }
                     }
-                } else if (arg != nullptr) {
+                } else {
+                    assert(arg != nullptr && "aggregator argument cannot be nullptr");
                     auto value = ValueTranslator::translate(context, symbolTable, *valueIndex, arg);
                     aggCond = addAggEqCondition(std::move(aggCond), std::move(value), i);
                 }

--- a/src/ast2ram/ClauseTranslator.cpp
+++ b/src/ast2ram/ClauseTranslator.cpp
@@ -262,14 +262,16 @@ Own<ram::Operation> ClauseTranslator::addGeneratorLevels(Own<ram::Operation> op)
                             break;
                         }
                     }
-                } else if (auto value = ValueTranslator::translate(context, symbolTable, *valueIndex, arg)) {
+                } else if (arg != nullptr) {
+                    auto value = ValueTranslator::translate(context, symbolTable, *valueIndex, arg);
                     aggCond = addAggEqCondition(std::move(aggCond), std::move(value), i);
                 }
             }
 
             // translate aggregate expression
-            auto expr =
-                    ValueTranslator::translate(context, symbolTable, *valueIndex, agg->getTargetExpression());
+            const auto* aggExpr = agg->getTargetExpression();
+            auto expr = aggExpr ? ValueTranslator::translate(context, symbolTable, *valueIndex, aggExpr)
+                                : nullptr;
 
             // add Ram-Aggregation layer
             op = mk<ram::Aggregate>(std::move(op), agg->getFinalType().value(),

--- a/src/ast2ram/ClauseTranslator.cpp
+++ b/src/ast2ram/ClauseTranslator.cpp
@@ -235,15 +235,10 @@ Own<ram::Operation> ClauseTranslator::instantiateAggregator(
 
     // translate constraints of sub-clause
     for (const auto* lit : agg->getBodyLiterals()) {
-        // atoms handled later
-        if (isA<ast::Atom>(lit)) {
-            continue;
-        }
-
         // literal becomes a constraint
-        auto newCondition = ConstraintTranslator::translate(context, symbolTable, *valueIndex, lit);
-        assert(newCondition != nullptr && "condition should be a valid value");
-        aggCond = addConjunctiveTerm(std::move(aggCond), std::move(newCondition));
+        if (auto condition = ConstraintTranslator::translate(context, symbolTable, *valueIndex, lit)) {
+            aggCond = addConjunctiveTerm(std::move(aggCond), std::move(condition));
+        }
     }
 
     // translate arguments of atom to conditions
@@ -321,15 +316,10 @@ Own<ram::Operation> ClauseTranslator::addGeneratorLevels(Own<ram::Operation> op)
 Own<ram::Operation> ClauseTranslator::addBodyLiteralConstraints(
         const ast::Clause& clause, Own<ram::Operation> op) {
     for (const auto* lit : clause.getBodyLiterals()) {
-        // atoms not handled here
-        if (isA<ast::Atom>(lit)) {
-            continue;
-        }
-
         // constraints become literals
-        auto condition = ConstraintTranslator::translate(context, symbolTable, *valueIndex, lit);
-        assert(condition != nullptr && "condition should be a valid value");
-        op = mk<ram::Filter>(std::move(condition), std::move(op));
+        if (auto condition = ConstraintTranslator::translate(context, symbolTable, *valueIndex, lit)) {
+            op = mk<ram::Filter>(std::move(condition), std::move(op));
+        }
     }
     return op;
 }

--- a/src/ast2ram/ClauseTranslator.cpp
+++ b/src/ast2ram/ClauseTranslator.cpp
@@ -244,8 +244,8 @@ Own<ram::Operation> ClauseTranslator::addGeneratorLevels(Own<ram::Operation> op)
             }
 
             // translate arguments's of atom to conditions
-            const auto& aggBodyAtoms = filter(agg->getBodyLiterals(),
-                    [&](const ast::Literal* lit) { return dynamic_cast<const ast::Atom*>(lit) != nullptr; });
+            const auto& aggBodyAtoms = filter(
+                    agg->getBodyLiterals(), [&](const ast::Literal* lit) { return isA<ast::Atom>(lit); });
             assert(aggBodyAtoms.size() == 1 && "exactly one atom should exist per aggregator body");
             const auto* aggAtom = static_cast<const ast::Atom*>(aggBodyAtoms.at(0));
 
@@ -468,8 +468,7 @@ void ClauseTranslator::indexNodeArguments(int nodeLevel, const std::vector<ast::
 
 std::optional<int> ClauseTranslator::addGenerator(const ast::Argument& arg) {
     // TODO: by-value comparison for CSE; do this elsewhere
-    if (dynamic_cast<const ast::Aggregator*>(&arg) != nullptr &&
-            any_of(generators, [&](auto* x) { return *x == arg; })) {
+    if (isA<ast::Aggregator>(&arg) && any_of(generators, [&](auto* x) { return *x == arg; })) {
         return {};
     }
     generators.push_back(&arg);

--- a/src/ast2ram/ClauseTranslator.cpp
+++ b/src/ast2ram/ClauseTranslator.cpp
@@ -304,7 +304,7 @@ Own<ram::Operation> ClauseTranslator::instantiateMultiResultFunctor(
 }
 
 Own<ram::Operation> ClauseTranslator::addGeneratorLevels(Own<ram::Operation> op) {
-    --level;
+    level--;
     for (auto* cur : reverse(generators)) {
         if (auto agg = dynamic_cast<const ast::Aggregator*>(cur)) {
             op = instantiateAggregator(std::move(op), agg);
@@ -313,7 +313,7 @@ Own<ram::Operation> ClauseTranslator::addGeneratorLevels(Own<ram::Operation> op)
         } else {
             assert(false && "unhandled generator");
         }
-        --level;
+        level--;
     }
     return op;
 }

--- a/src/ast2ram/ClauseTranslator.cpp
+++ b/src/ast2ram/ClauseTranslator.cpp
@@ -335,7 +335,7 @@ Own<ram::Operation> ClauseTranslator::addBodyLiteralConstraints(
 }
 
 Own<ram::Operation> ClauseTranslator::addAggregatorConstraints(Own<ram::Operation> op) {
-    // TODO: go through this one
+    // TODO (azreika): needs some clean up
     for (int curLevel = op_nesting.size() - 1; curLevel >= 0; curLevel--) {
         // Only interested in atom arguments
         const auto* atom = dynamic_cast<const ast::Atom*>(op_nesting.at(curLevel));
@@ -488,7 +488,7 @@ void ClauseTranslator::indexNodeArguments(int nodeLevel, const std::vector<ast::
 }
 
 std::optional<int> ClauseTranslator::addGenerator(const ast::Argument& arg) {
-    // TODO: by-value comparison for CSE; do this elsewhere
+    // TODO (azreika): by-value comparison for CSE; do this in the AST like other generators
     if (isA<ast::Aggregator>(&arg) && any_of(generators, [&](auto* x) { return *x == arg; })) {
         return {};
     }

--- a/src/ast2ram/ClauseTranslator.cpp
+++ b/src/ast2ram/ClauseTranslator.cpp
@@ -445,7 +445,7 @@ Own<ast::Clause> ClauseTranslator::getReorderedClause(const ast::Clause& clause,
     return reorderedClause;
 }
 
-void ClauseTranslator::indexValues(const ast::Node* curNode, const std::vector<ast::Argument*>& curNodeArgs,
+void ClauseTranslator::indexValues(int curNodeLevel, const std::vector<ast::Argument*>& curNodeArgs,
         std::map<const ast::Node*, int>& nodeLevel, const std::string& relationName, size_t relationArity) {
     for (size_t pos = 0; pos < curNodeArgs.size(); ++pos) {
         // get argument
@@ -454,9 +454,9 @@ void ClauseTranslator::indexValues(const ast::Node* curNode, const std::vector<a
         // check for variable references
         if (const auto* var = dynamic_cast<const ast::Variable*>(arg)) {
             if (pos < relationArity) {
-                valueIndex->addVarReference(*var, nodeLevel[curNode], pos, relationName);
+                valueIndex->addVarReference(*var, curNodeLevel, pos, relationName);
             } else {
-                valueIndex->addVarReference(*var, nodeLevel[curNode], pos);
+                valueIndex->addVarReference(*var, curNodeLevel, pos);
             }
         }
 
@@ -467,10 +467,10 @@ void ClauseTranslator::indexValues(const ast::Node* curNode, const std::vector<a
             nodeLevel[rec] = level++;
 
             // register location of record
-            valueIndex->setRecordDefinition(*rec, nodeLevel[curNode], pos);
+            valueIndex->setRecordDefinition(*rec, curNodeLevel, pos);
 
             // resolve nested components
-            indexValues(rec, rec->getArguments(), nodeLevel, relationName, relationArity);
+            indexValues(nodeLevel[rec], rec->getArguments(), nodeLevel, relationName, relationArity);
         }
     }
 }
@@ -498,7 +498,7 @@ void ClauseTranslator::indexAtoms(const ast::Clause& clause) {
         op_nesting.push_back(atom);
 
         // index each value in the atom
-        indexValues(atom, atom->getArguments(), nodeLevel, getConcreteRelationName(atom->getQualifiedName()),
+        indexValues(nodeLevel[atom], atom->getArguments(), nodeLevel, getConcreteRelationName(atom->getQualifiedName()),
                 atom->getArity());
     }
 }

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -26,9 +26,11 @@ class SymbolTable;
 }
 
 namespace souffle::ast {
+class Aggregator;
 class Argument;
 class Clause;
 class Constant;
+class IntrinsicFunctor;
 class Node;
 }  // namespace souffle::ast
 
@@ -106,6 +108,10 @@ private:
 
     static RamDomain getConstantRamRepresentation(SymbolTable& symbolTable, const ast::Constant& constant);
     static Own<ram::Expression> translateConstant(SymbolTable& symbolTable, const ast::Constant& constant);
+
+    Own<ram::Operation> instantiateAggregator(Own<ram::Operation> op, const ast::Aggregator* agg);
+    Own<ram::Operation> instantiateMultiResultFunctor(
+            Own<ram::Operation> op, const ast::IntrinsicFunctor* inf);
 };
 
 }  // namespace souffle::ast2ram

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -87,16 +87,9 @@ private:
     void indexMultiResultFunctors(const ast::Clause& clause);
     void indexNodeArguments(int nodeLevel, const std::vector<ast::Argument*>& nodeArgs);
 
-    // Add equivalence constraints imposed by variable bindings
     Own<ram::Operation> addVariableBindingConstraints(Own<ram::Operation> op);
-
-    // Add constraints imposed by the body literals
     Own<ram::Operation> addBodyLiteralConstraints(const ast::Clause& clause, Own<ram::Operation> op);
-
-    // Add aggregator conditions
     Own<ram::Operation> addAggregatorConstraints(Own<ram::Operation> op);
-
-    // Add generator levels
     Own<ram::Operation> addGeneratorLevels(Own<ram::Operation> op);
 
     // Build operation bottom-up

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -101,6 +101,9 @@ private:
     Own<ram::Operation> buildFinalOperation(const ast::Clause& clause, const ast::Clause& originalClause,
             int version, Own<ram::Operation> op);
 
+    // Return the write-location for the generator, or {} if an equivalent arg was already seen
+    std::optional<int> addGenerator(const ast::Argument& arg);
+
     static RamDomain getConstantRamRepresentation(SymbolTable& symbolTable, const ast::Constant& constant);
     static Own<ram::Expression> translateConstant(SymbolTable& symbolTable, const ast::Constant& constant);
 };

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -84,7 +84,7 @@ private:
     void indexAggregators(const ast::Clause& clause);
     void indexMultiResultFunctors(const ast::Clause& clause);
 
-    void indexValues(const ast::Node* curNode, const std::vector<ast::Argument*>& curNodeArgs,
+    void indexValues(int curNodeLevel, const std::vector<ast::Argument*>& curNodeArgs,
             std::map<const ast::Node*, int>& nodeLevel, const std::string& relationName,
             size_t relationArity);
 

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -83,9 +83,7 @@ private:
     void indexAtoms(const ast::Clause& clause);
     void indexAggregators(const ast::Clause& clause);
     void indexMultiResultFunctors(const ast::Clause& clause);
-
-    void indexValues(int curNodeLevel, const std::vector<ast::Argument*>& curNodeArgs,
-            const std::string& relationName, size_t relationArity);
+    void indexNodeArguments(int nodeLevel, const std::vector<ast::Argument*>& nodeArgs);
 
     // Add equivalence constraints imposed by variable bindings
     Own<ram::Operation> addVariableBindingConstraints(Own<ram::Operation> op);

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -85,8 +85,7 @@ private:
     void indexMultiResultFunctors(const ast::Clause& clause);
 
     void indexValues(int curNodeLevel, const std::vector<ast::Argument*>& curNodeArgs,
-            std::map<const ast::Node*, int>& nodeLevel, const std::string& relationName,
-            size_t relationArity);
+            const std::string& relationName, size_t relationArity);
 
     // Add equivalence constraints imposed by variable bindings
     Own<ram::Operation> addVariableBindingConstraints(Own<ram::Operation> op);

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -79,11 +79,14 @@ private:
 
     Own<ast::Clause> getReorderedClause(const ast::Clause& clause, const int version) const;
 
+    void indexClause(const ast::Clause& clause);
+    void indexAtoms(const ast::Clause& clause);
+    void indexAggregators(const ast::Clause& clause);
+    void indexMultiResultFunctors(const ast::Clause& clause);
+
     void indexValues(const ast::Node* curNode, const std::vector<ast::Argument*>& curNodeArgs,
             std::map<const ast::Node*, int>& nodeLevel, const std::string& relationName,
             size_t relationArity);
-
-    void createValueIndex(const ast::Clause& clause);
 
     // Add equivalence constraints imposed by variable bindings
     Own<ram::Operation> addVariableBindingConstraints(Own<ram::Operation> op);

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -50,8 +50,9 @@ public:
     ClauseTranslator(const TranslatorContext& context, SymbolTable& symbolTable)
             : context(context), symbolTable(symbolTable) {}
 
+    /** Generate RAM code for a clause */
     Own<ram::Statement> translateClause(
-            const ast::Clause& clause, const ast::Clause& originalClause, const int version = 0);
+            const ast::Clause& clause, const ast::Clause& originalClause, int version = 0);
 
 protected:
     const TranslatorContext& context;
@@ -63,7 +64,7 @@ protected:
     // current nesting level
     int level = 0;
 
-    virtual Own<ram::Operation> createOperation(const ast::Clause& clause);
+    virtual Own<ram::Operation> createProjection(const ast::Clause& clause);
     virtual Own<ram::Condition> createCondition(const ast::Clause& originalClause);
 
     /** apply constraint filters to a given operation */
@@ -83,6 +84,22 @@ private:
             size_t relationArity);
 
     void createValueIndex(const ast::Clause& clause);
+
+    // Add equivalence constraints imposed by variable bindings
+    Own<ram::Operation> addVariableBindingConstraints(Own<ram::Operation> op);
+
+    // Add constraints imposed by the body literals
+    Own<ram::Operation> addBodyLiteralConstraints(const ast::Clause& clause, Own<ram::Operation> op);
+
+    // Add aggregator conditions
+    Own<ram::Operation> addAggregatorConstraints(Own<ram::Operation> op);
+
+    // Add generator levels
+    Own<ram::Operation> addGeneratorLevels(Own<ram::Operation> op);
+
+    // Build operation bottom-up
+    Own<ram::Operation> buildFinalOperation(const ast::Clause& clause, const ast::Clause& originalClause,
+            int version, Own<ram::Operation> op);
 
     static RamDomain getConstantRamRepresentation(SymbolTable& symbolTable, const ast::Constant& constant);
     static Own<ram::Expression> translateConstant(SymbolTable& symbolTable, const ast::Constant& constant);

--- a/src/ast2ram/ProvenanceClauseTranslator.cpp
+++ b/src/ast2ram/ProvenanceClauseTranslator.cpp
@@ -34,7 +34,8 @@ Own<ram::Condition> ProvenanceClauseTranslator::createCondition(const ast::Claus
     return nullptr;
 }
 
-Own<ram::Operation> ProvenanceClauseTranslator::createOperation(const ast::Clause& clause) {
+// TODO: this doesn't fit
+Own<ram::Operation> ProvenanceClauseTranslator::createProjection(const ast::Clause& clause) {
     VecOwn<ram::Expression> values;
 
     // get all values in the body

--- a/src/ast2ram/ProvenanceClauseTranslator.cpp
+++ b/src/ast2ram/ProvenanceClauseTranslator.cpp
@@ -34,7 +34,7 @@ Own<ram::Condition> ProvenanceClauseTranslator::createCondition(const ast::Claus
     return nullptr;
 }
 
-// TODO: this doesn't fit
+// TODO (azreika): this overload doesn't really fit
 Own<ram::Operation> ProvenanceClauseTranslator::createProjection(const ast::Clause& clause) {
     VecOwn<ram::Expression> values;
 

--- a/src/ast2ram/ProvenanceClauseTranslator.h
+++ b/src/ast2ram/ProvenanceClauseTranslator.h
@@ -37,7 +37,7 @@ public:
             : ClauseTranslator(context, symbolTable) {}
 
 protected:
-    Own<ram::Operation> createOperation(const ast::Clause& clause) override;
+    Own<ram::Operation> createProjection(const ast::Clause& clause) override;
     Own<ram::Condition> createCondition(const ast::Clause& originalClause) override;
 };
 }  // namespace souffle::ast2ram

--- a/src/ast2ram/ValueTranslator.cpp
+++ b/src/ast2ram/ValueTranslator.cpp
@@ -40,7 +40,7 @@ namespace souffle::ast2ram {
 
 Own<ram::Expression> ValueTranslator::translate(const TranslatorContext& context, SymbolTable& symbolTable,
         const ValueIndex& index, const ast::Argument* arg) {
-    if (arg == nullptr) return nullptr;
+    assert(arg != nullptr && "arg should be defined");
     return ValueTranslator(context, symbolTable, index)(*arg);
 }
 

--- a/src/ast2ram/utility/Location.h
+++ b/src/ast2ram/utility/Location.h
@@ -26,7 +26,7 @@ struct Location {
     const int identifier;
     const int element;
 
-    // TODO: should probably be size_t
+    // TODO (azreika): change these to size_t
     Location(int ident, int elem) : identifier(ident), element(elem) {}
 
     Location(const Location& l) = default;

--- a/src/ast2ram/utility/Location.h
+++ b/src/ast2ram/utility/Location.h
@@ -25,11 +25,9 @@ namespace souffle::ast2ram {
 struct Location {
     const int identifier;
     const int element;
-    std::string relation;
 
     // TODO: should probably be size_t
-    Location(int ident, int elem, std::string rel = "")
-            : identifier(ident), element(elem), relation(std::move(rel)) {}
+    Location(int ident, int elem) : identifier(ident), element(elem) {}
 
     Location(const Location& l) = default;
 

--- a/src/ast2ram/utility/Location.h
+++ b/src/ast2ram/utility/Location.h
@@ -27,6 +27,7 @@ struct Location {
     const int element;
     std::string relation;
 
+    // TODO: should probably be size_t
     Location(int ident, int elem, std::string rel = "")
             : identifier(ident), element(elem), relation(std::move(rel)) {}
 

--- a/src/ast2ram/utility/Utils.cpp
+++ b/src/ast2ram/utility/Utils.cpp
@@ -24,6 +24,8 @@
 #include "ast/utility/Utils.h"
 #include "ast2ram/utility/Location.h"
 #include "ram/Clear.h"
+#include "ram/Condition.h"
+#include "ram/Conjunction.h"
 #include "ram/TupleElement.h"
 #include "souffle/utility/ContainerUtil.h"
 #include "souffle/utility/StringUtil.h"
@@ -85,6 +87,11 @@ void nameUnnamedVariables(ast::Clause* clause) {
 
 Own<ram::TupleElement> makeRamTupleElement(const Location& loc) {
     return mk<ram::TupleElement>(loc.identifier, loc.element);
+}
+
+Own<ram::Condition> addConjunctiveTerm(Own<ram::Condition> curCondition, Own<ram::Condition> newTerm) {
+    return curCondition ? mk<ram::Conjunction>(std::move(curCondition), std::move(newTerm))
+                        : std::move(newTerm);
 }
 
 }  // namespace souffle::ast2ram

--- a/src/ast2ram/utility/Utils.h
+++ b/src/ast2ram/utility/Utils.h
@@ -28,6 +28,7 @@ class Relation;
 
 namespace souffle::ram {
 class Clear;
+class Condition;
 class Statement;
 class TupleElement;
 }  // namespace souffle::ram
@@ -56,5 +57,8 @@ void nameUnnamedVariables(ast::Clause* clause);
 
 /** Create a RAM element access node */
 Own<ram::TupleElement> makeRamTupleElement(const Location& loc);
+
+/** Add a term to a conjunction */
+Own<ram::Condition> addConjunctiveTerm(Own<ram::Condition> curCondition, Own<ram::Condition> newTerm);
 
 }  // namespace souffle::ast2ram

--- a/src/ast2ram/utility/ValueIndex.cpp
+++ b/src/ast2ram/utility/ValueIndex.cpp
@@ -35,8 +35,8 @@ void ValueIndex::addVarReference(const ast::Variable& var, const Location& l) {
     locs.insert(l);
 }
 
-void ValueIndex::addVarReference(const ast::Variable& var, int ident, int pos, std::string rel) {
-    addVarReference(var, Location({ident, pos, rel}));
+void ValueIndex::addVarReference(const ast::Variable& var, int ident, int pos) {
+    addVarReference(var, Location({ident, pos}));
 }
 
 bool ValueIndex::isDefined(const ast::Variable& var) const {
@@ -73,8 +73,8 @@ const Location& ValueIndex::getGeneratorLoc(const ast::Argument& arg) const {
     fatal("arg `%s` has no generator location", arg);
 }
 
-void ValueIndex::setRecordDefinition(const ast::RecordInit& init, int ident, int pos, std::string rel) {
-    recordDefinitionPoints.insert({&init, Location({ident, pos, rel})});
+void ValueIndex::setRecordDefinition(const ast::RecordInit& init, int ident, int pos) {
+    recordDefinitionPoints.insert({&init, Location({ident, pos})});
 }
 
 const Location& ValueIndex::getDefinitionPoint(const ast::RecordInit& init) const {

--- a/src/ast2ram/utility/ValueIndex.h
+++ b/src/ast2ram/utility/ValueIndex.h
@@ -43,12 +43,12 @@ public:
         return varReferencePoints;
     }
     void addVarReference(const ast::Variable& var, const Location& l);
-    void addVarReference(const ast::Variable& var, int ident, int pos, std::string rel = "");
+    void addVarReference(const ast::Variable& var, int ident, int pos);
     bool isDefined(const ast::Variable& var) const;
     const Location& getDefinitionPoint(const ast::Variable& var) const;
 
     // -- records --
-    void setRecordDefinition(const ast::RecordInit& init, int ident, int pos, std::string rel = "");
+    void setRecordDefinition(const ast::RecordInit& init, int ident, int pos);
     const Location& getDefinitionPoint(const ast::RecordInit& init) const;
 
     // -- generators (aggregates & some functors) --


### PR DESCRIPTION
Follows up on PR #1768 with some clause translator refactoring.

This PR is focused on the first steps of modularising the clause translator. The goal is to make it less clunky, and a lot more straightforward and maintainable.

The next step should be removing the generator CSE so that things can be streamlined a little - see issue #1736. This should remove a considerable amount of special handling. After that, cleaning up the clause translator further to get it to the point where cloning can be eliminated nicely, and, consequently, the type-state introduced in PR #1725 can finally be removed.