### PR TITLE
Removed aggregator CSE from translator.

### DIFF
--- a/src/ast2ram/ClauseTranslator.cpp
+++ b/src/ast2ram/ClauseTranslator.cpp
@@ -478,13 +478,8 @@ void ClauseTranslator::indexNodeArguments(int nodeLevel, const std::vector<ast::
 }
 
 std::optional<int> ClauseTranslator::addGenerator(const ast::Argument& arg) {
-    // TODO (azreika): by-value comparison for CSE; do this in the AST like other generators
-    if (isA<ast::Aggregator>(&arg) && any_of(generators, [&](auto* x) { return *x == arg; })) {
-        return {};
-    }
-    generators.push_back(&arg);
-
     int aggLoc = level++;
+    generators.push_back(&arg);
     valueIndex->setGeneratorLoc(arg, Location({aggLoc, 0}));
     return aggLoc;
 }

--- a/src/ast2ram/utility/ValueIndex.cpp
+++ b/src/ast2ram/utility/ValueIndex.cpp
@@ -51,26 +51,12 @@ const Location& ValueIndex::getDefinitionPoint(const ast::Variable& var) const {
 }
 
 void ValueIndex::setGeneratorLoc(const ast::Argument& arg, const Location& loc) {
-    generatorDefinitionPoints.push_back(std::make_pair(&arg, loc));
+    generatorDefinitionPoints.insert({&arg, loc});
 }
 
 const Location& ValueIndex::getGeneratorLoc(const ast::Argument& arg) const {
-    if (dynamic_cast<const ast::Aggregator*>(&arg) != nullptr) {
-        // aggregators can be used interchangeably if syntactically equal
-        for (const auto& cur : generatorDefinitionPoints) {
-            if (*cur.first == arg) {
-                return cur.second;
-            }
-        }
-    } else {
-        // otherwise, unique for each appearance
-        for (const auto& cur : generatorDefinitionPoints) {
-            if (cur.first == &arg) {
-                return cur.second;
-            }
-        }
-    }
-    fatal("arg `%s` has no generator location", arg);
+    assert(contains(generatorDefinitionPoints, &arg) && "undefined generator");
+    return generatorDefinitionPoints.at(&arg);
 }
 
 void ValueIndex::setRecordDefinition(const ast::RecordInit& init, int ident, int pos) {

--- a/src/ast2ram/utility/ValueIndex.h
+++ b/src/ast2ram/utility/ValueIndex.h
@@ -68,8 +68,7 @@ private:
     std::map<const ast::RecordInit*, Location> recordDefinitionPoints;
 
     // Map from generative arguments to definition point
-    // Arguments indexed by value, not address, so std::map can't be used
-    std::vector<std::pair<const ast::Argument*, Location>> generatorDefinitionPoints;
+    std::map<const ast::Argument*, Location> generatorDefinitionPoints;
 };
 
 }  // namespace souffle::ast2ram


### PR DESCRIPTION
Aggregates are no longer duplicated across all use-points, and so this code is no longer useful. If CSE is needed, then it should be done on the AST level instead.