### PR TITLE
Third stage of clause translator refactoring.

### DIFF
--- a/src/ast2ram/ClauseTranslator.cpp
+++ b/src/ast2ram/ClauseTranslator.cpp
@@ -460,10 +460,9 @@ void ClauseTranslator::indexNodeArguments(int nodeLevel, const std::vector<ast::
     }
 }
 
-std::optional<int> ClauseTranslator::addGenerator(const ast::Argument& arg) {
+void ClauseTranslator::indexGenerator(const ast::Argument& arg) {
     int aggLoc = addGeneratorLevel(&arg);
     valueIndex->setGeneratorLoc(arg, Location({aggLoc, 0}));
-    return aggLoc;
 }
 
 void ClauseTranslator::indexAtoms(const ast::Clause& clause) {
@@ -495,7 +494,7 @@ void ClauseTranslator::indexAggregatorBody(const ast::Aggregator& agg) {
 
 void ClauseTranslator::indexAggregators(const ast::Clause& clause) {
     // Add each aggregator as an internal generator
-    visitDepthFirst(clause, [&](const ast::Aggregator& agg) { addGenerator(agg); });
+    visitDepthFirst(clause, [&](const ast::Aggregator& agg) { indexGenerator(agg); });
 
     // Index aggregator bodies
     visitDepthFirst(clause, [&](const ast::Aggregator& agg) { indexAggregatorBody(agg); });
@@ -514,7 +513,7 @@ void ClauseTranslator::indexMultiResultFunctors(const ast::Clause& clause) {
     // Add each multi-result functor as an internal generator
     visitDepthFirst(clause, [&](const ast::IntrinsicFunctor& func) {
         if (ast::analysis::FunctorAnalysis::isMultiResult(func)) {
-            addGenerator(func);
+            indexGenerator(func);
         }
     });
 

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -88,6 +88,9 @@ private:
     void indexNodeArguments(int nodeLevel, const std::vector<ast::Argument*>& nodeArgs);
     void indexAggregatorBody(const ast::Aggregator& agg);
 
+    Own<ram::Operation> addEqualityCheck(
+            Own<ram::Operation> op, Own<ram::Expression> lhs, Own<ram::Expression> rhs, bool isFloat) const;
+
     Own<ram::Statement> createRamFactQuery(const ast::Clause& clause) const;
     Own<ram::Statement> createRamRuleQuery(
             const ast::Clause& clause, const ast::Clause& originalClause, int version);

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -69,8 +69,8 @@ protected:
     virtual Own<ram::Condition> createCondition(const ast::Clause& originalClause) const;
 
     /** apply constraint filters to a given operation */
-    Own<ram::Operation> filterByConstraints(size_t level, const std::vector<ast::Argument*>& arguments,
-            Own<ram::Operation> op, bool constrainByFunctors = true) const;
+    Own<ram::Operation> addConstantConstraints(
+            size_t level, const std::vector<ast::Argument*>& arguments, Own<ram::Operation> op) const;
 
 private:
     std::vector<const ast::Argument*> generators;

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -88,7 +88,8 @@ private:
     void indexNodeArguments(int nodeLevel, const std::vector<ast::Argument*>& nodeArgs);
     void indexAggregator(const ast::Aggregator& agg);
 
-    Own<ram::Statement> createRamQuery(
+    Own<ram::Statement> createRamFactQuery(const ast::Clause& clause) const;
+    Own<ram::Statement> createRamRuleQuery(
             const ast::Clause& clause, const ast::Clause& originalClause, int version);
     Own<ram::Operation> addVariableBindingConstraints(Own<ram::Operation> op) const;
     Own<ram::Operation> addBodyLiteralConstraints(const ast::Clause& clause, Own<ram::Operation> op) const;

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -86,7 +86,7 @@ private:
     void indexAggregators(const ast::Clause& clause);
     void indexMultiResultFunctors(const ast::Clause& clause);
     void indexNodeArguments(int nodeLevel, const std::vector<ast::Argument*>& nodeArgs);
-    void indexAggregator(const ast::Aggregator& agg);
+    void indexAggregatorBody(const ast::Aggregator& agg);
 
     Own<ram::Statement> createRamFactQuery(const ast::Clause& clause) const;
     Own<ram::Statement> createRamRuleQuery(

--- a/src/ast2ram/ClauseTranslator.h
+++ b/src/ast2ram/ClauseTranslator.h
@@ -68,49 +68,53 @@ protected:
     virtual Own<ram::Operation> createProjection(const ast::Clause& clause) const;
     virtual Own<ram::Condition> createCondition(const ast::Clause& originalClause) const;
 
-    /** apply constraint filters to a given operation */
-    Own<ram::Operation> addConstantConstraints(
-            size_t level, const std::vector<ast::Argument*>& arguments, Own<ram::Operation> op) const;
-
 private:
     std::vector<const ast::Argument*> generators;
     std::vector<const ast::Node*> operators;
 
     Own<ast::Clause> getReorderedClause(const ast::Clause& clause, const int version) const;
 
+    /** Operation levelling */
     int addGeneratorLevel(const ast::Argument* arg);
     int addOperatorLevel(const ast::Node* node);
 
+    /** Indexing */
     void indexClause(const ast::Clause& clause);
     void indexAtoms(const ast::Clause& clause);
     void indexAggregators(const ast::Clause& clause);
     void indexMultiResultFunctors(const ast::Clause& clause);
     void indexNodeArguments(int nodeLevel, const std::vector<ast::Argument*>& nodeArgs);
     void indexAggregatorBody(const ast::Aggregator& agg);
+    void indexGenerator(const ast::Argument& arg);
 
-    Own<ram::Operation> addEqualityCheck(
-            Own<ram::Operation> op, Own<ram::Expression> lhs, Own<ram::Expression> rhs, bool isFloat) const;
-
+    /** Main clause translation */
     Own<ram::Statement> createRamFactQuery(const ast::Clause& clause) const;
     Own<ram::Statement> createRamRuleQuery(
             const ast::Clause& clause, const ast::Clause& originalClause, int version);
+
+    /** Core clause translation stages */
     Own<ram::Operation> addVariableBindingConstraints(Own<ram::Operation> op) const;
     Own<ram::Operation> addBodyLiteralConstraints(const ast::Clause& clause, Own<ram::Operation> op) const;
     Own<ram::Operation> addGeneratorLevels(Own<ram::Operation> op) const;
     Own<ram::Operation> addVariableIntroductions(const ast::Clause& clause, const ast::Clause& originalClause,
             int version, Own<ram::Operation> op);
     Own<ram::Operation> addEntryPoint(const ast::Clause& originalClause, Own<ram::Operation> op) const;
+
+    /** Helper methods */
     Own<ram::Operation> addAtomScan(Own<ram::Operation> op, const ast::Atom* atom, const ast::Clause& clause,
             const ast::Clause& originalClause, int curLevel, int version) const;
     Own<ram::Operation> addRecordUnpack(
             Own<ram::Operation> op, const ast::RecordInit* rec, int curLevel) const;
+    Own<ram::Operation> addConstantConstraints(
+            size_t level, const std::vector<ast::Argument*>& arguments, Own<ram::Operation> op) const;
+    Own<ram::Operation> addEqualityCheck(
+            Own<ram::Operation> op, Own<ram::Expression> lhs, Own<ram::Expression> rhs, bool isFloat) const;
 
-    // Return the write-location for the generator, or {} if an equivalent arg was already seen
-    std::optional<int> addGenerator(const ast::Argument& arg);
-
+    /** Constant translation */
     static RamDomain getConstantRamRepresentation(SymbolTable& symbolTable, const ast::Constant& constant);
     static Own<ram::Expression> translateConstant(SymbolTable& symbolTable, const ast::Constant& constant);
 
+    /** Generator instantiation */
     Own<ram::Operation> instantiateAggregator(
             Own<ram::Operation> op, const ast::Aggregator* agg, int curLevel) const;
     Own<ram::Operation> instantiateMultiResultFunctor(


### PR DESCRIPTION
Cleans up some lingering problems with the clause translator, interface should be mostly complete for the time-being.

Next steps will focus on cleaning up the provenance translator sections (the provenance clause translator is in particular oddly placed), and working towards eliminating the cloning of clauses in the translator in general. Again, the main milestones here are (1) removing the type state in AST objects (which requires the removal of clause clones at the moment), and (2) integrating provenance as a customisable evaluation strategy in a way that alternative evaluation strategies can be more easily added later on.

Follows up from PR #1783. 