### PR TITLE
Fix #1774

### DIFF
--- a/src/ast/analysis/RedundantRelations.cpp
+++ b/src/ast/analysis/RedundantRelations.cpp
@@ -67,7 +67,7 @@ void RedundantRelationsAnalysis::run(const TranslationUnit& translationUnit) {
     redundantRelations.clear();
     for (const Relation* r : relations) {
         if (notRedundant.count(r) == 0u) {
-            redundantRelations.insert(r);
+            redundantRelations.insert(r->getQualifiedName());
         }
     }
 }

--- a/src/ast/analysis/RedundantRelations.h
+++ b/src/ast/analysis/RedundantRelations.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "ast/QualifiedName.h"
 #include "ast/analysis/Analysis.h"
 #include <set>
 #include <string>
@@ -43,14 +44,13 @@ public:
 
     void print(std::ostream& os) const override;
 
-    const std::set<const Relation*>& getRedundantRelations() const {
+    const std::set<QualifiedName>& getRedundantRelations() const {
         return redundantRelations;
     }
 
 private:
     PrecedenceGraphAnalysis* precedenceGraph = nullptr;
-
-    std::set<const Relation*> redundantRelations;
+    std::set<QualifiedName> redundantRelations;
 };
 
 }  // namespace analysis

--- a/src/ast/transform/RemoveEmptyRelations.cpp
+++ b/src/ast/transform/RemoveEmptyRelations.cpp
@@ -35,10 +35,10 @@ namespace souffle::ast::transform {
 
 bool RemoveEmptyRelationsTransformer::removeEmptyRelations(TranslationUnit& translationUnit) {
     Program& program = translationUnit.getProgram();
-    auto* ioTypes = translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
     std::set<QualifiedName> emptyRelations;
     bool changed = false;
     for (auto rel : program.getRelations()) {
+        auto* ioTypes = translationUnit.getAnalysis<analysis::IOTypeAnalysis>();
         if (!getClauses(program, *rel).empty() || ioTypes->isInput(rel)) {
             continue;
         }

--- a/src/ast/transform/RemoveRedundantRelations.cpp
+++ b/src/ast/transform/RemoveRedundantRelations.cpp
@@ -24,12 +24,10 @@ namespace souffle::ast::transform {
 bool RemoveRedundantRelationsTransformer::transform(TranslationUnit& translationUnit) {
     bool changed = false;
     auto* redundantRelationsAnalysis = translationUnit.getAnalysis<analysis::RedundantRelationsAnalysis>();
-    const std::set<const Relation*>& redundantRelations = redundantRelationsAnalysis->getRedundantRelations();
-    if (!redundantRelations.empty()) {
-        for (auto rel : redundantRelations) {
-            removeRelation(translationUnit, rel->getQualifiedName());
-            changed = true;
-        }
+    std::set<QualifiedName> redundantRelations = redundantRelationsAnalysis->getRedundantRelations();
+    for (auto name : redundantRelations) {
+        removeRelation(translationUnit, name);
+        changed = true;
     }
     return changed;
 }

--- a/src/ast/utility/Utils.cpp
+++ b/src/ast/utility/Utils.cpp
@@ -117,6 +117,8 @@ void removeRelationClauses(TranslationUnit& tu, const QualifiedName& name) {
     for (const auto& clause : clausesToRemove) {
         program.removeClause(clause.get());
     }
+
+    tu.invalidateAnalyses();
 }
 
 void removeRelationIOs(TranslationUnit& tu, const QualifiedName& name) {

--- a/tests/semantic/rel_redundant/rel_redundant.dl
+++ b/tests/semantic/rel_redundant/rel_redundant.dl
@@ -34,3 +34,21 @@ f(0,[1]).
 f(1,[1]).
 g(x, [x]) :- f(x, [x]).
 record1(x, y) :- g(x, [y]).
+
+// Another test case (see Issue #1774) 
+
+.decl aX(x:number)
+.decl bX(x:number, y:number)
+.decl cX(x:number)
+.decl dX(A:number, B:number, C:number)
+.decl eX(A:number, B:number)
+.decl fX(A:number)
+.decl outX(A:number)
+
+cX(x)  :- aX(x), y=0.
+dX(q,V,O) :- bX(O,V), aX(q).
+fX(x) :- cX(x).
+outX(Y) :- dX(f,Y,f), fX(c), eX(a,b).
+
+.output outX
+

--- a/tests/semantic/rel_redundant/rel_redundant.dl
+++ b/tests/semantic/rel_redundant/rel_redundant.dl
@@ -35,7 +35,7 @@ f(1,[1]).
 g(x, [x]) :- f(x, [x]).
 record1(x, y) :- g(x, [y]).
 
-// Another test case (see Issue #1774) 
+// Another test case (see Issue #1774)
 
 .decl aX(x:number)
 .decl bX(x:number, y:number)


### PR DESCRIPTION
This PR fixes bug #1774. 

We need to take more care in future when programming destructively updating transformers that invalidate the state of the analyses. 

Transformers that destructively update the state of AST programs, must  
1) call `getAnalysis<..>()` just before its use to accommodate for changes, and
2) store all analyses results in memory rather than reference it.