### PR TITLE
Fix #1775

### DIFF
--- a/src/ast/analysis/TypeConstraints.cpp
+++ b/src/ast/analysis/TypeConstraints.cpp
@@ -574,19 +574,26 @@ void TypeConstraintsAnalysis::visitBranchInit(const BranchInit& adt) {
     // Constraint on the whole branch. $Branch(...) <: ADTtype
     addConstraint(isSubtypeOf(getVar(adt), *correspondingType));
 
-    // Constraints on arguments
-    auto branchTypes = as<AlgebraicDataType>(correspondingType)->getBranchTypes(adt.getConstructor());
-    auto branchArgs = adt.getArguments();
+    // Even if the branch was declared,
+    // it could be that the corresponding branch doesn't exist in the type environment.
+    // This can happen when the branch was declared over the invalid type.
+    try {
+        // Constraints on arguments
+        auto branchTypes = as<AlgebraicDataType>(correspondingType)->getBranchTypes(adt.getConstructor());
+        auto branchArgs = adt.getArguments();
 
-    if (branchTypes.size() != branchArgs.size()) {
-        // invalid program - handled by semantic checker later.
-        return;
-    }
+        if (branchTypes.size() != branchArgs.size()) {
+            // invalid program - handled by semantic checker later.
+            return;
+        }
 
-    // Add constraints for each of the branch arguments.
-    for (size_t i = 0; i < branchArgs.size(); ++i) {
-        auto argVar = getVar(branchArgs[i]);
-        addConstraint(isSubtypeOf(argVar, *branchTypes[i]));
+        // Add constraints for each of the branch arguments.
+        for (size_t i = 0; i < branchArgs.size(); ++i) {
+            auto argVar = getVar(branchArgs[i]);
+            addConstraint(isSubtypeOf(argVar, *branchTypes[i]));
+        }
+    } catch (...) {
+        // malformed program - reported by semantic checker.
     }
 }
 

--- a/tests/semantic.at
+++ b/tests/semantic.at
@@ -130,6 +130,7 @@ m4_define([POSITIVE_TEST_SQLITE3],[
 ##########################################################################
 
 NEGATIVE_TEST([adt_invalid_arity],[semantic])
+NEGATIVE_TEST([adt_invalid_branch],[semantic])
 NEGATIVE_TEST([agg_checks],[semantic])
 NEGATIVE_TEST([agg_checks2],[semantic])
 POSITIVE_TEST([agg_checks3],[semantic])

--- a/tests/semantic/adt_invalid_branch/adt_invalid_branch.dl
+++ b/tests/semantic/adt_invalid_branch/adt_invalid_branch.dl
@@ -1,0 +1,28 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020 The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+//
+// ADT invalid branch
+// Test if ADTs declared with invalid types fail correctly.
+//
+// Created for #1775.
+//
+
+
+// Example by langston-barrett
+.type A = Int {x: n} | Float {x: float}
+
+.decl R(x: A)
+R($Int(0)) :- $Int(1) != $Int(2).
+R($Int(1)) :- $Int(1) != $Int(1).
+R($Int(2)) :- $Int(1) = $Int(1).
+R($Int(3)) :- $Int(1) != $Float(1).
+.output R
+
+
+

--- a/tests/semantic/adt_invalid_branch/adt_invalid_branch.err
+++ b/tests/semantic/adt_invalid_branch/adt_invalid_branch.err
@@ -1,0 +1,4 @@
+Error: Undefined type n in definition of branch Int in file adt_invalid_branch.dl at line 18
+.type A = Int {x: n} | Float {x: float}
+------------------^---------------------
+1 errors generated, evaluation aborted

--- a/tests/semantic/type_system_sum_types2/type_system_sum_types2.err
+++ b/tests/semantic/type_system_sum_types2/type_system_sum_types2.err
@@ -1,7 +1,4 @@
-Error: Ambiguous branch in file type_system_sum_types2.dl at line 18
-R($Y(-1)). // Undeclared.
---^-----------------------
 Error: Undeclared branch in file type_system_sum_types2.dl at line 18
 R($Y(-1)). // Undeclared.
 --^-----------------------
-2 errors generated, evaluation aborted
+1 errors generated, evaluation aborted


### PR DESCRIPTION
- Fix #1775. The bug was caused by incorrect handling of branches declared over invalid types.
- Move responsibility of reporting the undeclared branches from `SemanticChecker` to `TypeChecker`.