### PR TITLE
Index analysis refactor #3

### DIFF
--- a/src/interpreter/BTreeIndex.cpp
+++ b/src/interpreter/BTreeIndex.cpp
@@ -28,7 +28,7 @@ namespace souffle::interpreter {
     }
 
 Own<RelationWrapper> createBTreeRelation(
-        const ram::Relation& id, const ram::analysis::FinalIndexSelection& indexSelection) {
+        const ram::Relation& id, const ram::analysis::IndexCluster& indexSelection) {
     switch (id.getArity()) {
         FOR_EACH_BTREE(CREATE_BTREE_REL);
 

--- a/src/interpreter/BrieIndex.cpp
+++ b/src/interpreter/BrieIndex.cpp
@@ -27,7 +27,7 @@ namespace souffle::interpreter {
     }
 
 Own<RelationWrapper> createBrieRelation(
-        const ram::Relation& id, const ram::analysis::FinalIndexSelection& /* orderSet */) {
+        const ram::Relation& id, const ram::analysis::IndexCluster& /* orderSet */) {
     switch (id.getArity()) {
         FOR_EACH_BRIE(CREATE_BRIE_REL);
 

--- a/src/interpreter/EqrelIndex.cpp
+++ b/src/interpreter/EqrelIndex.cpp
@@ -21,7 +21,7 @@
 namespace souffle::interpreter {
 
 Own<RelationWrapper> createEqrelRelation(
-        const ram::Relation& id, const ram::analysis::FinalIndexSelection& indexSelection) {
+        const ram::Relation& id, const ram::analysis::IndexCluster& indexSelection) {
     assert(id.getArity() == 2 && "Eqivalence relation must have arity size 2.");
     return mk<EqrelRelation>(id.getAuxiliaryArity(), id.getName(), indexSelection);
 }

--- a/src/interpreter/ProvenanceIndex.cpp
+++ b/src/interpreter/ProvenanceIndex.cpp
@@ -25,7 +25,7 @@ namespace souffle::interpreter {
     }
 
 Own<RelationWrapper> createProvenanceRelation(
-        const ram::Relation& id, const ram::analysis::FinalIndexSelection& indexSelection) {
+        const ram::Relation& id, const ram::analysis::IndexCluster& indexSelection) {
     switch (id.getArity()) {
         FOR_EACH_PROVENANCE(CREATE_PROVENANCE_REL);
 

--- a/src/interpreter/Relation.h
+++ b/src/interpreter/Relation.h
@@ -180,8 +180,8 @@ public:
     /**
      * Creates a relation, build all necessary indexes.
      */
-    Relation(size_t auxiliaryArity, const std::string& name,
-            const ram::analysis::FinalIndexSelection& indexSelection)
+    Relation(
+            size_t auxiliaryArity, const std::string& name, const ram::analysis::IndexCluster& indexSelection)
             : RelationWrapper(Arity, auxiliaryArity, name) {
         for (const auto& order : indexSelection.getAllOrders()) {
             ram::analysis::LexOrder fullOrder = order;
@@ -415,19 +415,19 @@ public:
 
 // The type of relation factory functions.
 using RelationFactory = Own<RelationWrapper> (*)(
-        const ram::Relation& id, const ram::analysis::FinalIndexSelection& indexSelection);
+        const ram::Relation& id, const ram::analysis::IndexCluster& indexSelection);
 
 // A factory for BTree based relation.
 Own<RelationWrapper> createBTreeRelation(
-        const ram::Relation& id, const ram::analysis::FinalIndexSelection& indexSelection);
+        const ram::Relation& id, const ram::analysis::IndexCluster& indexSelection);
 
 // A factory for BTree provenance index.
 Own<RelationWrapper> createProvenanceRelation(
-        const ram::Relation& id, const ram::analysis::FinalIndexSelection& indexSelection);
+        const ram::Relation& id, const ram::analysis::IndexCluster& indexSelection);
 // A factory for Brie based index.
 Own<RelationWrapper> createBrieRelation(
-        const ram::Relation& id, const ram::analysis::FinalIndexSelection& indexSelection);
+        const ram::Relation& id, const ram::analysis::IndexCluster& indexSelection);
 // A factory for Eqrel index.
 Own<RelationWrapper> createEqrelRelation(
-        const ram::Relation& id, const ram::analysis::FinalIndexSelection& indexSelection);
+        const ram::Relation& id, const ram::analysis::IndexCluster& indexSelection);
 }  // namespace souffle::interpreter

--- a/src/interpreter/tests/interpreter_relation_test.cpp
+++ b/src/interpreter/tests/interpreter_relation_test.cpp
@@ -28,7 +28,7 @@
 namespace souffle::interpreter::test {
 
 using ::souffle::ram::analysis::AttributeConstraint;
-using ::souffle::ram::analysis::FinalIndexSelection;
+using ::souffle::ram::analysis::IndexCluster;
 using ::souffle::ram::analysis::LexOrder;
 using ::souffle::ram::analysis::OrderCollection;
 using ::souffle::ram::analysis::SearchSet;
@@ -44,7 +44,7 @@ TEST(Relation0, Construction) {
     SearchSet searches;
     LexOrder emptyOrder;
     OrderCollection orders = {emptyOrder};
-    FinalIndexSelection indexSelection(mapping, searches, orders);
+    IndexCluster indexSelection(mapping, searches, orders);
 
     Relation<0, interpreter::Btree> rel(0, "test", indexSelection);
 
@@ -66,7 +66,7 @@ TEST(Relation0, Iteration) {
     SearchSet searches;
     LexOrder emptyOrder;
     OrderCollection orders = {emptyOrder};
-    FinalIndexSelection indexSelection(mapping, searches, orders);
+    IndexCluster indexSelection(mapping, searches, orders);
 
     Relation<0, interpreter::Btree> rel(0, "test", indexSelection);
     RelationWrapper* wrapper = &rel;
@@ -93,7 +93,7 @@ TEST(Relation1, Construction) {
     LexOrder fullOrder = {0};
     OrderCollection orders = {fullOrder};
     mapping.insert({existenceCheck, fullOrder});
-    FinalIndexSelection indexSelection(mapping, searches, orders);
+    IndexCluster indexSelection(mapping, searches, orders);
 
     Relation<1, interpreter::Btree> rel(0, "test", indexSelection);
     RelInterface relInt(rel, symbolTable, "test", {"i"}, {"i"}, 0);
@@ -122,7 +122,7 @@ TEST(Basic, Iteration) {
     LexOrder fullOrder = {0};
     OrderCollection orders = {fullOrder};
     mapping.insert({existenceCheck, fullOrder});
-    FinalIndexSelection indexSelection(mapping, searches, orders);
+    IndexCluster indexSelection(mapping, searches, orders);
 
     Relation<1, interpreter::Btree> rel(0, "test", indexSelection);
     RelInterface relInt(rel, symbolTable, "test", {"i"}, {"i"}, 0);
@@ -157,7 +157,7 @@ TEST(Independence, Iteration) {
     LexOrder fullOrder = {0};
     OrderCollection orders = {fullOrder};
     mapping.insert({existenceCheck, fullOrder});
-    FinalIndexSelection indexSelection(mapping, searches, orders);
+    IndexCluster indexSelection(mapping, searches, orders);
 
     Relation<1, interpreter::Btree> rel(0, "test", indexSelection);
     RelInterface relInt(rel, symbolTable, "test", {"i"}, {"i"}, 0);
@@ -193,7 +193,7 @@ TEST(IndependentMoving, Iteration) {
     LexOrder fullOrder = {0};
     OrderCollection orders = {fullOrder};
     mapping.insert({existenceCheck, fullOrder});
-    FinalIndexSelection indexSelection(mapping, searches, orders);
+    IndexCluster indexSelection(mapping, searches, orders);
 
     Relation<1, interpreter::Btree> rel(0, "test", indexSelection);
     RelInterface relInt(rel, symbolTable, "test", {"i"}, {"i"}, 0);
@@ -224,7 +224,7 @@ TEST(IndependentCopying, Iteration) {
     LexOrder fullOrder = {0};
     OrderCollection orders = {fullOrder};
     mapping.insert({existenceCheck, fullOrder});
-    FinalIndexSelection indexSelection(mapping, searches, orders);
+    IndexCluster indexSelection(mapping, searches, orders);
 
     Relation<1, interpreter::Btree> rel(0, "test", indexSelection);
     RelInterface relInt(rel, symbolTable, "test", {"i"}, {"i"}, 0);
@@ -256,7 +256,7 @@ TEST(Reordering, Iteration) {
     LexOrder fullOrder = {0, 2, 1};
     OrderCollection orders = {fullOrder};
     mapping.insert({existenceCheck, fullOrder});
-    FinalIndexSelection indexSelection(mapping, searches, orders);
+    IndexCluster indexSelection(mapping, searches, orders);
 
     Relation<3, interpreter::Btree> rel(0, "test", indexSelection);
     souffle::Tuple<RamDomain, 3> tuple{0, 1, 2};

--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -220,6 +220,8 @@ const MaxMatching::Matchings& MaxMatching::solve() {
 }
 
 FinalIndexSelection MinIndexSelection::solve(const SearchSet& givenSearches) {
+    OrderCollection orders;  // collection of lexicographical orders
+
     searches = givenSearches;
 
     // if there are no orders then the arity of the relation is zero
@@ -287,7 +289,7 @@ FinalIndexSelection MinIndexSelection::solve(const SearchSet& givenSearches) {
     // Validate the lex-order
     for (auto chain : chains) {
         for (auto search : chain) {
-            int idx = map(search);
+            size_t idx = map(search, orders, chains);
 
             SearchSignature k(search.arity());
             for (size_t i = 0; i < card(search); i++) {
@@ -307,7 +309,8 @@ FinalIndexSelection MinIndexSelection::solve(const SearchSet& givenSearches) {
     // Return the index selection
     SignatureOrderMap indexSelection;
     for (const auto& search : searches) {
-        indexSelection.insert({search, getLexOrder(search)});
+        size_t orderIndex = map(search, orders, chains);
+        indexSelection.insert({search, orders.at(orderIndex)});
     }
 
     return FinalIndexSelection(indexSelection, searches, orders);
@@ -344,6 +347,7 @@ Chain MinIndexSelection::getChain(const SearchSignature umn, const MaxMatching::
 const ChainOrderMap MinIndexSelection::getChainsFromMatching(
         const MaxMatching::Matchings& match, const SearchSet& nodes) {
     assert(!nodes.empty());
+    ChainOrderMap chainToOrder;
 
     // Get all unmatched nodes from A
     const SearchSet& umKeys = getUnmatchedKeys(match, nodes);

--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -219,7 +219,7 @@ const MaxMatching::Matchings& MaxMatching::solve() {
     return match;
 }
 
-FinalIndexSelection MinIndexSelectionStrategy::solve(const SearchSet& searches) const {
+IndexCluster MinIndexSelectionStrategy::solve(const SearchSet& searches) const {
     OrderCollection orders;
     SignatureOrderMap indexSelection;
 
@@ -230,7 +230,7 @@ FinalIndexSelection MinIndexSelectionStrategy::solve(const SearchSet& searches) 
         LexOrder emptyOrder;
         orders.push_back(emptyOrder);
         indexSelection.insert({search, emptyOrder});
-        return FinalIndexSelection(indexSelection, {search}, orders);
+        return IndexCluster(indexSelection, {search}, orders);
     }
 
     // Map the signatures of each search to a unique node in each bipartition for the matching problem
@@ -313,7 +313,7 @@ FinalIndexSelection MinIndexSelectionStrategy::solve(const SearchSet& searches) 
         indexSelection.insert({search, orders.at(orderIndex)});
     }
 
-    return FinalIndexSelection(indexSelection, searches, orders);
+    return IndexCluster(indexSelection, searches, orders);
 }
 
 Chain MinIndexSelectionStrategy::getChain(const SearchSignature umn, const MaxMatching::Matchings& match,

--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -442,6 +442,31 @@ void IndexAnalysis::run(const TranslationUnit& translationUnit) {
     }
 }
 
+void IndexAnalysis::print(std::ostream& os) const {
+    for (auto& cur : indexCover) {
+        const std::string& relName = cur.first;
+        const auto& selection = cur.second;
+
+        os << "Relation " << relName << "\n";
+
+        /* print searches */
+        os << "\tNumber of Searches: " << selection.getSearches().size() << "\n";
+        for (auto& search : selection.getSearches()) {
+            os << "\t\t";
+            os << search;
+            os << "\n";
+        }
+
+        /* print indexes */
+        os << "\tNumber of Indexes: " << selection.getAllOrders().size() << "\n";
+        for (auto& order : selection.getAllOrders()) {
+            os << "\t\t";
+            os << join(order, "<") << "\n";
+            os << "\n";
+        }
+    }
+}
+
 namespace {
 // handles equality constraints
 template <typename Iter>

--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -438,7 +438,7 @@ void IndexAnalysis::run(const TranslationUnit& translationUnit) {
     for (auto& relToSearch : relationToSearches) {
         const std::string& relation = relToSearch.first;
         auto& searches = relToSearch.second;
-        indexCover.insert({relation, solver.solve(searches)});
+        indexCover.insert({relation, solver->solve(searches)});
     }
 }
 

--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -291,10 +291,17 @@ FinalIndexSelection MinIndexSelection::solve(const SearchSet& givenSearches) {
         for (auto search : chain) {
             int idx = map(search, orders, chains);
 
+            // rebuild the search from the order
             SearchSignature k(search.arity());
-            for (size_t i = 0; i < card(search); i++) {
+            size_t numConstraints = std::count_if(
+                    search.begin(), search.end(), [](auto c) { return c != AttributeConstraint::None; });
+
+            // map the k-th prefix of the order to a search
+            for (size_t i = 0; i < numConstraints; i++) {
                 k[orders[idx][i]] = AttributeConstraint::Equal;
             }
+
+            // validate that the prefix concides with the original search (ignoring inequalities)
             for (size_t i = 0; i < search.arity(); ++i) {
                 if (k[i] == AttributeConstraint::None && search[i] != AttributeConstraint::None) {
                     assert("incorrect lexicographical order");

--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -289,7 +289,7 @@ FinalIndexSelection MinIndexSelection::solve(const SearchSet& givenSearches) {
     // Validate the lex-order
     for (auto chain : chains) {
         for (auto search : chain) {
-            size_t idx = map(search, orders, chains);
+            int idx = map(search, orders, chains);
 
             SearchSignature k(search.arity());
             for (size_t i = 0; i < card(search); i++) {
@@ -316,7 +316,7 @@ FinalIndexSelection MinIndexSelection::solve(const SearchSet& givenSearches) {
     return FinalIndexSelection(indexSelection, searches, orders);
 }
 
-Chain MinIndexSelection::getChain(const SearchSignature umn, const MaxMatching::Matchings& match) {
+Chain MinIndexSelection::getChain(const SearchSignature umn, const MaxMatching::Matchings& match) const {
     SearchSignature start = umn;  // start at an unmatched node
     Chain chain;
     // given an unmapped node from set A we follow it from set B until it cannot be matched from B
@@ -325,7 +325,7 @@ Chain MinIndexSelection::getChain(const SearchSignature umn, const MaxMatching::
     // Assume : no circular mappings, i.e. a in A -> b in B -> ........ -> a in A is not allowed.
     // Given this, the loop will terminate
     while (true) {
-        auto mit = match.find(signatureToIndexB[start]);  // we start from B side
+        auto mit = match.find(signatureToIndexB.at(start));  // we start from B side
         // on each iteration we swap sides when collecting the chain so we use the corresponding index map
         if (std::find(chain.begin(), chain.end(), start) == chain.end()) {
             chain.push_back(start);
@@ -345,7 +345,7 @@ Chain MinIndexSelection::getChain(const SearchSignature umn, const MaxMatching::
 }
 
 const ChainOrderMap MinIndexSelection::getChainsFromMatching(
-        const MaxMatching::Matchings& match, const SearchSet& nodes) {
+        const MaxMatching::Matchings& match, const SearchSet& nodes) const {
     assert(!nodes.empty());
     ChainOrderMap chainToOrder;
 

--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -436,7 +436,6 @@ void IndexAnalysis::run(const TranslationUnit& translationUnit) {
 
     // find optimal indexes for relations
     for (auto& relToSearch : relationToSearches) {
-        solver = MinIndexSelection();
         const std::string& relation = relToSearch.first;
         auto& searches = relToSearch.second;
         indexCover.insert({relation, solver.solve(searches)});

--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -219,10 +219,8 @@ const MaxMatching::Matchings& MaxMatching::solve() {
     return match;
 }
 
-FinalIndexSelection MinIndexSelection::solve(const SearchSet& givenSearches) {
+FinalIndexSelection MinIndexSelection::solve(const SearchSet& searches) {
     OrderCollection orders;  // collection of lexicographical orders
-
-    searches = givenSearches;
 
     // if there are no orders then the arity of the relation is zero
     // this is because every non-nullary relation has an existence check

--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -219,7 +219,7 @@ const MaxMatching::Matchings& MaxMatching::solve() {
     return match;
 }
 
-FinalIndexSelection MinIndexSelection::solve(const SearchSet& searches) {
+FinalIndexSelection MinIndexSelectionStrategy::solve(const SearchSet& searches) const {
     OrderCollection orders;
     SignatureOrderMap indexSelection;
 
@@ -316,7 +316,7 @@ FinalIndexSelection MinIndexSelection::solve(const SearchSet& searches) {
     return FinalIndexSelection(indexSelection, searches, orders);
 }
 
-Chain MinIndexSelection::getChain(const SearchSignature umn, const MaxMatching::Matchings& match,
+Chain MinIndexSelectionStrategy::getChain(const SearchSignature umn, const MaxMatching::Matchings& match,
         const SearchBipartiteMap& mapping) const {
     SearchSignature start = umn;  // start at an unmatched node
     Chain chain;
@@ -345,7 +345,7 @@ Chain MinIndexSelection::getChain(const SearchSignature umn, const MaxMatching::
     }
 }
 
-const ChainOrderMap MinIndexSelection::getChainsFromMatching(const MaxMatching::Matchings& match,
+const ChainOrderMap MinIndexSelectionStrategy::getChainsFromMatching(const MaxMatching::Matchings& match,
         const SearchSet& nodes, const SearchBipartiteMap& mapping) const {
     assert(!nodes.empty());
     ChainOrderMap chainToOrder;

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -343,17 +343,6 @@ protected:
     SearchSet searches;                   // set of search patterns on table
     MaxMatching matching;                 // matching problem for finding minimal number of orders
 
-    /** @Brief count the number of constraints in key */
-    static size_t card(SearchSignature cols) {
-        size_t sz = 0;
-        for (size_t i = 0; i < cols.arity(); i++) {
-            if (cols[i] != AttributeConstraint::None) {
-                sz++;
-            }
-        }
-        return sz;
-    }
-
     /** @Brief maps a provided search to its corresponding lexicographical ordering **/
     size_t map(SearchSignature cols, const OrderCollection& orders, const ChainOrderMap& chainToOrder) const {
         assert(orders.size() == chainToOrder.size() && "Order and Chain Sizes do not match!!");

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -340,7 +340,6 @@ protected:
     SignatureIndexMap signatureToIndexA;  // mapping of a SearchSignature on A to its unique index
     SignatureIndexMap signatureToIndexB;  // mapping of a SearchSignature on B to its unique index
     IndexSignatureMap indexToSignature;   // mapping of a unique index to its SearchSignature
-    SearchSet searches;                   // set of search patterns on table
     MaxMatching matching;                 // matching problem for finding minimal number of orders
 
     /** @Brief maps a provided search to its corresponding lexicographical ordering **/

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -326,7 +326,7 @@ using SearchSet = std::set<SearchSignature, SearchComparator>;
 // when we output the name of the collection of searches and therefore we order the SearchSignatures
 // arbitrarily by their hashes
 
-class FinalIndexSelection;
+class IndexCluster;
 
 /**
  * @class SearchBipartiteMap
@@ -370,7 +370,7 @@ private:
 class IndexSelectionStrategy {
 public:
     /** @brief Run analysis for a RAM translation unit */
-    virtual FinalIndexSelection solve(const SearchSet& searches) const = 0;
+    virtual IndexCluster solve(const SearchSet& searches) const = 0;
 };
 
 class MinIndexSelectionStrategy : public IndexSelectionStrategy {
@@ -379,7 +379,7 @@ public:
     ~MinIndexSelectionStrategy() = default;
 
     /** @Brief map the keys in the key set to lexicographical order */
-    FinalIndexSelection solve(const SearchSet& searches) const override;
+    IndexCluster solve(const SearchSet& searches) const override;
 
 protected:
     /** @Brief maps a provided search to its corresponding lexicographical ordering **/
@@ -444,13 +444,13 @@ protected:
 };
 
 /**
- * @class FinalIndexSelection
+ * @class IndexCluster
  * @Brief Encapsulates the result of the IndexAnalysis
  * i.e. mapping each search (SearchSignature) to a corresponding index (LexOrder)
  */
-class FinalIndexSelection {
+class IndexCluster {
 public:
-    FinalIndexSelection(const SignatureOrderMap& indexSelection, const SearchSet& searchSet,
+    IndexCluster(const SignatureOrderMap& indexSelection, const SearchSet& searchSet,
             const OrderCollection& orders)
             : indexSelection(indexSelection), searches(searchSet.begin(), searchSet.end()), orders(orders) {}
 
@@ -494,7 +494,7 @@ public:
 
     void print(std::ostream& os) const override;
 
-    const FinalIndexSelection getIndexSelection(const std::string& relName) const {
+    const IndexCluster getIndexSelection(const std::string& relName) const {
         return indexCover.at(relName);
     }
 
@@ -543,7 +543,7 @@ private:
      * minimal index cover for relations, i.e., maps a relation to a set of indexes
      */
     Own<IndexSelectionStrategy> solver;
-    std::map<std::string, FinalIndexSelection> indexCover;
+    std::map<std::string, IndexCluster> indexCover;
     std::map<std::string, SearchSet> relationToSearches;
 };
 

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -328,15 +328,6 @@ using SearchSet = std::set<SearchSignature, SearchComparator>;
 
 class MinIndexSelection {
 public:
-    /** @Brief Add new key to an Index Set */
-    inline void addSearch(SearchSignature cols) {
-        if (cols.empty()) {
-            return;
-        }
-
-        searches.insert(cols);
-    }
-
     MinIndexSelection() = default;
     ~MinIndexSelection() = default;
 
@@ -371,7 +362,7 @@ public:
     }
 
     /** @Brief map the keys in the key set to lexicographical order */
-    void solve();
+    void solve(const SearchSet& searches);
 
     /** @Brief insert a total order index
      *  @param size of the index
@@ -535,7 +526,7 @@ public:
     void run(const TranslationUnit& translationUnit) override;
 
     const FinalIndexSelection getIndexSelection(const std::string& relName) const {
-        SignatureOrderMap indexSelection = {};
+        SignatureOrderMap indexSelection;
         const auto& cover = minIndexCover.at(relName);
         for (const auto& search : cover.getSearches()) {
             indexSelection.insert({search, cover.getLexOrder(search)});
@@ -597,6 +588,7 @@ private:
      * minimal index cover for relations, i.e., maps a relation to a set of indexes
      */
     std::map<std::string, MinIndexSelection> minIndexCover;
+    std::map<std::string, SearchSet> relationToSearches;
 };
 
 }  // namespace souffle::ram::analysis

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -357,14 +357,19 @@ protected:
     /** @Brief maps a provided search to its corresponding lexicographical ordering **/
     size_t map(SearchSignature cols, const OrderCollection& orders, const ChainOrderMap& chainToOrder) const {
         assert(orders.size() == chainToOrder.size() && "Order and Chain Sizes do not match!!");
-        size_t i = 0;
-        for (auto it = chainToOrder.begin(); it != chainToOrder.end(); ++it, ++i) {
-            if (std::find(it->begin(), it->end(), cols) != it->end()) {
-                assert(i < orders.size());
-                return i;
-            }
+
+        // find the chain which contains the search
+        auto it = std::find_if(chainToOrder.begin(), chainToOrder.end(), [cols](const Chain& chain) {
+            return std::find(chain.begin(), chain.end(), cols) != chain.end();
+        });
+
+        // ensure we have a matching lex-order
+        if (it == chainToOrder.end()) {
+            fatal("cannot find matching lexicographical order");
         }
-        fatal("cannot find matching lexicographical order");
+
+        // return its index
+        return std::distance(chainToOrder.begin(), it);
     }
 
     /** @Brief insert an index based on the delta */

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -373,7 +373,7 @@ protected:
     }
 
     /** @Brief insert an index based on the delta */
-    void insertIndex(LexOrder& ids, SearchSignature delta) {
+    void insertIndex(LexOrder& ids, SearchSignature delta) const {
         LexOrder backlog;  // add inequalities at the end
         for (size_t pos = 0; pos < delta.arity(); pos++) {
             if (delta[pos] == AttributeConstraint::Equal) {
@@ -393,18 +393,19 @@ protected:
      * we follow it from set B until it cannot be matched from B
      * if not matched from B then umn is a chain.
      */
-    Chain getChain(const SearchSignature umn, const MaxMatching::Matchings& match);
+    Chain getChain(const SearchSignature umn, const MaxMatching::Matchings& match) const;
 
     /** @Brief get all chains from the matching */
-    const ChainOrderMap getChainsFromMatching(const MaxMatching::Matchings& match, const SearchSet& nodes);
+    const ChainOrderMap getChainsFromMatching(
+            const MaxMatching::Matchings& match, const SearchSet& nodes) const;
 
     /** @Brief get all nodes which are unmatched from A-> B */
-    const SearchSet getUnmatchedKeys(const MaxMatching::Matchings& match, const SearchSet& nodes) {
+    const SearchSet getUnmatchedKeys(const MaxMatching::Matchings& match, const SearchSet& nodes) const {
         SearchSet unmatched;
 
         // For all nodes n such that n is not in match
         for (auto node : nodes) {
-            if (match.find(signatureToIndexA[node]) == match.end()) {
+            if (match.find(signatureToIndexA.at(node)) == match.end()) {
                 unmatched.insert(node);
             }
         }

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -288,7 +288,7 @@ private:
 };
 
 /**
- * @class MinIndexSelection
+ * @class MinIndexSelectionStrategy
  * @Brief computes the minimal index cover for a relation
  *        in a RAM Program.
  *
@@ -363,13 +363,23 @@ private:
     NodeSearchMap nodeToSignature;
 };
 
-class MinIndexSelection {
+/**
+ * @class IndexSelectionStrategy
+ * @brief Abstracts selection strategy for index analysis
+ */
+class IndexSelectionStrategy {
 public:
-    MinIndexSelection() = default;
-    ~MinIndexSelection() = default;
+    /** @brief Run analysis for a RAM translation unit */
+    virtual FinalIndexSelection solve(const SearchSet& searches) const = 0;
+};
+
+class MinIndexSelectionStrategy : public IndexSelectionStrategy {
+public:
+    MinIndexSelectionStrategy() = default;
+    ~MinIndexSelectionStrategy() = default;
 
     /** @Brief map the keys in the key set to lexicographical order */
-    FinalIndexSelection solve(const SearchSet& searches);
+    FinalIndexSelection solve(const SearchSet& searches) const override;
 
 protected:
     /** @Brief maps a provided search to its corresponding lexicographical ordering **/
@@ -529,7 +539,7 @@ private:
     /**
      * minimal index cover for relations, i.e., maps a relation to a set of indexes
      */
-    MinIndexSelection solver;
+    MinIndexSelectionStrategy solver;
     std::map<std::string, FinalIndexSelection> indexCover;
     std::map<std::string, SearchSet> relationToSearches;
 };

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -333,38 +333,6 @@ public:
     MinIndexSelection() = default;
     ~MinIndexSelection() = default;
 
-private:
-    /** @Brief Get searches **/
-    const SearchSet& getSearches() const {
-        return searches;
-    }
-
-public:
-    /** @Brief Get index for a search */
-    const LexOrder& getLexOrder(SearchSignature cols) const {
-        int idx = map(cols);
-        return orders[idx];
-    }
-
-    /** @Brief Get all indexes */
-    const OrderCollection getAllOrders() const {
-        return orders;
-    }
-
-    /** @Brief Get all chains */
-    const ChainOrderMap getAllChains() const {
-        return chainToOrder;
-    }
-
-    /**
-     * Check whether number of constraints in k is not equal to number of columns in lexicographical
-     * order
-     * */
-    bool isSubset(SearchSignature cols) const {
-        int idx = map(cols);
-        return card(cols) < orders[idx].size();
-    }
-
     /** @Brief map the keys in the key set to lexicographical order */
     FinalIndexSelection solve(const SearchSet& searches);
 
@@ -373,8 +341,6 @@ protected:
     SignatureIndexMap signatureToIndexB;  // mapping of a SearchSignature on B to its unique index
     IndexSignatureMap indexToSignature;   // mapping of a unique index to its SearchSignature
     SearchSet searches;                   // set of search patterns on table
-    OrderCollection orders;               // collection of lexicographical orders
-    ChainOrderMap chainToOrder;           // maps order index to set of searches covered by chain
     MaxMatching matching;                 // matching problem for finding minimal number of orders
 
     /** @Brief count the number of constraints in key */
@@ -388,13 +354,13 @@ protected:
         return sz;
     }
 
-    /** @Brief maps search columns to an lexicographical order (labeled by a number) */
-    int map(SearchSignature cols) const {
+    /** @Brief maps a provided search to its corresponding lexicographical ordering **/
+    size_t map(SearchSignature cols, const OrderCollection& orders, const ChainOrderMap& chainToOrder) const {
         assert(orders.size() == chainToOrder.size() && "Order and Chain Sizes do not match!!");
-        int i = 0;
+        size_t i = 0;
         for (auto it = chainToOrder.begin(); it != chainToOrder.end(); ++it, ++i) {
             if (std::find(it->begin(), it->end(), cols) != it->end()) {
-                assert((size_t)i < orders.size());
+                assert(i < orders.size());
                 return i;
             }
         }

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -485,7 +485,8 @@ private:
  */
 class IndexAnalysis : public Analysis {
 public:
-    IndexAnalysis(const char* id) : Analysis(id), relAnalysis(nullptr) {}
+    IndexAnalysis(const char* id)
+            : Analysis(id), relAnalysis(nullptr), solver(mk<MinIndexSelectionStrategy>()) {}
 
     static constexpr const char* name = "index-analysis";
 
@@ -539,7 +540,7 @@ private:
     /**
      * minimal index cover for relations, i.e., maps a relation to a set of indexes
      */
-    MinIndexSelectionStrategy solver;
+    Own<IndexSelectionStrategy> solver;
     std::map<std::string, FinalIndexSelection> indexCover;
     std::map<std::string, SearchSet> relationToSearches;
 };

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -492,6 +492,8 @@ public:
 
     void run(const TranslationUnit& translationUnit) override;
 
+    void print(std::ostream& os) const override;
+
     const FinalIndexSelection getIndexSelection(const std::string& relName) const {
         return indexCover.at(relName);
     }

--- a/src/ram/analysis/Index.h
+++ b/src/ram/analysis/Index.h
@@ -328,6 +328,10 @@ using SearchSet = std::set<SearchSignature, SearchComparator>;
 
 class FinalIndexSelection;
 
+/**
+ * @class SearchBipartiteMap
+ * @Brief Represents the mapping between searches and their nodes in bipartitions A and B of the graph
+ */
 class SearchBipartiteMap {
 public:
     void addSearch(SearchSignature s) {

--- a/src/ram/tests/matching_test.cpp
+++ b/src/ram/tests/matching_test.cpp
@@ -52,13 +52,14 @@ TEST(Matching, StaticTest_1) {
     size_t arity = 5;
 
     uint64_t patterns[] = {1, 3, 5, 7, 15, 23, 31};
+    SearchSet searches;
     for (auto pattern : patterns) {
         SearchSignature search = setBits(arity, pattern);
-        order.addSearch(search);
+        searches.insert(search);
         nodes.insert(search);
     }
 
-    order.solve();
+    order.solve(searches);
     int num = order.getNumMatchings();
 
     EXPECT_EQ(num, 5);
@@ -71,13 +72,14 @@ TEST(Matching, StaticTest_2) {
     size_t arity = 7;
 
     uint64_t patterns[] = {7, 11, 23, 32, 33, 39, 49, 53, 104, 121};
+    SearchSet searches;
     for (auto pattern : patterns) {
         SearchSignature search = setBits(arity, pattern);
-        order.addSearch(search);
+        searches.insert(search);
         nodes.insert(search);
     }
 
-    order.solve();
+    order.solve(searches);
     int num = order.getNumMatchings();
 
     EXPECT_EQ(num, 5);
@@ -117,13 +119,8 @@ TEST(Matching, TestOver64BitSignature) {
     nodes.insert(fourth);
     nodes.insert(fifth);
 
-    order.addSearch(first);
-    order.addSearch(second);
-    order.addSearch(third);
-    order.addSearch(fourth);
-    order.addSearch(fifth);
-
-    order.solve();
+    SearchSet searches = {first, second, third, fourth, fifth};
+    order.solve(searches);
     int num = order.getNumMatchings();
 
     EXPECT_EQ(num, 3);

--- a/src/ram/tests/matching_test.cpp
+++ b/src/ram/tests/matching_test.cpp
@@ -24,9 +24,9 @@
 namespace souffle::ram {
 using namespace analysis;
 
-class TestAutoIndex : public MinIndexSelection {
+class TestAutoIndex : public MinIndexSelectionStrategy {
 public:
-    TestAutoIndex() : MinIndexSelection() {}
+    TestAutoIndex() : MinIndexSelectionStrategy() {}
 };
 
 using Nodes = SearchSet;

--- a/src/ram/tests/matching_test.cpp
+++ b/src/ram/tests/matching_test.cpp
@@ -55,10 +55,9 @@ TEST(Matching, StaticTest_1) {
         nodes.insert(search);
     }
 
-    order.solve(searches);
-    int num = order.getNumMatchings();
-
-    EXPECT_EQ(num, 5);
+    auto selection = order.solve(searches);
+    size_t num = selection.getAllOrders().size();
+    EXPECT_EQ(num, 2);
 }
 
 TEST(Matching, StaticTest_2) {
@@ -116,7 +115,7 @@ TEST(Matching, TestOver64BitSignature) {
     SearchSet searches = {first, second, third, fourth, fifth};
     auto selection = order.solve(searches);
     size_t num = selection.getAllOrders().size();
-    EXPECT_EQ(num, 3);
+    EXPECT_EQ(num, 2);
 }
 
 }  // namespace souffle::ram

--- a/src/ram/tests/matching_test.cpp
+++ b/src/ram/tests/matching_test.cpp
@@ -27,10 +27,6 @@ using namespace analysis;
 class TestAutoIndex : public MinIndexSelection {
 public:
     TestAutoIndex() : MinIndexSelection() {}
-    /** returns number of unique matchings */
-    int getNumMatchings() {
-        return matching.getNumMatchings();
-    }
 };
 
 using Nodes = SearchSet;
@@ -78,10 +74,8 @@ TEST(Matching, StaticTest_2) {
         searches.insert(search);
         nodes.insert(search);
     }
-
-    order.solve(searches);
-    int num = order.getNumMatchings();
-
+    auto selection = order.solve(searches);
+    size_t num = selection.getAllOrders().size();
     EXPECT_EQ(num, 5);
 }
 
@@ -120,9 +114,8 @@ TEST(Matching, TestOver64BitSignature) {
     nodes.insert(fifth);
 
     SearchSet searches = {first, second, third, fourth, fifth};
-    order.solve(searches);
-    int num = order.getNumMatchings();
-
+    auto selection = order.solve(searches);
+    size_t num = selection.getAllOrders().size();
     EXPECT_EQ(num, 3);
 }
 

--- a/src/synthesiser/Relation.cpp
+++ b/src/synthesiser/Relation.cpp
@@ -42,8 +42,8 @@ std::string Relation::getTypeAttributeString(const std::vector<std::string>& att
     return type.str();
 }
 
-Own<Relation> Relation::getSynthesiserRelation(const ram::Relation& ramRel,
-        const ram::analysis::FinalIndexSelection& indexSelection, bool isProvenance) {
+Own<Relation> Relation::getSynthesiserRelation(
+        const ram::Relation& ramRel, const ram::analysis::IndexCluster& indexSelection, bool isProvenance) {
     Relation* rel;
 
     // Handle the qualifier in souffle code

--- a/src/synthesiser/Relation.h
+++ b/src/synthesiser/Relation.h
@@ -43,7 +43,7 @@ public:
     }
 
     /** Get list of indices used for relation,
-     * guaranteed that original indices in analysis::MinIndexSelection
+     * guaranteed that original indices in analysis::MinIndexSelectionStrategy
      * come before any generated indices */
     ram::analysis::OrderCollection getIndices() const {
         return computedIndices;

--- a/src/synthesiser/Relation.h
+++ b/src/synthesiser/Relation.h
@@ -23,7 +23,7 @@ namespace souffle::synthesiser {
 
 class Relation {
 public:
-    Relation(const ram::Relation& rel, const ram::analysis::FinalIndexSelection& indexSelection,
+    Relation(const ram::Relation& rel, const ram::analysis::IndexCluster& indexSelection,
             const bool isProvenance = false)
             : relation(rel), indexSelection(indexSelection), isProvenance(isProvenance) {}
 
@@ -70,14 +70,14 @@ public:
 
     /** Factory method to generate a SynthesiserRelation */
     static Own<Relation> getSynthesiserRelation(const ram::Relation& ramRel,
-            const ram::analysis::FinalIndexSelection& indexSelection, bool isProvenance);
+            const ram::analysis::IndexCluster& indexSelection, bool isProvenance);
 
 protected:
     /** Ram relation referred to by this */
     const ram::Relation& relation;
 
     /** Indices used for this relation */
-    const ram::analysis::FinalIndexSelection indexSelection;
+    const ram::analysis::IndexCluster indexSelection;
 
     /** The data structure used for the relation */
     std::string dataStructure;
@@ -97,8 +97,8 @@ protected:
 
 class NullaryRelation : public Relation {
 public:
-    NullaryRelation(const ram::Relation& ramRel, const ram::analysis::FinalIndexSelection& indexSelection,
-            bool isProvenance)
+    NullaryRelation(
+            const ram::Relation& ramRel, const ram::analysis::IndexCluster& indexSelection, bool isProvenance)
             : Relation(ramRel, indexSelection, isProvenance) {}
 
     void computeIndices() override;
@@ -108,8 +108,8 @@ public:
 
 class InfoRelation : public Relation {
 public:
-    InfoRelation(const ram::Relation& ramRel, const ram::analysis::FinalIndexSelection& indexSelection,
-            bool isProvenance)
+    InfoRelation(
+            const ram::Relation& ramRel, const ram::analysis::IndexCluster& indexSelection, bool isProvenance)
             : Relation(ramRel, indexSelection, isProvenance) {}
 
     void computeIndices() override;
@@ -119,8 +119,8 @@ public:
 
 class DirectRelation : public Relation {
 public:
-    DirectRelation(const ram::Relation& ramRel, const ram::analysis::FinalIndexSelection& indexSelection,
-            bool isProvenance)
+    DirectRelation(
+            const ram::Relation& ramRel, const ram::analysis::IndexCluster& indexSelection, bool isProvenance)
             : Relation(ramRel, indexSelection, isProvenance) {}
 
     void computeIndices() override;
@@ -130,8 +130,8 @@ public:
 
 class IndirectRelation : public Relation {
 public:
-    IndirectRelation(const ram::Relation& ramRel, const ram::analysis::FinalIndexSelection& indexSelection,
-            bool isProvenance)
+    IndirectRelation(
+            const ram::Relation& ramRel, const ram::analysis::IndexCluster& indexSelection, bool isProvenance)
             : Relation(ramRel, indexSelection, isProvenance) {}
 
     void computeIndices() override;
@@ -141,8 +141,8 @@ public:
 
 class BrieRelation : public Relation {
 public:
-    BrieRelation(const ram::Relation& ramRel, const ram::analysis::FinalIndexSelection& indexSelection,
-            bool isProvenance)
+    BrieRelation(
+            const ram::Relation& ramRel, const ram::analysis::IndexCluster& indexSelection, bool isProvenance)
             : Relation(ramRel, indexSelection, isProvenance) {}
 
     void computeIndices() override;
@@ -152,8 +152,8 @@ public:
 
 class EqrelRelation : public Relation {
 public:
-    EqrelRelation(const ram::Relation& ramRel, const ram::analysis::FinalIndexSelection& indexSelection,
-            bool isProvenance)
+    EqrelRelation(
+            const ram::Relation& ramRel, const ram::analysis::IndexCluster& indexSelection, bool isProvenance)
             : Relation(ramRel, indexSelection, isProvenance) {}
 
     void computeIndices() override;


### PR DESCRIPTION
In this PR I've refactored the MinIndexSelection (now MinIndexSelectionStrategy) class to conform to a strategy pattern.

Specifically, the MinIndexSelectionStrategy class is now stateless and conforms to an interface IndexSelectionStrategy.

The interface defines the following function:

    FinalIndexSelection solve(const SearchSet& searches) const

Since the MinIndexSelectionStrategy is now stateless, it can be reused as a solver across different relations. It also makes the logic much easier to follow/simpler since it's in a functional style with all const methods. 

The strategy pattern is helpful for future situations where we might experiment with other index selection strategies (such as a single index per relation for low-memory environments) or other new ones.

Sidenote:

The design is not a pure strategy because the analysis is constructed using the getAnalysis<Analysis> template and I felt it would be weird to write a template specialization just for this analysis. Therefore, at this point, the MinIndexSelectionStrategy is encoded directly in the constructor of IndexAnalysis. I'd much appreciate any feedback on how I can improve the design!