### PR TITLE
Remove const cast - MERGE FIRST

### DIFF
--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -71,8 +71,8 @@ public:
         body = std::move(bodyLiterals);
     }
 
-    std::vector<const Node*> getChildNodes() const override {
-        auto res = Argument::getChildNodes();
+    std::vector<const Node*> getChildNodesImpl() const override {
+        auto res = Argument::getChildNodesImpl();
         if (targetExpression) {
             res.push_back(targetExpression.get());
         }

--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -61,6 +61,10 @@ public:
         return targetExpression.get();
     }
 
+    Argument* getTargetExpression() {
+        return targetExpression.get();
+    }
+
     /** Return body literals */
     std::vector<Literal*> getBodyLiterals() const {
         return toPtrVector(body);

--- a/src/ast/Atom.h
+++ b/src/ast/Atom.h
@@ -82,7 +82,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (auto& cur : arguments) {
             res.push_back(cur.get());

--- a/src/ast/BinaryConstraint.h
+++ b/src/ast/BinaryConstraint.h
@@ -78,7 +78,7 @@ public:
         rhs = map(std::move(rhs));
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         return {lhs.get(), rhs.get()};
     }
 

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -101,7 +101,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res = {head.get()};
         for (auto& cur : bodyLiterals) {
             res.push_back(cur.get());

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -185,7 +185,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res;
 
         res.push_back(componentType.get());

--- a/src/ast/ComponentInit.h
+++ b/src/ast/ComponentInit.h
@@ -71,7 +71,7 @@ public:
         componentType = mapper(std::move(componentType));
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         return {componentType.get()};
     }
 

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -73,7 +73,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> childNodes;
         for (auto& plan : plans) {
             childNodes.push_back(plan.second.get());

--- a/src/ast/FunctionalConstraint.h
+++ b/src/ast/FunctionalConstraint.h
@@ -68,7 +68,7 @@ public:
         return keys.size();
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (auto& cur : keys) {
             res.push_back(cur.get());

--- a/src/ast/Negation.h
+++ b/src/ast/Negation.h
@@ -58,7 +58,7 @@ public:
         atom = map(std::move(atom));
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         return {atom.get()};
     }
 

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -163,7 +163,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (const auto& cur : pragmas) {
             res.push_back(cur.get());

--- a/src/ast/Relation.h
+++ b/src/ast/Relation.h
@@ -132,7 +132,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (const auto& cur : attributes) {
             res.push_back(cur.get());

--- a/src/ast/Term.h
+++ b/src/ast/Term.h
@@ -56,8 +56,8 @@ public:
         args.push_back(std::move(arg));
     }
 
-    std::vector<const Node*> getChildNodes() const override {
-        auto res = Argument::getChildNodes();
+    std::vector<const Node*> getChildNodesImpl() const override {
+        auto res = Argument::getChildNodesImpl();
         for (auto& cur : args) {
             res.push_back(cur.get());
         }

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -57,8 +57,8 @@ public:
         this->type = type;
     }
 
-    std::vector<const Node*> getChildNodes() const override {
-        auto res = Argument::getChildNodes();
+    std::vector<const Node*> getChildNodesImpl() const override {
+        auto res = Argument::getChildNodesImpl();
         res.push_back(value.get());
         return res;
     }

--- a/src/ast/UnionType.h
+++ b/src/ast/UnionType.h
@@ -51,6 +51,10 @@ public:
         return types;
     }
 
+    std::vector<QualifiedName>& getTypes() {
+        return types;
+    }
+
     /** Add another unioned type */
     void add(QualifiedName type) {
         types.push_back(std::move(type));

--- a/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
+++ b/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
@@ -34,7 +34,7 @@ namespace souffle::ast::transform {
 bool AddNullariesToAtomlessAggregatesTransformer::transform(TranslationUnit& translationUnit) {
     bool changed{false};
     Program& program = translationUnit.getProgram();
-    visitDepthFirst(program, [&](const Aggregator& agg) {
+    visitDepthFirst(program, [&](Aggregator& agg) {
         bool seenAtom{false};
         for (const auto& literal : agg.getBodyLiterals()) {
             if (isA<Atom>(literal)) {
@@ -66,7 +66,7 @@ bool AddNullariesToAtomlessAggregatesTransformer::transform(TranslationUnit& tra
             newBody.push_back(souffle::clone(lit));
         }
         newBody.push_back(souffle::clone(nullaryAtom));
-        const_cast<Aggregator&>(agg).setBody(std::move(newBody));
+        agg.setBody(std::move(newBody));
     });
     return changed;
 }

--- a/src/ast/transform/MagicSet.cpp
+++ b/src/ast/transform/MagicSet.cpp
@@ -817,11 +817,11 @@ bool NegativeLabellingTransformer::transform(TranslationUnit& translationUnit) {
         atom->setQualifiedName(getNegativeLabel(relName));
         relationsToLabel.insert(relName);
     });
-    visitDepthFirst(program, [&](const Aggregator& aggr) {
-        visitDepthFirst(aggr, [&](const Atom& atom) {
+    visitDepthFirst(program, [&](Aggregator& aggr) {
+        visitDepthFirst(aggr, [&](Atom& atom) {
             auto relName = atom.getQualifiedName();
             if (contains(relationsToNotLabel, relName)) return;
-            const_cast<Atom&>(atom).setQualifiedName(getNegativeLabel(relName));
+            atom.setQualifiedName(getNegativeLabel(relName));
             relationsToLabel.insert(relName);
         });
     });

--- a/src/ast/transform/MaterializeAggregationQueries.cpp
+++ b/src/ast/transform/MaterializeAggregationQueries.cpp
@@ -269,8 +269,8 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
         });
     });
 
-    visitDepthFirst(program, [&](const Clause& clause) {
-        visitDepthFirst(clause, [&](const Aggregator& agg) {
+    visitDepthFirst(program, [&](Clause& clause) {
+        visitDepthFirst(clause, [&](Aggregator& agg) {
             if (!needsMaterializedRelation(agg)) {
                 return;
             }
@@ -343,7 +343,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
 
             VecOwn<Literal> newBody;
             newBody.push_back(std::move(aggAtom));
-            const_cast<Aggregator&>(agg).setBody(std::move(newBody));
+            agg.setBody(std::move(newBody));
             // Now we can just add these new things (relation and its single clause) to the program
             program.addClause(std::move(aggClause));
             program.addRelation(std::move(aggRel));

--- a/src/ast/transform/MaterializeSingletonAggregation.cpp
+++ b/src/ast/transform/MaterializeSingletonAggregation.cpp
@@ -58,8 +58,8 @@ bool MaterializeSingletonAggregationTransformer::transform(TranslationUnit& tran
     });
 
     // collect references to clause / aggregate pairs
-    visitDepthFirst(program, [&](const Clause& clause) {
-        visitDepthFirst(clause, [&](const Aggregator& agg) {
+    visitDepthFirst(program, [&](Clause& clause) {
+        visitDepthFirst(clause, [&](Aggregator& agg) {
             // only unroll one level at a time
             if (innerAggregates.find(&agg) != innerAggregates.end()) {
                 return;
@@ -71,8 +71,8 @@ bool MaterializeSingletonAggregationTransformer::transform(TranslationUnit& tran
             if (!isSingleValued(translationUnit, agg, clause) || clause.getBodyLiterals().size() == 1) {
                 return;
             }
-            auto* foundAggregate = const_cast<Aggregator*>(&agg);
-            auto* foundClause = const_cast<Clause*>(&clause);
+            auto* foundAggregate = &agg;
+            auto* foundClause = &clause;
             pairs.insert(std::make_pair(foundAggregate, foundClause));
         });
     });

--- a/src/ast/transform/RemoveRelationCopies.cpp
+++ b/src/ast/transform/RemoveRelationCopies.cpp
@@ -128,10 +128,10 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(TranslationUnit& tran
     }
 
     // replace usage of relations according to alias map
-    visitDepthFirst(program, [&](const Atom& atom) {
+    visitDepthFirst(program, [&](Atom& atom) {
         auto pos = isAliasOf.find(atom.getQualifiedName());
         if (pos != isAliasOf.end()) {
-            const_cast<Atom&>(atom).setQualifiedName(pos->second);
+            atom.setQualifiedName(pos->second);
         }
     });
 

--- a/src/ast/transform/SimplifyAggregateTargetExpression.cpp
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.cpp
@@ -23,20 +23,20 @@
 namespace souffle::ast::transform {
 
 Aggregator* SimplifyAggregateTargetExpressionTransformer::simplifyTargetExpression(
-        const TranslationUnit& tu, const Clause* clause, const Aggregator* aggregator) {
-    const auto* origTargetExpression = aggregator->getTargetExpression();
+        const TranslationUnit& tu, const Clause& clause, Aggregator& aggregator) {
+    auto* origTargetExpression = aggregator.getTargetExpression();
     assert(origTargetExpression != nullptr && !isA<Variable>(origTargetExpression) &&
             "aggregator should have complex target expression");
 
     // Create the new simplified target expression
-    auto newTargetExpression = mk<Variable>(analysis::findUniqueVariableName(*clause, "x"));
+    auto newTargetExpression = mk<Variable>(analysis::findUniqueVariableName(clause, "x"));
 
     // Create the new body, with the necessary equality between old and new target expressions
     auto equalityLiteral = std::make_unique<BinaryConstraint>(BinaryConstraintOp::EQ,
             souffle::clone(newTargetExpression), souffle::clone(origTargetExpression));
 
     std::vector<Own<Literal>> newBody;
-    for (const auto* literal : aggregator->getBodyLiterals()) {
+    for (const auto* literal : aggregator.getBodyLiterals()) {
         newBody.push_back(souffle::clone(literal));
     }
     newBody.push_back(std::move(equalityLiteral));
@@ -60,8 +60,8 @@ Aggregator* SimplifyAggregateTargetExpressionTransformer::simplifyTargetExpressi
     //         renamed
 
     // Therefore, variables to rename are non-witness outer scope variables
-    auto witnesses = analysis::getWitnessVariables(tu, *clause, *aggregator);
-    std::set<std::string> varsOutside = analysis::getVariablesOutsideAggregate(*clause, *aggregator);
+    auto witnesses = analysis::getWitnessVariables(tu, clause, aggregator);
+    std::set<std::string> varsOutside = analysis::getVariablesOutsideAggregate(clause, aggregator);
 
     std::set<std::string> varsGroundedOutside;
     for (auto& varName : varsOutside) {
@@ -71,20 +71,20 @@ Aggregator* SimplifyAggregateTargetExpressionTransformer::simplifyTargetExpressi
     }
 
     // Rename the necessary variables in the new aggregator
-    visitDepthFirst(*origTargetExpression, [&](const Variable& v) {
+    visitDepthFirst(*origTargetExpression, [&](Variable& v) {
         if (contains(varsGroundedOutside, v.getName())) {
             // Rename everywhere in the body to fix scoping
-            std::string newVarName = analysis::findUniqueVariableName(*clause, v.getName());
-            visitDepthFirst(newBody, [&](const Variable& literalVar) {
+            std::string newVarName = analysis::findUniqueVariableName(clause, v.getName());
+            visitDepthFirst(newBody, [&](Variable& literalVar) {
                 if (literalVar.getName() == v.getName()) {
-                    const_cast<Variable&>(literalVar).setName(newVarName);
+                    literalVar.setName(newVarName);
                 }
             });
         }
     });
 
     // Create the new simplified aggregator
-    return new Aggregator(aggregator->getBaseOperator(), std::move(newTargetExpression), std::move(newBody));
+    return new Aggregator(aggregator.getBaseOperator(), std::move(newTargetExpression), std::move(newBody));
 }
 
 bool SimplifyAggregateTargetExpressionTransformer::transform(TranslationUnit& translationUnit) {
@@ -109,12 +109,12 @@ bool SimplifyAggregateTargetExpressionTransformer::transform(TranslationUnit& tr
 
     // Generate the necessary simplified forms for each complex aggregator
     std::map<const Aggregator*, Aggregator*> complexToSimple;
-    for (const auto* clause : program.getClauses()) {
-        visitDepthFirst(*clause, [&](const Aggregator& aggregator) {
+    for (auto* clause : program.getClauses()) {
+        visitDepthFirst(*clause, [&](Aggregator& aggregator) {
             const auto* targetExpression = aggregator.getTargetExpression();
             if (targetExpression != nullptr && !isA<Variable>(targetExpression)) {
                 complexToSimple.insert(
-                        {&aggregator, simplifyTargetExpression(translationUnit, clause, &aggregator)});
+                        {&aggregator, simplifyTargetExpression(translationUnit, *clause, aggregator)});
             }
         });
     }

--- a/src/ast/transform/SimplifyAggregateTargetExpression.h
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.h
@@ -43,6 +43,6 @@ private:
      * @return equivalent aggregator with a simple target expression
      */
     static Aggregator* simplifyTargetExpression(
-            const TranslationUnit& tu, const Clause* clause, const Aggregator* aggregator);
+            const TranslationUnit& tu, const Clause& clause, Aggregator& aggregator);
 };
 }  // namespace souffle::ast::transform

--- a/src/ast/transform/UniqueAggregationVariables.cpp
+++ b/src/ast/transform/UniqueAggregationVariables.cpp
@@ -35,10 +35,10 @@ bool UniqueAggregationVariablesTransformer::transform(TranslationUnit& translati
     bool changed = false;
 
     // make variables in aggregates unique
-    visitDepthFirst(translationUnit.getProgram(), [&](const Clause& clause) {
+    visitDepthFirst(translationUnit.getProgram(), [&](Clause& clause) {
         // find out if the target expression variable occurs elsewhere in the rule. If so, rename it
         // to avoid naming conflicts
-        visitDepthFirst(clause, [&](const Aggregator& agg) {
+        visitDepthFirst(clause, [&](Aggregator& agg) {
             // get the set of local variables in this aggregate and rename
             // those that occur outside the aggregate
             std::set<std::string> localVariables = analysis::getLocalVariables(translationUnit, clause, agg);
@@ -48,9 +48,9 @@ bool UniqueAggregationVariablesTransformer::transform(TranslationUnit& translati
                 if (variablesOutsideAggregate.find(name) != variablesOutsideAggregate.end()) {
                     // then this MUST be renamed to avoid scoping issues
                     std::string uniqueName = analysis::findUniqueVariableName(clause, name);
-                    visitDepthFirst(agg, [&](const Variable& var) {
+                    visitDepthFirst(agg, [&](Variable& var) {
                         if (var.getName() == name) {
-                            const_cast<Variable&>(var).setName(uniqueName);
+                            var.setName(uniqueName);
                             changed = true;
                         }
                     });

--- a/src/ast/utility/Visitor.h
+++ b/src/ast/utility/Visitor.h
@@ -146,9 +146,9 @@ struct Visitor : public ast_visitor_tag {
         fatal("unsupported type: %s", typeid(node).name());
     }
 
-#define LINK(Kind, Parent)                                   \
+#define LINK(Kind, Parent)                                                          \
     virtual R visit##Kind(copy_const_t<NodeType, Kind>& n, Params const&... args) { \
-        return visit##Parent(n, args...);                     \
+        return visit##Parent(n, args...);                                           \
     }
 
     // -- types --

--- a/src/include/souffle/utility/ContainerUtil.h
+++ b/src/include/souffle/utility/ContainerUtil.h
@@ -185,115 +185,111 @@ auto clone(const std::vector<std::unique_ptr<A>>& xs) {
 // -------------------------------------------------------------
 //                            Iterators
 // -------------------------------------------------------------
-
 /**
- * A wrapper for an iterator obtaining pointers of a certain type,
- * dereferencing values before forwarding them to the consumer.
+ * A wrapper for an iterator that transforms values returned by
+ * the underlying iter.
  *
  * @tparam Iter ... the type of wrapped iterator
- * @tparam T    ... the value to be accessed by the resulting iterator
+ * @tparam F    ... the function to apply
+ *
  */
-template <typename Iter, typename T = typename std::remove_pointer<typename Iter::value_type>::type>
-struct IterDerefWrapper : public std::iterator<std::forward_iterator_tag, T> {
-    /* The nested iterator. */
-    Iter iter;
+template <typename Iter, typename F>
+class TransformIterator {
+    using iter_t = std::iterator_traits<Iter>;
+    using difference_type = typename iter_t::difference_type;
+    using result_type = decltype(std::declval<F&>()(*std::declval<Iter>()));
 
 public:
     // some constructors
-    IterDerefWrapper() = default;
-    IterDerefWrapper(const Iter& iter) : iter(iter) {}
+    TransformIterator() = default;
+    TransformIterator(Iter iter, F f) : iter(std::move(iter)), fun(std::move(f)) {}
 
     // defaulted copy and move constructors
-    IterDerefWrapper(const IterDerefWrapper&) = default;
-    IterDerefWrapper(IterDerefWrapper&&) = default;
+    TransformIterator(const TransformIterator&) = default;
+    TransformIterator(TransformIterator&&) = default;
 
     // default assignment operators
-    IterDerefWrapper& operator=(const IterDerefWrapper&) = default;
-    IterDerefWrapper& operator=(IterDerefWrapper&&) = default;
+    TransformIterator& operator=(const TransformIterator&) = default;
+    TransformIterator& operator=(TransformIterator&&) = default;
 
     /* The equality operator as required by the iterator concept. */
-    bool operator==(const IterDerefWrapper& other) const {
+    bool operator==(const TransformIterator& other) const {
         return iter == other.iter;
     }
 
     /* The not-equality operator as required by the iterator concept. */
-    bool operator!=(const IterDerefWrapper& other) const {
+    bool operator!=(const TransformIterator& other) const {
         return iter != other.iter;
     }
 
     /* The deref operator as required by the iterator concept. */
-    const T& operator*() const {
-        return **iter;
+    auto operator*() const -> result_type {
+        return fun(*iter);
     }
 
     /* Support for the pointer operator. */
-    const T* operator->() const {
-        return &(**iter);
+    auto operator->() const {
+        return &**this;
     }
 
     /* The increment operator as required by the iterator concept. */
-    IterDerefWrapper& operator++() {
+    TransformIterator& operator++() {
         ++iter;
         return *this;
     }
+
+    TransformIterator operator++(int) {
+        auto res = *this;
+        ++iter;
+        return res;
+    }
+
+    TransformIterator& operator--() {
+        --iter;
+        return *this;
+    }
+
+    TransformIterator operator--(int) {
+        auto res = *this;
+        --iter;
+        return res;
+    }
+
+    auto operator[](difference_type ii) const {
+        return f(iter[ii]);
+    }
+
+private:
+    /* The nested iterator. */
+    Iter iter;
+    F fun;
 };
+
+template <typename Iter, typename F>
+auto makeTransformIter(Iter&& iter, F&& f) {
+    return TransformIterator<std::remove_reference_t<Iter>, std::remove_reference_t<F>>(
+            std::forward<Iter>(iter), std::forward<F>(f));
+}
+
+/**
+ * A wrapper for an iterator obtaining pointers of a certain type,
+ * dereferencing values before forwarding them to the consumer.
+ */
+namespace detail {
+inline auto iterDeref = [](auto& p) -> decltype(*p) { return *p; };
+}
+
+template <typename Iter>
+using IterDerefWrapper = TransformIterator<Iter, decltype(detail::iterDeref)>;
 
 /**
  * A factory function enabling the construction of a dereferencing
  * iterator utilizing the automated deduction of template parameters.
  */
 template <typename Iter>
-IterDerefWrapper<Iter> derefIter(const Iter& iter) {
-    return IterDerefWrapper<Iter>(iter);
+auto derefIter(Iter&& iter) {
+    return makeTransformIter(std::forward<Iter>(iter), detail::iterDeref);
 }
-
-/**
- * An iterator to be utilized if there is only a single element to iterate over.
- */
-template <typename T>
-class SingleValueIterator : public std::iterator<std::forward_iterator_tag, T> {
-    T value;
-
-    bool end = true;
-
-public:
-    SingleValueIterator() = default;
-
-    SingleValueIterator(const T& value) : value(value), end(false) {}
-
-    // a copy constructor
-    SingleValueIterator(const SingleValueIterator& other) = default;
-
-    // an assignment operator
-    SingleValueIterator& operator=(const SingleValueIterator& other) = default;
-
-    // the equality operator as required by the iterator concept
-    bool operator==(const SingleValueIterator& other) const {
-        // only equivalent if pointing to the end
-        return end && other.end;
-    }
-
-    // the not-equality operator as required by the iterator concept
-    bool operator!=(const SingleValueIterator& other) const {
-        return !(*this == other);
-    }
-
-    // the deref operator as required by the iterator concept
-    const T& operator*() const {
-        return value;
-    }
-
-    // support for the pointer operator
-    const T* operator->() const {
-        return &value;
-    }
-
-    // the increment operator as required by the iterator concept
-    SingleValueIterator& operator++() {
-        end = true;
-        return *this;
-    }
-};
 
 // -------------------------------------------------------------
 //                             Ranges
@@ -470,3 +466,16 @@ bool equal_targets(
 }
 
 }  // namespace souffle
+
+namespace std {
+template <typename Iter, typename F>
+struct iterator_traits<souffle::TransformIterator<Iter, F>> {
+    using iter_t = std::iterator_traits<Iter>;
+    using iter_tag = typename iter_t::iterator_category;
+    using difference_type = typename iter_t::difference_type;
+    using result_type = decltype(std::declval<F&>()(*std::declval<Iter>()));
+    using value_type = std::remove_cv_t<std::remove_reference_t<result_type>>;
+    using iterator_category = std::conditional_t<std::is_base_of_v<std::random_access_iterator_tag, iter_tag>,
+            std::random_access_iterator_tag, iter_tag>;
+};
+}  // namespace std

--- a/src/include/souffle/utility/MiscUtil.h
+++ b/src/include/souffle/utility/MiscUtil.h
@@ -199,3 +199,12 @@ template <typename... Args>
 // HACK:  Workaround to suppress spurious reachability warnings.
 #define UNREACHABLE_BAD_CASE_ANALYSIS fatal("unhandled switch branch");
 }  // namespace souffle
+
+/**
+ * Copy the const qualifier of type T onto type U
+ */
+template <typename T, typename U>
+using copy_const = typename std::conditional<std::is_const_v<T>, U const, U>;
+
+template <typename T, typename U>
+using copy_const_t = typename copy_const<T, U>::type;

--- a/src/include/souffle/utility/MiscUtil.h
+++ b/src/include/souffle/utility/MiscUtil.h
@@ -140,8 +140,14 @@ bool equal_ptr(const std::unique_ptr<T>& a, const std::unique_ptr<T>& b) {
     return equal_ptr(a.get(), b.get());
 }
 
+/**
+ * Copy the const qualifier of type T onto type U
+ */
 template <typename A, typename B>
-using copy_const_t = std::conditional_t<std::is_const_v<A>, const B, B>;
+using copy_const = std::conditional<std::is_const_v<A>, const B, B>;
+
+template <typename A, typename B>
+using copy_const_t = typename copy_const<A, B>::type;
 
 /**
  * Helpers for `dynamic_cast`ing without having to specify redundant type qualifiers.
@@ -199,12 +205,3 @@ template <typename... Args>
 // HACK:  Workaround to suppress spurious reachability warnings.
 #define UNREACHABLE_BAD_CASE_ANALYSIS fatal("unhandled switch branch");
 }  // namespace souffle
-
-/**
- * Copy the const qualifier of type T onto type U
- */
-template <typename T, typename U>
-using copy_const = typename std::conditional<std::is_const_v<T>, U const, U>;
-
-template <typename T, typename U>
-using copy_const_t = typename copy_const<T, U>::type;


### PR DESCRIPTION
This is the first of several PRs to clean up the code and express more invariants at the type  level.
Specifically, I will be focusing on replacing pointers with references where a nullptr is not possible; and on improving const-correctness.

This PR improves const-correctness for the AST visitor framework.  I did not want to touch the RAM code visitation because I know @azreika is working on it and I didn't want to cause merge issues.  In any case, all const_casts<> inside of AST visitors are now gone.

The other improvement is that the visitor lambdas no longer go through `std::function`, effectively removing one level of virtual dispatch, which should improve performance of compilation a bit.

Finally, as part of this work, I replaced `IterDerefWrapper` with a more generic `TransformIterator`, which simply applies a function to each returned element.  `IterDerefWrapper` is now just a special case of this.
