### PR TITLE
Better ast clone - MERGE THIRD

### DIFF
--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -86,11 +86,6 @@ public:
         return res;
     }
 
-    Aggregator* clone() const override {
-        return new Aggregator(
-                baseOperator, souffle::clone(targetExpression), souffle::clone(body), getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         if (targetExpression) {
             targetExpression = map(std::move(targetExpression));
@@ -113,6 +108,12 @@ protected:
         const auto& other = asAssert<Aggregator>(node);
         return baseOperator == other.baseOperator && equal_ptr(targetExpression, other.targetExpression) &&
                equal_targets(body, other.body);
+    }
+
+private:
+    Aggregator* cloneImpl() const override {
+        return new Aggregator(
+                baseOperator, souffle::clone(targetExpression), souffle::clone(body), getSrcLoc());
     }
 
 private:

--- a/src/ast/AlgebraicDataType.h
+++ b/src/ast/AlgebraicDataType.h
@@ -62,14 +62,15 @@ public:
         os << tfm::format(".type %s = %s", getQualifiedName(), join(branches, " | "));
     }
 
-    AlgebraicDataType* clone() const override {
-        return new AlgebraicDataType(getQualifiedName(), souffle::clone(branches), getSrcLoc());
-    }
-
 protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<AlgebraicDataType>(node);
         return getQualifiedName() == other.getQualifiedName() && branches == other.branches;
+    }
+
+private:
+    AlgebraicDataType* cloneImpl() const override {
+        return new AlgebraicDataType(getQualifiedName(), souffle::clone(branches), getSrcLoc());
     }
 
 private:

--- a/src/ast/Argument.h
+++ b/src/ast/Argument.h
@@ -27,9 +27,6 @@ namespace souffle::ast {
 class Argument : public Node {
 public:
     using Node::Node;
-
-    /** Create clone */
-    Argument* clone() const override = 0;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Atom.h
+++ b/src/ast/Atom.h
@@ -73,10 +73,6 @@ public:
         return toPtrVector(arguments);
     }
 
-    Atom* clone() const override {
-        return new Atom(name, souffle::clone(arguments), getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         for (auto& arg : arguments) {
             arg = map(std::move(arg));
@@ -101,6 +97,12 @@ protected:
         return name == other.name && equal_targets(arguments, other.arguments);
     }
 
+private:
+    Atom* cloneImpl() const override {
+        return new Atom(name, souffle::clone(arguments), getSrcLoc());
+    }
+
+private:
     /** Name of atom */
     QualifiedName name;
 

--- a/src/ast/Attribute.h
+++ b/src/ast/Attribute.h
@@ -55,10 +55,6 @@ public:
         typeName = std::move(name);
     }
 
-    Attribute* clone() const override {
-        return new Attribute(name, typeName, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << name << ":" << typeName;
@@ -67,6 +63,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<Attribute>(node);
         return name == other.name && typeName == other.typeName;
+    }
+
+private:
+    Attribute* cloneImpl() const override {
+        return new Attribute(name, typeName, getSrcLoc());
     }
 
 private:

--- a/src/ast/BinaryConstraint.h
+++ b/src/ast/BinaryConstraint.h
@@ -69,10 +69,6 @@ public:
         operation = op;
     }
 
-    BinaryConstraint* clone() const override {
-        return new BinaryConstraint(operation, souffle::clone(lhs), souffle::clone(rhs), getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         lhs = map(std::move(lhs));
         rhs = map(std::move(rhs));
@@ -96,6 +92,12 @@ protected:
         return operation == other.operation && equal_ptr(lhs, other.lhs) && equal_ptr(rhs, other.rhs);
     }
 
+private:
+    BinaryConstraint* cloneImpl() const override {
+        return new BinaryConstraint(operation, souffle::clone(lhs), souffle::clone(rhs), getSrcLoc());
+    }
+
+private:
     /** Constraint (base) operator */
     BinaryConstraintOp operation;
 

--- a/src/ast/BooleanConstraint.h
+++ b/src/ast/BooleanConstraint.h
@@ -51,10 +51,6 @@ public:
         truthValue = value;
     }
 
-    BooleanConstraint* clone() const override {
-        return new BooleanConstraint(truthValue, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << (truthValue ? "true" : "false");
@@ -65,6 +61,12 @@ protected:
         return truthValue == other.truthValue;
     }
 
+private:
+    BooleanConstraint* cloneImpl() const override {
+        return new BooleanConstraint(truthValue, getSrcLoc());
+    }
+
+private:
     /** Truth value of Boolean constraint */
     bool truthValue;
 };

--- a/src/ast/BranchDeclaration.h
+++ b/src/ast/BranchDeclaration.h
@@ -52,13 +52,14 @@ public:
         return toPtrVector(fields);
     }
 
-    BranchDeclaration* clone() const override {
-        return new BranchDeclaration(constructor, souffle::clone(fields), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << tfm::format("%s {%s}", constructor, join(fields, ", "));
+    }
+
+private:
+    BranchDeclaration* cloneImpl() const override {
+        return new BranchDeclaration(constructor, souffle::clone(fields), getSrcLoc());
     }
 
 private:

--- a/src/ast/BranchInit.h
+++ b/src/ast/BranchInit.h
@@ -50,10 +50,6 @@ public:
         return constructor;
     }
 
-    BranchInit* clone() const override {
-        return new BranchInit(constructor, souffle::clone(args), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << tfm::format("$%s(%s)", constructor, join(args, ", "));
@@ -63,6 +59,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<BranchInit>(node);
         return (constructor == other.constructor) && equal_targets(args, other.args);
+    }
+
+private:
+    BranchInit* cloneImpl() const override {
+        return new BranchInit(constructor, souffle::clone(args), getSrcLoc());
     }
 
 private:

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -89,11 +89,6 @@ public:
         plan = nullptr;
     }
 
-    Clause* clone() const override {
-        return new Clause(
-                souffle::clone(head), souffle::clone(bodyLiterals), souffle::clone(plan), getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         head = map(std::move(head));
         for (auto& lit : bodyLiterals) {
@@ -129,6 +124,13 @@ protected:
                equal_ptr(plan, other.plan);
     }
 
+private:
+    Clause* cloneImpl() const override {
+        return new Clause(
+                souffle::clone(head), souffle::clone(bodyLiterals), souffle::clone(plan), getSrcLoc());
+    }
+
+private:
     /** Head of the clause */
     Own<Atom> head;
 

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -268,9 +268,6 @@ private:
     }
 
 private:
-
-
-
     /** Name of component and its formal component arguments. */
     Own<ComponentType> componentType;
 

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -146,20 +146,6 @@ public:
         return overrideRules;
     }
 
-    Component* clone() const override {
-        auto* res = new Component();
-        res->componentType = souffle::clone(componentType);
-        res->baseComponents = souffle::clone(baseComponents);
-        res->components = souffle::clone(components);
-        res->instantiations = souffle::clone(instantiations);
-        res->types = souffle::clone(types);
-        res->relations = souffle::clone(relations);
-        res->clauses = souffle::clone(clauses);
-        res->directives = souffle::clone(directives);
-        res->overrideRules = overrideRules;
-        return res;
-    }
-
     void apply(const NodeMapper& mapper) override {
         componentType = mapper(std::move(componentType));
         for (auto& cur : baseComponents) {
@@ -265,6 +251,25 @@ protected:
         }
         return true;
     }
+
+private:
+    Component* cloneImpl() const override {
+        auto* res = new Component();
+        res->componentType = souffle::clone(componentType);
+        res->baseComponents = souffle::clone(baseComponents);
+        res->components = souffle::clone(components);
+        res->instantiations = souffle::clone(instantiations);
+        res->types = souffle::clone(types);
+        res->relations = souffle::clone(relations);
+        res->clauses = souffle::clone(clauses);
+        res->directives = souffle::clone(directives);
+        res->overrideRules = overrideRules;
+        return res;
+    }
+
+private:
+
+
 
     /** Name of component and its formal component arguments. */
     Own<ComponentType> componentType;

--- a/src/ast/ComponentInit.h
+++ b/src/ast/ComponentInit.h
@@ -63,10 +63,6 @@ public:
         componentType = std::move(type);
     }
 
-    ComponentInit* clone() const override {
-        return new ComponentInit(instanceName, souffle::clone(componentType), getSrcLoc());
-    }
-
     void apply(const NodeMapper& mapper) override {
         componentType = mapper(std::move(componentType));
     }
@@ -85,6 +81,12 @@ protected:
         return instanceName == other.instanceName && *componentType == *other.componentType;
     }
 
+private:
+    ComponentInit* cloneImpl() const override {
+        return new ComponentInit(instanceName, souffle::clone(componentType), getSrcLoc());
+    }
+
+private:
     /** Instance name */
     std::string instanceName;
 

--- a/src/ast/ComponentType.h
+++ b/src/ast/ComponentType.h
@@ -62,10 +62,6 @@ public:
         typeParams = params;
     }
 
-    ComponentType* clone() const override {
-        return new ComponentType(name, typeParams, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << name;
@@ -77,6 +73,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<ComponentType>(node);
         return name == other.name && typeParams == other.typeParams;
+    }
+
+private:
+    ComponentType* cloneImpl() const override {
+        return new ComponentType(name, typeParams, getSrcLoc());
     }
 
 private:

--- a/src/ast/Constant.h
+++ b/src/ast/Constant.h
@@ -32,8 +32,6 @@ namespace souffle::ast {
  */
 class Constant : public Argument {
 public:
-    Constant* clone() const override = 0;
-
     /** Get string representation of Constant */
     const std::string& getConstant() const {
         return constant;

--- a/src/ast/Constraint.h
+++ b/src/ast/Constraint.h
@@ -27,8 +27,6 @@ namespace souffle::ast {
 class Constraint : public Literal {
 public:
     using Literal::Literal;
-
-    Constraint* clone() const override = 0;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Counter.h
+++ b/src/ast/Counter.h
@@ -38,7 +38,6 @@ private:
     Counter* cloneImpl() const override {
         return new Counter(getSrcLoc());
     }
-
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Counter.h
+++ b/src/ast/Counter.h
@@ -29,14 +29,16 @@ class Counter : public Argument {
 public:
     using Argument::Argument;
 
-    Counter* clone() const override {
-        return new Counter(getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << "$";
     }
+
+private:
+    Counter* cloneImpl() const override {
+        return new Counter(getSrcLoc());
+    }
+
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Directive.h
+++ b/src/ast/Directive.h
@@ -92,12 +92,6 @@ public:
         return parameters;
     }
 
-    Directive* clone() const override {
-        auto res = new Directive(type, name, getSrcLoc());
-        res->parameters = parameters;
-        return res;
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << "." << type << " " << name;
@@ -113,6 +107,14 @@ protected:
         return other.type == type && other.name == name && other.parameters == parameters;
     }
 
+private:
+    Directive* cloneImpl() const override {
+        auto res = new Directive(type, name, getSrcLoc());
+        res->parameters = parameters;
+        return res;
+    }
+
+private:
     /** Type of directive */
     DirectiveType type;
 

--- a/src/ast/ExecutionOrder.h
+++ b/src/ast/ExecutionOrder.h
@@ -45,10 +45,6 @@ public:
         return order;
     }
 
-    ExecutionOrder* clone() const override {
-        return new ExecutionOrder(order, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& out) const override {
         out << "(" << join(order) << ")";
@@ -57,6 +53,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<ExecutionOrder>(node);
         return order == other.order;
+    }
+
+private:
+    ExecutionOrder* cloneImpl() const override {
+        return new ExecutionOrder(order, getSrcLoc());
     }
 
 private:

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -59,15 +59,6 @@ public:
         return result;
     }
 
-    ExecutionPlan* clone() const override {
-        auto res = new ExecutionPlan();
-        res->setSrcLoc(getSrcLoc());
-        for (auto& plan : plans) {
-            res->setOrderFor(plan.first, Own<ExecutionOrder>(plan.second->clone()));
-        }
-        return res;
-    }
-
     void apply(const NodeMapper& map) override {
         for (auto& plan : plans) {
             plan.second = map(std::move(plan.second));
@@ -95,6 +86,17 @@ protected:
         const auto& other = asAssert<ExecutionPlan>(node);
         return equal_targets(plans, other.plans);
     }
+
+private:
+    ExecutionPlan* cloneImpl() const override {
+        auto res = new ExecutionPlan();
+        res->setSrcLoc(getSrcLoc());
+        for (auto& plan : plans) {
+            res->setOrderFor(plan.first, souffle::clone(plan.second));
+        }
+        return res;
+    }
+
 
 private:
     /** Mapping versions of clauses to execution orders */

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -97,7 +97,6 @@ private:
         return res;
     }
 
-
 private:
     /** Mapping versions of clauses to execution orders */
     std::map<int, Own<ExecutionOrder>> plans;

--- a/src/ast/FunctionalConstraint.h
+++ b/src/ast/FunctionalConstraint.h
@@ -77,16 +77,6 @@ public:
         return res;
     }
 
-    FunctionalConstraint* clone() const override {
-        VecOwn<Variable> newKeys;
-        for (const auto& key : keys) {
-            newKeys.push_back(Own<Variable>(key->clone()));
-        }
-        auto* res = new FunctionalConstraint(std::move(newKeys));
-        res->setSrcLoc(getSrcLoc());
-        return res;
-    }
-
 public:
     void print(std::ostream& os) const override {
         os << "keys ";
@@ -128,6 +118,18 @@ public:
         return true;
     }
 
+private:
+    FunctionalConstraint* cloneImpl() const override {
+        VecOwn<Variable> newKeys;
+        for (const auto& key : keys) {
+            newKeys.push_back(souffle::clone(key));
+        }
+        auto* res = new FunctionalConstraint(std::move(newKeys));
+        res->setSrcLoc(getSrcLoc());
+        return res;
+    }
+
+private:
     /* Functional constraint */
     VecOwn<Variable> keys;
 };

--- a/src/ast/Functor.h
+++ b/src/ast/Functor.h
@@ -28,9 +28,6 @@ namespace souffle::ast {
  */
 
 class Functor : public Term {
-public:
-    Functor* clone() const override = 0;
-
 protected:
     using Term::Term;
 };

--- a/src/ast/FunctorDeclaration.h
+++ b/src/ast/FunctorDeclaration.h
@@ -74,10 +74,6 @@ public:
         return stateful;
     }
 
-    FunctorDeclaration* clone() const override {
-        return new FunctorDeclaration(name, argsTypes, returnType, stateful, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& out) const override {
         auto convert = [&](TypeAttribute type) {
@@ -105,6 +101,12 @@ protected:
         return name == other.name && argsTypes == other.argsTypes && returnType == other.returnType &&
                stateful == other.stateful;
     }
+
+private:
+    FunctorDeclaration* cloneImpl() const override {
+        return new FunctorDeclaration(name, argsTypes, returnType, stateful, getSrcLoc());
+    }
+
 
     /** Name of functor */
     const std::string name;

--- a/src/ast/FunctorDeclaration.h
+++ b/src/ast/FunctorDeclaration.h
@@ -107,7 +107,6 @@ private:
         return new FunctorDeclaration(name, argsTypes, returnType, stateful, getSrcLoc());
     }
 
-
     /** Name of functor */
     const std::string name;
 

--- a/src/ast/IntrinsicFunctor.h
+++ b/src/ast/IntrinsicFunctor.h
@@ -62,10 +62,6 @@ public:
         function = std::move(functor);
     }
 
-    IntrinsicFunctor* clone() const override {
-        return new IntrinsicFunctor(function, souffle::clone(args), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         if (isInfixFunctorOp(function)) {
@@ -86,6 +82,12 @@ protected:
         return function == other.function && Functor::equal(node);
     }
 
+private:
+    IntrinsicFunctor* cloneImpl() const override {
+        return new IntrinsicFunctor(function, souffle::clone(args), getSrcLoc());
+    }
+
+private:
     /** Function */
     std::string function;
 };

--- a/src/ast/Literal.h
+++ b/src/ast/Literal.h
@@ -30,8 +30,6 @@ namespace souffle::ast {
 class Literal : public Node {
 public:
     using Node::Node;
-
-    Literal* clone() const override = 0;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Negation.h
+++ b/src/ast/Negation.h
@@ -50,10 +50,6 @@ public:
         return atom.get();
     }
 
-    Negation* clone() const override {
-        return new Negation(souffle::clone(atom), getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         atom = map(std::move(atom));
     }
@@ -72,6 +68,12 @@ protected:
         return equal_ptr(atom, other.atom);
     }
 
+private:
+    Negation* cloneImpl() const override {
+        return new Negation(souffle::clone(atom), getSrcLoc());
+    }
+
+private:
     /** Negated atom */
     Own<Atom> atom;
 };

--- a/src/ast/NilConstant.h
+++ b/src/ast/NilConstant.h
@@ -31,7 +31,8 @@ class NilConstant : public Constant {
 public:
     NilConstant(SrcLocation loc = {}) : Constant("nil", std::move(loc)) {}
 
-    NilConstant* clone() const override {
+private:
+    NilConstant* cloneImpl() const override {
         return new NilConstant(getSrcLoc());
     }
 };

--- a/src/ast/Node.h
+++ b/src/ast/Node.h
@@ -69,7 +69,9 @@ public:
     }
 
     /** Create a clone (i.e. deep copy) of this node */
-    virtual Node* clone() const = 0;
+    Own<Node> clone() const {
+        return Own<Node>(cloneImpl());
+    }
 
     /** Apply the mapper to all child nodes */
     virtual void apply(const NodeMapper& /* mapper */) {}
@@ -147,8 +149,11 @@ protected:
     }
 
 private:
+    virtual Node* cloneImpl() const = 0;
+
+private:
     /** Source location of a syntactic element */
     SrcLocation location;
-};
+};  // namespace souffle::ast
 
 }  // namespace souffle::ast

--- a/src/ast/NumericConstant.h
+++ b/src/ast/NumericConstant.h
@@ -50,12 +50,6 @@ public:
         setSrcLoc(std::move(loc));
     }
 
-    NumericConstant* clone() const override {
-        auto* copy = new NumericConstant(getConstant(), getFixedType());
-        copy->setSrcLoc(getSrcLoc());
-        return copy;
-    }
-
     const std::optional<Type>& getFixedType() const {
         return fixedType;
     }
@@ -64,6 +58,12 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<NumericConstant>(node);
         return Constant::equal(node) && fixedType == other.fixedType;
+    }
+private:
+    NumericConstant* cloneImpl() const override {
+        auto* copy = new NumericConstant(getConstant(), getFixedType());
+        copy->setSrcLoc(getSrcLoc());
+        return copy;
     }
 
 private:

--- a/src/ast/NumericConstant.h
+++ b/src/ast/NumericConstant.h
@@ -59,6 +59,7 @@ protected:
         const auto& other = asAssert<NumericConstant>(node);
         return Constant::equal(node) && fixedType == other.fixedType;
     }
+
 private:
     NumericConstant* cloneImpl() const override {
         auto* copy = new NumericConstant(getConstant(), getFixedType());

--- a/src/ast/Pragma.h
+++ b/src/ast/Pragma.h
@@ -34,10 +34,6 @@ public:
     Pragma(std::string key, std::string value, SrcLocation loc = {})
             : Node(std::move(loc)), key(std::move(key)), value(std::move(value)) {}
 
-    Pragma* clone() const override {
-        return new Pragma(key, value, getSrcLoc());
-    }
-
     /* Get kvp */
     std::pair<std::string, std::string> getkvp() const {
         return std::pair<std::string, std::string>(key, value);
@@ -51,6 +47,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<Pragma>(node);
         return other.key == key && other.value == value;
+    }
+
+private:
+    Pragma* cloneImpl() const override {
+        return new Pragma(key, value, getSrcLoc());
     }
 
     /** Name of the key */

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -124,19 +124,6 @@ public:
     /** Remove components and components' instantiations */
     void clearComponents();
 
-    Program* clone() const override {
-        auto res = new Program();
-        res->pragmas = souffle::clone(pragmas);
-        res->components = souffle::clone(components);
-        res->instantiations = souffle::clone(instantiations);
-        res->types = souffle::clone(types);
-        res->functors = souffle::clone(functors);
-        res->relations = souffle::clone(relations);
-        res->clauses = souffle::clone(clauses);
-        res->directives = souffle::clone(directives);
-        return res;
-    }
-
     void apply(const NodeMapper& map) override {
         for (auto& cur : pragmas) {
             cur = map(std::move(cur));
@@ -256,6 +243,21 @@ protected:
         assert(instantiation && "NULL instantiation");
         instantiations.push_back(std::move(instantiation));
     }
+
+private:
+    Program* cloneImpl() const override {
+        auto res = new Program();
+        res->pragmas = souffle::clone(pragmas);
+        res->components = souffle::clone(components);
+        res->instantiations = souffle::clone(instantiations);
+        res->types = souffle::clone(types);
+        res->functors = souffle::clone(functors);
+        res->relations = souffle::clone(relations);
+        res->clauses = souffle::clone(clauses);
+        res->directives = souffle::clone(directives);
+        return res;
+    }
+
 
     /** Program types  */
     VecOwn<Type> types;

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -258,7 +258,6 @@ private:
         return res;
     }
 
-
     /** Program types  */
     VecOwn<Type> types;
 

--- a/src/ast/RecordInit.h
+++ b/src/ast/RecordInit.h
@@ -38,14 +38,16 @@ public:
     RecordInit(VecOwn<Argument> operands = {}, SrcLocation loc = {})
             : Term(std::move(operands), std::move(loc)) {}
 
-    RecordInit* clone() const override {
-        return new RecordInit(souffle::clone(args), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << "[" << join(args) << "]";
     }
+
+private:
+    RecordInit* cloneImpl() const override {
+        return new RecordInit(souffle::clone(args), getSrcLoc());
+    }
+
 };
 
 }  // namespace souffle::ast

--- a/src/ast/RecordInit.h
+++ b/src/ast/RecordInit.h
@@ -47,7 +47,6 @@ private:
     RecordInit* cloneImpl() const override {
         return new RecordInit(souffle::clone(args), getSrcLoc());
     }
-
 };
 
 }  // namespace souffle::ast

--- a/src/ast/RecordType.h
+++ b/src/ast/RecordType.h
@@ -62,10 +62,6 @@ public:
         fields.at(idx)->setTypeName(std::move(type));
     }
 
-    RecordType* clone() const override {
-        return new RecordType(getQualifiedName(), souffle::clone(fields), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << tfm::format(".type %s = [%s]", getQualifiedName(), join(fields, ", "));
@@ -74,6 +70,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<RecordType>(node);
         return getQualifiedName() == other.getQualifiedName() && equal_targets(fields, other.fields);
+    }
+
+private:
+    RecordType* cloneImpl() const override {
+        return new RecordType(getQualifiedName(), souffle::clone(fields), getSrcLoc());
     }
 
 private:

--- a/src/ast/Relation.h
+++ b/src/ast/Relation.h
@@ -119,14 +119,6 @@ public:
         return toPtrVector(functionalDependencies);
     }
 
-    Relation* clone() const override {
-        auto res = new Relation(name, getSrcLoc());
-        res->attributes = souffle::clone(attributes);
-        res->qualifiers = qualifiers;
-        res->representation = representation;
-        return res;
-    }
-
     void apply(const NodeMapper& map) override {
         for (auto& cur : attributes) {
             cur = map(std::move(cur));
@@ -152,6 +144,16 @@ protected:
         return name == other.name && equal_targets(attributes, other.attributes);
     }
 
+private:
+    Relation* cloneImpl() const override {
+        auto res = new Relation(name, getSrcLoc());
+        res->attributes = souffle::clone(attributes);
+        res->qualifiers = qualifiers;
+        res->representation = representation;
+        return res;
+    }
+
+private:
     /** Name of relation */
     QualifiedName name;
 

--- a/src/ast/StringConstant.h
+++ b/src/ast/StringConstant.h
@@ -34,15 +34,16 @@ public:
         setSrcLoc(std::move(loc));
     }
 
-    StringConstant* clone() const override {
-        auto* res = new StringConstant(getConstant());
-        res->setSrcLoc(getSrcLoc());
-        return res;
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << "\"" << getConstant() << "\"";
+    }
+
+private:
+    StringConstant* cloneImpl() const override {
+        auto* res = new StringConstant(getConstant());
+        res->setSrcLoc(getSrcLoc());
+        return res;
     }
 };
 

--- a/src/ast/SubsetType.h
+++ b/src/ast/SubsetType.h
@@ -39,10 +39,6 @@ public:
     SubsetType(QualifiedName name, QualifiedName baseTypeName, SrcLocation loc = {})
             : Type(std::move(name), std::move(loc)), baseType(std::move(baseTypeName)) {}
 
-    SubsetType* clone() const override {
-        return new SubsetType(getQualifiedName(), getBaseType(), getSrcLoc());
-    }
-
     /** Return base type */
     const QualifiedName& getBaseType() const {
         return baseType;
@@ -56,6 +52,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<SubsetType>(node);
         return getQualifiedName() == other.getQualifiedName() && baseType == other.baseType;
+    }
+
+private:
+    SubsetType* cloneImpl() const override {
+        return new SubsetType(getQualifiedName(), getBaseType(), getSrcLoc());
     }
 
 private:

--- a/src/ast/Type.h
+++ b/src/ast/Type.h
@@ -42,8 +42,6 @@ public:
         this->name = std::move(name);
     }
 
-    Type* clone() const override = 0;
-
 private:
     /** type name */
     QualifiedName name;

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -63,10 +63,6 @@ public:
         return res;
     }
 
-    TypeCast* clone() const override {
-        return new TypeCast(souffle::clone(value), type, getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         value = map(std::move(value));
     }
@@ -81,6 +77,12 @@ protected:
         return type == other.type && equal_ptr(value, other.value);
     }
 
+private:
+    TypeCast* cloneImpl() const override {
+        return new TypeCast(souffle::clone(value), type, getSrcLoc());
+    }
+
+private:
     /** Casted value */
     Own<Argument> value;
 

--- a/src/ast/UnionType.h
+++ b/src/ast/UnionType.h
@@ -66,10 +66,6 @@ public:
         types.at(idx) = std::move(type);
     }
 
-    UnionType* clone() const override {
-        return new UnionType(getQualifiedName(), types, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << ".type " << getQualifiedName() << " = " << join(types, " | ");
@@ -78,6 +74,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<UnionType>(node);
         return getQualifiedName() == other.getQualifiedName() && types == other.types;
+    }
+
+private:
+    UnionType* cloneImpl() const override {
+        return new UnionType(getQualifiedName(), types, getSrcLoc());
     }
 
 private:

--- a/src/ast/UnnamedVariable.h
+++ b/src/ast/UnnamedVariable.h
@@ -29,14 +29,16 @@ class UnnamedVariable : public Argument {
 public:
     using Argument::Argument;
 
-    UnnamedVariable* clone() const override {
-        return new UnnamedVariable(getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << "_";
     }
+
+private:
+    UnnamedVariable* cloneImpl() const override {
+        return new UnnamedVariable(getSrcLoc());
+    }
+
 };
 
 }  // namespace souffle::ast

--- a/src/ast/UnnamedVariable.h
+++ b/src/ast/UnnamedVariable.h
@@ -38,7 +38,6 @@ private:
     UnnamedVariable* cloneImpl() const override {
         return new UnnamedVariable(getSrcLoc());
     }
-
 };
 
 }  // namespace souffle::ast

--- a/src/ast/UserDefinedFunctor.h
+++ b/src/ast/UserDefinedFunctor.h
@@ -50,10 +50,6 @@ public:
         return name;
     }
 
-    UserDefinedFunctor* clone() const override {
-        return new UserDefinedFunctor(name, souffle::clone(args), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << '@' << name << "(" << join(args) << ")";
@@ -66,6 +62,11 @@ protected:
 
     /** Name */
     const std::string name;
+
+private:
+    UserDefinedFunctor* cloneImpl() const override {
+        return new UserDefinedFunctor(name, souffle::clone(args), getSrcLoc());
+    }
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Variable.h
+++ b/src/ast/Variable.h
@@ -44,10 +44,6 @@ public:
         return name;
     }
 
-    Variable* clone() const override {
-        return new Variable(name, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << name;
@@ -58,6 +54,12 @@ protected:
         return name == other.name;
     }
 
+private:
+    Variable* cloneImpl() const override {
+        return new Variable(name, getSrcLoc());
+    }
+
+private:
     /** Name */
     std::string name;
 };

--- a/src/ast/analysis/Aggregate.cpp
+++ b/src/ast/analysis/Aggregate.cpp
@@ -89,33 +89,33 @@ std::set<std::string> getWitnessVariables(
                 // Keep track of which variables are bound to aggregators
                 aggregatorVariables.insert(newVariableName.str());
 
-                return std::make_unique<Variable>(newVariableName.str());
+                return mk<Variable>(newVariableName.str());
             }
             node->apply(*this);
             return node;
         }
     };
 
-    auto aggregatorlessClause = std::make_unique<Clause>();
-    aggregatorlessClause->setHead(std::make_unique<Atom>("*"));
+    auto aggregatorlessClause = mk<Clause>();
+    aggregatorlessClause->setHead(mk<Atom>("*"));
     for (Literal* lit : clause.getBodyLiterals()) {
         aggregatorlessClause->addToBody(souffle::clone(lit));
     }
 
-    auto negatedHead = std::make_unique<Negation>(souffle::clone(clause.getHead()));
+    auto negatedHead = mk<Negation>(souffle::clone(clause.getHead()));
     aggregatorlessClause->addToBody(std::move(negatedHead));
 
     // Replace all aggregates with variables
     M update;
     aggregatorlessClause->apply(update);
-    auto groundingAtom = std::make_unique<Atom>("+grounding_atom");
+    auto groundingAtom = mk<Atom>("+grounding_atom");
     for (std::string variableName : update.getAggregatorVariables()) {
-        groundingAtom->addArgument(std::make_unique<Variable>(variableName));
+        groundingAtom->addArgument(mk<Variable>(variableName));
     }
     aggregatorlessClause->addToBody(std::move(groundingAtom));
     // 2. Create an aggregate clause so that we can check
     // that it IS this aggregate giving a grounding to the candidate variable.
-    auto aggregateSubclause = std::make_unique<Clause>();
+    auto aggregateSubclause = mk<Clause>();
     aggregateSubclause->setHead(mk<Atom>("*"));
     for (const auto& lit : aggregate.getBodyLiterals()) {
         aggregateSubclause->addToBody(souffle::clone(lit));

--- a/src/ast/tests/ast_program_test.cpp
+++ b/src/ast/tests/ast_program_test.cpp
@@ -94,7 +94,7 @@ TEST(Program, Parse) {
         Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(DL, e, d); \
         Program& program = tu->getProgram();                                    \
         EXPECT_EQ(program, program);                                            \
-        Own<Program> clone(program.clone());                                    \
+        Own<Program> clone(souffle::clone(program));                            \
         EXPECT_NE(clone.get(), &program);                                       \
         EXPECT_EQ(*clone, program);                                             \
     }

--- a/src/ast/transform/AddNullariesToAtomlessAggregates.h
+++ b/src/ast/transform/AddNullariesToAtomlessAggregates.h
@@ -37,11 +37,11 @@ public:
         return "AddNullariesToAtomlessAggregatesTransformer";
     }
 
-    AddNullariesToAtomlessAggregatesTransformer* clone() const override {
+private:
+    AddNullariesToAtomlessAggregatesTransformer* cloneImpl() const override {
         return new AddNullariesToAtomlessAggregatesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/ComponentChecker.h
+++ b/src/ast/transform/ComponentChecker.h
@@ -37,11 +37,11 @@ public:
         return "ComponentChecker";
     }
 
-    ComponentChecker* clone() const override {
+private:
+    ComponentChecker* cloneImpl() const override {
         return new ComponentChecker();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     static const Component* checkComponentNameReference(ErrorReport& report,

--- a/src/ast/transform/ComponentInstantiation.cpp
+++ b/src/ast/transform/ComponentInstantiation.cpp
@@ -183,7 +183,7 @@ void collectContent(Program& program, const Component& component, const TypeBind
     // and continue with the local types
     for (const auto& cur : component.getTypes()) {
         // create a clone
-        Own<ast::Type> type(cur->clone());
+        Own<ast::Type> type(souffle::clone(cur));
 
         // instantiate elements of union types
         visitDepthFirst(*type, [&](ast::UnionType& type) {
@@ -212,7 +212,7 @@ void collectContent(Program& program, const Component& component, const TypeBind
     // and the local relations
     for (const auto& cur : component.getRelations()) {
         // create a clone
-        Own<Relation> rel(cur->clone());
+        Own<Relation> rel(souffle::clone(cur));
 
         // update attribute types
         for (Attribute* attr : rel->getAttributes()) {
@@ -229,7 +229,7 @@ void collectContent(Program& program, const Component& component, const TypeBind
     // and the local directive directives
     for (const auto& directive : component.getDirectives()) {
         // create a clone
-        Own<Directive> instantiatedIO(directive->clone());
+        Own<Directive> instantiatedIO(souffle::clone(directive));
 
         res.add(instantiatedIO, report);
     }
@@ -246,10 +246,10 @@ void collectContent(Program& program, const Component& component, const TypeBind
         if (overridden.count(cur->getHead()->getQualifiedName().getQualifiers()[0]) == 0) {
             Relation* rel = index[cur->getHead()->getQualifiedName()];
             if (rel != nullptr) {
-                Own<Clause> instantiatedClause(cur->clone());
+                Own<Clause> instantiatedClause(souffle::clone(cur));
                 res.add(instantiatedClause, report);
             } else {
-                orphans.emplace_back(cur->clone());
+                orphans.emplace_back(souffle::clone(cur));
             }
         }
     }
@@ -260,7 +260,7 @@ void collectContent(Program& program, const Component& component, const TypeBind
         Relation* rel = index[cur->getHead()->getQualifiedName()];
         if (rel != nullptr) {
             // add orphan to current instance and delete from orphan list
-            Own<Clause> instantiatedClause(cur->clone());
+            Own<Clause> instantiatedClause(souffle::clone(cur));
             res.add(instantiatedClause, report);
             iter = orphans.erase(iter);
         } else {

--- a/src/ast/transform/ComponentInstantiation.h
+++ b/src/ast/transform/ComponentInstantiation.h
@@ -26,11 +26,11 @@ public:
         return "ComponentInstantiationTransformer";
     }
 
-    ComponentInstantiationTransformer* clone() const override {
+private:
+    ComponentInstantiationTransformer* cloneImpl() const override {
         return new ComponentInstantiationTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/Conditional.h
+++ b/src/ast/transform/Conditional.h
@@ -73,17 +73,18 @@ public:
         return "ConditionalTransformer";
     }
 
-    ConditionalTransformer* clone() const override {
+private:
+    ConditionalTransformer* cloneImpl() const override {
         return new ConditionalTransformer(condition, souffle::clone(transformer));
+    }
+
+    bool transform(TranslationUnit& translationUnit) override {
+        return condition() ? applySubtransformer(translationUnit, transformer.get()) : false;
     }
 
 private:
     std::function<bool()> condition;
     Own<Transformer> transformer;
-
-    bool transform(TranslationUnit& translationUnit) override {
-        return condition() ? applySubtransformer(translationUnit, transformer.get()) : false;
-    }
 };
 
 }  // namespace souffle::ast::transform

--- a/src/ast/transform/DebugReporter.h
+++ b/src/ast/transform/DebugReporter.h
@@ -63,7 +63,7 @@ public:
         return "DebugReporter";
     }
 
-    DebugReporter* clone() const override {
+    DebugReporter* cloneImpl() const override {
         return new DebugReporter(souffle::clone(wrappedTransformer));
     }
 

--- a/src/ast/transform/ExecutionPlanChecker.h
+++ b/src/ast/transform/ExecutionPlanChecker.h
@@ -28,11 +28,11 @@ public:
         return "ExecutionPlanChecker";
     }
 
-    ExecutionPlanChecker* clone() const override {
+private:
+    ExecutionPlanChecker* cloneImpl() const override {
         return new ExecutionPlanChecker();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/Fixpoint.h
+++ b/src/ast/transform/Fixpoint.h
@@ -68,12 +68,11 @@ public:
         return "FixpointTransformer";
     }
 
-    FixpointTransformer* clone() const override {
+private:
+    FixpointTransformer* cloneImpl() const override {
         return new FixpointTransformer(souffle::clone(transformer));
     }
 
-private:
-    Own<Transformer> transformer;
     bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
         while (applySubtransformer(translationUnit, transformer.get())) {
@@ -81,6 +80,9 @@ private:
         }
         return changed;
     }
+
+private:
+    Own<Transformer> transformer;
 };
 
 }  // namespace souffle::ast::transform

--- a/src/ast/transform/FoldAnonymousRecords.cpp
+++ b/src/ast/transform/FoldAnonymousRecords.cpp
@@ -168,7 +168,7 @@ bool FoldAnonymousRecords::transform(TranslationUnit& translationUnit) {
             changed = true;
             transformClause(*clause, newClauses);
         } else {
-            newClauses.emplace_back(clause->clone());
+            newClauses.emplace_back(souffle::clone(clause));
         }
     }
 

--- a/src/ast/transform/FoldAnonymousRecords.h
+++ b/src/ast/transform/FoldAnonymousRecords.h
@@ -51,11 +51,11 @@ public:
         return "FoldAnonymousRecords";
     }
 
-    FoldAnonymousRecords* clone() const override {
+private:
+    FoldAnonymousRecords* cloneImpl() const override {
         return new FoldAnonymousRecords();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /**

--- a/src/ast/transform/GroundWitnesses.h
+++ b/src/ast/transform/GroundWitnesses.h
@@ -45,11 +45,11 @@ public:
         return "GroundWitnessesTransformer";
     }
 
-    GroundWitnessesTransformer* clone() const override {
+private:
+    GroundWitnessesTransformer* cloneImpl() const override {
         return new GroundWitnessesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/GroundedTermsChecker.h
+++ b/src/ast/transform/GroundedTermsChecker.h
@@ -31,11 +31,11 @@ public:
     // `apply` but doesn't immediately bail if any errors are found.
     void verify(TranslationUnit& translationUnit);
 
-    GroundedTermsChecker* clone() const override {
+private:
+    GroundedTermsChecker* cloneImpl() const override {
         return new GroundedTermsChecker();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         verify(translationUnit);
         return false;

--- a/src/ast/transform/IOAttributes.h
+++ b/src/ast/transform/IOAttributes.h
@@ -56,11 +56,11 @@ public:
         return "IOAttributesTransformer";
     }
 
-    IOAttributesTransformer* clone() const override {
+private:
+    IOAttributesTransformer* cloneImpl() const override {
         return new IOAttributesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
 

--- a/src/ast/transform/IODefaults.h
+++ b/src/ast/transform/IODefaults.h
@@ -38,11 +38,11 @@ public:
         return "IODefaultsTransformer";
     }
 
-    IODefaultsTransformer* clone() const override {
+private:
+    IODefaultsTransformer* cloneImpl() const override {
         return new IODefaultsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
 

--- a/src/ast/transform/InlineRelations.h
+++ b/src/ast/transform/InlineRelations.h
@@ -31,11 +31,11 @@ public:
         return "InlineRelationsTransformer";
     }
 
-    InlineRelationsTransformer* clone() const override {
+private:
+    InlineRelationsTransformer* cloneImpl() const override {
         return new InlineRelationsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/MagicSet.h
+++ b/src/ast/transform/MagicSet.h
@@ -64,11 +64,11 @@ public:
         return "MagicSetTransformer";
     }
 
-    MagicSetTransformer* clone() const override {
+private:
+    MagicSetTransformer* cloneImpl() const override {
         return new MagicSetTransformer();
     }
 
-private:
     bool transform(TranslationUnit& tu) override {
         return shouldRun(tu) ? PipelineTransformer::transform(tu) : false;
     }
@@ -115,11 +115,11 @@ public:
         return "NormaliseDatabaseTransformer";
     }
 
-    NormaliseDatabaseTransformer* clone() const override {
+private:
+    NormaliseDatabaseTransformer* cloneImpl() const override {
         return new NormaliseDatabaseTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /**
@@ -168,11 +168,11 @@ public:
         return "LabelDatabaseTransformer";
     }
 
-    LabelDatabaseTransformer* clone() const override {
+private:
+    LabelDatabaseTransformer* cloneImpl() const override {
         return new LabelDatabaseTransformer();
     }
 
-private:
     /** Check if a relation is negatively labelled. */
     static bool isNegativelyLabelled(const QualifiedName& name);
 };
@@ -188,11 +188,11 @@ public:
         return "NegativeLabellingTransformer";
     }
 
-    NegativeLabellingTransformer* clone() const override {
+private:
+    NegativeLabellingTransformer* cloneImpl() const override {
         return new NegativeLabellingTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /** Provide a unique name for negatively-labelled relations. */
@@ -211,11 +211,11 @@ public:
         return "PositiveLabellingTransformer";
     }
 
-    PositiveLabellingTransformer* clone() const override {
+private:
+    PositiveLabellingTransformer* cloneImpl() const override {
         return new PositiveLabellingTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /** Provide a unique name for a positively labelled relation copy. */
@@ -233,11 +233,11 @@ public:
         return "AdornDatabaseTransformer";
     }
 
-    AdornDatabaseTransformer* clone() const override {
+private:
+    AdornDatabaseTransformer* cloneImpl() const override {
         return new AdornDatabaseTransformer();
     }
 
-private:
     using adorned_predicate = std::pair<QualifiedName, std::string>;
 
     std::set<adorned_predicate> headAdornmentsToDo;
@@ -289,11 +289,11 @@ public:
         return "MagicSetCoreTransformer";
     }
 
-    MagicSetCoreTransformer* clone() const override {
+private:
+    MagicSetCoreTransformer* cloneImpl() const override {
         return new MagicSetCoreTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /** Gets a unique magic identifier for a given adorned relation name */

--- a/src/ast/transform/MaterializeAggregationQueries.cpp
+++ b/src/ast/transform/MaterializeAggregationQueries.cpp
@@ -221,7 +221,7 @@ void MaterializeAggregationQueriesTransformer::groundInjectedParameters(
                 for (auto arg : atom->getArguments()) {
                     if (auto* var = as<ast::Variable>(arg)) {
                         if (var->getName() == ungroundedVariableName) {
-                            arguments.emplace_back(arg->clone());
+                            arguments.emplace_back(souffle::clone(arg));
                             continue;
                         }
                     }
@@ -335,7 +335,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
                         continue;
                     }
                 }
-                args.emplace_back(arg->clone());
+                args.emplace_back(souffle::clone(arg));
             }
             auto aggAtom =
                     mk<Atom>(aggClauseHead->getQualifiedName(), std::move(args), aggClauseHead->getSrcLoc());

--- a/src/ast/transform/MaterializeAggregationQueries.h
+++ b/src/ast/transform/MaterializeAggregationQueries.h
@@ -42,11 +42,11 @@ public:
      */
     static bool materializeAggregationQueries(TranslationUnit& translationUnit);
 
-    MaterializeAggregationQueriesTransformer* clone() const override {
+private:
+    MaterializeAggregationQueriesTransformer* cloneImpl() const override {
         return new MaterializeAggregationQueriesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         return materializeAggregationQueries(translationUnit);
     }

--- a/src/ast/transform/MaterializeSingletonAggregation.h
+++ b/src/ast/transform/MaterializeSingletonAggregation.h
@@ -36,11 +36,11 @@ public:
         return "MaterializeSingletonAggregationTransformer";
     }
 
-    MaterializeSingletonAggregationTransformer* clone() const override {
+private:
+    MaterializeSingletonAggregationTransformer* cloneImpl() const override {
         return new MaterializeSingletonAggregationTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
     /**
      * Determines whether an aggregate is single-valued,

--- a/src/ast/transform/Meta.h
+++ b/src/ast/transform/Meta.h
@@ -46,8 +46,6 @@ public:
 
     /* Apply a nested transformer */
     bool applySubtransformer(TranslationUnit& translationUnit, Transformer* transformer);
-
-    MetaTransformer* clone() const override = 0;
 };
 
 }  // namespace souffle::ast::transform

--- a/src/ast/transform/MinimiseProgram.h
+++ b/src/ast/transform/MinimiseProgram.h
@@ -37,11 +37,11 @@ public:
     static bool areBijectivelyEquivalent(
             const analysis::NormalisedClause& left, const analysis::NormalisedClause& right);
 
-    MinimiseProgramTransformer* clone() const override {
+private:
+    MinimiseProgramTransformer* cloneImpl() const override {
         return new MinimiseProgramTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /** -- Bijective Equivalence Helper Methods -- */

--- a/src/ast/transform/NameUnnamedVariables.h
+++ b/src/ast/transform/NameUnnamedVariables.h
@@ -35,11 +35,11 @@ public:
         return "NameUnnamedVariablesTransformer";
     }
 
-    NameUnnamedVariablesTransformer* clone() const override {
+private:
+    NameUnnamedVariablesTransformer* cloneImpl() const override {
         return new NameUnnamedVariablesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/NormaliseGenerators.cpp
+++ b/src/ast/transform/NormaliseGenerators.cpp
@@ -53,13 +53,13 @@ bool NormaliseGeneratorsTransformer::transform(TranslationUnit& translationUnit)
                 // Multi-result functors
                 if (analysis::FunctorAnalysis::isMultiResult(*inf)) {
                     std::string name = getUniqueName();
-                    generatorNames.push_back({name, Own<IntrinsicFunctor>(inf->clone())});
+                    generatorNames.emplace_back(name, souffle::clone(inf));
                     return mk<Variable>(name);
                 }
             } else if (auto* agg = as<Aggregator>(node)) {
                 // Aggregators
                 std::string name = getUniqueName();
-                generatorNames.push_back({name, Own<Aggregator>(agg->clone())});
+                generatorNames.emplace_back(name, souffle::clone(agg));
                 return mk<Variable>(name);
             }
 

--- a/src/ast/transform/NormaliseGenerators.h
+++ b/src/ast/transform/NormaliseGenerators.h
@@ -31,7 +31,7 @@ public:
 private:
     bool transform(TranslationUnit& translationUnit) override;
 
-    NormaliseGeneratorsTransformer* clone() const override {
+    NormaliseGeneratorsTransformer* cloneImpl() const override {
         return new NormaliseGeneratorsTransformer();
     }
 };

--- a/src/ast/transform/Null.h
+++ b/src/ast/transform/Null.h
@@ -49,7 +49,7 @@ public:
         return "NullTransformer";
     }
 
-    NullTransformer* clone() const override {
+    NullTransformer* cloneImpl() const override {
         return new NullTransformer();
     }
 };

--- a/src/ast/transform/PartitionBodyLiterals.h
+++ b/src/ast/transform/PartitionBodyLiterals.h
@@ -41,11 +41,11 @@ public:
         return "PartitionBodyLiteralsTransformer";
     }
 
-    PartitionBodyLiteralsTransformer* clone() const override {
+private:
+    PartitionBodyLiteralsTransformer* cloneImpl() const override {
         return new PartitionBodyLiteralsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/Pipeline.h
+++ b/src/ast/transform/Pipeline.h
@@ -84,14 +84,6 @@ public:
         return "PipelineTransformer";
     }
 
-    PipelineTransformer* clone() const override {
-        VecOwn<Transformer> transformers;
-        for (const auto& transformer : pipeline) {
-            transformers.push_back(souffle::clone(transformer));
-        }
-        return new PipelineTransformer(std::move(transformers));
-    }
-
 protected:
     VecOwn<Transformer> pipeline;
     bool transform(TranslationUnit& translationUnit) override {
@@ -100,6 +92,15 @@ protected:
             changed |= applySubtransformer(translationUnit, transformer.get());
         }
         return changed;
+    }
+
+private:
+    PipelineTransformer* cloneImpl() const override {
+        VecOwn<Transformer> transformers;
+        for (const auto& transformer : pipeline) {
+            transformers.push_back(souffle::clone(transformer));
+        }
+        return new PipelineTransformer(std::move(transformers));
     }
 };
 

--- a/src/ast/transform/PragmaChecker.h
+++ b/src/ast/transform/PragmaChecker.h
@@ -28,11 +28,11 @@ public:
         return "PragmaChecker";
     }
 
-    PragmaChecker* clone() const override {
+private:
+    PragmaChecker* cloneImpl() const override {
         return new PragmaChecker();
     }
 
-private:
     bool transform(TranslationUnit&) override;
 };
 

--- a/src/ast/transform/Provenance.h
+++ b/src/ast/transform/Provenance.h
@@ -31,11 +31,11 @@ public:
         return "ProvenanceTransformer";
     }
 
-    ProvenanceTransformer* clone() const override {
+private:
+    ProvenanceTransformer* cloneImpl() const override {
         return new ProvenanceTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
     bool transformMaxHeight(TranslationUnit& translationUnit);
 };

--- a/src/ast/transform/ReduceExistentials.h
+++ b/src/ast/transform/ReduceExistentials.h
@@ -33,11 +33,11 @@ public:
         return "ReduceExistentialsTransformer";
     }
 
-    ReduceExistentialsTransformer* clone() const override {
+private:
+    ReduceExistentialsTransformer* cloneImpl() const override {
         return new ReduceExistentialsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/RemoveBooleanConstraints.h
+++ b/src/ast/transform/RemoveBooleanConstraints.h
@@ -30,11 +30,11 @@ public:
         return "RemoveBooleanConstraintsTransformer";
     }
 
-    RemoveBooleanConstraintsTransformer* clone() const override {
+private:
+    RemoveBooleanConstraintsTransformer* cloneImpl() const override {
         return new RemoveBooleanConstraintsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/RemoveEmptyRelations.h
+++ b/src/ast/transform/RemoveEmptyRelations.h
@@ -38,11 +38,11 @@ public:
      */
     static bool removeEmptyRelations(TranslationUnit& translationUnit);
 
-    RemoveEmptyRelationsTransformer* clone() const override {
+private:
+    RemoveEmptyRelationsTransformer* cloneImpl() const override {
         return new RemoveEmptyRelationsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         return removeEmptyRelations(translationUnit);
     }

--- a/src/ast/transform/RemoveRedundantRelations.h
+++ b/src/ast/transform/RemoveRedundantRelations.h
@@ -29,11 +29,11 @@ public:
         return "RemoveRedundantRelationsTransformer";
     }
 
-    RemoveRedundantRelationsTransformer* clone() const override {
+private:
+    RemoveRedundantRelationsTransformer* cloneImpl() const override {
         return new RemoveRedundantRelationsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/RemoveRedundantSums.h
+++ b/src/ast/transform/RemoveRedundantSums.h
@@ -32,11 +32,11 @@ public:
         return "RemoveRedundantSumsTransformer";
     }
 
-    RemoveRedundantSumsTransformer* clone() const override {
+private:
+    RemoveRedundantSumsTransformer* cloneImpl() const override {
         return new RemoveRedundantSumsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/RemoveRelationCopies.h
+++ b/src/ast/transform/RemoveRelationCopies.h
@@ -42,11 +42,11 @@ public:
      */
     static bool removeRelationCopies(TranslationUnit& translationUnit);
 
-    RemoveRelationCopiesTransformer* clone() const override {
+private:
+    RemoveRelationCopiesTransformer* cloneImpl() const override {
         return new RemoveRelationCopiesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         return removeRelationCopies(translationUnit);
     }

--- a/src/ast/transform/ReorderLiterals.h
+++ b/src/ast/transform/ReorderLiterals.h
@@ -37,10 +37,6 @@ public:
         return "ReorderLiteralsTransformer";
     }
 
-    ReorderLiteralsTransformer* clone() const override {
-        return new ReorderLiteralsTransformer();
-    }
-
     /**
      * Reorder the clause based on a given SIPS function.
      * @param sipsFunction SIPS metric to use
@@ -50,6 +46,10 @@ public:
     static Clause* reorderClauseWithSips(const SipsMetric& sips, const Clause* clause);
 
 private:
+    ReorderLiteralsTransformer* cloneImpl() const override {
+        return new ReorderLiteralsTransformer();
+    }
+
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/ReplaceSingletonVariables.h
+++ b/src/ast/transform/ReplaceSingletonVariables.h
@@ -31,11 +31,11 @@ public:
         return "ReplaceSingletonVariablesTransformer";
     }
 
-    ReplaceSingletonVariablesTransformer* clone() const override {
+private:
+    ReplaceSingletonVariablesTransformer* cloneImpl() const override {
         return new ReplaceSingletonVariablesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/ResolveAliases.cpp
+++ b/src/ast/transform/ResolveAliases.cpp
@@ -384,7 +384,7 @@ Own<Clause> ResolveAliasesTransformer::removeTrivialEquality(const Clause& claus
 }
 
 Own<Clause> ResolveAliasesTransformer::removeComplexTermsInAtoms(const Clause& clause) {
-    Own<Clause> res(clause.clone());
+    Own<Clause> res(souffle::clone(clause));
 
     // get list of atoms
     std::vector<Atom*> atoms = getBodyLiterals<Atom>(*res);

--- a/src/ast/transform/ResolveAliases.h
+++ b/src/ast/transform/ResolveAliases.h
@@ -59,11 +59,11 @@ public:
      */
     static Own<Clause> removeComplexTermsInAtoms(const Clause& clause);
 
-    ResolveAliasesTransformer* clone() const override {
+private:
+    ResolveAliasesTransformer* cloneImpl() const override {
         return new ResolveAliasesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/ResolveAnonymousRecordAliases.h
+++ b/src/ast/transform/ResolveAnonymousRecordAliases.h
@@ -38,11 +38,11 @@ public:
         return "ResolveAnonymousRecordAliases";
     }
 
-    ResolveAnonymousRecordAliasesTransformer* clone() const override {
+private:
+    ResolveAnonymousRecordAliasesTransformer* cloneImpl() const override {
         return new ResolveAnonymousRecordAliasesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /**

--- a/src/ast/transform/SemanticChecker.h
+++ b/src/ast/transform/SemanticChecker.h
@@ -30,11 +30,11 @@ public:
         return "SemanticChecker";
     }
 
-    SemanticChecker* clone() const override {
+private:
+    SemanticChecker* cloneImpl() const override {
         return new SemanticChecker();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/SimplifyAggregateTargetExpression.cpp
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.cpp
@@ -32,8 +32,8 @@ Aggregator* SimplifyAggregateTargetExpressionTransformer::simplifyTargetExpressi
     auto newTargetExpression = mk<Variable>(analysis::findUniqueVariableName(clause, "x"));
 
     // Create the new body, with the necessary equality between old and new target expressions
-    auto equalityLiteral = mk<BinaryConstraint>(BinaryConstraintOp::EQ,
-            souffle::clone(newTargetExpression), souffle::clone(origTargetExpression));
+    auto equalityLiteral = mk<BinaryConstraint>(BinaryConstraintOp::EQ, souffle::clone(newTargetExpression),
+            souffle::clone(origTargetExpression));
 
     std::vector<Own<Literal>> newBody;
     for (const auto* literal : aggregator.getBodyLiterals()) {

--- a/src/ast/transform/SimplifyAggregateTargetExpression.cpp
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.cpp
@@ -32,7 +32,7 @@ Aggregator* SimplifyAggregateTargetExpressionTransformer::simplifyTargetExpressi
     auto newTargetExpression = mk<Variable>(analysis::findUniqueVariableName(clause, "x"));
 
     // Create the new body, with the necessary equality between old and new target expressions
-    auto equalityLiteral = std::make_unique<BinaryConstraint>(BinaryConstraintOp::EQ,
+    auto equalityLiteral = mk<BinaryConstraint>(BinaryConstraintOp::EQ,
             souffle::clone(newTargetExpression), souffle::clone(origTargetExpression));
 
     std::vector<Own<Literal>> newBody;

--- a/src/ast/transform/SimplifyAggregateTargetExpression.h
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.h
@@ -28,11 +28,11 @@ public:
         return "SimplifyAggregateTargetExpressionTransformer";
     }
 
-    SimplifyAggregateTargetExpressionTransformer* clone() const override {
+private:
+    SimplifyAggregateTargetExpressionTransformer* cloneImpl() const override {
         return new SimplifyAggregateTargetExpressionTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /**

--- a/src/ast/transform/Transformer.h
+++ b/src/ast/transform/Transformer.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "ast/TranslationUnit.h"
+#include "souffle/utility/Types.h"
 #include <string>
 
 namespace souffle::ast::transform {
@@ -32,7 +33,12 @@ public:
 
     virtual std::string getName() const = 0;
 
-    virtual Transformer* clone() const = 0;
+    Own<Transformer> clone() const {
+        return Own<Transformer>(cloneImpl());
+    }
+
+private:
+    virtual Transformer* cloneImpl() const = 0;
 };
 
 }  // namespace souffle::ast::transform

--- a/src/ast/transform/TypeChecker.h
+++ b/src/ast/transform/TypeChecker.h
@@ -35,11 +35,11 @@ public:
     // `apply` but doesn't immediately bail if any errors are found.
     void verify(TranslationUnit& translationUnit);
 
-    TypeChecker* clone() const override {
+private:
+    TypeChecker* cloneImpl() const override {
         return new TypeChecker();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         verify(translationUnit);
         return false;

--- a/src/ast/transform/UniqueAggregationVariables.h
+++ b/src/ast/transform/UniqueAggregationVariables.h
@@ -29,11 +29,11 @@ public:
         return "UniqueAggregationVariablesTransformer";
     }
 
-    UniqueAggregationVariablesTransformer* clone() const override {
+private:
+    UniqueAggregationVariablesTransformer* cloneImpl() const override {
         return new UniqueAggregationVariablesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/While.h
+++ b/src/ast/transform/While.h
@@ -70,13 +70,10 @@ public:
         return "WhileTransformer";
     }
 
-    WhileTransformer* clone() const override {
+private:
+    WhileTransformer* cloneImpl() const override {
         return new WhileTransformer(condition, souffle::clone(transformer));
     }
-
-private:
-    std::function<bool()> condition;
-    Own<Transformer> transformer;
 
     bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
@@ -85,6 +82,10 @@ private:
         }
         return changed;
     }
+
+private:
+    std::function<bool()> condition;
+    Own<Transformer> transformer;
 };
 
 }  // namespace souffle::ast::transform

--- a/src/ast/utility/SipsMetric.cpp
+++ b/src/ast/utility/SipsMetric.cpp
@@ -61,28 +61,28 @@ std::vector<unsigned int> SipsMetric::getReordering(const Clause* clause) const 
 /** Create a SIPS metric based on a given heuristic. */
 std::unique_ptr<SipsMetric> SipsMetric::create(const std::string& heuristic, const TranslationUnit& tu) {
     if (heuristic == "strict")
-        return std::make_unique<StrictSips>();
+        return mk<StrictSips>();
     else if (heuristic == "all-bound")
-        return std::make_unique<AllBoundSips>();
+        return mk<AllBoundSips>();
     else if (heuristic == "naive")
-        return std::make_unique<NaiveSips>();
+        return mk<NaiveSips>();
     else if (heuristic == "max-bound")
-        return std::make_unique<MaxBoundSips>();
+        return mk<MaxBoundSips>();
     else if (heuristic == "max-ratio")
-        return std::make_unique<MaxRatioSips>();
+        return mk<MaxRatioSips>();
     else if (heuristic == "least-free")
-        return std::make_unique<LeastFreeSips>();
+        return mk<LeastFreeSips>();
     else if (heuristic == "least-free-vars")
-        return std::make_unique<LeastFreeVarsSips>();
+        return mk<LeastFreeVarsSips>();
     else if (heuristic == "profile-use")
-        return std::make_unique<ProfileUseSips>(*tu.getAnalysis<analysis::ProfileUseAnalysis>());
+        return mk<ProfileUseSips>(*tu.getAnalysis<analysis::ProfileUseAnalysis>());
     else if (heuristic == "delta")
-        return std::make_unique<DeltaSips>();
+        return mk<DeltaSips>();
     else if (heuristic == "input")
-        return std::make_unique<InputSips>(*tu.getAnalysis<analysis::RelationDetailCacheAnalysis>(),
+        return mk<InputSips>(*tu.getAnalysis<analysis::RelationDetailCacheAnalysis>(),
                 *tu.getAnalysis<analysis::IOTypeAnalysis>());
     else if (heuristic == "delta-input")
-        return std::make_unique<DeltaInputSips>(*tu.getAnalysis<analysis::RelationDetailCacheAnalysis>(),
+        return mk<DeltaInputSips>(*tu.getAnalysis<analysis::RelationDetailCacheAnalysis>(),
                 *tu.getAnalysis<analysis::IOTypeAnalysis>());
 
     // default is all-bound

--- a/src/include/souffle/datastructure/Brie.h
+++ b/src/include/souffle/datastructure/Brie.h
@@ -2738,7 +2738,7 @@ public:
         // conduct a lock-free lazy-creation of nested trees
         if (!nextPtr) {
             // create a sub-tree && register it atomically
-            auto newNested = std::make_unique<nested_trie_type>();
+            auto newNested = mk<nested_trie_type>();
             if (next.compare_exchange_weak(nextPtr, newNested.get())) {
                 nextPtr = newNested.release();  // worked, ownership is acquired by `store`
             }

--- a/src/include/souffle/io/ReadStreamCSV.h
+++ b/src/include/souffle/io/ReadStreamCSV.h
@@ -67,7 +67,7 @@ protected:
             return nullptr;
         }
         std::string line;
-        Own<RamDomain[]> tuple = std::make_unique<RamDomain[]>(typeAttributes.size());
+        Own<RamDomain[]> tuple = mk<RamDomain[]>(typeAttributes.size());
 
         if (!getline(file, line)) {
             return nullptr;

--- a/src/include/souffle/io/ReadStreamJSON.h
+++ b/src/include/souffle/io/ReadStreamJSON.h
@@ -114,7 +114,7 @@ protected:
             return nullptr;
         }
 
-        Own<RamDomain[]> tuple = std::make_unique<RamDomain[]>(typeAttributes.size());
+        Own<RamDomain[]> tuple = mk<RamDomain[]>(typeAttributes.size());
         const Json& jsonObj = jsonSource[pos];
         assert(jsonObj.is_array() && "the input is not json array");
         pos++;
@@ -209,7 +209,7 @@ protected:
             return nullptr;
         }
 
-        Own<RamDomain[]> tuple = std::make_unique<RamDomain[]>(typeAttributes.size());
+        Own<RamDomain[]> tuple = mk<RamDomain[]>(typeAttributes.size());
         const Json& jsonObj = jsonSource[pos];
         assert(jsonObj.is_object() && "the input is not json object");
         pos++;

--- a/src/include/souffle/io/ReadStreamSQLite.h
+++ b/src/include/souffle/io/ReadStreamSQLite.h
@@ -60,7 +60,7 @@ protected:
             return nullptr;
         }
 
-        Own<RamDomain[]> tuple = std::make_unique<RamDomain[]>(arity + auxiliaryArity);
+        Own<RamDomain[]> tuple = mk<RamDomain[]>(arity + auxiliaryArity);
 
         uint32_t column;
         for (column = 0; column < arity; column++) {

--- a/src/include/souffle/profile/ProfileDatabase.h
+++ b/src/include/souffle/profile/ProfileDatabase.h
@@ -379,7 +379,7 @@ public:
         DirectoryEntry* dir = lookupPath(path);
 
         const std::string& key = qualifier.back();
-        Own<TextEntry> entry = std::make_unique<TextEntry>(key, text);
+        Own<TextEntry> entry = mk<TextEntry>(key, text);
         dir->writeEntry(std::move(entry));
     }
 
@@ -390,7 +390,7 @@ public:
         DirectoryEntry* dir = lookupPath(path);
 
         const std::string& key = qualifier.back();
-        Own<DurationEntry> entry = std::make_unique<DurationEntry>(key, start, end);
+        Own<DurationEntry> entry = mk<DurationEntry>(key, start, end);
         dir->writeEntry(std::move(entry));
     }
 
@@ -401,7 +401,7 @@ public:
         DirectoryEntry* dir = lookupPath(path);
 
         const std::string& key = qualifier.back();
-        Own<TimeEntry> entry = std::make_unique<TimeEntry>(key, time);
+        Own<TimeEntry> entry = mk<TimeEntry>(key, time);
         dir->writeEntry(std::move(entry));
     }
 

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -473,7 +473,7 @@ relation_decl
             }
 
             for (auto&& fd : $dependency_list) {
-                rel->addDependency(Own<ast::FunctionalConstraint>(fd->clone()));
+                rel->addDependency(souffle::clone(fd));
             }
 
             rel->setAttributes(clone(attributes_list));


### PR DESCRIPTION
Please merge #1816 first.

- Refactored `ast::Node::clone()` and `ast::Transformer::clone()` to return `Own<>` instead of raw pointers.  (Still needs to be done for `ram::Node`).
- changed usages of `std::make_unique<>` to `mk<>` to bring it back in line with the rest of the codebase.