### PR TITLE
Improved ast node invariants - MERGE FOURTH

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,6 +28,7 @@ souffle_sources = \
         ast/BooleanConstraint.h                            \
         ast/BranchDeclaration.h                            \
         ast/BranchInit.h                                   \
+        ast/Clause.cpp                                     \
         ast/Clause.h                                       \
         ast/Component.h                                    \
         ast/ComponentInit.h                                \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -488,10 +488,12 @@ souffleutility_HEADERS = \
         include/souffle/utility/FileUtil.h                 \
         include/souffle/utility/EvaluatorUtil.h            \
         include/souffle/utility/FunctionalUtil.h           \
+        include/souffle/utility/Iteration.h                \
         include/souffle/utility/MiscUtil.h                 \
         include/souffle/utility/ParallelUtil.h             \
         include/souffle/utility/StreamUtil.h               \
         include/souffle/utility/StringUtil.h               \
+        include/souffle/utility/Types.h                    \
         include/souffle/utility/json11.h                   \
         include/souffle/utility/span.h                     \
         include/souffle/utility/tinyformat.h

--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -71,8 +71,8 @@ public:
         body = std::move(bodyLiterals);
     }
 
-    std::vector<const Node*> getChildNodes() const override {
-        auto res = Argument::getChildNodes();
+    std::vector<const Node*> getChildNodesImpl() const override {
+        auto res = Argument::getChildNodesImpl();
         if (targetExpression) {
             res.push_back(targetExpression.get());
         }

--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -46,10 +46,14 @@ namespace souffle::ast {
  */
 class Aggregator : public Argument {
 public:
-    Aggregator(AggregateOp baseOperator, Own<Argument> expr = nullptr, VecOwn<Literal> body = {},
+    Aggregator(AggregateOp baseOperator, Own<Argument> expr = {}, VecOwn<Literal> body = {},
             SrcLocation loc = {})
             : Argument(std::move(loc)), baseOperator(baseOperator), targetExpression(std::move(expr)),
-              body(std::move(body)) {}
+              body(std::move(body)) {
+        // targetExpression can be nullptr - it's used e.g. when aggregator
+        // has no parameters, such as count: { body }
+        assert(allValidPtrs(this->body));
+    }
 
     /** Return the (base type) operator of the aggregator */
     AggregateOp getBaseOperator() const {
@@ -72,6 +76,7 @@ public:
 
     /** Set body */
     void setBody(VecOwn<Literal> bodyLiterals) {
+        assert(allValidPtrs(body));
         body = std::move(bodyLiterals);
     }
 

--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -86,11 +86,6 @@ public:
         return res;
     }
 
-    Aggregator* clone() const override {
-        return new Aggregator(
-                baseOperator, souffle::clone(targetExpression), souffle::clone(body), getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         if (targetExpression) {
             targetExpression = map(std::move(targetExpression));
@@ -113,6 +108,12 @@ protected:
         const auto& other = asAssert<Aggregator>(node);
         return baseOperator == other.baseOperator && equal_ptr(targetExpression, other.targetExpression) &&
                equal_targets(body, other.body);
+    }
+
+private:
+    Aggregator* cloneImpl() const override {
+        return new Aggregator(
+                baseOperator, souffle::clone(targetExpression), souffle::clone(body), getSrcLoc());
     }
 
 private:

--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -61,6 +61,10 @@ public:
         return targetExpression.get();
     }
 
+    Argument* getTargetExpression() {
+        return targetExpression.get();
+    }
+
     /** Return body literals */
     std::vector<Literal*> getBodyLiterals() const {
         return toPtrVector(body);

--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -110,7 +110,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Aggregator&>(node);
+        const auto& other = asAssert<Aggregator>(node);
         return baseOperator == other.baseOperator && equal_ptr(targetExpression, other.targetExpression) &&
                equal_targets(body, other.body);
     }

--- a/src/ast/AlgebraicDataType.h
+++ b/src/ast/AlgebraicDataType.h
@@ -52,6 +52,7 @@ public:
     AlgebraicDataType(QualifiedName name, VecOwn<BranchDeclaration> branches, SrcLocation loc = {})
             : Type(std::move(name), std::move(loc)), branches(std::move(branches)) {
         assert(!this->branches.empty());
+        assert(allValidPtrs(this->branches));
     };
 
     std::vector<BranchDeclaration*> getBranches() const {

--- a/src/ast/AlgebraicDataType.h
+++ b/src/ast/AlgebraicDataType.h
@@ -22,6 +22,7 @@
 #include "ast/Type.h"
 #include "parser/SrcLocation.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include "souffle/utility/tinyformat.h"
 #include <cassert>
@@ -67,7 +68,7 @@ public:
 
 protected:
     bool equal(const Node& node) const override {
-        const auto& other = dynamic_cast<const AlgebraicDataType&>(node);
+        const auto& other = asAssert<AlgebraicDataType>(node);
         return getQualifiedName() == other.getQualifiedName() && branches == other.branches;
     }
 

--- a/src/ast/AlgebraicDataType.h
+++ b/src/ast/AlgebraicDataType.h
@@ -62,14 +62,15 @@ public:
         os << tfm::format(".type %s = %s", getQualifiedName(), join(branches, " | "));
     }
 
-    AlgebraicDataType* clone() const override {
-        return new AlgebraicDataType(getQualifiedName(), souffle::clone(branches), getSrcLoc());
-    }
-
 protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<AlgebraicDataType>(node);
         return getQualifiedName() == other.getQualifiedName() && branches == other.branches;
+    }
+
+private:
+    AlgebraicDataType* cloneImpl() const override {
+        return new AlgebraicDataType(getQualifiedName(), souffle::clone(branches), getSrcLoc());
     }
 
 private:

--- a/src/ast/Argument.h
+++ b/src/ast/Argument.h
@@ -27,9 +27,6 @@ namespace souffle::ast {
 class Argument : public Node {
 public:
     using Node::Node;
-
-    /** Create clone */
-    Argument* clone() const override = 0;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Atom.h
+++ b/src/ast/Atom.h
@@ -26,6 +26,7 @@
 #include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <iostream>
 #include <memory>
@@ -46,7 +47,9 @@ namespace souffle::ast {
 class Atom : public Literal {
 public:
     Atom(QualifiedName name = {}, VecOwn<Argument> args = {}, SrcLocation loc = {})
-            : Literal(std::move(loc)), name(std::move(name)), arguments(std::move(args)) {}
+            : Literal(std::move(loc)), name(std::move(name)), arguments(std::move(args)) {
+        assert(allValidPtrs(arguments));
+    }
 
     /** Return qualified name */
     const QualifiedName& getQualifiedName() const {
@@ -65,6 +68,7 @@ public:
 
     /** Add argument to the atom */
     void addArgument(Own<Argument> arg) {
+        assert(arg != nullptr);
         arguments.push_back(std::move(arg));
     }
 

--- a/src/ast/Atom.h
+++ b/src/ast/Atom.h
@@ -23,6 +23,7 @@
 #include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <algorithm>
 #include <cstddef>
@@ -96,7 +97,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Atom&>(node);
+        const auto& other = asAssert<Atom>(node);
         return name == other.name && equal_targets(arguments, other.arguments);
     }
 

--- a/src/ast/Atom.h
+++ b/src/ast/Atom.h
@@ -82,7 +82,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (auto& cur : arguments) {
             res.push_back(cur.get());

--- a/src/ast/Atom.h
+++ b/src/ast/Atom.h
@@ -73,10 +73,6 @@ public:
         return toPtrVector(arguments);
     }
 
-    Atom* clone() const override {
-        return new Atom(name, souffle::clone(arguments), getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         for (auto& arg : arguments) {
             arg = map(std::move(arg));
@@ -101,6 +97,12 @@ protected:
         return name == other.name && equal_targets(arguments, other.arguments);
     }
 
+private:
+    Atom* cloneImpl() const override {
+        return new Atom(name, souffle::clone(arguments), getSrcLoc());
+    }
+
+private:
     /** Name of atom */
     QualifiedName name;
 

--- a/src/ast/Attribute.h
+++ b/src/ast/Attribute.h
@@ -19,6 +19,8 @@
 #include "ast/Node.h"
 #include "ast/QualifiedName.h"
 #include "parser/SrcLocation.h"
+#include "souffle/utility/MiscUtil.h"
+
 #include <ostream>
 #include <string>
 #include <utility>
@@ -63,7 +65,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Attribute&>(node);
+        const auto& other = asAssert<Attribute>(node);
         return name == other.name && typeName == other.typeName;
     }
 

--- a/src/ast/Attribute.h
+++ b/src/ast/Attribute.h
@@ -55,10 +55,6 @@ public:
         typeName = std::move(name);
     }
 
-    Attribute* clone() const override {
-        return new Attribute(name, typeName, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << name << ":" << typeName;
@@ -67,6 +63,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<Attribute>(node);
         return name == other.name && typeName == other.typeName;
+    }
+
+private:
+    Attribute* cloneImpl() const override {
+        return new Attribute(name, typeName, getSrcLoc());
     }
 
 private:

--- a/src/ast/BinaryConstraint.h
+++ b/src/ast/BinaryConstraint.h
@@ -78,7 +78,7 @@ public:
         rhs = map(std::move(rhs));
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         return {lhs.get(), rhs.get()};
     }
 

--- a/src/ast/BinaryConstraint.h
+++ b/src/ast/BinaryConstraint.h
@@ -47,7 +47,10 @@ namespace souffle::ast {
 class BinaryConstraint : public Constraint {
 public:
     BinaryConstraint(BinaryConstraintOp o, Own<Argument> ls, Own<Argument> rs, SrcLocation loc = {})
-            : Constraint(std::move(loc)), operation(o), lhs(std::move(ls)), rhs(std::move(rs)) {}
+            : Constraint(std::move(loc)), operation(o), lhs(std::move(ls)), rhs(std::move(rs)) {
+        assert(lhs != nullptr);
+        assert(rhs != nullptr);
+    }
 
     /** Return left-hand side argument */
     Argument* getLHS() const {

--- a/src/ast/BinaryConstraint.h
+++ b/src/ast/BinaryConstraint.h
@@ -92,8 +92,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        assert(isA<BinaryConstraint>(&node));
-        const auto& other = static_cast<const BinaryConstraint&>(node);
+        const auto& other = asAssert<BinaryConstraint>(node);
         return operation == other.operation && equal_ptr(lhs, other.lhs) && equal_ptr(rhs, other.rhs);
     }
 

--- a/src/ast/BinaryConstraint.h
+++ b/src/ast/BinaryConstraint.h
@@ -69,10 +69,6 @@ public:
         operation = op;
     }
 
-    BinaryConstraint* clone() const override {
-        return new BinaryConstraint(operation, souffle::clone(lhs), souffle::clone(rhs), getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         lhs = map(std::move(lhs));
         rhs = map(std::move(rhs));
@@ -96,6 +92,12 @@ protected:
         return operation == other.operation && equal_ptr(lhs, other.lhs) && equal_ptr(rhs, other.rhs);
     }
 
+private:
+    BinaryConstraint* cloneImpl() const override {
+        return new BinaryConstraint(operation, souffle::clone(lhs), souffle::clone(rhs), getSrcLoc());
+    }
+
+private:
     /** Constraint (base) operator */
     BinaryConstraintOp operation;
 

--- a/src/ast/BooleanConstraint.h
+++ b/src/ast/BooleanConstraint.h
@@ -51,10 +51,6 @@ public:
         truthValue = value;
     }
 
-    BooleanConstraint* clone() const override {
-        return new BooleanConstraint(truthValue, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << (truthValue ? "true" : "false");
@@ -65,6 +61,12 @@ protected:
         return truthValue == other.truthValue;
     }
 
+private:
+    BooleanConstraint* cloneImpl() const override {
+        return new BooleanConstraint(truthValue, getSrcLoc());
+    }
+
+private:
     /** Truth value of Boolean constraint */
     bool truthValue;
 };

--- a/src/ast/BooleanConstraint.h
+++ b/src/ast/BooleanConstraint.h
@@ -61,8 +61,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        assert(isA<BooleanConstraint>(&node));
-        const auto& other = static_cast<const BooleanConstraint&>(node);
+        const auto& other = asAssert<BooleanConstraint>(node);
         return truthValue == other.truthValue;
     }
 

--- a/src/ast/BranchDeclaration.h
+++ b/src/ast/BranchDeclaration.h
@@ -42,7 +42,9 @@ namespace souffle::ast {
 class BranchDeclaration : public Node {
 public:
     BranchDeclaration(std::string constructor, VecOwn<Attribute> fields, SrcLocation loc = {})
-            : Node(std::move(loc)), constructor(std::move(constructor)), fields(std::move(fields)){};
+            : Node(std::move(loc)), constructor(std::move(constructor)), fields(std::move(fields)) {
+        assert(allValidPtrs(this->fields));
+    }
 
     const std::string& getConstructor() const {
         return constructor;

--- a/src/ast/BranchDeclaration.h
+++ b/src/ast/BranchDeclaration.h
@@ -52,13 +52,14 @@ public:
         return toPtrVector(fields);
     }
 
-    BranchDeclaration* clone() const override {
-        return new BranchDeclaration(constructor, souffle::clone(fields), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << tfm::format("%s {%s}", constructor, join(fields, ", "));
+    }
+
+private:
+    BranchDeclaration* cloneImpl() const override {
+        return new BranchDeclaration(constructor, souffle::clone(fields), getSrcLoc());
     }
 
 private:

--- a/src/ast/BranchInit.h
+++ b/src/ast/BranchInit.h
@@ -50,10 +50,6 @@ public:
         return constructor;
     }
 
-    BranchInit* clone() const override {
-        return new BranchInit(constructor, souffle::clone(args), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << tfm::format("$%s(%s)", constructor, join(args, ", "));
@@ -63,6 +59,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<BranchInit>(node);
         return (constructor == other.constructor) && equal_targets(args, other.args);
+    }
+
+private:
+    BranchInit* cloneImpl() const override {
+        return new BranchInit(constructor, souffle::clone(args), getSrcLoc());
     }
 
 private:

--- a/src/ast/BranchInit.h
+++ b/src/ast/BranchInit.h
@@ -21,6 +21,7 @@
 #include "ast/Term.h"
 #include "parser/SrcLocation.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include "souffle/utility/tinyformat.h"
 #include <iosfwd>
@@ -60,7 +61,7 @@ protected:
 
     /** Implements the node comparison for this node type */
     bool equal(const Node& node) const override {
-        const auto& other = dynamic_cast<const BranchInit&>(node);
+        const auto& other = asAssert<BranchInit>(node);
         return (constructor == other.constructor) && equal_targets(args, other.args);
     }
 

--- a/src/ast/Clause.cpp
+++ b/src/ast/Clause.cpp
@@ -1,0 +1,10 @@
+#include "ast/Clause.h"
+
+namespace souffle::ast {
+
+void Clause::addToBody(VecOwn<Literal>&& literals) {
+    assert(allValidPtrs(literals));
+    bodyLiterals.insert(bodyLiterals.end(), std::make_move_iterator(literals.begin()),
+            std::make_move_iterator(literals.end()));
+}
+}  // namespace souffle::ast

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -101,7 +101,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res = {head.get()};
         for (auto& cur : bodyLiterals) {
             res.push_back(cur.get());

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -44,23 +44,33 @@ namespace souffle::ast {
  */
 class Clause : public Node {
 public:
-    Clause(Own<Atom> head = {}, VecOwn<Literal> bodyLiterals = {}, Own<ExecutionPlan> plan = {},
-            SrcLocation loc = {})
+    Clause(Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan = {}, SrcLocation loc = {})
             : Node(std::move(loc)), head(std::move(head)), bodyLiterals(std::move(bodyLiterals)),
-              plan(std::move(plan)) {}
+              plan(std::move(plan)) {
+        assert(this->head != nullptr);
+        assert(allValidPtrs(this->bodyLiterals));
+        // Execution plan can be null
+    }
+
+    Clause(Own<Atom> head, SrcLocation loc = {}) : Clause(std::move(head), {}, {}, std::move(loc)) {}
+
+    Clause(QualifiedName name, SrcLocation loc = {}) : Clause(mk<Atom>(name), std::move(loc)) {}
 
     /** Add a literal to the body of the clause */
     void addToBody(Own<Literal> literal) {
+        assert(literal != nullptr);
         bodyLiterals.push_back(std::move(literal));
     }
 
     /** Set the head of clause to @p h */
     void setHead(Own<Atom> h) {
+        assert(h != nullptr);
         head = std::move(h);
     }
 
     /** Set the bodyLiterals of clause to @p body */
     void setBodyLiterals(VecOwn<Literal> body) {
+        assert(allValidPtrs(body));
         bodyLiterals = std::move(body);
     }
 

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -89,11 +89,6 @@ public:
         plan = nullptr;
     }
 
-    Clause* clone() const override {
-        return new Clause(
-                souffle::clone(head), souffle::clone(bodyLiterals), souffle::clone(plan), getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         head = map(std::move(head));
         for (auto& lit : bodyLiterals) {
@@ -129,6 +124,13 @@ protected:
                equal_ptr(plan, other.plan);
     }
 
+private:
+    Clause* cloneImpl() const override {
+        return new Clause(
+                souffle::clone(head), souffle::clone(bodyLiterals), souffle::clone(plan), getSrcLoc());
+    }
+
+private:
     /** Head of the clause */
     Own<Atom> head;
 

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -124,7 +124,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Clause&>(node);
+        const auto& other = asAssert<Clause>(node);
         return equal_ptr(head, other.head) && equal_targets(bodyLiterals, other.bodyLiterals) &&
                equal_ptr(plan, other.plan);
     }

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -62,6 +62,9 @@ public:
         bodyLiterals.push_back(std::move(literal));
     }
 
+    /** Add a collection of literals to the body of the clause */
+    void addToBody(VecOwn<Literal>&& literals);
+
     /** Set the head of clause to @p h */
     void setHead(Own<Atom> h) {
         assert(h != nullptr);

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -268,9 +268,6 @@ private:
     }
 
 private:
-
-
-
     /** Name of component and its formal component arguments. */
     Own<ComponentType> componentType;
 

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -28,6 +28,7 @@
 #include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <algorithm>
+#include <cassert>
 #include <memory>
 #include <ostream>
 #include <set>
@@ -58,6 +59,7 @@ public:
 
     /** Set component type */
     void setComponentType(Own<ComponentType> other) {
+        assert(other != nullptr);
         componentType = std::move(other);
     }
 
@@ -68,11 +70,13 @@ public:
 
     /** Add base components */
     void addBaseComponent(Own<ComponentType> component) {
+        assert(component != nullptr);
         baseComponents.push_back(std::move(component));
     }
 
     /** Add type */
     void addType(Own<Type> t) {
+        assert(t != nullptr);
         types.push_back(std::move(t));
     }
 
@@ -88,6 +92,7 @@ public:
 
     /** Add relation */
     void addRelation(Own<Relation> r) {
+        assert(r != nullptr);
         relations.push_back(std::move(r));
     }
 
@@ -98,6 +103,7 @@ public:
 
     /** Add clause */
     void addClause(Own<Clause> c) {
+        assert(c != nullptr);
         clauses.push_back(std::move(c));
     }
 
@@ -108,6 +114,7 @@ public:
 
     /** Add directive */
     void addDirective(Own<Directive> directive) {
+        assert(directive != nullptr);
         directives.push_back(std::move(directive));
     }
 
@@ -118,6 +125,7 @@ public:
 
     /** Add components */
     void addComponent(Own<Component> c) {
+        assert(c != nullptr);
         components.push_back(std::move(c));
     }
 
@@ -128,6 +136,7 @@ public:
 
     /** Add instantiation */
     void addInstantiation(Own<ComponentInit> i) {
+        assert(i != nullptr);
         instantiations.push_back(std::move(i));
     }
 

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -234,7 +234,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Component&>(node);
+        const auto& other = asAssert<Component>(node);
 
         if (equal_ptr(componentType, other.componentType)) {
             return true;

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -185,7 +185,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res;
 
         res.push_back(componentType.get());

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -146,20 +146,6 @@ public:
         return overrideRules;
     }
 
-    Component* clone() const override {
-        auto* res = new Component();
-        res->componentType = souffle::clone(componentType);
-        res->baseComponents = souffle::clone(baseComponents);
-        res->components = souffle::clone(components);
-        res->instantiations = souffle::clone(instantiations);
-        res->types = souffle::clone(types);
-        res->relations = souffle::clone(relations);
-        res->clauses = souffle::clone(clauses);
-        res->directives = souffle::clone(directives);
-        res->overrideRules = overrideRules;
-        return res;
-    }
-
     void apply(const NodeMapper& mapper) override {
         componentType = mapper(std::move(componentType));
         for (auto& cur : baseComponents) {
@@ -265,6 +251,25 @@ protected:
         }
         return true;
     }
+
+private:
+    Component* cloneImpl() const override {
+        auto* res = new Component();
+        res->componentType = souffle::clone(componentType);
+        res->baseComponents = souffle::clone(baseComponents);
+        res->components = souffle::clone(components);
+        res->instantiations = souffle::clone(instantiations);
+        res->types = souffle::clone(types);
+        res->relations = souffle::clone(relations);
+        res->clauses = souffle::clone(clauses);
+        res->directives = souffle::clone(directives);
+        res->overrideRules = overrideRules;
+        return res;
+    }
+
+private:
+
+
 
     /** Name of component and its formal component arguments. */
     Own<ComponentType> componentType;

--- a/src/ast/ComponentInit.h
+++ b/src/ast/ComponentInit.h
@@ -63,10 +63,6 @@ public:
         componentType = std::move(type);
     }
 
-    ComponentInit* clone() const override {
-        return new ComponentInit(instanceName, souffle::clone(componentType), getSrcLoc());
-    }
-
     void apply(const NodeMapper& mapper) override {
         componentType = mapper(std::move(componentType));
     }
@@ -85,6 +81,12 @@ protected:
         return instanceName == other.instanceName && *componentType == *other.componentType;
     }
 
+private:
+    ComponentInit* cloneImpl() const override {
+        return new ComponentInit(instanceName, souffle::clone(componentType), getSrcLoc());
+    }
+
+private:
     /** Instance name */
     std::string instanceName;
 

--- a/src/ast/ComponentInit.h
+++ b/src/ast/ComponentInit.h
@@ -81,7 +81,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const ComponentInit&>(node);
+        const auto& other = asAssert<ComponentInit>(node);
         return instanceName == other.instanceName && *componentType == *other.componentType;
     }
 

--- a/src/ast/ComponentInit.h
+++ b/src/ast/ComponentInit.h
@@ -71,7 +71,7 @@ public:
         componentType = mapper(std::move(componentType));
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         return {componentType.get()};
     }
 

--- a/src/ast/ComponentInit.h
+++ b/src/ast/ComponentInit.h
@@ -21,6 +21,7 @@
 #include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
 #include "souffle/utility/MiscUtil.h"
+#include <cassert>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -41,7 +42,9 @@ namespace souffle::ast {
 class ComponentInit : public Node {
 public:
     ComponentInit(std::string name, Own<ComponentType> type, SrcLocation loc = {})
-            : Node(std::move(loc)), instanceName(std::move(name)), componentType(std::move(type)) {}
+            : Node(std::move(loc)), instanceName(std::move(name)), componentType(std::move(type)) {
+        assert(componentType);
+    }
 
     /** Return instance name */
     const std::string& getInstanceName() const {
@@ -60,6 +63,7 @@ public:
 
     /** Set component type */
     void setComponentType(Own<ComponentType> type) {
+        assert(type != nullptr);
         componentType = std::move(type);
     }
 

--- a/src/ast/ComponentType.h
+++ b/src/ast/ComponentType.h
@@ -19,6 +19,7 @@
 #include "ast/Node.h"
 #include "ast/QualifiedName.h"
 #include "parser/SrcLocation.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <ostream>
 #include <string>
@@ -74,7 +75,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const ComponentType&>(node);
+        const auto& other = asAssert<ComponentType>(node);
         return name == other.name && typeParams == other.typeParams;
     }
 

--- a/src/ast/ComponentType.h
+++ b/src/ast/ComponentType.h
@@ -62,10 +62,6 @@ public:
         typeParams = params;
     }
 
-    ComponentType* clone() const override {
-        return new ComponentType(name, typeParams, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << name;
@@ -77,6 +73,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<ComponentType>(node);
         return name == other.name && typeParams == other.typeParams;
+    }
+
+private:
+    ComponentType* cloneImpl() const override {
+        return new ComponentType(name, typeParams, getSrcLoc());
     }
 
 private:

--- a/src/ast/Constant.h
+++ b/src/ast/Constant.h
@@ -19,6 +19,7 @@
 #include "ast/Argument.h"
 #include "ast/Node.h"
 #include "parser/SrcLocation.h"
+#include "souffle/utility/MiscUtil.h"
 #include <ostream>
 #include <string>
 #include <utility>
@@ -44,7 +45,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Constant&>(node);
+        const auto& other = asAssert<Constant>(node);
         return constant == other.constant;
     }
 

--- a/src/ast/Constant.h
+++ b/src/ast/Constant.h
@@ -32,8 +32,6 @@ namespace souffle::ast {
  */
 class Constant : public Argument {
 public:
-    Constant* clone() const override = 0;
-
     /** Get string representation of Constant */
     const std::string& getConstant() const {
         return constant;

--- a/src/ast/Constraint.h
+++ b/src/ast/Constraint.h
@@ -27,8 +27,6 @@ namespace souffle::ast {
 class Constraint : public Literal {
 public:
     using Literal::Literal;
-
-    Constraint* clone() const override = 0;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Counter.h
+++ b/src/ast/Counter.h
@@ -38,7 +38,6 @@ private:
     Counter* cloneImpl() const override {
         return new Counter(getSrcLoc());
     }
-
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Counter.h
+++ b/src/ast/Counter.h
@@ -29,14 +29,16 @@ class Counter : public Argument {
 public:
     using Argument::Argument;
 
-    Counter* clone() const override {
-        return new Counter(getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << "$";
     }
+
+private:
+    Counter* cloneImpl() const override {
+        return new Counter(getSrcLoc());
+    }
+
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Directive.h
+++ b/src/ast/Directive.h
@@ -92,12 +92,6 @@ public:
         return parameters;
     }
 
-    Directive* clone() const override {
-        auto res = new Directive(type, name, getSrcLoc());
-        res->parameters = parameters;
-        return res;
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << "." << type << " " << name;
@@ -113,6 +107,14 @@ protected:
         return other.type == type && other.name == name && other.parameters == parameters;
     }
 
+private:
+    Directive* cloneImpl() const override {
+        auto res = new Directive(type, name, getSrcLoc());
+        res->parameters = parameters;
+        return res;
+    }
+
+private:
     /** Type of directive */
     DirectiveType type;
 

--- a/src/ast/Directive.h
+++ b/src/ast/Directive.h
@@ -109,7 +109,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Directive&>(node);
+        const auto& other = asAssert<Directive>(node);
         return other.type == type && other.name == name && other.parameters == parameters;
     }
 

--- a/src/ast/ExecutionOrder.h
+++ b/src/ast/ExecutionOrder.h
@@ -18,6 +18,7 @@
 
 #include "ast/Node.h"
 #include "parser/SrcLocation.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <ostream>
 #include <string>
@@ -54,7 +55,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const ExecutionOrder&>(node);
+        const auto& other = asAssert<ExecutionOrder>(node);
         return order == other.order;
     }
 

--- a/src/ast/ExecutionOrder.h
+++ b/src/ast/ExecutionOrder.h
@@ -36,9 +36,8 @@ class ExecutionOrder : public Node {
 public:
     using ExecOrder = std::vector<unsigned int>;
 
-    ExecutionOrder(ExecOrder order = {}, SrcLocation loc = {}) : order(std::move(order)) {
-        setSrcLoc(std::move(loc));
-    }
+    ExecutionOrder(ExecOrder order = {}, SrcLocation loc = {})
+            : Node(std::move(loc)), order(std::move(order)) {}
 
     /** Get order */
     const ExecOrder& getOrder() const {

--- a/src/ast/ExecutionOrder.h
+++ b/src/ast/ExecutionOrder.h
@@ -45,10 +45,6 @@ public:
         return order;
     }
 
-    ExecutionOrder* clone() const override {
-        return new ExecutionOrder(order, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& out) const override {
         out << "(" << join(order) << ")";
@@ -57,6 +53,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<ExecutionOrder>(node);
         return order == other.order;
+    }
+
+private:
+    ExecutionOrder* cloneImpl() const override {
+        return new ExecutionOrder(order, getSrcLoc());
     }
 
 private:

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -59,15 +59,6 @@ public:
         return result;
     }
 
-    ExecutionPlan* clone() const override {
-        auto res = new ExecutionPlan();
-        res->setSrcLoc(getSrcLoc());
-        for (auto& plan : plans) {
-            res->setOrderFor(plan.first, Own<ExecutionOrder>(plan.second->clone()));
-        }
-        return res;
-    }
-
     void apply(const NodeMapper& map) override {
         for (auto& plan : plans) {
             plan.second = map(std::move(plan.second));
@@ -95,6 +86,17 @@ protected:
         const auto& other = asAssert<ExecutionPlan>(node);
         return equal_targets(plans, other.plans);
     }
+
+private:
+    ExecutionPlan* cloneImpl() const override {
+        auto res = new ExecutionPlan();
+        res->setSrcLoc(getSrcLoc());
+        for (auto& plan : plans) {
+            res->setOrderFor(plan.first, souffle::clone(plan.second));
+        }
+        return res;
+    }
+
 
 private:
     /** Mapping versions of clauses to execution orders */

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -45,6 +45,8 @@ namespace souffle::ast {
  */
 class ExecutionPlan : public Node {
 public:
+    using Node::Node;
+
     /** Set execution order for a given rule version */
     void setOrderFor(int version, Own<ExecutionOrder> plan) {
         plans[version] = std::move(plan);
@@ -89,12 +91,11 @@ protected:
 
 private:
     ExecutionPlan* cloneImpl() const override {
-        auto res = new ExecutionPlan();
-        res->setSrcLoc(getSrcLoc());
+        auto res = mk<ExecutionPlan>(getSrcLoc());
         for (auto& plan : plans) {
             res->setOrderFor(plan.first, souffle::clone(plan.second));
         }
-        return res;
+        return res.release();
     }
 
 private:

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -73,7 +73,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> childNodes;
         for (auto& plan : plans) {
             childNodes.push_back(plan.second.get());

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -97,7 +97,6 @@ private:
         return res;
     }
 
-
 private:
     /** Mapping versions of clauses to execution orders */
     std::map<int, Own<ExecutionOrder>> plans;

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -49,6 +49,7 @@ public:
 
     /** Set execution order for a given rule version */
     void setOrderFor(int version, Own<ExecutionOrder> plan) {
+        assert(plan != nullptr);
         plans[version] = std::move(plan);
     }
 

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -20,6 +20,7 @@
 #include "ast/Node.h"
 #include "ast/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <algorithm>
 #include <map>
@@ -91,7 +92,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const ExecutionPlan&>(node);
+        const auto& other = asAssert<ExecutionPlan>(node);
         return equal_targets(plans, other.plans);
     }
 

--- a/src/ast/FunctionalConstraint.h
+++ b/src/ast/FunctionalConstraint.h
@@ -100,7 +100,7 @@ public:
     }
 
     bool equal(const Node& node) const override {
-        assert(nullptr != dynamic_cast<const FunctionalConstraint*>(&node));
+        assert(nullptr != as<FunctionalConstraint>(node));
         const auto& other = static_cast<const FunctionalConstraint&>(node);
         if (keys.size() != other.keys.size()) {
             return false;

--- a/src/ast/FunctionalConstraint.h
+++ b/src/ast/FunctionalConstraint.h
@@ -100,8 +100,7 @@ public:
     }
 
     bool equal(const Node& node) const override {
-        assert(nullptr != as<FunctionalConstraint>(node));
-        const auto& other = static_cast<const FunctionalConstraint&>(node);
+        const auto& other = asAssert<FunctionalConstraint>(node);
         if (keys.size() != other.keys.size()) {
             return false;
         }

--- a/src/ast/FunctionalConstraint.h
+++ b/src/ast/FunctionalConstraint.h
@@ -68,7 +68,7 @@ public:
         return keys.size();
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (auto& cur : keys) {
             res.push_back(cur.get());

--- a/src/ast/FunctionalConstraint.h
+++ b/src/ast/FunctionalConstraint.h
@@ -53,8 +53,8 @@ class FunctionalConstraint : public Constraint {
 public:
     FunctionalConstraint(VecOwn<Variable> keys, SrcLocation loc = {})
             : Constraint(std::move(loc)), keys(std::move(keys)) {
-                assert(allValidPtrs(this->keys));
-            }
+        assert(allValidPtrs(this->keys));
+    }
 
     FunctionalConstraint(Own<Variable> key, SrcLocation loc = {}) : Constraint(std::move(loc)) {
         assert(key != nullptr);

--- a/src/ast/FunctionalConstraint.h
+++ b/src/ast/FunctionalConstraint.h
@@ -52,9 +52,12 @@ namespace souffle::ast {
 class FunctionalConstraint : public Constraint {
 public:
     FunctionalConstraint(VecOwn<Variable> keys, SrcLocation loc = {})
-            : Constraint(std::move(loc)), keys(std::move(keys)) {}
+            : Constraint(std::move(loc)), keys(std::move(keys)) {
+                assert(allValidPtrs(this->keys));
+            }
 
     FunctionalConstraint(Own<Variable> key, SrcLocation loc = {}) : Constraint(std::move(loc)) {
+        assert(key != nullptr);
         keys.push_back(std::move(key));
     }
 

--- a/src/ast/FunctionalConstraint.h
+++ b/src/ast/FunctionalConstraint.h
@@ -77,16 +77,6 @@ public:
         return res;
     }
 
-    FunctionalConstraint* clone() const override {
-        VecOwn<Variable> newKeys;
-        for (const auto& key : keys) {
-            newKeys.push_back(Own<Variable>(key->clone()));
-        }
-        auto* res = new FunctionalConstraint(std::move(newKeys));
-        res->setSrcLoc(getSrcLoc());
-        return res;
-    }
-
 public:
     void print(std::ostream& os) const override {
         os << "keys ";
@@ -128,6 +118,18 @@ public:
         return true;
     }
 
+private:
+    FunctionalConstraint* cloneImpl() const override {
+        VecOwn<Variable> newKeys;
+        for (const auto& key : keys) {
+            newKeys.push_back(souffle::clone(key));
+        }
+        auto* res = new FunctionalConstraint(std::move(newKeys));
+        res->setSrcLoc(getSrcLoc());
+        return res;
+    }
+
+private:
     /* Functional constraint */
     VecOwn<Variable> keys;
 };

--- a/src/ast/FunctionalConstraint.h
+++ b/src/ast/FunctionalConstraint.h
@@ -124,9 +124,7 @@ private:
         for (const auto& key : keys) {
             newKeys.push_back(souffle::clone(key));
         }
-        auto* res = new FunctionalConstraint(std::move(newKeys));
-        res->setSrcLoc(getSrcLoc());
-        return res;
+        return new FunctionalConstraint(std::move(newKeys), getSrcLoc());
     }
 
 private:

--- a/src/ast/Functor.h
+++ b/src/ast/Functor.h
@@ -28,9 +28,6 @@ namespace souffle::ast {
  */
 
 class Functor : public Term {
-public:
-    Functor* clone() const override = 0;
-
 protected:
     using Term::Term;
 };

--- a/src/ast/FunctorDeclaration.h
+++ b/src/ast/FunctorDeclaration.h
@@ -74,10 +74,6 @@ public:
         return stateful;
     }
 
-    FunctorDeclaration* clone() const override {
-        return new FunctorDeclaration(name, argsTypes, returnType, stateful, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& out) const override {
         auto convert = [&](TypeAttribute type) {
@@ -105,6 +101,12 @@ protected:
         return name == other.name && argsTypes == other.argsTypes && returnType == other.returnType &&
                stateful == other.stateful;
     }
+
+private:
+    FunctorDeclaration* cloneImpl() const override {
+        return new FunctorDeclaration(name, argsTypes, returnType, stateful, getSrcLoc());
+    }
+
 
     /** Name of functor */
     const std::string name;

--- a/src/ast/FunctorDeclaration.h
+++ b/src/ast/FunctorDeclaration.h
@@ -107,7 +107,6 @@ private:
         return new FunctorDeclaration(name, argsTypes, returnType, stateful, getSrcLoc());
     }
 
-
     /** Name of functor */
     const std::string name;
 

--- a/src/ast/FunctorDeclaration.h
+++ b/src/ast/FunctorDeclaration.h
@@ -101,7 +101,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const FunctorDeclaration&>(node);
+        const auto& other = asAssert<FunctorDeclaration>(node);
         return name == other.name && argsTypes == other.argsTypes && returnType == other.returnType &&
                stateful == other.stateful;
     }

--- a/src/ast/IntrinsicFunctor.h
+++ b/src/ast/IntrinsicFunctor.h
@@ -23,6 +23,7 @@
 #include "parser/SrcLocation.h"
 #include "souffle/TypeAttribute.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <cassert>
 #include <cstddef>
@@ -81,7 +82,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const IntrinsicFunctor&>(node);
+        const auto& other = asAssert<IntrinsicFunctor>(node);
         return function == other.function && Functor::equal(node);
     }
 

--- a/src/ast/IntrinsicFunctor.h
+++ b/src/ast/IntrinsicFunctor.h
@@ -62,10 +62,6 @@ public:
         function = std::move(functor);
     }
 
-    IntrinsicFunctor* clone() const override {
-        return new IntrinsicFunctor(function, souffle::clone(args), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         if (isInfixFunctorOp(function)) {
@@ -86,6 +82,12 @@ protected:
         return function == other.function && Functor::equal(node);
     }
 
+private:
+    IntrinsicFunctor* cloneImpl() const override {
+        return new IntrinsicFunctor(function, souffle::clone(args), getSrcLoc());
+    }
+
+private:
     /** Function */
     std::string function;
 };

--- a/src/ast/Literal.h
+++ b/src/ast/Literal.h
@@ -30,8 +30,6 @@ namespace souffle::ast {
 class Literal : public Node {
 public:
     using Node::Node;
-
-    Literal* clone() const override = 0;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Negation.h
+++ b/src/ast/Negation.h
@@ -43,7 +43,9 @@ namespace souffle::ast {
  */
 class Negation : public Literal {
 public:
-    Negation(Own<Atom> atom, SrcLocation loc = {}) : Literal(std::move(loc)), atom(std::move(atom)) {}
+    Negation(Own<Atom> atom, SrcLocation loc = {}) : Literal(std::move(loc)), atom(std::move(atom)) {
+        assert(this->atom != nullptr);
+    }
 
     /** Get negated atom */
     Atom* getAtom() const {

--- a/src/ast/Negation.h
+++ b/src/ast/Negation.h
@@ -68,8 +68,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        assert(isA<Negation>(&node));
-        const auto& other = static_cast<const Negation&>(node);
+        const auto& other = asAssert<Negation>(node);
         return equal_ptr(atom, other.atom);
     }
 

--- a/src/ast/Negation.h
+++ b/src/ast/Negation.h
@@ -58,7 +58,7 @@ public:
         atom = map(std::move(atom));
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         return {atom.get()};
     }
 

--- a/src/ast/Negation.h
+++ b/src/ast/Negation.h
@@ -50,10 +50,6 @@ public:
         return atom.get();
     }
 
-    Negation* clone() const override {
-        return new Negation(souffle::clone(atom), getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         atom = map(std::move(atom));
     }
@@ -72,6 +68,12 @@ protected:
         return equal_ptr(atom, other.atom);
     }
 
+private:
+    Negation* cloneImpl() const override {
+        return new Negation(souffle::clone(atom), getSrcLoc());
+    }
+
+private:
     /** Negated atom */
     Own<Atom> atom;
 };

--- a/src/ast/NilConstant.h
+++ b/src/ast/NilConstant.h
@@ -31,7 +31,8 @@ class NilConstant : public Constant {
 public:
     NilConstant(SrcLocation loc = {}) : Constant("nil", std::move(loc)) {}
 
-    NilConstant* clone() const override {
+private:
+    NilConstant* cloneImpl() const override {
         return new NilConstant(getSrcLoc());
     }
 };

--- a/src/ast/Node.h
+++ b/src/ast/Node.h
@@ -69,7 +69,9 @@ public:
     }
 
     /** Create a clone (i.e. deep copy) of this node */
-    virtual Node* clone() const = 0;
+    Own<Node> clone() const {
+        return Own<Node>(cloneImpl());
+    }
 
     /** Apply the mapper to all child nodes */
     virtual void apply(const NodeMapper& /* mapper */) {}
@@ -147,8 +149,11 @@ protected:
     }
 
 private:
+    virtual Node* cloneImpl() const = 0;
+
+private:
     /** Source location of a syntactic element */
     SrcLocation location;
-};
+};  // namespace souffle::ast
 
 }  // namespace souffle::ast

--- a/src/ast/Node.h
+++ b/src/ast/Node.h
@@ -18,7 +18,7 @@
 
 #include "parser/SrcLocation.h"
 #include "souffle/utility/ContainerUtil.h"
-
+#include "souffle/utility/MiscUtil.h"
 #include <iosfwd>
 #include <string>
 #include <typeinfo>

--- a/src/ast/Node.h
+++ b/src/ast/Node.h
@@ -92,19 +92,19 @@ public:
         ChildNodes(ConstChildNodes&& cn) : childNodes(std::move(cn)) {}
 
         auto begin() const {
-            return makeTransformIter(childNodes.begin(), caster());
+            return transformIter(childNodes.begin(), caster());
         }
 
         auto cbegin() const {
-            return makeTransformIter(childNodes.cbegin(), caster());
+            return transformIter(childNodes.cbegin(), caster());
         }
 
         auto end() const {
-            return makeTransformIter(childNodes.end(), caster());
+            return transformIter(childNodes.end(), caster());
         }
 
         auto cend() const {
-            return makeTransformIter(childNodes.cend(), caster());
+            return transformIter(childNodes.cend(), caster());
         }
 
         auto size() const {

--- a/src/ast/NumericConstant.h
+++ b/src/ast/NumericConstant.h
@@ -50,12 +50,6 @@ public:
         setSrcLoc(std::move(loc));
     }
 
-    NumericConstant* clone() const override {
-        auto* copy = new NumericConstant(getConstant(), getFixedType());
-        copy->setSrcLoc(getSrcLoc());
-        return copy;
-    }
-
     const std::optional<Type>& getFixedType() const {
         return fixedType;
     }
@@ -64,6 +58,12 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<NumericConstant>(node);
         return Constant::equal(node) && fixedType == other.fixedType;
+    }
+private:
+    NumericConstant* cloneImpl() const override {
+        auto* copy = new NumericConstant(getConstant(), getFixedType());
+        copy->setSrcLoc(getSrcLoc());
+        return copy;
     }
 
 private:

--- a/src/ast/NumericConstant.h
+++ b/src/ast/NumericConstant.h
@@ -20,6 +20,7 @@
 #include "ast/Node.h"
 #include "parser/SrcLocation.h"
 #include "souffle/RamTypes.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <optional>
 #include <string>
@@ -61,7 +62,7 @@ public:
 
 protected:
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const NumericConstant&>(node);
+        const auto& other = asAssert<NumericConstant>(node);
         return Constant::equal(node) && fixedType == other.fixedType;
     }
 

--- a/src/ast/NumericConstant.h
+++ b/src/ast/NumericConstant.h
@@ -59,6 +59,7 @@ protected:
         const auto& other = asAssert<NumericConstant>(node);
         return Constant::equal(node) && fixedType == other.fixedType;
     }
+
 private:
     NumericConstant* cloneImpl() const override {
         auto* copy = new NumericConstant(getConstant(), getFixedType());

--- a/src/ast/NumericConstant.h
+++ b/src/ast/NumericConstant.h
@@ -41,14 +41,10 @@ public:
 
     NumericConstant(RamSigned value) : Constant(std::to_string(value)), fixedType(Type::Int) {}
 
-    NumericConstant(std::string constant, SrcLocation loc) : Constant(std::move(constant)) {
-        setSrcLoc(std::move(loc));
-    }
+    NumericConstant(std::string constant, SrcLocation loc) : Constant(std::move(constant), std::move(loc)) {}
 
     NumericConstant(std::string constant, std::optional<Type> fixedType = std::nullopt, SrcLocation loc = {})
-            : Constant(std::move(constant)), fixedType(fixedType) {
-        setSrcLoc(std::move(loc));
-    }
+            : Constant(std::move(constant), std::move(loc)), fixedType(fixedType) {}
 
     const std::optional<Type>& getFixedType() const {
         return fixedType;
@@ -62,9 +58,7 @@ protected:
 
 private:
     NumericConstant* cloneImpl() const override {
-        auto* copy = new NumericConstant(getConstant(), getFixedType());
-        copy->setSrcLoc(getSrcLoc());
-        return copy;
+        return new NumericConstant(getConstant(), getFixedType(), getSrcLoc());
     }
 
 private:

--- a/src/ast/Pragma.h
+++ b/src/ast/Pragma.h
@@ -18,6 +18,7 @@
 
 #include "ast/Node.h"
 #include "parser/SrcLocation.h"
+#include "souffle/utility/MiscUtil.h"
 #include <ostream>
 #include <string>
 #include <utility>
@@ -48,7 +49,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Pragma&>(node);
+        const auto& other = asAssert<Pragma>(node);
         return other.key == key && other.value == value;
     }
 

--- a/src/ast/Pragma.h
+++ b/src/ast/Pragma.h
@@ -34,10 +34,6 @@ public:
     Pragma(std::string key, std::string value, SrcLocation loc = {})
             : Node(std::move(loc)), key(std::move(key)), value(std::move(value)) {}
 
-    Pragma* clone() const override {
-        return new Pragma(key, value, getSrcLoc());
-    }
-
     /* Get kvp */
     std::pair<std::string, std::string> getkvp() const {
         return std::pair<std::string, std::string>(key, value);
@@ -51,6 +47,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<Pragma>(node);
         return other.key == key && other.value == value;
+    }
+
+private:
+    Pragma* cloneImpl() const override {
+        return new Pragma(key, value, getSrcLoc());
     }
 
     /** Name of the key */

--- a/src/ast/Program.cpp
+++ b/src/ast/Program.cpp
@@ -33,6 +33,7 @@
 namespace souffle::ast {
 
 void Program::addRelation(Own<Relation> relation) {
+    assert(relation != nullptr);
     auto* existingRelation = getIf(getRelations(), [&](const Relation* current) {
         return current->getQualifiedName() == relation->getQualifiedName();
     });
@@ -78,6 +79,7 @@ bool Program::removeDirective(const Directive* directive) {
 }
 
 void Program::addType(Own<Type> type) {
+    assert(type != nullptr);
     auto* existingType = getIf(getTypes(),
             [&](const Type* current) { return current->getQualifiedName() == type->getQualifiedName(); });
     assert(existingType == nullptr && "Redefinition of type!");
@@ -90,6 +92,7 @@ void Program::addPragma(Own<Pragma> pragma) {
 }
 
 void Program::addFunctorDeclaration(Own<FunctorDeclaration> f) {
+    assert(f != nullptr);
     auto* existingFunctorDecl = getIf(getFunctorDeclarations(),
             [&](const FunctorDeclaration* current) { return current->getName() == f->getName(); });
     assert(existingFunctorDecl == nullptr && "Redefinition of functor!");

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -124,19 +124,6 @@ public:
     /** Remove components and components' instantiations */
     void clearComponents();
 
-    Program* clone() const override {
-        auto res = new Program();
-        res->pragmas = souffle::clone(pragmas);
-        res->components = souffle::clone(components);
-        res->instantiations = souffle::clone(instantiations);
-        res->types = souffle::clone(types);
-        res->functors = souffle::clone(functors);
-        res->relations = souffle::clone(relations);
-        res->clauses = souffle::clone(clauses);
-        res->directives = souffle::clone(directives);
-        return res;
-    }
-
     void apply(const NodeMapper& map) override {
         for (auto& cur : pragmas) {
             cur = map(std::move(cur));
@@ -256,6 +243,21 @@ protected:
         assert(instantiation && "NULL instantiation");
         instantiations.push_back(std::move(instantiation));
     }
+
+private:
+    Program* cloneImpl() const override {
+        auto res = new Program();
+        res->pragmas = souffle::clone(pragmas);
+        res->components = souffle::clone(components);
+        res->instantiations = souffle::clone(instantiations);
+        res->types = souffle::clone(types);
+        res->functors = souffle::clone(functors);
+        res->relations = souffle::clone(relations);
+        res->clauses = souffle::clone(clauses);
+        res->directives = souffle::clone(directives);
+        return res;
+    }
+
 
     /** Program types  */
     VecOwn<Type> types;

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -163,7 +163,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (const auto& cur : pragmas) {
             res.push_back(cur.get());

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -96,6 +96,7 @@ public:
 
     /** Set clauses */
     void setClauses(VecOwn<Clause> newClauses) {
+        assert(allValidPtrs(newClauses));
         clauses = std::move(newClauses);
     }
 

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -28,6 +28,7 @@
 #include "ast/Type.h"
 #include "ast/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <algorithm>
 #include <cassert>
@@ -209,7 +210,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Program&>(node);
+        const auto& other = asAssert<Program>(node);
         if (!equal_targets(pragmas, other.pragmas)) {
             return false;
         }

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -258,7 +258,6 @@ private:
         return res;
     }
 
-
     /** Program types  */
     VecOwn<Type> types;
 

--- a/src/ast/RecordInit.h
+++ b/src/ast/RecordInit.h
@@ -38,14 +38,16 @@ public:
     RecordInit(VecOwn<Argument> operands = {}, SrcLocation loc = {})
             : Term(std::move(operands), std::move(loc)) {}
 
-    RecordInit* clone() const override {
-        return new RecordInit(souffle::clone(args), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << "[" << join(args) << "]";
     }
+
+private:
+    RecordInit* cloneImpl() const override {
+        return new RecordInit(souffle::clone(args), getSrcLoc());
+    }
+
 };
 
 }  // namespace souffle::ast

--- a/src/ast/RecordInit.h
+++ b/src/ast/RecordInit.h
@@ -47,7 +47,6 @@ private:
     RecordInit* cloneImpl() const override {
         return new RecordInit(souffle::clone(args), getSrcLoc());
     }
-
 };
 
 }  // namespace souffle::ast

--- a/src/ast/RecordType.h
+++ b/src/ast/RecordType.h
@@ -46,8 +46,8 @@ class RecordType : public Type {
 public:
     RecordType(QualifiedName name, VecOwn<Attribute> fields, SrcLocation loc = {})
             : Type(std::move(name), std::move(loc)), fields(std::move(fields)) {
-                assert(allValidPtrs(this->fields));
-            }
+        assert(allValidPtrs(this->fields));
+    }
 
     /** Add field to record type */
     void add(std::string name, QualifiedName type) {

--- a/src/ast/RecordType.h
+++ b/src/ast/RecordType.h
@@ -45,7 +45,9 @@ namespace souffle::ast {
 class RecordType : public Type {
 public:
     RecordType(QualifiedName name, VecOwn<Attribute> fields, SrcLocation loc = {})
-            : Type(std::move(name), std::move(loc)), fields(std::move(fields)) {}
+            : Type(std::move(name), std::move(loc)), fields(std::move(fields)) {
+                assert(allValidPtrs(this->fields));
+            }
 
     /** Add field to record type */
     void add(std::string name, QualifiedName type) {

--- a/src/ast/RecordType.h
+++ b/src/ast/RecordType.h
@@ -22,6 +22,7 @@
 #include "ast/Type.h"
 #include "parser/SrcLocation.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include "souffle/utility/tinyformat.h"
 #include <algorithm>
@@ -71,7 +72,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = dynamic_cast<const RecordType&>(node);
+        const auto& other = asAssert<RecordType>(node);
         return getQualifiedName() == other.getQualifiedName() && equal_targets(fields, other.fields);
     }
 

--- a/src/ast/RecordType.h
+++ b/src/ast/RecordType.h
@@ -62,10 +62,6 @@ public:
         fields.at(idx)->setTypeName(std::move(type));
     }
 
-    RecordType* clone() const override {
-        return new RecordType(getQualifiedName(), souffle::clone(fields), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << tfm::format(".type %s = [%s]", getQualifiedName(), join(fields, ", "));
@@ -74,6 +70,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<RecordType>(node);
         return getQualifiedName() == other.getQualifiedName() && equal_targets(fields, other.fields);
+    }
+
+private:
+    RecordType* cloneImpl() const override {
+        return new RecordType(getQualifiedName(), souffle::clone(fields), getSrcLoc());
     }
 
 private:

--- a/src/ast/Relation.h
+++ b/src/ast/Relation.h
@@ -70,6 +70,7 @@ public:
 
     /** Set relation attributes */
     void setAttributes(VecOwn<Attribute> attrs) {
+        assert(allValidPtrs(attrs));
         attributes = std::move(attrs);
     }
 
@@ -110,6 +111,7 @@ public:
 
     /** Add functional dependency to this relation */
     void addDependency(Own<FunctionalConstraint> fd) {
+        assert(fd != nullptr);
         functionalDependencies.push_back(std::move(fd));
     }
 

--- a/src/ast/Relation.h
+++ b/src/ast/Relation.h
@@ -45,9 +45,7 @@ namespace souffle::ast {
 class Relation : public Node {
 public:
     Relation() = default;
-    Relation(QualifiedName name, SrcLocation loc = {}) : name(std::move(name)) {
-        setSrcLoc(std::move(loc));
-    }
+    Relation(QualifiedName name, SrcLocation loc = {}) : Node(std::move(loc)), name(std::move(name)) {}
 
     /** Get qualified relation name */
     const QualifiedName& getQualifiedName() const {

--- a/src/ast/Relation.h
+++ b/src/ast/Relation.h
@@ -119,14 +119,6 @@ public:
         return toPtrVector(functionalDependencies);
     }
 
-    Relation* clone() const override {
-        auto res = new Relation(name, getSrcLoc());
-        res->attributes = souffle::clone(attributes);
-        res->qualifiers = qualifiers;
-        res->representation = representation;
-        return res;
-    }
-
     void apply(const NodeMapper& map) override {
         for (auto& cur : attributes) {
             cur = map(std::move(cur));
@@ -152,6 +144,16 @@ protected:
         return name == other.name && equal_targets(attributes, other.attributes);
     }
 
+private:
+    Relation* cloneImpl() const override {
+        auto res = new Relation(name, getSrcLoc());
+        res->attributes = souffle::clone(attributes);
+        res->qualifiers = qualifiers;
+        res->representation = representation;
+        return res;
+    }
+
+private:
     /** Name of relation */
     QualifiedName name;
 

--- a/src/ast/Relation.h
+++ b/src/ast/Relation.h
@@ -24,6 +24,7 @@
 #include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <algorithm>
 #include <cassert>
@@ -147,7 +148,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Relation&>(node);
+        const auto& other = asAssert<Relation>(node);
         return name == other.name && equal_targets(attributes, other.attributes);
     }
 

--- a/src/ast/Relation.h
+++ b/src/ast/Relation.h
@@ -132,7 +132,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodes() const override {
+    std::vector<const Node*> getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (const auto& cur : attributes) {
             res.push_back(cur.get());

--- a/src/ast/StringConstant.h
+++ b/src/ast/StringConstant.h
@@ -34,15 +34,16 @@ public:
         setSrcLoc(std::move(loc));
     }
 
-    StringConstant* clone() const override {
-        auto* res = new StringConstant(getConstant());
-        res->setSrcLoc(getSrcLoc());
-        return res;
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << "\"" << getConstant() << "\"";
+    }
+
+private:
+    StringConstant* cloneImpl() const override {
+        auto* res = new StringConstant(getConstant());
+        res->setSrcLoc(getSrcLoc());
+        return res;
     }
 };
 

--- a/src/ast/StringConstant.h
+++ b/src/ast/StringConstant.h
@@ -30,9 +30,8 @@ namespace souffle::ast {
  */
 class StringConstant : public Constant {
 public:
-    explicit StringConstant(std::string value, SrcLocation loc = {}) : Constant(std::move(value)) {
-        setSrcLoc(std::move(loc));
-    }
+    explicit StringConstant(std::string value, SrcLocation loc = {})
+            : Constant(std::move(value), std::move(loc)) {}
 
 protected:
     void print(std::ostream& os) const override {
@@ -41,9 +40,7 @@ protected:
 
 private:
     StringConstant* cloneImpl() const override {
-        auto* res = new StringConstant(getConstant());
-        res->setSrcLoc(getSrcLoc());
-        return res;
+        return new StringConstant(getConstant(), getSrcLoc());
     }
 };
 

--- a/src/ast/SubsetType.h
+++ b/src/ast/SubsetType.h
@@ -39,10 +39,6 @@ public:
     SubsetType(QualifiedName name, QualifiedName baseTypeName, SrcLocation loc = {})
             : Type(std::move(name), std::move(loc)), baseType(std::move(baseTypeName)) {}
 
-    SubsetType* clone() const override {
-        return new SubsetType(getQualifiedName(), getBaseType(), getSrcLoc());
-    }
-
     /** Return base type */
     const QualifiedName& getBaseType() const {
         return baseType;
@@ -56,6 +52,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<SubsetType>(node);
         return getQualifiedName() == other.getQualifiedName() && baseType == other.baseType;
+    }
+
+private:
+    SubsetType* cloneImpl() const override {
+        return new SubsetType(getQualifiedName(), getBaseType(), getSrcLoc());
     }
 
 private:

--- a/src/ast/SubsetType.h
+++ b/src/ast/SubsetType.h
@@ -20,6 +20,7 @@
 #include "ast/QualifiedName.h"
 #include "ast/Type.h"
 #include "parser/SrcLocation.h"
+#include "souffle/utility/MiscUtil.h"
 #include <iostream>
 #include <string>
 #include <utility>
@@ -53,7 +54,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const SubsetType&>(node);
+        const auto& other = asAssert<SubsetType>(node);
         return getQualifiedName() == other.getQualifiedName() && baseType == other.baseType;
     }
 

--- a/src/ast/Term.h
+++ b/src/ast/Term.h
@@ -44,7 +44,9 @@ protected:
             : Term(asVec(std::forward<Operands>(operands)...), std::move(loc)) {}
 
     Term(VecOwn<Argument> operands, SrcLocation loc = {})
-            : Argument(std::move(loc)), args(std::move(operands)) {}
+            : Argument(std::move(loc)), args(std::move(operands)) {
+                assert(allValidPtrs(args));
+            }
 
 public:
     /** Get arguments */
@@ -54,6 +56,7 @@ public:
 
     /** Add argument to argument list */
     void addArgument(Own<Argument> arg) {
+        assert(arg != nullptr);
         args.push_back(std::move(arg));
     }
 

--- a/src/ast/Term.h
+++ b/src/ast/Term.h
@@ -45,8 +45,8 @@ protected:
 
     Term(VecOwn<Argument> operands, SrcLocation loc = {})
             : Argument(std::move(loc)), args(std::move(operands)) {
-                assert(allValidPtrs(args));
-            }
+        assert(allValidPtrs(args));
+    }
 
 public:
     /** Get arguments */

--- a/src/ast/Term.h
+++ b/src/ast/Term.h
@@ -21,6 +21,7 @@
 #include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include <algorithm>
 #include <memory>
 #include <string>
@@ -72,7 +73,7 @@ public:
 
 protected:
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Term&>(node);
+        const auto& other = asAssert<Term>(node);
         return equal_targets(args, other.args);
     }
 

--- a/src/ast/Term.h
+++ b/src/ast/Term.h
@@ -56,8 +56,8 @@ public:
         args.push_back(std::move(arg));
     }
 
-    std::vector<const Node*> getChildNodes() const override {
-        auto res = Argument::getChildNodes();
+    std::vector<const Node*> getChildNodesImpl() const override {
+        auto res = Argument::getChildNodesImpl();
         for (auto& cur : args) {
             res.push_back(cur.get());
         }

--- a/src/ast/TranslationUnit.h
+++ b/src/ast/TranslationUnit.h
@@ -62,8 +62,8 @@ public:
             if (debug) {
                 std::stringstream ss;
                 analyses[name]->print(ss);
-                if (!isA<analysis::PrecedenceGraphAnalysis>(analyses[name].get()) &&
-                        !isA<analysis::SCCGraphAnalysis>(analyses[name].get())) {
+                if (!isA<analysis::PrecedenceGraphAnalysis>(analyses[name]) &&
+                        !isA<analysis::SCCGraphAnalysis>(analyses[name])) {
                     debugReport.addSection(name, "Ast Analysis [" + name + "]", ss.str());
                 } else {
                     debugReport.addSection(
@@ -71,7 +71,7 @@ public:
                 }
             }
         }
-        return dynamic_cast<Analysis*>(analyses[name].get());
+        return as<Analysis>(analyses[name]);
     }
 
     /** Return the program */

--- a/src/ast/Type.h
+++ b/src/ast/Type.h
@@ -42,8 +42,6 @@ public:
         this->name = std::move(name);
     }
 
-    Type* clone() const override = 0;
-
 private:
     /** type name */
     QualifiedName name;

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -41,8 +41,8 @@ class TypeCast : public Argument {
 public:
     TypeCast(Own<Argument> value, QualifiedName type, SrcLocation loc = {})
             : Argument(std::move(loc)), value(std::move(value)), type(std::move(type)) {
-                assert(this->value != nullptr);
-            }
+        assert(this->value != nullptr);
+    }
 
     /** Return value */
     Argument* getValue() const {

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -63,10 +63,6 @@ public:
         return res;
     }
 
-    TypeCast* clone() const override {
-        return new TypeCast(souffle::clone(value), type, getSrcLoc());
-    }
-
     void apply(const NodeMapper& map) override {
         value = map(std::move(value));
     }
@@ -81,6 +77,12 @@ protected:
         return type == other.type && equal_ptr(value, other.value);
     }
 
+private:
+    TypeCast* cloneImpl() const override {
+        return new TypeCast(souffle::clone(value), type, getSrcLoc());
+    }
+
+private:
     /** Casted value */
     Own<Argument> value;
 

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -57,8 +57,8 @@ public:
         this->type = type;
     }
 
-    std::vector<const Node*> getChildNodes() const override {
-        auto res = Argument::getChildNodes();
+    std::vector<const Node*> getChildNodesImpl() const override {
+        auto res = Argument::getChildNodesImpl();
         res.push_back(value.get());
         return res;
     }

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -77,7 +77,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const TypeCast&>(node);
+        const auto& other = asAssert<TypeCast>(node);
         return type == other.type && equal_ptr(value, other.value);
     }
 

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -40,7 +40,9 @@ namespace souffle::ast {
 class TypeCast : public Argument {
 public:
     TypeCast(Own<Argument> value, QualifiedName type, SrcLocation loc = {})
-            : Argument(std::move(loc)), value(std::move(value)), type(std::move(type)) {}
+            : Argument(std::move(loc)), value(std::move(value)), type(std::move(type)) {
+                assert(this->value != nullptr);
+            }
 
     /** Return value */
     Argument* getValue() const {

--- a/src/ast/UnionType.h
+++ b/src/ast/UnionType.h
@@ -66,10 +66,6 @@ public:
         types.at(idx) = std::move(type);
     }
 
-    UnionType* clone() const override {
-        return new UnionType(getQualifiedName(), types, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << ".type " << getQualifiedName() << " = " << join(types, " | ");
@@ -78,6 +74,11 @@ protected:
     bool equal(const Node& node) const override {
         const auto& other = asAssert<UnionType>(node);
         return getQualifiedName() == other.getQualifiedName() && types == other.types;
+    }
+
+private:
+    UnionType* cloneImpl() const override {
+        return new UnionType(getQualifiedName(), types, getSrcLoc());
     }
 
 private:

--- a/src/ast/UnionType.h
+++ b/src/ast/UnionType.h
@@ -51,6 +51,10 @@ public:
         return types;
     }
 
+    std::vector<QualifiedName>& getTypes() {
+        return types;
+    }
+
     /** Add another unioned type */
     void add(QualifiedName type) {
         types.push_back(std::move(type));

--- a/src/ast/UnionType.h
+++ b/src/ast/UnionType.h
@@ -20,6 +20,7 @@
 #include "ast/QualifiedName.h"
 #include "ast/Type.h"
 #include "parser/SrcLocation.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <algorithm>
 #include <cstddef>
@@ -75,7 +76,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const UnionType&>(node);
+        const auto& other = asAssert<UnionType>(node);
         return getQualifiedName() == other.getQualifiedName() && types == other.types;
     }
 

--- a/src/ast/UnnamedVariable.h
+++ b/src/ast/UnnamedVariable.h
@@ -29,14 +29,16 @@ class UnnamedVariable : public Argument {
 public:
     using Argument::Argument;
 
-    UnnamedVariable* clone() const override {
-        return new UnnamedVariable(getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << "_";
     }
+
+private:
+    UnnamedVariable* cloneImpl() const override {
+        return new UnnamedVariable(getSrcLoc());
+    }
+
 };
 
 }  // namespace souffle::ast

--- a/src/ast/UnnamedVariable.h
+++ b/src/ast/UnnamedVariable.h
@@ -38,7 +38,6 @@ private:
     UnnamedVariable* cloneImpl() const override {
         return new UnnamedVariable(getSrcLoc());
     }
-
 };
 
 }  // namespace souffle::ast

--- a/src/ast/UserDefinedFunctor.h
+++ b/src/ast/UserDefinedFunctor.h
@@ -50,10 +50,6 @@ public:
         return name;
     }
 
-    UserDefinedFunctor* clone() const override {
-        return new UserDefinedFunctor(name, souffle::clone(args), getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << '@' << name << "(" << join(args) << ")";
@@ -66,6 +62,11 @@ protected:
 
     /** Name */
     const std::string name;
+
+private:
+    UserDefinedFunctor* cloneImpl() const override {
+        return new UserDefinedFunctor(name, souffle::clone(args), getSrcLoc());
+    }
 };
 
 }  // namespace souffle::ast

--- a/src/ast/UserDefinedFunctor.h
+++ b/src/ast/UserDefinedFunctor.h
@@ -43,7 +43,7 @@ public:
     explicit UserDefinedFunctor(std::string name) : Functor({}, {}), name(std::move(name)){};
 
     UserDefinedFunctor(std::string name, VecOwn<Argument> args, SrcLocation loc = {})
-            : Functor(std::move(args), std::move(loc)), name(std::move(name)){};
+            : Functor(std::move(args), std::move(loc)), name(std::move(name)) {}
 
     /** return the name */
     const std::string& getName() const {

--- a/src/ast/UserDefinedFunctor.h
+++ b/src/ast/UserDefinedFunctor.h
@@ -22,6 +22,7 @@
 #include "parser/SrcLocation.h"
 #include "souffle/TypeAttribute.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <cassert>
 #include <cstddef>
@@ -59,7 +60,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const UserDefinedFunctor&>(node);
+        const auto& other = asAssert<UserDefinedFunctor>(node);
         return name == other.name && Functor::equal(node);
     }
 

--- a/src/ast/Variable.h
+++ b/src/ast/Variable.h
@@ -19,6 +19,7 @@
 #include "ast/Argument.h"
 #include "ast/Node.h"
 #include "parser/SrcLocation.h"
+#include "souffle/utility/MiscUtil.h"
 #include <ostream>
 #include <string>
 #include <utility>
@@ -53,7 +54,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Variable&>(node);
+        const auto& other = asAssert<Variable>(node);
         return name == other.name;
     }
 

--- a/src/ast/Variable.h
+++ b/src/ast/Variable.h
@@ -44,10 +44,6 @@ public:
         return name;
     }
 
-    Variable* clone() const override {
-        return new Variable(name, getSrcLoc());
-    }
-
 protected:
     void print(std::ostream& os) const override {
         os << name;
@@ -58,6 +54,12 @@ protected:
         return name == other.name;
     }
 
+private:
+    Variable* cloneImpl() const override {
+        return new Variable(name, getSrcLoc());
+    }
+
+private:
     /** Name */
     std::string name;
 };

--- a/src/ast/analysis/Aggregate.cpp
+++ b/src/ast/analysis/Aggregate.cpp
@@ -97,10 +97,7 @@ std::set<std::string> getWitnessVariables(
     };
 
     auto aggregatorlessClause = mk<Clause>("*");
-    // FIXME: tomp - this can be improved
-    for (Literal* lit : clause.getBodyLiterals()) {
-        aggregatorlessClause->addToBody(souffle::clone(lit));
-    }
+    aggregatorlessClause->setBodyLiterals(souffle::clone(clause.getBodyLiterals()));
 
     auto negatedHead = mk<Negation>(souffle::clone(clause.getHead()));
     aggregatorlessClause->addToBody(std::move(negatedHead));
@@ -116,10 +113,7 @@ std::set<std::string> getWitnessVariables(
     // 2. Create an aggregate clause so that we can check
     // that it IS this aggregate giving a grounding to the candidate variable.
     auto aggregateSubclause = mk<Clause>("*");
-    // FIXME: tomp - this can be improved
-    for (const auto& lit : aggregate.getBodyLiterals()) {
-        aggregateSubclause->addToBody(souffle::clone(lit));
-    }
+    aggregateSubclause->setBodyLiterals(souffle::clone(aggregate.getBodyLiterals()));
 
     std::set<std::string> witnessVariables;
     auto isGroundedInAggregateSubclause = analysis::getGroundedTerms(tu, *aggregateSubclause);
@@ -329,11 +323,8 @@ std::set<std::string> getInjectedVariables(
     // 2. make a clone of the clause and then apply that mapper onto it
     auto clauseCopy = souffle::clone(clause);
     auto tweakedClause = mk<Clause>("*");
-    // FIXME: tomp - this can be improved
-    // copy in all the old body literals
-    for (Literal* lit : clause.getBodyLiterals()) {
-        tweakedClause->addToBody(souffle::clone(lit));
-    }
+    tweakedClause->setBodyLiterals(souffle::clone(clause.getBodyLiterals()));
+
     // copy in the head as a negated atom
     tweakedClause->addToBody(mk<Negation>(souffle::clone(clause.getHead())));
     // copy in body literals and also add the old head as a negated atom

--- a/src/ast/analysis/Aggregate.cpp
+++ b/src/ast/analysis/Aggregate.cpp
@@ -89,33 +89,33 @@ std::set<std::string> getWitnessVariables(
                 // Keep track of which variables are bound to aggregators
                 aggregatorVariables.insert(newVariableName.str());
 
-                return std::make_unique<Variable>(newVariableName.str());
+                return mk<Variable>(newVariableName.str());
             }
             node->apply(*this);
             return node;
         }
     };
 
-    auto aggregatorlessClause = std::make_unique<Clause>();
-    aggregatorlessClause->setHead(std::make_unique<Atom>("*"));
+    auto aggregatorlessClause = mk<Clause>();
+    aggregatorlessClause->setHead(mk<Atom>("*"));
     for (Literal* lit : clause.getBodyLiterals()) {
         aggregatorlessClause->addToBody(souffle::clone(lit));
     }
 
-    auto negatedHead = std::make_unique<Negation>(souffle::clone(clause.getHead()));
+    auto negatedHead = mk<Negation>(souffle::clone(clause.getHead()));
     aggregatorlessClause->addToBody(std::move(negatedHead));
 
     // Replace all aggregates with variables
     M update;
     aggregatorlessClause->apply(update);
-    auto groundingAtom = std::make_unique<Atom>("+grounding_atom");
+    auto groundingAtom = mk<Atom>("+grounding_atom");
     for (std::string variableName : update.getAggregatorVariables()) {
-        groundingAtom->addArgument(std::make_unique<Variable>(variableName));
+        groundingAtom->addArgument(mk<Variable>(variableName));
     }
     aggregatorlessClause->addToBody(std::move(groundingAtom));
     // 2. Create an aggregate clause so that we can check
     // that it IS this aggregate giving a grounding to the candidate variable.
-    auto aggregateSubclause = std::make_unique<Clause>();
+    auto aggregateSubclause = mk<Clause>();
     aggregateSubclause->setHead(mk<Atom>("*"));
     for (const auto& lit : aggregate.getBodyLiterals()) {
         aggregateSubclause->addToBody(souffle::clone(lit));

--- a/src/ast/analysis/Aggregate.cpp
+++ b/src/ast/analysis/Aggregate.cpp
@@ -81,7 +81,7 @@ std::set<std::string> getWitnessVariables(
 
         std::unique_ptr<Node> operator()(std::unique_ptr<Node> node) const override {
             static int numReplaced = 0;
-            if (dynamic_cast<Aggregator*>(node.get()) != nullptr) {
+            if (isA<Aggregator>(node)) {
                 // Replace the aggregator with a variable
                 std::stringstream newVariableName;
                 newVariableName << "+aggr_var_" << numReplaced++;
@@ -126,13 +126,13 @@ std::set<std::string> getWitnessVariables(
     // 3. Calculate all the witness variables
     // A witness will occur ungrounded in the aggregatorlessClause
     for (const auto& argPair : analysis::getGroundedTerms(tu, *aggregatorlessClause)) {
-        if (const auto* variable = dynamic_cast<const Variable*>(argPair.first)) {
+        if (const auto* variable = as<Variable>(argPair.first)) {
             bool variableIsGrounded = argPair.second;
             if (!variableIsGrounded) {
                 // then we expect it to be grounded in the aggregate subclause
                 // if it's a witness!!
                 for (const auto& aggArgPair : isGroundedInAggregateSubclause) {
-                    if (const auto* var = dynamic_cast<const Variable*>(aggArgPair.first)) {
+                    if (const auto* var = as<Variable>(aggArgPair.first)) {
                         bool aggVariableIsGrounded = aggArgPair.second;
                         if (var->getName() == variable->getName() && aggVariableIsGrounded) {
                             witnessVariables.insert(variable->getName());
@@ -294,7 +294,7 @@ std::set<std::string> getInjectedVariables(
 
         std::unique_ptr<Node> operator()(std::unique_ptr<Node> node) const override {
             static int numReplaced = 0;
-            if (auto* aggregate = dynamic_cast<Aggregator*>(node.get())) {
+            if (auto* aggregate = as<Aggregator>(node)) {
                 // If we come across an aggregate that is NOT an ancestor of
                 // the target aggregate, or that IS itself the target aggregate,
                 // we should replace it with a dummy variable.
@@ -351,7 +351,7 @@ std::set<std::string> getInjectedVariables(
     std::set<std::string> injectedVariables;
     // Search through the tweakedClause to find groundings!
     for (const auto& argPair : analysis::getGroundedTerms(tu, *tweakedClause)) {
-        if (const auto* variable = dynamic_cast<const Variable*>(argPair.first)) {
+        if (const auto* variable = as<Variable>(argPair.first)) {
             bool varIsGrounded = argPair.second;
             if (varIsGrounded && variablesInTargetAggregate.find(variable->getName()) !=
                                          variablesInTargetAggregate.end()) {

--- a/src/ast/analysis/Aggregate.cpp
+++ b/src/ast/analysis/Aggregate.cpp
@@ -96,8 +96,8 @@ std::set<std::string> getWitnessVariables(
         }
     };
 
-    auto aggregatorlessClause = mk<Clause>();
-    aggregatorlessClause->setHead(mk<Atom>("*"));
+    auto aggregatorlessClause = mk<Clause>("*");
+    // FIXME: tomp - this can be improved
     for (Literal* lit : clause.getBodyLiterals()) {
         aggregatorlessClause->addToBody(souffle::clone(lit));
     }
@@ -115,8 +115,8 @@ std::set<std::string> getWitnessVariables(
     aggregatorlessClause->addToBody(std::move(groundingAtom));
     // 2. Create an aggregate clause so that we can check
     // that it IS this aggregate giving a grounding to the candidate variable.
-    auto aggregateSubclause = mk<Clause>();
-    aggregateSubclause->setHead(mk<Atom>("*"));
+    auto aggregateSubclause = mk<Clause>("*");
+    // FIXME: tomp - this can be improved
     for (const auto& lit : aggregate.getBodyLiterals()) {
         aggregateSubclause->addToBody(souffle::clone(lit));
     }
@@ -269,7 +269,7 @@ std::set<std::string> getInjectedVariables(
     visitDepthFirst(clause, [&](const Aggregator& ancestor) {
         visitDepthFirst(ancestor, [&](const Aggregator& agg) {
             if (agg == aggregate) {
-                ancestorAggregates.insert(souffle::clone(&ancestor));
+                ancestorAggregates.insert(souffle::clone(ancestor));
             }
         });
     });
@@ -327,10 +327,9 @@ std::set<std::string> getInjectedVariables(
         }
     };
     // 2. make a clone of the clause and then apply that mapper onto it
-    auto clauseCopy = souffle::clone(&clause);
-    auto tweakedClause = mk<Clause>();
-    // put a fake head here
-    tweakedClause->setHead(mk<Atom>("*"));
+    auto clauseCopy = souffle::clone(clause);
+    auto tweakedClause = mk<Clause>("*");
+    // FIXME: tomp - this can be improved
     // copy in all the old body literals
     for (Literal* lit : clause.getBodyLiterals()) {
         tweakedClause->addToBody(souffle::clone(lit));
@@ -338,7 +337,7 @@ std::set<std::string> getInjectedVariables(
     // copy in the head as a negated atom
     tweakedClause->addToBody(mk<Negation>(souffle::clone(clause.getHead())));
     // copy in body literals and also add the old head as a negated atom
-    ReplaceAggregatesWithVariables update(std::move(ancestorAggregates), souffle::clone(&aggregate));
+    ReplaceAggregatesWithVariables update(std::move(ancestorAggregates), souffle::clone(aggregate));
     tweakedClause->apply(update);
     // the update will now tell us which variables we need to ground!
     auto groundingAtom = mk<Atom>("+grounding_atom");

--- a/src/ast/analysis/ClauseNormalisation.cpp
+++ b/src/ast/analysis/ClauseNormalisation.cpp
@@ -71,11 +71,11 @@ void NormalisedClause::addClauseAtom(
 }
 
 void NormalisedClause::addClauseBodyLiteral(const std::string& scopeID, const Literal* lit) {
-    if (const auto* atom = dynamic_cast<const Atom*>(lit)) {
+    if (const auto* atom = as<Atom>(lit)) {
         addClauseAtom("@min:atom", scopeID, atom);
-    } else if (const auto* neg = dynamic_cast<const Negation*>(lit)) {
+    } else if (const auto* neg = as<Negation>(lit)) {
         addClauseAtom("@min:neg", scopeID, neg->getAtom());
-    } else if (const auto* bc = dynamic_cast<const BinaryConstraint*>(lit)) {
+    } else if (const auto* bc = as<BinaryConstraint>(lit)) {
         QualifiedName name(toBinaryConstraintSymbol(bc->getBaseOperator()));
         name.prepend("@min:operator");
         std::vector<std::string> vars;
@@ -95,12 +95,12 @@ void NormalisedClause::addClauseBodyLiteral(const std::string& scopeID, const Li
 }
 
 std::string NormalisedClause::normaliseArgument(const Argument* arg) {
-    if (auto* stringCst = dynamic_cast<const StringConstant*>(arg)) {
+    if (auto* stringCst = as<StringConstant>(arg)) {
         std::stringstream name;
         name << "@min:cst:str" << *stringCst;
         constants.insert(name.str());
         return name.str();
-    } else if (auto* numericCst = dynamic_cast<const NumericConstant*>(arg)) {
+    } else if (auto* numericCst = as<NumericConstant>(arg)) {
         std::stringstream name;
         name << "@min:cst:num:" << *numericCst;
         constants.insert(name.str());
@@ -108,17 +108,17 @@ std::string NormalisedClause::normaliseArgument(const Argument* arg) {
     } else if (isA<NilConstant>(arg)) {
         constants.insert("@min:cst:nil");
         return "@min:cst:nil";
-    } else if (auto* var = dynamic_cast<const ast::Variable*>(arg)) {
+    } else if (auto* var = as<ast::Variable>(arg)) {
         auto name = var->getName();
         variables.insert(name);
         return name;
-    } else if (dynamic_cast<const UnnamedVariable*>(arg)) {
+    } else if (as<UnnamedVariable>(arg)) {
         static size_t countUnnamed = 0;
         std::stringstream name;
         name << "@min:unnamed:" << countUnnamed++;
         variables.insert(name.str());
         return name.str();
-    } else if (auto* aggr = dynamic_cast<const Aggregator*>(arg)) {
+    } else if (auto* aggr = as<Aggregator>(arg)) {
         // Set the scope to uniquely identify the aggregator
         std::stringstream scopeID;
         scopeID << "@min:scope:" << ++aggrScopeCount;

--- a/src/ast/analysis/Constraint.h
+++ b/src/ast/analysis/Constraint.h
@@ -98,7 +98,7 @@ protected:
      * @return the analysis variable representing its associated value
      */
     AnalysisVar getVar(const Argument& arg) {
-        const auto* var = dynamic_cast<const ast::Variable*>(&arg);
+        const auto* var = as<ast::Variable>(arg);
         if (var == nullptr) {
             // no mapping required
             return AnalysisVar(arg);

--- a/src/ast/analysis/Type.cpp
+++ b/src/ast/analysis/Type.cpp
@@ -68,11 +68,11 @@ Own<Clause> TypeAnalysis::createAnnotatedClause(
         TypeAnnotator(const std::map<const Argument*, TypeSet>& types) : types(types) {}
 
         Own<Node> operator()(Own<Node> node) const override {
-            if (auto* var = dynamic_cast<ast::Variable*>(node.get())) {
+            if (auto* var = as<ast::Variable>(node)) {
                 std::stringstream newVarName;
                 newVarName << var->getName() << "&isin;" << types.find(var)->second;
                 return mk<ast::Variable>(newVarName.str());
-            } else if (auto* var = dynamic_cast<UnnamedVariable*>(node.get())) {
+            } else if (auto* var = as<UnnamedVariable>(node)) {
                 std::stringstream newVarName;
                 newVarName << "_"
                            << "&isin;" << types.find(var)->second;
@@ -183,13 +183,13 @@ bool TypeAnalysis::isMultiResultFunctor(const Functor& functor) {
 std::set<TypeAttribute> TypeAnalysis::getTypeAttributes(const Argument* arg) const {
     std::set<TypeAttribute> typeAttributes;
 
-    if (const auto* inf = dynamic_cast<const IntrinsicFunctor*>(arg)) {
+    if (const auto* inf = as<IntrinsicFunctor>(arg)) {
         // intrinsic functor type is its return type if its set
         if (hasValidTypeInfo(inf)) {
             typeAttributes.insert(getFunctorReturnType(inf));
             return typeAttributes;
         }
-    } else if (const auto* udf = dynamic_cast<const UserDefinedFunctor*>(arg)) {
+    } else if (const auto* udf = as<UserDefinedFunctor>(arg)) {
         if (hasValidTypeInfo(udf)) {
             typeAttributes.insert(getFunctorReturnType(udf));
             return typeAttributes;

--- a/src/ast/analysis/TypeConstraints.cpp
+++ b/src/ast/analysis/TypeConstraints.cpp
@@ -112,7 +112,7 @@ static TypeConstraint hasSuperTypeInSet(const TypeVar& var, TypeSet values) {
 }
 
 static const Type& getBaseType(const Type* type) {
-    while (auto subset = dynamic_cast<const SubsetType*>(type)) {
+    while (auto subset = as<SubsetType>(type)) {
         type = &subset->getBaseType();
     };
     assert((isA<ConstantType>(type) || isA<RecordType>(type)) &&

--- a/src/ast/analysis/TypeSystem.cpp
+++ b/src/ast/analysis/TypeSystem.cpp
@@ -92,7 +92,7 @@ struct TypeVisitor {
     }
 
 #define FORWARD(TYPE) \
-    if (auto* t = dynamic_cast<const TYPE##Type*>(&type)) return visit##TYPE##Type(*t);
+    if (auto* t = as<TYPE##Type>(type)) return visit##TYPE##Type(*t);
 
     virtual R visit(const Type& type) const {
         FORWARD(Constant);

--- a/src/ast/tests/ast_parser_utils_test.cpp
+++ b/src/ast/tests/ast_parser_utils_test.cpp
@@ -107,9 +107,9 @@ TEST(RuleBody, ClauseBodyExtraction) {
     auto list = full.toClauseBodies();
     EXPECT_EQ(3, list.size());
 
-    EXPECT_EQ(" :- \n   A(),\n   B().", toString(*list[0]));
-    EXPECT_EQ(" :- \n   C(),\n   D().", toString(*list[1]));
-    EXPECT_EQ(" :- \n   E(),\n   F().", toString(*list[2]));
+    EXPECT_EQ("*() :- \n   A(),\n   B().", toString(*list[0]));
+    EXPECT_EQ("*() :- \n   C(),\n   D().", toString(*list[1]));
+    EXPECT_EQ("*() :- \n   E(),\n   F().", toString(*list[2]));
 }
 
 }  // end namespace test

--- a/src/ast/tests/ast_print_test.cpp
+++ b/src/ast/tests/ast_print_test.cpp
@@ -56,10 +56,9 @@ inline Own<TranslationUnit> makePrintedATU(Own<TranslationUnit>& tu) {
 }
 
 inline Own<Clause> makeClauseA(Own<Argument> headArgument) {
-    auto headAtom = mk<Atom>("A");
+    auto clause = mk<Clause>("A");
+    auto headAtom = clause->getHead();
     headAtom->addArgument(std::move(headArgument));
-    auto clause = mk<Clause>();
-    clause->setHead(std::move(headAtom));
     return clause;
 }
 

--- a/src/ast/tests/ast_program_test.cpp
+++ b/src/ast/tests/ast_program_test.cpp
@@ -94,7 +94,7 @@ TEST(Program, Parse) {
         Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(DL, e, d); \
         Program& program = tu->getProgram();                                    \
         EXPECT_EQ(program, program);                                            \
-        Own<Program> clone(program.clone());                                    \
+        Own<Program> clone(souffle::clone(program));                            \
         EXPECT_NE(clone.get(), &program);                                       \
         EXPECT_EQ(*clone, program);                                             \
     }

--- a/src/ast/tests/ast_program_test.cpp
+++ b/src/ast/tests/ast_program_test.cpp
@@ -48,10 +48,9 @@ inline Own<TranslationUnit> makeATU(std::string program) {
 }
 
 inline Own<Clause> makeClause(std::string name, Own<Argument> headArgument) {
-    auto headAtom = mk<Atom>(name);
+    auto clause = mk<Clause>(name);
+    auto headAtom = clause->getHead();
     headAtom->addArgument(std::move(headArgument));
-    auto clause = mk<Clause>();
-    clause->setHead(std::move(headAtom));
     return clause;
 }
 

--- a/src/ast/tests/ast_utils_test.cpp
+++ b/src/ast/tests/ast_utils_test.cpp
@@ -48,17 +48,16 @@ namespace test {
 
 TEST(AstUtils, Grounded) {
     // create an example clause:
-    auto clause = mk<Clause>();
+    auto clause = mk<Clause>("r");
 
     // something like:
     //   r(X,Y,Z) :- a(X), X = Y, !b(Z).
 
     // r(X,Y,Z)
-    auto* head = new Atom("r");
+    auto* head = clause->getHead();
     head->addArgument(Own<Argument>(new Variable("X")));
     head->addArgument(Own<Argument>(new Variable("Y")));
     head->addArgument(Own<Argument>(new Variable("Z")));
-    clause->setHead(Own<Atom>(head));
 
     // a(X)
     auto* a = new Atom("a");

--- a/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
+++ b/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
@@ -47,15 +47,13 @@ bool AddNullariesToAtomlessAggregatesTransformer::transform(TranslationUnit& tra
         // We will add in the Tautology atom to the body of this aggregate now
         changed = true;
         // +Tautology()
-        std::string relName = "+Tautology";
-        auto nullaryAtom = mk<Atom>(relName);
+        std::string const relName = "+Tautology";
 
         if (getRelation(program, relName) == nullptr) {
             // +Tautology().
-            auto fact = mk<Clause>(souffle::clone(nullaryAtom));
+            auto fact = mk<Clause>(relName);
             // .decl +Tautology()
-            auto tautologyRel = mk<Relation>();
-            tautologyRel->setQualifiedName(relName);
+            auto tautologyRel = mk<Relation>(relName);
             program.addRelation(std::move(tautologyRel));
             program.addClause(std::move(fact));
         }
@@ -63,7 +61,7 @@ bool AddNullariesToAtomlessAggregatesTransformer::transform(TranslationUnit& tra
         for (const auto& lit : agg.getBodyLiterals()) {
             newBody.push_back(souffle::clone(lit));
         }
-        newBody.push_back(souffle::clone(nullaryAtom));
+        newBody.push_back(mk<Atom>(relName));
         agg.setBody(std::move(newBody));
     });
     return changed;

--- a/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
+++ b/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
@@ -34,7 +34,7 @@ namespace souffle::ast::transform {
 bool AddNullariesToAtomlessAggregatesTransformer::transform(TranslationUnit& translationUnit) {
     bool changed{false};
     Program& program = translationUnit.getProgram();
-    visitDepthFirst(program, [&](const Aggregator& agg) {
+    visitDepthFirst(program, [&](Aggregator& agg) {
         bool seenAtom{false};
         for (const auto& literal : agg.getBodyLiterals()) {
             if (isA<Atom>(literal)) {
@@ -66,7 +66,7 @@ bool AddNullariesToAtomlessAggregatesTransformer::transform(TranslationUnit& tra
             newBody.push_back(souffle::clone(lit));
         }
         newBody.push_back(souffle::clone(nullaryAtom));
-        const_cast<Aggregator&>(agg).setBody(std::move(newBody));
+        agg.setBody(std::move(newBody));
     });
     return changed;
 }

--- a/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
+++ b/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
@@ -47,14 +47,12 @@ bool AddNullariesToAtomlessAggregatesTransformer::transform(TranslationUnit& tra
         // We will add in the Tautology atom to the body of this aggregate now
         changed = true;
         // +Tautology()
-        auto nullaryAtom = mk<Atom>();
         std::string relName = "+Tautology";
-        nullaryAtom->setQualifiedName(relName);
+        auto nullaryAtom = mk<Atom>(relName);
 
         if (getRelation(program, relName) == nullptr) {
             // +Tautology().
-            auto fact = mk<Clause>();
-            fact->setHead(souffle::clone(nullaryAtom));
+            auto fact = mk<Clause>(souffle::clone(nullaryAtom));
             // .decl +Tautology()
             auto tautologyRel = mk<Relation>();
             tautologyRel->setQualifiedName(relName);

--- a/src/ast/transform/AddNullariesToAtomlessAggregates.h
+++ b/src/ast/transform/AddNullariesToAtomlessAggregates.h
@@ -37,11 +37,11 @@ public:
         return "AddNullariesToAtomlessAggregatesTransformer";
     }
 
-    AddNullariesToAtomlessAggregatesTransformer* clone() const override {
+private:
+    AddNullariesToAtomlessAggregatesTransformer* cloneImpl() const override {
         return new AddNullariesToAtomlessAggregatesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/ComponentChecker.h
+++ b/src/ast/transform/ComponentChecker.h
@@ -37,11 +37,11 @@ public:
         return "ComponentChecker";
     }
 
-    ComponentChecker* clone() const override {
+private:
+    ComponentChecker* cloneImpl() const override {
         return new ComponentChecker();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     static const Component* checkComponentNameReference(ErrorReport& report,

--- a/src/ast/transform/ComponentInstantiation.cpp
+++ b/src/ast/transform/ComponentInstantiation.cpp
@@ -123,8 +123,7 @@ struct ComponentContent {
  */
 ComponentContent getInstantiatedContent(Program& program, const ComponentInit& componentInit,
         const Component* enclosingComponent, const ComponentLookupAnalysis& componentLookup,
-        VecOwn<Clause>& orphans, ErrorReport& report,
-        const TypeBinding& binding = analysis::TypeBinding(),
+        VecOwn<Clause>& orphans, ErrorReport& report, const TypeBinding& binding = analysis::TypeBinding(),
         unsigned int maxDepth = MAX_INSTANTIATION_DEPTH);
 
 /**
@@ -271,8 +270,7 @@ void collectContent(Program& program, const Component& component, const TypeBind
 
 ComponentContent getInstantiatedContent(Program& program, const ComponentInit& componentInit,
         const Component* enclosingComponent, const ComponentLookupAnalysis& componentLookup,
-        VecOwn<Clause>& orphans, ErrorReport& report, const TypeBinding& binding,
-        unsigned int maxDepth) {
+        VecOwn<Clause>& orphans, ErrorReport& report, const TypeBinding& binding, unsigned int maxDepth) {
     // start with an empty list
     ComponentContent res;
 

--- a/src/ast/transform/ComponentInstantiation.cpp
+++ b/src/ast/transform/ComponentInstantiation.cpp
@@ -55,10 +55,10 @@ static const unsigned int MAX_INSTANTIATION_DEPTH = 1000;
  * A container type for the (instantiated) content of a component.
  */
 struct ComponentContent {
-    std::vector<Own<ast::Type>> types;
-    std::vector<Own<Relation>> relations;
-    std::vector<Own<Directive>> directives;
-    std::vector<Own<Clause>> clauses;
+    VecOwn<ast::Type> types;
+    VecOwn<Relation> relations;
+    VecOwn<Directive> directives;
+    VecOwn<Clause> clauses;
 
     void add(Own<ast::Type>& type, ErrorReport& report) {
         // add to result content (check existence first)
@@ -123,7 +123,7 @@ struct ComponentContent {
  */
 ComponentContent getInstantiatedContent(Program& program, const ComponentInit& componentInit,
         const Component* enclosingComponent, const ComponentLookupAnalysis& componentLookup,
-        std::vector<Own<Clause>>& orphans, ErrorReport& report,
+        VecOwn<Clause>& orphans, ErrorReport& report,
         const TypeBinding& binding = analysis::TypeBinding(),
         unsigned int maxDepth = MAX_INSTANTIATION_DEPTH);
 
@@ -132,7 +132,7 @@ ComponentContent getInstantiatedContent(Program& program, const ComponentInit& c
  */
 void collectContent(Program& program, const Component& component, const TypeBinding& binding,
         const Component* enclosingComponent, const ComponentLookupAnalysis& componentLookup,
-        ComponentContent& res, std::vector<Own<Clause>>& orphans, const std::set<std::string>& overridden,
+        ComponentContent& res, VecOwn<Clause>& orphans, const std::set<std::string>& overridden,
         ErrorReport& report, unsigned int maxInstantiationDepth) {
     // start with relations and clauses of the base components
     for (const auto& base : component.getBaseComponents()) {
@@ -271,7 +271,7 @@ void collectContent(Program& program, const Component& component, const TypeBind
 
 ComponentContent getInstantiatedContent(Program& program, const ComponentInit& componentInit,
         const Component* enclosingComponent, const ComponentLookupAnalysis& componentLookup,
-        std::vector<Own<Clause>>& orphans, ErrorReport& report, const TypeBinding& binding,
+        VecOwn<Clause>& orphans, ErrorReport& report, const TypeBinding& binding,
         unsigned int maxDepth) {
     // start with an empty list
     ComponentContent res;
@@ -436,7 +436,7 @@ bool ComponentInstantiationTransformer::transform(TranslationUnit& translationUn
     auto* componentLookup = translationUnit.getAnalysis<ComponentLookupAnalysis>();
 
     for (const auto* cur : program.getComponentInstantiations()) {
-        std::vector<Own<Clause>> orphans;
+        VecOwn<Clause> orphans;
 
         auto content = getInstantiatedContent(program, *cur, nullptr, *componentLookup, orphans, report);
         if (report.getNumErrors() != 0) continue;

--- a/src/ast/transform/ComponentInstantiation.cpp
+++ b/src/ast/transform/ComponentInstantiation.cpp
@@ -183,7 +183,7 @@ void collectContent(Program& program, const Component& component, const TypeBind
     // and continue with the local types
     for (const auto& cur : component.getTypes()) {
         // create a clone
-        Own<ast::Type> type(cur->clone());
+        Own<ast::Type> type(souffle::clone(cur));
 
         // instantiate elements of union types
         visitDepthFirst(*type, [&](ast::UnionType& type) {
@@ -212,7 +212,7 @@ void collectContent(Program& program, const Component& component, const TypeBind
     // and the local relations
     for (const auto& cur : component.getRelations()) {
         // create a clone
-        Own<Relation> rel(cur->clone());
+        Own<Relation> rel(souffle::clone(cur));
 
         // update attribute types
         for (Attribute* attr : rel->getAttributes()) {
@@ -229,7 +229,7 @@ void collectContent(Program& program, const Component& component, const TypeBind
     // and the local directive directives
     for (const auto& directive : component.getDirectives()) {
         // create a clone
-        Own<Directive> instantiatedIO(directive->clone());
+        Own<Directive> instantiatedIO(souffle::clone(directive));
 
         res.add(instantiatedIO, report);
     }
@@ -246,10 +246,10 @@ void collectContent(Program& program, const Component& component, const TypeBind
         if (overridden.count(cur->getHead()->getQualifiedName().getQualifiers()[0]) == 0) {
             Relation* rel = index[cur->getHead()->getQualifiedName()];
             if (rel != nullptr) {
-                Own<Clause> instantiatedClause(cur->clone());
+                Own<Clause> instantiatedClause(souffle::clone(cur));
                 res.add(instantiatedClause, report);
             } else {
-                orphans.emplace_back(cur->clone());
+                orphans.emplace_back(souffle::clone(cur));
             }
         }
     }
@@ -260,7 +260,7 @@ void collectContent(Program& program, const Component& component, const TypeBind
         Relation* rel = index[cur->getHead()->getQualifiedName()];
         if (rel != nullptr) {
             // add orphan to current instance and delete from orphan list
-            Own<Clause> instantiatedClause(cur->clone());
+            Own<Clause> instantiatedClause(souffle::clone(cur));
             res.add(instantiatedClause, report);
             iter = orphans.erase(iter);
         } else {

--- a/src/ast/transform/ComponentInstantiation.h
+++ b/src/ast/transform/ComponentInstantiation.h
@@ -26,11 +26,11 @@ public:
         return "ComponentInstantiationTransformer";
     }
 
-    ComponentInstantiationTransformer* clone() const override {
+private:
+    ComponentInstantiationTransformer* cloneImpl() const override {
         return new ComponentInstantiationTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/Conditional.h
+++ b/src/ast/transform/Conditional.h
@@ -47,7 +47,7 @@ public:
     }
 
     void setDebugReport() override {
-        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+        if (auto* mt = as<MetaTransformer>(transformer)) {
             mt->setDebugReport();
         } else {
             transformer = mk<DebugReporter>(std::move(transformer));
@@ -56,13 +56,13 @@ public:
 
     void setVerbosity(bool verbose) override {
         this->verbose = verbose;
-        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+        if (auto* mt = as<MetaTransformer>(transformer)) {
             mt->setVerbosity(verbose);
         }
     }
 
     void disableTransformers(const std::set<std::string>& transforms) override {
-        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+        if (auto* mt = as<MetaTransformer>(transformer)) {
             mt->disableTransformers(transforms);
         } else if (transforms.find(transformer->getName()) != transforms.end()) {
             transformer = mk<NullTransformer>();

--- a/src/ast/transform/Conditional.h
+++ b/src/ast/transform/Conditional.h
@@ -73,17 +73,18 @@ public:
         return "ConditionalTransformer";
     }
 
-    ConditionalTransformer* clone() const override {
+private:
+    ConditionalTransformer* cloneImpl() const override {
         return new ConditionalTransformer(condition, souffle::clone(transformer));
+    }
+
+    bool transform(TranslationUnit& translationUnit) override {
+        return condition() ? applySubtransformer(translationUnit, transformer.get()) : false;
     }
 
 private:
     std::function<bool()> condition;
     Own<Transformer> transformer;
-
-    bool transform(TranslationUnit& translationUnit) override {
-        return condition() ? applySubtransformer(translationUnit, transformer.get()) : false;
-    }
 };
 
 }  // namespace souffle::ast::transform

--- a/src/ast/transform/DebugReporter.h
+++ b/src/ast/transform/DebugReporter.h
@@ -46,13 +46,13 @@ public:
 
     void setVerbosity(bool verbose) override {
         this->verbose = verbose;
-        if (auto* mt = dynamic_cast<MetaTransformer*>(wrappedTransformer.get())) {
+        if (auto* mt = as<MetaTransformer>(wrappedTransformer)) {
             mt->setVerbosity(verbose);
         }
     }
 
     void disableTransformers(const std::set<std::string>& transforms) override {
-        if (auto* mt = dynamic_cast<MetaTransformer*>(wrappedTransformer.get())) {
+        if (auto* mt = as<MetaTransformer>(wrappedTransformer)) {
             mt->disableTransformers(transforms);
         } else if (transforms.find(wrappedTransformer->getName()) != transforms.end()) {
             wrappedTransformer = mk<NullTransformer>();

--- a/src/ast/transform/DebugReporter.h
+++ b/src/ast/transform/DebugReporter.h
@@ -63,7 +63,7 @@ public:
         return "DebugReporter";
     }
 
-    DebugReporter* clone() const override {
+    DebugReporter* cloneImpl() const override {
         return new DebugReporter(souffle::clone(wrappedTransformer));
     }
 

--- a/src/ast/transform/ExecutionPlanChecker.h
+++ b/src/ast/transform/ExecutionPlanChecker.h
@@ -28,11 +28,11 @@ public:
         return "ExecutionPlanChecker";
     }
 
-    ExecutionPlanChecker* clone() const override {
+private:
+    ExecutionPlanChecker* cloneImpl() const override {
         return new ExecutionPlanChecker();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/Fixpoint.h
+++ b/src/ast/transform/Fixpoint.h
@@ -68,12 +68,11 @@ public:
         return "FixpointTransformer";
     }
 
-    FixpointTransformer* clone() const override {
+private:
+    FixpointTransformer* cloneImpl() const override {
         return new FixpointTransformer(souffle::clone(transformer));
     }
 
-private:
-    Own<Transformer> transformer;
     bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
         while (applySubtransformer(translationUnit, transformer.get())) {
@@ -81,6 +80,9 @@ private:
         }
         return changed;
     }
+
+private:
+    Own<Transformer> transformer;
 };
 
 }  // namespace souffle::ast::transform

--- a/src/ast/transform/Fixpoint.h
+++ b/src/ast/transform/Fixpoint.h
@@ -38,7 +38,7 @@ public:
     FixpointTransformer(Own<Transformer> transformer) : transformer(std::move(transformer)) {}
 
     void setDebugReport() override {
-        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+        if (auto* mt = as<MetaTransformer>(transformer)) {
             mt->setDebugReport();
         } else {
             transformer = mk<DebugReporter>(std::move(transformer));
@@ -51,13 +51,13 @@ public:
 
     void setVerbosity(bool verbose) override {
         this->verbose = verbose;
-        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+        if (auto* mt = as<MetaTransformer>(transformer)) {
             mt->setVerbosity(verbose);
         }
     }
 
     void disableTransformers(const std::set<std::string>& transforms) override {
-        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+        if (auto* mt = as<MetaTransformer>(transformer)) {
             mt->disableTransformers(transforms);
         } else if (transforms.find(transformer->getName()) != transforms.end()) {
             transformer = mk<NullTransformer>();

--- a/src/ast/transform/FoldAnonymousRecords.cpp
+++ b/src/ast/transform/FoldAnonymousRecords.cpp
@@ -35,7 +35,7 @@
 namespace souffle::ast::transform {
 
 bool FoldAnonymousRecords::isValidRecordConstraint(const Literal* literal) {
-    auto constraint = dynamic_cast<const BinaryConstraint*>(literal);
+    auto constraint = as<BinaryConstraint>(literal);
 
     if (constraint == nullptr) {
         return false;
@@ -44,8 +44,8 @@ bool FoldAnonymousRecords::isValidRecordConstraint(const Literal* literal) {
     const auto* left = constraint->getLHS();
     const auto* right = constraint->getRHS();
 
-    const auto* leftRecord = dynamic_cast<const RecordInit*>(left);
-    const auto* rightRecord = dynamic_cast<const RecordInit*>(right);
+    const auto* leftRecord = as<RecordInit>(left);
+    const auto* rightRecord = as<RecordInit>(right);
 
     // Check if arguments are records records.
     if ((leftRecord == nullptr) || (rightRecord == nullptr)) {
@@ -74,8 +74,8 @@ bool FoldAnonymousRecords::containsValidRecordConstraint(const Clause& clause) {
 VecOwn<Literal> FoldAnonymousRecords::expandRecordBinaryConstraint(const BinaryConstraint& constraint) {
     VecOwn<Literal> replacedContraint;
 
-    const auto* left = dynamic_cast<RecordInit*>(constraint.getLHS());
-    const auto* right = dynamic_cast<RecordInit*>(constraint.getRHS());
+    const auto* left = as<RecordInit>(constraint.getLHS());
+    const auto* right = as<RecordInit>(constraint.getRHS());
     assert(left != nullptr && "Non-record passed to record method");
     assert(right != nullptr && "Non-record passed to record method");
 
@@ -111,7 +111,7 @@ void FoldAnonymousRecords::transformClause(const Clause& clause, VecOwn<Clause>&
     VecOwn<Literal> newBody;
     for (auto* literal : clause.getBodyLiterals()) {
         if (isValidRecordConstraint(literal)) {
-            const BinaryConstraint& constraint = dynamic_cast<BinaryConstraint&>(*literal);
+            auto& constraint = asAssert<BinaryConstraint>(literal);
 
             // Simple case, [a_0, ..., a_n] = [b_0, ..., b_n]
             if (isEqConstraint(constraint.getBaseOperator())) {
@@ -122,7 +122,7 @@ void FoldAnonymousRecords::transformClause(const Clause& clause, VecOwn<Clause>&
                 // else if: Case [a_0, ..., a_n] != [b_0, ..., b_n].
                 // track single such case, it will be expanded in the end.
             } else if (neqConstraint == nullptr) {
-                neqConstraint = dynamic_cast<BinaryConstraint*>(literal);
+                neqConstraint = as<BinaryConstraint>(literal);
 
                 // Else: repeated inequality.
             } else {

--- a/src/ast/transform/FoldAnonymousRecords.cpp
+++ b/src/ast/transform/FoldAnonymousRecords.cpp
@@ -137,7 +137,7 @@ void FoldAnonymousRecords::transformClause(const Clause& clause, VecOwn<Clause>&
 
     // If no inequality: create a single modified clause.
     if (neqConstraint == nullptr) {
-        auto newClause = souffle::clone(&clause);
+        auto newClause = souffle::clone(clause);
         newClause->setBodyLiterals(std::move(newBody));
         newClauses.emplace_back(std::move(newClause));
 
@@ -146,7 +146,7 @@ void FoldAnonymousRecords::transformClause(const Clause& clause, VecOwn<Clause>&
         auto transformedLiterals = expandRecordBinaryConstraint(*neqConstraint);
 
         for (auto it = begin(transformedLiterals); it != end(transformedLiterals); ++it) {
-            auto newClause = souffle::clone(&clause);
+            auto newClause = souffle::clone(clause);
             auto copyBody = souffle::clone(newBody);
             copyBody.push_back(std::move(*it));
 

--- a/src/ast/transform/FoldAnonymousRecords.cpp
+++ b/src/ast/transform/FoldAnonymousRecords.cpp
@@ -168,7 +168,7 @@ bool FoldAnonymousRecords::transform(TranslationUnit& translationUnit) {
             changed = true;
             transformClause(*clause, newClauses);
         } else {
-            newClauses.emplace_back(clause->clone());
+            newClauses.emplace_back(souffle::clone(clause));
         }
     }
 

--- a/src/ast/transform/FoldAnonymousRecords.h
+++ b/src/ast/transform/FoldAnonymousRecords.h
@@ -51,11 +51,11 @@ public:
         return "FoldAnonymousRecords";
     }
 
-    FoldAnonymousRecords* clone() const override {
+private:
+    FoldAnonymousRecords* cloneImpl() const override {
         return new FoldAnonymousRecords();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /**

--- a/src/ast/transform/GroundWitnesses.cpp
+++ b/src/ast/transform/GroundWitnesses.cpp
@@ -67,7 +67,7 @@ bool GroundWitnessesTransformer::transform(TranslationUnit& translationUnit) {
         // not to use it after that point.
         // 1. make a copy of all aggregate body literals, because they will need to
         // be added to the rule body
-        std::vector<std::unique_ptr<Literal>> aggregateLiterals;
+        VecOwn<Literal> aggregateLiterals;
         for (const auto& literal : agg->getBodyLiterals()) {
             aggregateLiterals.push_back(souffle::clone(literal));
         }

--- a/src/ast/transform/GroundWitnesses.cpp
+++ b/src/ast/transform/GroundWitnesses.cpp
@@ -93,7 +93,7 @@ bool GroundWitnessesTransformer::transform(TranslationUnit& translationUnit) {
             TargetVariableReplacer(Aggregator* agg, std::string target)
                     : aggregate(agg), targetVariable(std::move(target)) {}
             std::unique_ptr<Node> operator()(std::unique_ptr<Node> node) const override {
-                if (auto* variable = dynamic_cast<Variable*>(node.get())) {
+                if (auto* variable = as<Variable>(node)) {
                     if (variable->getName() == targetVariable) {
                         auto replacement = souffle::clone(aggregate);
                         return replacement;
@@ -103,7 +103,7 @@ bool GroundWitnessesTransformer::transform(TranslationUnit& translationUnit) {
                 return node;
             }
         };
-        const auto* targetVariable = dynamic_cast<const Variable*>(agg->getTargetExpression());
+        const auto* targetVariable = as<Variable>(agg->getTargetExpression());
         std::string targetVariableName = targetVariable->getName();
         TargetVariableReplacer replacer(agg, targetVariableName);
         for (std::unique_ptr<Literal>& literal : aggregateLiterals) {

--- a/src/ast/transform/GroundWitnesses.h
+++ b/src/ast/transform/GroundWitnesses.h
@@ -45,11 +45,11 @@ public:
         return "GroundWitnessesTransformer";
     }
 
-    GroundWitnessesTransformer* clone() const override {
+private:
+    GroundWitnessesTransformer* cloneImpl() const override {
         return new GroundWitnessesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/GroundedTermsChecker.h
+++ b/src/ast/transform/GroundedTermsChecker.h
@@ -31,11 +31,11 @@ public:
     // `apply` but doesn't immediately bail if any errors are found.
     void verify(TranslationUnit& translationUnit);
 
-    GroundedTermsChecker* clone() const override {
+private:
+    GroundedTermsChecker* cloneImpl() const override {
         return new GroundedTermsChecker();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         verify(translationUnit);
         return false;

--- a/src/ast/transform/IOAttributes.h
+++ b/src/ast/transform/IOAttributes.h
@@ -56,11 +56,11 @@ public:
         return "IOAttributesTransformer";
     }
 
-    IOAttributesTransformer* clone() const override {
+private:
+    IOAttributesTransformer* cloneImpl() const override {
         return new IOAttributesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
 

--- a/src/ast/transform/IOAttributes.h
+++ b/src/ast/transform/IOAttributes.h
@@ -200,9 +200,7 @@ private:
         std::map<std::string, json11::Json> sumTypes;
 
         visitDepthFirst(program.getTypes(), [&](const AlgebraicDataType& astAlgebraicDataType) {
-            auto& sumType =
-                    dynamic_cast<const analysis::AlgebraicDataType&>(typeEnv.getType(astAlgebraicDataType));
-
+            auto& sumType = asAssert<analysis::AlgebraicDataType>(typeEnv.getType(astAlgebraicDataType));
             auto& branches = sumType.getBranches();
 
             std::vector<json11::Json> branchesInfo;

--- a/src/ast/transform/IODefaults.h
+++ b/src/ast/transform/IODefaults.h
@@ -38,11 +38,11 @@ public:
         return "IODefaultsTransformer";
     }
 
-    IODefaultsTransformer* clone() const override {
+private:
+    IODefaultsTransformer* cloneImpl() const override {
         return new IODefaultsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
 

--- a/src/ast/transform/InlineRelations.cpp
+++ b/src/ast/transform/InlineRelations.cpp
@@ -96,9 +96,8 @@ bool normaliseInlinedHeads(Program& program) {
 
         for (Clause* clause : getClauses(program, *rel)) {
             // Set up the new clause with an empty body and no arguments in the head
-            auto newClause = mk<Clause>();
-            newClause->setSrcLoc(clause->getSrcLoc());
-            auto clauseHead = mk<Atom>(clause->getHead()->getQualifiedName());
+            auto newClause = mk<Clause>(clause->getHead()->getQualifiedName(), clause->getSrcLoc());
+            auto clauseHead = newClause->getHead();
 
             // Add in everything in the original body
             for (Literal* lit : clause->getBodyLiterals()) {
@@ -121,8 +120,6 @@ bool normaliseInlinedHeads(Program& program) {
                     clauseHead->addArgument(souffle::clone(arg));
                 }
             }
-
-            newClause->setHead(std::move(clauseHead));
 
             // Replace the old clause with this one
             program.addClause(std::move(newClause));
@@ -663,13 +660,12 @@ NullableVector<Argument*> getInlinedArgument(Program& program, const Argument* a
                         ++j;
                     }
                     if (const auto* intrFunc = as<IntrinsicFunctor>(arg)) {
-                        auto* newFunctor =
-                                new IntrinsicFunctor(intrFunc->getBaseFunctionOp(), std::move(argsCopy));
-                        newFunctor->setSrcLoc(functor->getSrcLoc());
+                        auto* newFunctor = new IntrinsicFunctor(
+                                intrFunc->getBaseFunctionOp(), std::move(argsCopy), functor->getSrcLoc());
                         versions.push_back(newFunctor);
                     } else if (const auto* userFunc = as<UserDefinedFunctor>(arg)) {
-                        auto* newFunctor = new UserDefinedFunctor(userFunc->getName(), std::move(argsCopy));
-                        newFunctor->setSrcLoc(userFunc->getSrcLoc());
+                        auto* newFunctor = new UserDefinedFunctor(
+                                userFunc->getName(), std::move(argsCopy), userFunc->getSrcLoc());
                         versions.push_back(newFunctor);
                     }
                 }
@@ -923,17 +919,15 @@ std::vector<Clause*> getInlinedClause(Program& program, const Clause& clause) {
 
         // Produce the new clauses with the replacement head atoms
         for (Atom* newHead : headVersions.getVector()) {
-            auto* newClause = new Clause();
-            newClause->setSrcLoc(clause.getSrcLoc());
-
-            newClause->setHead(Own<Atom>(newHead));
+            auto newClause = mk<Clause>(Own<Atom>(newHead), clause.getSrcLoc());
 
             // The body will remain unchanged
             for (Literal* lit : clause.getBodyLiterals()) {
                 newClause->addToBody(souffle::clone(lit));
             }
 
-            versions.push_back(newClause);
+            // FIXME: tomp - hack - this should be managed
+            versions.push_back(newClause.release());
         }
     }
 
@@ -962,7 +956,7 @@ std::vector<Clause*> getInlinedClause(Program& program, const Clause& clause) {
                 std::vector<std::vector<Literal*>> bodyVersions = litVersions.getVector();
 
                 // Create the base clause with the current literal removed
-                auto baseClause = Own<Clause>(cloneHead(&clause));
+                auto baseClause = cloneHead(clause);
                 for (Literal* oldLit : bodyLiterals) {
                     if (currLit != oldLit) {
                         baseClause->addToBody(souffle::clone(oldLit));

--- a/src/ast/transform/InlineRelations.cpp
+++ b/src/ast/transform/InlineRelations.cpp
@@ -960,7 +960,7 @@ std::vector<Clause*> getInlinedClause(Program& program, const Clause& clause) {
 
                     // Add in the current set of literals replacing the inlined literal
                     // In Case 2, each body contains exactly one literal
-                    replacementClause->setBodyLiterals(VecOwn<Literal>(body.begin(), body.end()));
+                    replacementClause->addToBody(VecOwn<Literal>(body.begin(), body.end()));
 
                     // FIXME: This is a horrible hack.  Should convert
                     // versions to hold Own<>

--- a/src/ast/transform/InlineRelations.h
+++ b/src/ast/transform/InlineRelations.h
@@ -31,11 +31,11 @@ public:
         return "InlineRelationsTransformer";
     }
 
-    InlineRelationsTransformer* clone() const override {
+private:
+    InlineRelationsTransformer* cloneImpl() const override {
         return new InlineRelationsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/MagicSet.cpp
+++ b/src/ast/transform/MagicSet.cpp
@@ -535,13 +535,9 @@ bool NormaliseDatabaseTransformer::normaliseArguments(TranslationUnit& translati
                 aggr->apply(aggrUpdate);
 
                 // Add the constraints to this level
-                std::vector<Own<Literal>> newBodyLiterals;
-                for (const auto* lit : aggr->getBodyLiterals()) {
-                    newBodyLiterals.push_back(souffle::clone(lit));
-                }
-                for (auto& constr : subConstraints) {
-                    newBodyLiterals.push_back(souffle::clone(constr));
-                }
+                VecOwn<Literal> newBodyLiterals;
+                append(newBodyLiterals, souffle::cloneRange(aggr->getBodyLiterals()));
+                append(newBodyLiterals, souffle::cloneRange(subConstraints));
 
                 // Update the node to reflect normalised aggregator
                 node = aggr->getTargetExpression() != nullptr
@@ -604,11 +600,7 @@ bool NormaliseDatabaseTransformer::normaliseArguments(TranslationUnit& translati
             }
         });
 
-        // Add each necessary new constraint to the clause
-        for (auto& constraint : constraintsToAdd) {
-            clause->addToBody(souffle::clone(constraint));
-        }
-
+        clause->addToBody(souffle::clone<Literal>(constraintsToAdd));
         changed |= changeCount != 0;
     }
 
@@ -676,7 +668,7 @@ Own<Clause> AdornDatabaseTransformer::adornClause(const Clause* clause, const st
     }
 
     // Add in adorned body literals
-    std::vector<Own<Literal>> adornedBodyLiterals;
+    VecOwn<Literal> adornedBodyLiterals;
     for (const auto* lit : clause->getBodyLiterals()) {
         if (const auto* negation = as<Negation>(lit)) {
             // Negated atoms should not be adorned, but their clauses should be anyway
@@ -1096,15 +1088,12 @@ void MagicSetCoreTransformer::addRelevantVariables(
 }
 
 Own<Clause> MagicSetCoreTransformer::createMagicClause(const Atom* atom,
-        const std::vector<Own<Atom>>& constrainingAtoms,
+        const VecOwn<Atom>& constrainingAtoms,
         const std::vector<const BinaryConstraint*> eqConstraints) {
     auto magicClause = mk<Clause>(createMagicAtom(atom));
-    auto magicHead = magicClause->getHead();
-
     // Add in all constraining atoms
-    for (const auto& bindingAtom : constrainingAtoms) {
-        magicClause->addToBody(souffle::clone(bindingAtom));
-    }
+    magicClause->setBodyLiterals(souffle::clone<Literal>(constrainingAtoms));
+    auto magicHead = magicClause->getHead();
 
     // Get the set of all variables that will be relevant to the magic clause
     std::set<std::string> relevantVariables;
@@ -1166,15 +1155,13 @@ bool MagicSetCoreTransformer::transform(TranslationUnit& translationUnit) {
             auto magicAtom = createMagicAtom(head);
             auto refinedClause = mk<Clause>(souffle::clone(head));
             refinedClause->addToBody(souffle::clone(magicAtom));
-            for (auto* literal : clause->getBodyLiterals()) {
-                refinedClause->addToBody(souffle::clone(literal));
-            }
+            refinedClause->addToBody(souffle::clone(clause->getBodyLiterals()));
             clausesToAdd.insert(std::move(refinedClause));
         }
 
         // (2) Add the associated magic rules
         std::vector<const BinaryConstraint*> eqConstraints = getBindingEqualityConstraints(clause);
-        std::vector<Own<Atom>> atomsToTheLeft;
+        VecOwn<Atom> atomsToTheLeft;
         if (isAdorned(relName)) {
             // Add the specialising head atom
             // Output relations are not specialised, and so the head will not contribute to specialisation

--- a/src/ast/transform/MagicSet.cpp
+++ b/src/ast/transform/MagicSet.cpp
@@ -528,7 +528,7 @@ bool NormaliseDatabaseTransformer::normaliseArguments(TranslationUnit& translati
                 : constraints(constraints), changeCount(changeCount) {}
 
         Own<Node> operator()(Own<Node> node) const override {
-            if (auto* aggr = dynamic_cast<Aggregator*>(node.get())) {
+            if (auto* aggr = as<Aggregator>(node)) {
                 // Aggregator variable scopes should be maintained, so changes shouldn't propagate
                 // above this level.
                 std::set<Own<BinaryConstraint>> subConstraints;
@@ -556,7 +556,7 @@ bool NormaliseDatabaseTransformer::normaliseArguments(TranslationUnit& translati
             }
 
             // All non-variables should be normalised
-            if (auto* arg = dynamic_cast<Argument*>(node.get())) {
+            if (auto* arg = as<Argument>(node)) {
                 if (!isA<ast::Variable>(arg)) {
                     std::stringstream name;
                     name << "@abdul" << changeCount++;
@@ -590,7 +590,7 @@ bool NormaliseDatabaseTransformer::normaliseArguments(TranslationUnit& translati
 
         // Apply to each body literal that isn't already a `<var> = <arg>` constraint
         for (Literal* lit : clause->getBodyLiterals()) {
-            if (auto* bc = dynamic_cast<BinaryConstraint*>(lit)) {
+            if (auto* bc = as<BinaryConstraint>(lit)) {
                 if (isEqConstraint(bc->getBaseOperator()) && isA<ast::Variable>(bc->getLHS())) {
                     continue;
                 }
@@ -649,7 +649,7 @@ Own<Clause> AdornDatabaseTransformer::adornClause(const Clause* clause, const st
      * Therefore, bound head atom vars should be marked as weakly bound.
      */
     for (size_t i = 0; i < adornmentMarker.length(); i++) {
-        const auto* var = dynamic_cast<ast::Variable*>(headArgs[i]);
+        const auto* var = as<ast::Variable>(headArgs[i]);
         assert(var != nullptr && "expected only variables in head");
         if (adornmentMarker[i] == 'b') {
             variableBindings.bindVariableWeakly(var->getName());
@@ -671,7 +671,7 @@ Own<Clause> AdornDatabaseTransformer::adornClause(const Clause* clause, const st
     assert((adornmentMarker == "" || headArgs.size() == adornmentMarker.length()) &&
             "adornment marker should correspond to head atom variables");
     for (const auto* arg : headArgs) {
-        const auto* var = dynamic_cast<const ast::Variable*>(arg);
+        const auto* var = as<ast::Variable>(arg);
         assert(var != nullptr && "expected only variables in head");
         adornedHeadAtom->addArgument(souffle::clone(var));
     }
@@ -680,7 +680,7 @@ Own<Clause> AdornDatabaseTransformer::adornClause(const Clause* clause, const st
     // Add in adorned body literals
     std::vector<Own<Literal>> adornedBodyLiterals;
     for (const auto* lit : clause->getBodyLiterals()) {
-        if (const auto* negation = dynamic_cast<const Negation*>(lit)) {
+        if (const auto* negation = as<Negation>(lit)) {
             // Negated atoms should not be adorned, but their clauses should be anyway
             const auto negatedAtomName = negation->getAtom()->getQualifiedName();
             assert(contains(weaklyIgnoredRelations, negatedAtomName) &&
@@ -694,14 +694,14 @@ Own<Clause> AdornDatabaseTransformer::adornClause(const Clause* clause, const st
             continue;
         }
 
-        const auto* atom = dynamic_cast<const Atom*>(lit);
+        const auto* atom = as<Atom>(lit);
         assert(atom != nullptr && "expected atom");
 
         // Form the appropriate adornment marker
         std::stringstream atomAdornment;
         if (!contains(weaklyIgnoredRelations, atom->getQualifiedName())) {
             for (const auto* arg : atom->getArguments()) {
-                const auto* var = dynamic_cast<const ast::Variable*>(arg);
+                const auto* var = as<ast::Variable>(arg);
                 assert(var != nullptr && "expected only variables in atom");
                 atomAdornment << (variableBindings.isBound(var->getName()) ? "b" : "f");
             }
@@ -718,7 +718,7 @@ Own<Clause> AdornDatabaseTransformer::adornClause(const Clause* clause, const st
 
         // All arguments are now bound
         for (const auto* arg : atom->getArguments()) {
-            const auto* var = dynamic_cast<const ast::Variable*>(arg);
+            const auto* var = as<ast::Variable>(arg);
             assert(var != nullptr && "expected only variables in atom");
             variableBindings.bindVariableStrongly(var->getName());
         }
@@ -1056,7 +1056,7 @@ void MagicSetCoreTransformer::addRelevantVariables(
 
     // Helper method to add all newly relevant variables given a lhs = rhs constraint
     auto addLocallyRelevantVariables = [&](const Argument* lhs, const Argument* rhs) {
-        const auto* lhsVar = dynamic_cast<const ast::Variable*>(lhs);
+        const auto* lhsVar = as<ast::Variable>(lhs);
         if (lhsVar == nullptr) return true;
 
         // if the rhs is fully bound, lhs is now bound
@@ -1071,9 +1071,9 @@ void MagicSetCoreTransformer::addRelevantVariables(
 
         // if the rhs is a record, and lhs is a bound var, then all rhs vars are bound
         bool fixpointReached = true;
-        if (const auto* rhsRec = dynamic_cast<const RecordInit*>(rhs)) {
+        if (const auto* rhsRec = as<RecordInit>(rhs)) {
             for (const auto* arg : rhsRec->getArguments()) {
-                const auto* subVar = dynamic_cast<const ast::Variable*>(arg);
+                const auto* subVar = as<ast::Variable>(arg);
                 assert(subVar != nullptr && "expected only variable arguments");
                 if (!contains(variables, subVar->getName())) {
                     fixpointReached = false;
@@ -1135,7 +1135,7 @@ std::vector<const BinaryConstraint*> MagicSetCoreTransformer::getBindingEquality
         const Clause* clause) {
     std::vector<const BinaryConstraint*> equalityConstraints;
     for (const auto* lit : clause->getBodyLiterals()) {
-        const auto* bc = dynamic_cast<const BinaryConstraint*>(lit);
+        const auto* bc = as<BinaryConstraint>(lit);
         if (bc == nullptr || !isEqConstraint(bc->getBaseOperator())) continue;
         if (isA<ast::Variable>(bc->getLHS()) || isA<Constant>(bc->getRHS())) {
             bool containsAggrs = false;
@@ -1185,7 +1185,7 @@ bool MagicSetCoreTransformer::transform(TranslationUnit& translationUnit) {
             atomsToTheLeft.push_back(createMagicAtom(clause->getHead()));
         }
         for (const auto* lit : clause->getBodyLiterals()) {
-            const auto* atom = dynamic_cast<const Atom*>(lit);
+            const auto* atom = as<Atom>(lit);
             if (atom == nullptr) continue;
             if (!isAdorned(atom->getQualifiedName())) {
                 atomsToTheLeft.push_back(souffle::clone(atom));

--- a/src/ast/transform/MagicSet.cpp
+++ b/src/ast/transform/MagicSet.cpp
@@ -1088,8 +1088,7 @@ void MagicSetCoreTransformer::addRelevantVariables(
 }
 
 Own<Clause> MagicSetCoreTransformer::createMagicClause(const Atom* atom,
-        const VecOwn<Atom>& constrainingAtoms,
-        const std::vector<const BinaryConstraint*> eqConstraints) {
+        const VecOwn<Atom>& constrainingAtoms, const std::vector<const BinaryConstraint*> eqConstraints) {
     auto magicClause = mk<Clause>(createMagicAtom(atom));
     // Add in all constraining atoms
     magicClause->setBodyLiterals(souffle::clone<Literal>(constrainingAtoms));

--- a/src/ast/transform/MagicSet.cpp
+++ b/src/ast/transform/MagicSet.cpp
@@ -817,11 +817,11 @@ bool NegativeLabellingTransformer::transform(TranslationUnit& translationUnit) {
         atom->setQualifiedName(getNegativeLabel(relName));
         relationsToLabel.insert(relName);
     });
-    visitDepthFirst(program, [&](const Aggregator& aggr) {
-        visitDepthFirst(aggr, [&](const Atom& atom) {
+    visitDepthFirst(program, [&](Aggregator& aggr) {
+        visitDepthFirst(aggr, [&](Atom& atom) {
             auto relName = atom.getQualifiedName();
             if (contains(relationsToNotLabel, relName)) return;
-            const_cast<Atom&>(atom).setQualifiedName(getNegativeLabel(relName));
+            atom.setQualifiedName(getNegativeLabel(relName));
             relationsToLabel.insert(relName);
         });
     });

--- a/src/ast/transform/MagicSet.h
+++ b/src/ast/transform/MagicSet.h
@@ -64,11 +64,11 @@ public:
         return "MagicSetTransformer";
     }
 
-    MagicSetTransformer* clone() const override {
+private:
+    MagicSetTransformer* cloneImpl() const override {
         return new MagicSetTransformer();
     }
 
-private:
     bool transform(TranslationUnit& tu) override {
         return shouldRun(tu) ? PipelineTransformer::transform(tu) : false;
     }
@@ -115,11 +115,11 @@ public:
         return "NormaliseDatabaseTransformer";
     }
 
-    NormaliseDatabaseTransformer* clone() const override {
+private:
+    NormaliseDatabaseTransformer* cloneImpl() const override {
         return new NormaliseDatabaseTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /**
@@ -168,11 +168,11 @@ public:
         return "LabelDatabaseTransformer";
     }
 
-    LabelDatabaseTransformer* clone() const override {
+private:
+    LabelDatabaseTransformer* cloneImpl() const override {
         return new LabelDatabaseTransformer();
     }
 
-private:
     /** Check if a relation is negatively labelled. */
     static bool isNegativelyLabelled(const QualifiedName& name);
 };
@@ -188,11 +188,11 @@ public:
         return "NegativeLabellingTransformer";
     }
 
-    NegativeLabellingTransformer* clone() const override {
+private:
+    NegativeLabellingTransformer* cloneImpl() const override {
         return new NegativeLabellingTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /** Provide a unique name for negatively-labelled relations. */
@@ -211,11 +211,11 @@ public:
         return "PositiveLabellingTransformer";
     }
 
-    PositiveLabellingTransformer* clone() const override {
+private:
+    PositiveLabellingTransformer* cloneImpl() const override {
         return new PositiveLabellingTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /** Provide a unique name for a positively labelled relation copy. */
@@ -233,11 +233,11 @@ public:
         return "AdornDatabaseTransformer";
     }
 
-    AdornDatabaseTransformer* clone() const override {
+private:
+    AdornDatabaseTransformer* cloneImpl() const override {
         return new AdornDatabaseTransformer();
     }
 
-private:
     using adorned_predicate = std::pair<QualifiedName, std::string>;
 
     std::set<adorned_predicate> headAdornmentsToDo;
@@ -289,11 +289,11 @@ public:
         return "MagicSetCoreTransformer";
     }
 
-    MagicSetCoreTransformer* clone() const override {
+private:
+    MagicSetCoreTransformer* cloneImpl() const override {
         return new MagicSetCoreTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /** Gets a unique magic identifier for a given adorned relation name */

--- a/src/ast/transform/MaterializeAggregationQueries.cpp
+++ b/src/ast/transform/MaterializeAggregationQueries.cpp
@@ -269,8 +269,8 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
         });
     });
 
-    visitDepthFirst(program, [&](const Clause& clause) {
-        visitDepthFirst(clause, [&](const Aggregator& agg) {
+    visitDepthFirst(program, [&](Clause& clause) {
+        visitDepthFirst(clause, [&](Aggregator& agg) {
             if (!needsMaterializedRelation(agg)) {
                 return;
             }
@@ -343,7 +343,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
 
             VecOwn<Literal> newBody;
             newBody.push_back(std::move(aggAtom));
-            const_cast<Aggregator&>(agg).setBody(std::move(newBody));
+            agg.setBody(std::move(newBody));
             // Now we can just add these new things (relation and its single clause) to the program
             program.addClause(std::move(aggClause));
             program.addRelation(std::move(aggRel));

--- a/src/ast/transform/MaterializeAggregationQueries.cpp
+++ b/src/ast/transform/MaterializeAggregationQueries.cpp
@@ -322,8 +322,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
             // so we should just quickly fetch the set of local variables for this aggregate.
             auto localVariables = analysis::getLocalVariables(translationUnit, clause, agg);
             if (agg.getTargetExpression() != nullptr) {
-                const auto* targetExpressionVariable =
-                        as<Variable>(agg.getTargetExpression());
+                const auto* targetExpressionVariable = as<Variable>(agg.getTargetExpression());
                 localVariables.erase(targetExpressionVariable->getName());
             }
             VecOwn<Argument> args;

--- a/src/ast/transform/MaterializeAggregationQueries.cpp
+++ b/src/ast/transform/MaterializeAggregationQueries.cpp
@@ -122,7 +122,7 @@ void MaterializeAggregationQueriesTransformer::groundInjectedParameters(
                  * then replace the atom with a negated version of the atom, so that
                  * injected parameters that occur in an inner aggregate don't "seem" grounded.
                  **/
-                std::vector<Own<Literal>> newBody;
+                VecOwn<Literal> newBody;
                 for (const auto& lit : aggregate->getBodyLiterals()) {
                     if (auto* atom = as<Atom>(lit)) {
                         newBody.push_back(mk<Negation>(souffle::clone(atom)));
@@ -280,11 +280,9 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
             }
             // begin materialisation process
             auto aggregateBodyRelationName = analysis::findUniqueRelationName(program, "__agg_subclause");
-            auto aggClause = mk<Clause>(aggregateBodyRelationName);
             // quickly copy in all the literals from the aggregate body
-            for (const auto& lit : agg.getBodyLiterals()) {
-                aggClause->addToBody(souffle::clone(lit));
-            }
+            auto aggClause = mk<Clause>(aggregateBodyRelationName);
+            aggClause->setBodyLiterals(souffle::clone(agg.getBodyLiterals()));
             if (agg.getBaseOperator() == AggregateOp::COUNT) {
                 instantiateUnnamedVariables(*aggClause);
             }

--- a/src/ast/transform/MaterializeAggregationQueries.cpp
+++ b/src/ast/transform/MaterializeAggregationQueries.cpp
@@ -221,7 +221,7 @@ void MaterializeAggregationQueriesTransformer::groundInjectedParameters(
                 for (auto arg : atom->getArguments()) {
                     if (auto* var = as<ast::Variable>(arg)) {
                         if (var->getName() == ungroundedVariableName) {
-                            arguments.emplace_back(arg->clone());
+                            arguments.emplace_back(souffle::clone(arg));
                             continue;
                         }
                     }
@@ -335,7 +335,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
                         continue;
                     }
                 }
-                args.emplace_back(arg->clone());
+                args.emplace_back(souffle::clone(arg));
             }
             auto aggAtom =
                     mk<Atom>(aggClauseHead->getQualifiedName(), std::move(args), aggClauseHead->getSrcLoc());

--- a/src/ast/transform/MaterializeAggregationQueries.h
+++ b/src/ast/transform/MaterializeAggregationQueries.h
@@ -42,11 +42,11 @@ public:
      */
     static bool materializeAggregationQueries(TranslationUnit& translationUnit);
 
-    MaterializeAggregationQueriesTransformer* clone() const override {
+private:
+    MaterializeAggregationQueriesTransformer* cloneImpl() const override {
         return new MaterializeAggregationQueriesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         return materializeAggregationQueries(translationUnit);
     }

--- a/src/ast/transform/MaterializeSingletonAggregation.cpp
+++ b/src/ast/transform/MaterializeSingletonAggregation.cpp
@@ -122,7 +122,7 @@ bool MaterializeSingletonAggregationTransformer::transform(TranslationUnit& tran
             replaceAggregate(const Aggregator& aggregate, Own<ast::Variable> variable)
                     : aggregate(aggregate), variable(std::move(variable)) {}
             Own<Node> operator()(Own<Node> node) const override {
-                if (auto* current = dynamic_cast<Aggregator*>(node.get())) {
+                if (auto* current = as<Aggregator>(node)) {
                     if (*current == aggregate) {
                         auto replacement = souffle::clone(variable);
                         assert(replacement != nullptr);

--- a/src/ast/transform/MaterializeSingletonAggregation.cpp
+++ b/src/ast/transform/MaterializeSingletonAggregation.cpp
@@ -58,8 +58,8 @@ bool MaterializeSingletonAggregationTransformer::transform(TranslationUnit& tran
     });
 
     // collect references to clause / aggregate pairs
-    visitDepthFirst(program, [&](const Clause& clause) {
-        visitDepthFirst(clause, [&](const Aggregator& agg) {
+    visitDepthFirst(program, [&](Clause& clause) {
+        visitDepthFirst(clause, [&](Aggregator& agg) {
             // only unroll one level at a time
             if (innerAggregates.find(&agg) != innerAggregates.end()) {
                 return;
@@ -71,8 +71,8 @@ bool MaterializeSingletonAggregationTransformer::transform(TranslationUnit& tran
             if (!isSingleValued(translationUnit, agg, clause) || clause.getBodyLiterals().size() == 1) {
                 return;
             }
-            auto* foundAggregate = const_cast<Aggregator*>(&agg);
-            auto* foundClause = const_cast<Clause*>(&clause);
+            auto* foundAggregate = &agg;
+            auto* foundClause = &clause;
             pairs.insert(std::make_pair(foundAggregate, foundClause));
         });
     });

--- a/src/ast/transform/MaterializeSingletonAggregation.h
+++ b/src/ast/transform/MaterializeSingletonAggregation.h
@@ -36,11 +36,11 @@ public:
         return "MaterializeSingletonAggregationTransformer";
     }
 
-    MaterializeSingletonAggregationTransformer* clone() const override {
+private:
+    MaterializeSingletonAggregationTransformer* cloneImpl() const override {
         return new MaterializeSingletonAggregationTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
     /**
      * Determines whether an aggregate is single-valued,

--- a/src/ast/transform/Meta.h
+++ b/src/ast/transform/Meta.h
@@ -46,8 +46,6 @@ public:
 
     /* Apply a nested transformer */
     bool applySubtransformer(TranslationUnit& translationUnit, Transformer* transformer);
-
-    MetaTransformer* clone() const override = 0;
 };
 
 }  // namespace souffle::ast::transform

--- a/src/ast/transform/MinimiseProgram.cpp
+++ b/src/ast/transform/MinimiseProgram.cpp
@@ -425,8 +425,7 @@ bool MinimiseProgramTransformer::reduceClauseBodies(TranslationUnit& translation
         }
 
         if (!redundantPositions.empty()) {
-            auto minimisedClause = mk<Clause>();
-            minimisedClause->setHead(souffle::clone(clause->getHead()));
+            auto minimisedClause = mk<Clause>(souffle::clone(clause->getHead()));
             for (size_t i = 0; i < bodyLiterals.size(); i++) {
                 if (!contains(redundantPositions, i)) {
                     minimisedClause->addToBody(souffle::clone(bodyLiterals[i]));

--- a/src/ast/transform/MinimiseProgram.cpp
+++ b/src/ast/transform/MinimiseProgram.cpp
@@ -363,7 +363,7 @@ bool MinimiseProgramTransformer::reduceSingletonRelations(TranslationUnit& trans
             // Remove appearances from children nodes
             node->apply(*this);
 
-            if (auto* atom = dynamic_cast<Atom*>(node.get())) {
+            if (auto* atom = as<Atom>(node)) {
                 auto pos = canonicalName.find(atom->getQualifiedName());
                 if (pos != canonicalName.end()) {
                     auto newAtom = souffle::clone(atom);

--- a/src/ast/transform/MinimiseProgram.h
+++ b/src/ast/transform/MinimiseProgram.h
@@ -37,11 +37,11 @@ public:
     static bool areBijectivelyEquivalent(
             const analysis::NormalisedClause& left, const analysis::NormalisedClause& right);
 
-    MinimiseProgramTransformer* clone() const override {
+private:
+    MinimiseProgramTransformer* cloneImpl() const override {
         return new MinimiseProgramTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /** -- Bijective Equivalence Helper Methods -- */

--- a/src/ast/transform/NameUnnamedVariables.cpp
+++ b/src/ast/transform/NameUnnamedVariables.cpp
@@ -40,10 +40,10 @@ bool NameUnnamedVariablesTransformer::transform(TranslationUnit& translationUnit
         nameVariables() = default;
 
         Own<Node> operator()(Own<Node> node) const override {
-            if (isA<Negation>(node.get())) {
+            if (isA<Negation>(node)) {
                 return node;
             }
-            if (isA<UnnamedVariable>(node.get())) {
+            if (isA<UnnamedVariable>(node)) {
                 changed = true;
                 std::stringstream name;
                 name << boundPrefix << "_" << underscoreCount++;

--- a/src/ast/transform/NameUnnamedVariables.h
+++ b/src/ast/transform/NameUnnamedVariables.h
@@ -35,11 +35,11 @@ public:
         return "NameUnnamedVariablesTransformer";
     }
 
-    NameUnnamedVariablesTransformer* clone() const override {
+private:
+    NameUnnamedVariablesTransformer* cloneImpl() const override {
         return new NameUnnamedVariablesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/NormaliseGenerators.cpp
+++ b/src/ast/transform/NormaliseGenerators.cpp
@@ -49,14 +49,14 @@ bool NormaliseGeneratorsTransformer::transform(TranslationUnit& translationUnit)
         Own<Node> operator()(Own<Node> node) const override {
             node->apply(*this);
 
-            if (auto* inf = dynamic_cast<IntrinsicFunctor*>(node.get())) {
+            if (auto* inf = as<IntrinsicFunctor>(node)) {
                 // Multi-result functors
                 if (analysis::FunctorAnalysis::isMultiResult(*inf)) {
                     std::string name = getUniqueName();
                     generatorNames.push_back({name, Own<IntrinsicFunctor>(inf->clone())});
                     return mk<Variable>(name);
                 }
-            } else if (auto* agg = dynamic_cast<Aggregator*>(node.get())) {
+            } else if (auto* agg = as<Aggregator>(node)) {
                 // Aggregators
                 std::string name = getUniqueName();
                 generatorNames.push_back({name, Own<Aggregator>(agg->clone())});

--- a/src/ast/transform/NormaliseGenerators.cpp
+++ b/src/ast/transform/NormaliseGenerators.cpp
@@ -53,13 +53,13 @@ bool NormaliseGeneratorsTransformer::transform(TranslationUnit& translationUnit)
                 // Multi-result functors
                 if (analysis::FunctorAnalysis::isMultiResult(*inf)) {
                     std::string name = getUniqueName();
-                    generatorNames.push_back({name, Own<IntrinsicFunctor>(inf->clone())});
+                    generatorNames.emplace_back(name, souffle::clone(inf));
                     return mk<Variable>(name);
                 }
             } else if (auto* agg = as<Aggregator>(node)) {
                 // Aggregators
                 std::string name = getUniqueName();
-                generatorNames.push_back({name, Own<Aggregator>(agg->clone())});
+                generatorNames.emplace_back(name, souffle::clone(agg));
                 return mk<Variable>(name);
             }
 

--- a/src/ast/transform/NormaliseGenerators.h
+++ b/src/ast/transform/NormaliseGenerators.h
@@ -31,7 +31,7 @@ public:
 private:
     bool transform(TranslationUnit& translationUnit) override;
 
-    NormaliseGeneratorsTransformer* clone() const override {
+    NormaliseGeneratorsTransformer* cloneImpl() const override {
         return new NormaliseGeneratorsTransformer();
     }
 };

--- a/src/ast/transform/Null.h
+++ b/src/ast/transform/Null.h
@@ -49,7 +49,7 @@ public:
         return "NullTransformer";
     }
 
-    NullTransformer* clone() const override {
+    NullTransformer* cloneImpl() const override {
         return new NullTransformer();
     }
 };

--- a/src/ast/transform/PartitionBodyLiterals.cpp
+++ b/src/ast/transform/PartitionBodyLiterals.cpp
@@ -157,8 +157,7 @@ bool PartitionBodyLiteralsTransformer::transform(TranslationUnit& translationUni
 
             // Create the extracted relation and clause for the component
             // newrelX() <- disconnectedLiterals(x).
-            auto newRelation = mk<Relation>();
-            newRelation->setQualifiedName(newRelationName);
+            auto newRelation = mk<Relation>(newRelationName);
             program.addRelation(std::move(newRelation));
 
             auto disconnectedClause = mk<Clause>(newRelationName, clause.getSrcLoc());
@@ -187,12 +186,9 @@ bool PartitionBodyLiteralsTransformer::transform(TranslationUnit& translationUni
 
         // Create the replacement clause
         // a(x) <- b(x), c(y), d(z). --> a(x) <- newrel0(), newrel1(), b(x).
-        auto replacementClause = mk<Clause>(souffle::clone(clause.getHead()), clause.getSrcLoc());
-
-        // Add the new propositions to the clause first
-        for (Atom* newAtom : replacementAtoms) {
-            replacementClause->addToBody(Own<Literal>(newAtom));
-        }
+        auto replacementClause = mk<Clause>(souffle::clone(clause.getHead()),
+                VecOwn<Literal>(replacementAtoms.begin(), replacementAtoms.end()), nullptr,
+                clause.getSrcLoc());
 
         // Add the remaining body literals to the clause
         for (Literal* bodyLiteral : clause.getBodyLiterals()) {

--- a/src/ast/transform/PartitionBodyLiterals.h
+++ b/src/ast/transform/PartitionBodyLiterals.h
@@ -41,11 +41,11 @@ public:
         return "PartitionBodyLiteralsTransformer";
     }
 
-    PartitionBodyLiteralsTransformer* clone() const override {
+private:
+    PartitionBodyLiteralsTransformer* cloneImpl() const override {
         return new PartitionBodyLiteralsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/Pipeline.h
+++ b/src/ast/transform/Pipeline.h
@@ -53,7 +53,7 @@ public:
 
     void setDebugReport() override {
         for (auto& i : pipeline) {
-            if (auto* mt = dynamic_cast<MetaTransformer*>(i.get())) {
+            if (auto* mt = as<MetaTransformer>(i)) {
                 mt->setDebugReport();
             } else {
                 i = mk<DebugReporter>(std::move(i));
@@ -64,7 +64,7 @@ public:
     void setVerbosity(bool verbose) override {
         this->verbose = verbose;
         for (auto& cur : pipeline) {
-            if (auto* mt = dynamic_cast<MetaTransformer*>(cur.get())) {
+            if (auto* mt = as<MetaTransformer>(cur)) {
                 mt->setVerbosity(verbose);
             }
         }
@@ -72,7 +72,7 @@ public:
 
     void disableTransformers(const std::set<std::string>& transforms) override {
         for (auto& i : pipeline) {
-            if (auto* mt = dynamic_cast<MetaTransformer*>(i.get())) {
+            if (auto* mt = as<MetaTransformer>(i)) {
                 mt->disableTransformers(transforms);
             } else if (transforms.find(i->getName()) != transforms.end()) {
                 i = mk<NullTransformer>();

--- a/src/ast/transform/Pipeline.h
+++ b/src/ast/transform/Pipeline.h
@@ -84,14 +84,6 @@ public:
         return "PipelineTransformer";
     }
 
-    PipelineTransformer* clone() const override {
-        VecOwn<Transformer> transformers;
-        for (const auto& transformer : pipeline) {
-            transformers.push_back(souffle::clone(transformer));
-        }
-        return new PipelineTransformer(std::move(transformers));
-    }
-
 protected:
     VecOwn<Transformer> pipeline;
     bool transform(TranslationUnit& translationUnit) override {
@@ -100,6 +92,15 @@ protected:
             changed |= applySubtransformer(translationUnit, transformer.get());
         }
         return changed;
+    }
+
+private:
+    PipelineTransformer* cloneImpl() const override {
+        VecOwn<Transformer> transformers;
+        for (const auto& transformer : pipeline) {
+            transformers.push_back(souffle::clone(transformer));
+        }
+        return new PipelineTransformer(std::move(transformers));
     }
 };
 

--- a/src/ast/transform/PragmaChecker.h
+++ b/src/ast/transform/PragmaChecker.h
@@ -28,11 +28,11 @@ public:
         return "PragmaChecker";
     }
 
-    PragmaChecker* clone() const override {
+private:
+    PragmaChecker* cloneImpl() const override {
         return new PragmaChecker();
     }
 
-private:
     bool transform(TranslationUnit&) override;
 };
 

--- a/src/ast/transform/Provenance.cpp
+++ b/src/ast/transform/Provenance.cpp
@@ -97,9 +97,9 @@ Own<Relation> makeInfoRelation(
     int functorNumber = 0;
     int aggregateNumber = 0;
     auto getArgInfo = [&](Argument* arg) -> std::string {
-        if (auto* var = dynamic_cast<ast::Variable*>(arg)) {
+        if (auto* var = as<ast::Variable>(arg)) {
             return toString(*var);
-        } else if (auto* constant = dynamic_cast<Constant*>(arg)) {
+        } else if (auto* constant = as<Constant>(arg)) {
             return toString(*constant);
         }
         if (isA<UnnamedVariable>(arg)) {
@@ -168,7 +168,7 @@ Own<Relation> makeInfoRelation(
     for (size_t i = 0; i < originalClause.getBodyLiterals().size(); i++) {
         auto lit = originalClause.getBodyLiterals()[i];
 
-        if (auto con = dynamic_cast<BinaryConstraint*>(lit)) {
+        if (auto con = as<BinaryConstraint>(lit)) {
             // for a constraint, add the constraint symbol and LHS and RHS
             std::string constraintDescription = toBinaryConstraintSymbol(con->getBaseOperator());
 
@@ -295,10 +295,10 @@ bool ProvenanceTransformer::transformMaxHeight(TranslationUnit& translationUnit)
 
                 Own<Node> operator()(Own<Node> node) const override {
                     // add provenance columns
-                    if (auto atom = dynamic_cast<Atom*>(node.get())) {
+                    if (auto atom = as<Atom>(node)) {
                         atom->addArgument(mk<UnnamedVariable>());
                         atom->addArgument(mk<UnnamedVariable>());
-                    } else if (auto neg = dynamic_cast<Negation*>(node.get())) {
+                    } else if (auto neg = as<Negation>(node)) {
                         auto atom = neg->getAtom();
                         atom->addArgument(mk<UnnamedVariable>());
                         atom->addArgument(mk<UnnamedVariable>());
@@ -327,7 +327,7 @@ bool ProvenanceTransformer::transformMaxHeight(TranslationUnit& translationUnit)
                     lit->apply(M());
 
                     // add two provenance columns to lit; first is rule num, second is level num
-                    if (auto atom = dynamic_cast<Atom*>(lit)) {
+                    if (auto atom = as<Atom>(lit)) {
                         atom->addArgument(mk<UnnamedVariable>());
                         atom->addArgument(mk<ast::Variable>("@level_num_" + std::to_string(i)));
                         bodyLevels.push_back(new ast::Variable("@level_num_" + std::to_string(i)));

--- a/src/ast/transform/Provenance.cpp
+++ b/src/ast/transform/Provenance.cpp
@@ -80,9 +80,8 @@ Own<Relation> makeInfoRelation(
     infoRelation->setRepresentation(RelationRepresentation::INFO);
 
     // create new clause containing a single fact
-    auto infoClause = new Clause();
-    auto infoClauseHead = new Atom();
-    infoClauseHead->setQualifiedName(name);
+    auto infoClause = mk<Clause>(name);
+    auto infoClauseHead = infoClause->getHead();
 
     // (darth_tytus): Can this be unsigned?
     infoRelation->addAttribute(mk<Attribute>("clause_num", QualifiedName("number")));
@@ -183,9 +182,8 @@ Own<Relation> makeInfoRelation(
     infoClauseHead->addArgument(mk<StringConstant>(toString(originalClause)));
 
     // set clause head and add clause to info relation
-    infoClause->setHead(Own<Atom>(infoClauseHead));
     Program& program = translationUnit.getProgram();
-    program.addClause(Own<Clause>(infoClause));
+    program.addClause(std::move(infoClause));
 
     return Own<Relation>(infoRelation);
 }
@@ -200,8 +198,8 @@ void transformEqrelRelation(Program& program, Relation& rel) {
 
     // transitivity
     // transitive clause: A(x, z) :- A(x, y), A(y, z).
-    auto transitiveClause = new Clause();
-    auto transitiveClauseHead = new Atom(rel.getQualifiedName());
+    auto transitiveClause = mk<Clause>(rel.getQualifiedName());
+    auto transitiveClauseHead = transitiveClause->getHead();
     transitiveClauseHead->addArgument(mk<ast::Variable>("x"));
     transitiveClauseHead->addArgument(mk<ast::Variable>("z"));
 
@@ -213,15 +211,14 @@ void transformEqrelRelation(Program& program, Relation& rel) {
     transitiveClauseBody2->addArgument(mk<ast::Variable>("y"));
     transitiveClauseBody2->addArgument(mk<ast::Variable>("z"));
 
-    transitiveClause->setHead(Own<Atom>(transitiveClauseHead));
     transitiveClause->addToBody(Own<Literal>(transitiveClauseBody));
     transitiveClause->addToBody(Own<Literal>(transitiveClauseBody2));
-    program.addClause(Own<Clause>(transitiveClause));
+    program.addClause(std::move(transitiveClause));
 
     // symmetric
     // symmetric clause: A(x, y) :- A(y, x).
-    auto symClause = new Clause();
-    auto symClauseHead = new Atom(rel.getQualifiedName());
+    auto symClause = mk<Clause>(rel.getQualifiedName());
+    auto symClauseHead = symClause->getHead();
     symClauseHead->addArgument(mk<ast::Variable>("x"));
     symClauseHead->addArgument(mk<ast::Variable>("y"));
 
@@ -229,14 +226,13 @@ void transformEqrelRelation(Program& program, Relation& rel) {
     symClauseBody->addArgument(mk<ast::Variable>("y"));
     symClauseBody->addArgument(mk<ast::Variable>("x"));
 
-    symClause->setHead(Own<Atom>(symClauseHead));
     symClause->addToBody(Own<Literal>(symClauseBody));
-    program.addClause(Own<Clause>(symClause));
+    program.addClause(std::move(symClause));
 
     // reflexivity
     // reflexive clause: A(x, x) :- A(x, _).
-    auto reflexiveClause = new Clause();
-    auto reflexiveClauseHead = new Atom(rel.getQualifiedName());
+    auto reflexiveClause = mk<Clause>(rel.getQualifiedName());
+    auto reflexiveClauseHead = reflexiveClause->getHead();
     reflexiveClauseHead->addArgument(mk<ast::Variable>("x"));
     reflexiveClauseHead->addArgument(mk<ast::Variable>("x"));
 
@@ -244,9 +240,8 @@ void transformEqrelRelation(Program& program, Relation& rel) {
     reflexiveClauseBody->addArgument(mk<ast::Variable>("x"));
     reflexiveClauseBody->addArgument(mk<UnnamedVariable>());
 
-    reflexiveClause->setHead(Own<Atom>(reflexiveClauseHead));
     reflexiveClause->addToBody(Own<Literal>(reflexiveClauseBody));
-    program.addClause(Own<Clause>(reflexiveClause));
+    program.addClause(std::move(reflexiveClause));
 }
 
 namespace {

--- a/src/ast/transform/Provenance.cpp
+++ b/src/ast/transform/Provenance.cpp
@@ -74,8 +74,7 @@ Own<Relation> makeInfoRelation(
             makeRelationName(originalClause.getHead()->getQualifiedName(), "@info", originalClauseNum);
 
     // initialise info relation
-    auto infoRelation = new Relation();
-    infoRelation->setQualifiedName(name);
+    auto infoRelation = mk<Relation>(name);
     // set qualifier to INFO_RELATION
     infoRelation->setRepresentation(RelationRepresentation::INFO);
 
@@ -185,7 +184,7 @@ Own<Relation> makeInfoRelation(
     Program& program = translationUnit.getProgram();
     program.addClause(std::move(infoClause));
 
-    return Own<Relation>(infoRelation);
+    return infoRelation;
 }
 
 /** Transform eqrel relations to explicitly define equivalence relations */

--- a/src/ast/transform/Provenance.h
+++ b/src/ast/transform/Provenance.h
@@ -31,11 +31,11 @@ public:
         return "ProvenanceTransformer";
     }
 
-    ProvenanceTransformer* clone() const override {
+private:
+    ProvenanceTransformer* cloneImpl() const override {
         return new ProvenanceTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
     bool transformMaxHeight(TranslationUnit& translationUnit);
 };

--- a/src/ast/transform/ReduceExistentials.cpp
+++ b/src/ast/transform/ReduceExistentials.cpp
@@ -167,12 +167,12 @@ bool ReduceExistentialsTransformer::transform(TranslationUnit& translationUnit) 
         renameExistentials(std::set<QualifiedName>& relations) : relations(relations) {}
 
         Own<Node> operator()(Own<Node> node) const override {
-            if (auto* clause = dynamic_cast<Clause*>(node.get())) {
+            if (auto* clause = as<Clause>(node)) {
                 if (relations.find(clause->getHead()->getQualifiedName()) != relations.end()) {
                     // Clause is going to be removed, so don't rename it
                     return node;
                 }
-            } else if (auto* atom = dynamic_cast<Atom*>(node.get())) {
+            } else if (auto* atom = as<Atom>(node)) {
                 if (relations.find(atom->getQualifiedName()) != relations.end()) {
                     // Relation is now existential, so rename it
                     std::stringstream newName;

--- a/src/ast/transform/ReduceExistentials.cpp
+++ b/src/ast/transform/ReduceExistentials.cpp
@@ -139,16 +139,10 @@ bool ReduceExistentialsTransformer::transform(TranslationUnit& translationUnit) 
         // Keep all non-recursive clauses
         for (Clause* clause : getClauses(program, *originalRelation)) {
             if (!isRecursiveClause(*clause)) {
-                auto newClause = mk<Clause>(newRelationName.str(), clause->getSrcLoc());
-
-                if (const ExecutionPlan* plan = clause->getExecutionPlan()) {
-                    newClause->setExecutionPlan(souffle::clone(plan));
-                }
-
-                for (Literal* lit : clause->getBodyLiterals()) {
-                    newClause->addToBody(souffle::clone(lit));
-                }
-
+                auto newClause =
+                        mk<Clause>(mk<Atom>(newRelationName.str()), souffle::clone(clause->getBodyLiterals()),
+                                // clone handles nullptr gracefully
+                                souffle::clone(clause->getExecutionPlan()), clause->getSrcLoc());
                 program.addClause(std::move(newClause));
             }
         }

--- a/src/ast/transform/ReduceExistentials.cpp
+++ b/src/ast/transform/ReduceExistentials.cpp
@@ -129,9 +129,7 @@ bool ReduceExistentialsTransformer::transform(TranslationUnit& translationUnit) 
         std::stringstream newRelationName;
         newRelationName << "+?exists_" << relationName;
 
-        auto newRelation = mk<Relation>();
-        newRelation->setQualifiedName(newRelationName.str());
-        newRelation->setSrcLoc(originalRelation->getSrcLoc());
+        auto newRelation = mk<Relation>(newRelationName.str(), originalRelation->getSrcLoc());
 
         // EqRel relations require two arguments, so remove it from the qualifier
         if (newRelation->getRepresentation() == RelationRepresentation::EQREL) {
@@ -141,13 +139,12 @@ bool ReduceExistentialsTransformer::transform(TranslationUnit& translationUnit) 
         // Keep all non-recursive clauses
         for (Clause* clause : getClauses(program, *originalRelation)) {
             if (!isRecursiveClause(*clause)) {
-                auto newClause = mk<Clause>();
+                auto newClause = mk<Clause>(newRelationName.str(), clause->getSrcLoc());
 
-                newClause->setSrcLoc(clause->getSrcLoc());
                 if (const ExecutionPlan* plan = clause->getExecutionPlan()) {
                     newClause->setExecutionPlan(souffle::clone(plan));
                 }
-                newClause->setHead(mk<Atom>(newRelationName.str()));
+
                 for (Literal* lit : clause->getBodyLiterals()) {
                     newClause->addToBody(souffle::clone(lit));
                 }

--- a/src/ast/transform/ReduceExistentials.h
+++ b/src/ast/transform/ReduceExistentials.h
@@ -33,11 +33,11 @@ public:
         return "ReduceExistentialsTransformer";
     }
 
-    ReduceExistentialsTransformer* clone() const override {
+private:
+    ReduceExistentialsTransformer* cloneImpl() const override {
         return new ReduceExistentialsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/RemoveBooleanConstraints.cpp
+++ b/src/ast/transform/RemoveBooleanConstraints.cpp
@@ -48,13 +48,13 @@ bool RemoveBooleanConstraintsTransformer::transform(TranslationUnit& translation
             // Remove them from child nodes
             node->apply(*this);
 
-            if (auto* aggr = dynamic_cast<Aggregator*>(node.get())) {
+            if (auto* aggr = as<Aggregator>(node)) {
                 bool containsTrue = false;
                 bool containsFalse = false;
 
                 // Check if aggregator body contains booleans.
                 for (Literal* lit : aggr->getBodyLiterals()) {
-                    if (auto* bc = dynamic_cast<BooleanConstraint*>(lit)) {
+                    if (auto* bc = as<BooleanConstraint>(lit)) {
                         if (bc->isTrue()) {
                             containsTrue = true;
                         } else {
@@ -117,7 +117,7 @@ bool RemoveBooleanConstraintsTransformer::transform(TranslationUnit& translation
             bool containsFalse = false;
 
             for (Literal* lit : clause->getBodyLiterals()) {
-                if (auto* bc = dynamic_cast<BooleanConstraint*>(lit)) {
+                if (auto* bc = as<BooleanConstraint>(lit)) {
                     bc->isTrue() ? containsTrue = true : containsFalse = true;
                 }
             }

--- a/src/ast/transform/RemoveBooleanConstraints.cpp
+++ b/src/ast/transform/RemoveBooleanConstraints.cpp
@@ -126,7 +126,7 @@ bool RemoveBooleanConstraintsTransformer::transform(TranslationUnit& translation
                 // Clause will always fail
                 program.removeClause(clause);
             } else if (containsTrue) {
-                auto replacementClause = Own<Clause>(cloneHead(clause));
+                auto replacementClause = cloneHead(*clause);
 
                 // Only keep non-'true' literals
                 for (Literal* lit : clause->getBodyLiterals()) {

--- a/src/ast/transform/RemoveBooleanConstraints.h
+++ b/src/ast/transform/RemoveBooleanConstraints.h
@@ -30,11 +30,11 @@ public:
         return "RemoveBooleanConstraintsTransformer";
     }
 
-    RemoveBooleanConstraintsTransformer* clone() const override {
+private:
+    RemoveBooleanConstraintsTransformer* cloneImpl() const override {
         return new RemoveBooleanConstraintsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/RemoveEmptyRelations.cpp
+++ b/src/ast/transform/RemoveEmptyRelations.cpp
@@ -87,7 +87,7 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelationUses(
 
         bool removed = false;
         for (Literal* lit : cl->getBodyLiterals()) {
-            if (auto* arg = dynamic_cast<Atom*>(lit)) {
+            if (auto* arg = as<Atom>(lit)) {
                 if (arg->getQualifiedName() == emptyRelationName) {
                     program.removeClause(cl);
                     removed = true;
@@ -102,7 +102,7 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelationUses(
 
             bool rewrite = false;
             for (Literal* lit : cl->getBodyLiterals()) {
-                if (auto* neg = dynamic_cast<Negation*>(lit)) {
+                if (auto* neg = as<Negation>(lit)) {
                     if (neg->getAtom()->getQualifiedName() == emptyRelationName) {
                         rewrite = true;
                         break;
@@ -116,7 +116,7 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelationUses(
                 auto res = Own<Clause>(cloneHead(cl));
 
                 for (Literal* lit : cl->getBodyLiterals()) {
-                    if (auto* neg = dynamic_cast<Negation*>(lit)) {
+                    if (auto* neg = as<Negation>(lit)) {
                         if (neg->getAtom()->getQualifiedName() != emptyRelationName) {
                             res->addToBody(souffle::clone(lit));
                         }

--- a/src/ast/transform/RemoveEmptyRelations.cpp
+++ b/src/ast/transform/RemoveEmptyRelations.cpp
@@ -113,7 +113,7 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelationUses(
             if (rewrite) {
                 // clone clause without negation for empty relations
 
-                auto res = Own<Clause>(cloneHead(cl));
+                auto res = cloneHead(*cl);
 
                 for (Literal* lit : cl->getBodyLiterals()) {
                     if (auto* neg = as<Negation>(lit)) {

--- a/src/ast/transform/RemoveEmptyRelations.h
+++ b/src/ast/transform/RemoveEmptyRelations.h
@@ -38,11 +38,11 @@ public:
      */
     static bool removeEmptyRelations(TranslationUnit& translationUnit);
 
-    RemoveEmptyRelationsTransformer* clone() const override {
+private:
+    RemoveEmptyRelationsTransformer* cloneImpl() const override {
         return new RemoveEmptyRelationsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         return removeEmptyRelations(translationUnit);
     }

--- a/src/ast/transform/RemoveRedundantRelations.h
+++ b/src/ast/transform/RemoveRedundantRelations.h
@@ -29,11 +29,11 @@ public:
         return "RemoveRedundantRelationsTransformer";
     }
 
-    RemoveRedundantRelationsTransformer* clone() const override {
+private:
+    RemoveRedundantRelationsTransformer* cloneImpl() const override {
         return new RemoveRedundantRelationsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/RemoveRedundantSums.cpp
+++ b/src/ast/transform/RemoveRedundantSums.cpp
@@ -38,10 +38,10 @@ bool RemoveRedundantSumsTransformer::transform(TranslationUnit& translationUnit)
         Own<Node> operator()(Own<Node> node) const override {
             // Apply to all aggregates of the form
             // sum k : { .. } where k is a constant
-            if (auto* agg = dynamic_cast<Aggregator*>(node.get())) {
+            if (auto* agg = as<Aggregator>(node)) {
                 if (agg->getBaseOperator() == AggregateOp::SUM) {
                     if (const auto* constant =
-                                    dynamic_cast<const NumericConstant*>(agg->getTargetExpression())) {
+                                    as<NumericConstant>(agg->getTargetExpression())) {
                         changed = true;
                         // Then construct the new thing to replace it with
                         auto count = mk<Aggregator>(AggregateOp::COUNT);

--- a/src/ast/transform/RemoveRedundantSums.cpp
+++ b/src/ast/transform/RemoveRedundantSums.cpp
@@ -40,8 +40,7 @@ bool RemoveRedundantSumsTransformer::transform(TranslationUnit& translationUnit)
             // sum k : { .. } where k is a constant
             if (auto* agg = as<Aggregator>(node)) {
                 if (agg->getBaseOperator() == AggregateOp::SUM) {
-                    if (const auto* constant =
-                                    as<NumericConstant>(agg->getTargetExpression())) {
+                    if (const auto* constant = as<NumericConstant>(agg->getTargetExpression())) {
                         changed = true;
                         // Then construct the new thing to replace it with
                         auto count = mk<Aggregator>(AggregateOp::COUNT);

--- a/src/ast/transform/RemoveRedundantSums.h
+++ b/src/ast/transform/RemoveRedundantSums.h
@@ -32,11 +32,11 @@ public:
         return "RemoveRedundantSumsTransformer";
     }
 
-    RemoveRedundantSumsTransformer* clone() const override {
+private:
+    RemoveRedundantSumsTransformer* cloneImpl() const override {
         return new RemoveRedundantSumsTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/RemoveRelationCopies.cpp
+++ b/src/ast/transform/RemoveRelationCopies.cpp
@@ -128,10 +128,10 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(TranslationUnit& tran
     }
 
     // replace usage of relations according to alias map
-    visitDepthFirst(program, [&](const Atom& atom) {
+    visitDepthFirst(program, [&](Atom& atom) {
         auto pos = isAliasOf.find(atom.getQualifiedName());
         if (pos != isAliasOf.end()) {
-            const_cast<Atom&>(atom).setQualifiedName(pos->second);
+            atom.setQualifiedName(pos->second);
         }
     });
 

--- a/src/ast/transform/RemoveRelationCopies.cpp
+++ b/src/ast/transform/RemoveRelationCopies.cpp
@@ -76,9 +76,9 @@ bool RemoveRelationCopiesTransformer::removeRelationCopies(TranslationUnit& tran
                         const auto cur = args.back();
                         args.pop_back();
 
-                        if (auto var = dynamic_cast<const ast::Variable*>(cur)) {
+                        if (auto var = as<ast::Variable>(cur)) {
                             onlyDistinctHeadVars &= headVars.insert(var->getName()).second;
-                        } else if (auto init = dynamic_cast<const RecordInit*>(cur)) {
+                        } else if (auto init = as<RecordInit>(cur)) {
                             // records are decomposed and their arguments are checked
                             for (auto rec_arg : init->getArguments()) {
                                 args.push_back(rec_arg);

--- a/src/ast/transform/RemoveRelationCopies.h
+++ b/src/ast/transform/RemoveRelationCopies.h
@@ -42,11 +42,11 @@ public:
      */
     static bool removeRelationCopies(TranslationUnit& translationUnit);
 
-    RemoveRelationCopiesTransformer* clone() const override {
+private:
+    RemoveRelationCopiesTransformer* cloneImpl() const override {
         return new RemoveRelationCopiesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         return removeRelationCopies(translationUnit);
     }

--- a/src/ast/transform/ReorderLiterals.h
+++ b/src/ast/transform/ReorderLiterals.h
@@ -37,10 +37,6 @@ public:
         return "ReorderLiteralsTransformer";
     }
 
-    ReorderLiteralsTransformer* clone() const override {
-        return new ReorderLiteralsTransformer();
-    }
-
     /**
      * Reorder the clause based on a given SIPS function.
      * @param sipsFunction SIPS metric to use
@@ -50,6 +46,10 @@ public:
     static Clause* reorderClauseWithSips(const SipsMetric& sips, const Clause* clause);
 
 private:
+    ReorderLiteralsTransformer* cloneImpl() const override {
+        return new ReorderLiteralsTransformer();
+    }
+
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/ReplaceSingletonVariables.cpp
+++ b/src/ast/transform/ReplaceSingletonVariables.cpp
@@ -43,7 +43,7 @@ bool ReplaceSingletonVariablesTransformer::transform(TranslationUnit& translatio
         replaceSingletons(std::set<std::string>& singletons) : singletons(singletons) {}
 
         Own<Node> operator()(Own<Node> node) const override {
-            if (auto* var = dynamic_cast<ast::Variable*>(node.get())) {
+            if (auto* var = as<ast::Variable>(node)) {
                 if (singletons.find(var->getName()) != singletons.end()) {
                     return mk<UnnamedVariable>();
                 }

--- a/src/ast/transform/ReplaceSingletonVariables.h
+++ b/src/ast/transform/ReplaceSingletonVariables.h
@@ -31,11 +31,11 @@ public:
         return "ReplaceSingletonVariablesTransformer";
     }
 
-    ReplaceSingletonVariablesTransformer* clone() const override {
+private:
+    ReplaceSingletonVariablesTransformer* cloneImpl() const override {
         return new ReplaceSingletonVariablesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/ResolveAliases.cpp
+++ b/src/ast/transform/ResolveAliases.cpp
@@ -95,7 +95,7 @@ public:
 
             Own<Node> operator()(Own<Node> node) const override {
                 // see whether it is a variable to be substituted
-                if (auto var = dynamic_cast<ast::Variable*>(node.get())) {
+                if (auto var = as<ast::Variable>(node)) {
                     auto pos = map.find(var->getName());
                     if (pos != map.end()) {
                         return souffle::clone(pos->second);
@@ -118,8 +118,8 @@ public:
     template <typename T>
     Own<T> operator()(Own<T> node) const {
         Own<Node> resPtr = (*this)(Own<Node>(node.release()));
-        assert(isA<T>(resPtr.get()) && "Invalid node type mapping.");
-        return Own<T>(dynamic_cast<T*>(resPtr.release()));
+        assert(isA<T>(resPtr) && "Invalid node type mapping.");
+        return Own<T>(as<T>(resPtr.release()));
     }
 
     /**
@@ -219,7 +219,7 @@ Own<Clause> ResolveAliasesTransformer::resolveAliases(const Clause& clause) {
         if (isA<Aggregator>(&arg)) return true;
 
         // or multi-result functors
-        const auto* inf = dynamic_cast<const IntrinsicFunctor*>(&arg);
+        const auto* inf = as<IntrinsicFunctor>(arg);
         if (inf == nullptr) return false;
         return analysis::FunctorAnalysis::isMultiResult(*inf);
     };
@@ -236,13 +236,13 @@ Own<Clause> ResolveAliasesTransformer::resolveAliases(const Clause& clause) {
     std::set<std::string> baseGroundedVariables;
     for (const auto* atom : getBodyLiterals<Atom>(clause)) {
         for (const Argument* arg : atom->getArguments()) {
-            if (const auto* var = dynamic_cast<const ast::Variable*>(arg)) {
+            if (const auto* var = as<ast::Variable>(arg)) {
                 baseGroundedVariables.insert(var->getName());
             }
         }
         visitDepthFirst(*atom, [&](const RecordInit& rec) {
             for (const Argument* arg : rec.getArguments()) {
-                if (const auto* var = dynamic_cast<const ast::Variable*>(arg)) {
+                if (const auto* var = as<ast::Variable>(arg)) {
                     baseGroundedVariables.insert(var->getName());
                 }
             }
@@ -367,7 +367,7 @@ Own<Clause> ResolveAliasesTransformer::removeTrivialEquality(const Clause& claus
 
     // add all literals, except filtering out t = t constraints
     for (Literal* literal : clause.getBodyLiterals()) {
-        if (auto* constraint = dynamic_cast<BinaryConstraint*>(literal)) {
+        if (auto* constraint = as<BinaryConstraint>(literal)) {
             // TODO: don't filter out `FEQ` constraints, since `x = x` can fail when `x` is a NaN
             if (isEqConstraint(constraint->getBaseOperator())) {
                 if (*constraint->getLHS() == *constraint->getRHS()) {

--- a/src/ast/transform/ResolveAliases.cpp
+++ b/src/ast/transform/ResolveAliases.cpp
@@ -384,7 +384,7 @@ Own<Clause> ResolveAliasesTransformer::removeTrivialEquality(const Clause& claus
 }
 
 Own<Clause> ResolveAliasesTransformer::removeComplexTermsInAtoms(const Clause& clause) {
-    Own<Clause> res(clause.clone());
+    Own<Clause> res(souffle::clone(clause));
 
     // get list of atoms
     std::vector<Atom*> atoms = getBodyLiterals<Atom>(*res);

--- a/src/ast/transform/ResolveAliases.cpp
+++ b/src/ast/transform/ResolveAliases.cpp
@@ -170,8 +170,7 @@ public:
     Own<Argument> lhs;
     Own<Argument> rhs;
 
-    Equation(const Argument& lhs, const Argument& rhs)
-            : lhs(souffle::clone(&lhs)), rhs(souffle::clone(&rhs)) {}
+    Equation(const Argument& lhs, const Argument& rhs) : lhs(souffle::clone(lhs)), rhs(souffle::clone(rhs)) {}
 
     Equation(const Argument* lhs, const Argument* rhs) : lhs(souffle::clone(lhs)), rhs(souffle::clone(rhs)) {}
 
@@ -359,11 +358,11 @@ Own<Clause> ResolveAliasesTransformer::resolveAliases(const Clause& clause) {
     }
 
     // III) compute resulting clause
-    return substitution(souffle::clone(&clause));
+    return substitution(souffle::clone(clause));
 }
 
 Own<Clause> ResolveAliasesTransformer::removeTrivialEquality(const Clause& clause) {
-    Own<Clause> res(cloneHead(&clause));
+    auto res = cloneHead(clause);
 
     // add all literals, except filtering out t = t constraints
     for (Literal* literal : clause.getBodyLiterals()) {

--- a/src/ast/transform/ResolveAliases.h
+++ b/src/ast/transform/ResolveAliases.h
@@ -59,11 +59,11 @@ public:
      */
     static Own<Clause> removeComplexTermsInAtoms(const Clause& clause);
 
-    ResolveAliasesTransformer* clone() const override {
+private:
+    ResolveAliasesTransformer* cloneImpl() const override {
         return new ResolveAliasesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/ResolveAnonymousRecordAliases.cpp
+++ b/src/ast/transform/ResolveAnonymousRecordAliases.cpp
@@ -48,7 +48,7 @@ std::map<std::string, const RecordInit*> ResolveAnonymousRecordAliasesTransforme
     auto groundedTerms = analysis::getGroundedTerms(tu, clause);
 
     for (auto* literal : clause.getBodyLiterals()) {
-        if (auto constraint = dynamic_cast<BinaryConstraint*>(literal)) {
+        if (auto constraint = as<BinaryConstraint>(literal)) {
             if (!isEqConstraint(constraint->getBaseOperator())) {
                 continue;
             }
@@ -100,7 +100,7 @@ bool ResolveAnonymousRecordAliasesTransformer::replaceNamedVariables(Translation
                 : varToRecordMap(std::move(varToRecordMap)){};
 
         Own<Node> operator()(Own<Node> node) const override {
-            if (auto variable = dynamic_cast<ast::Variable*>(node.get())) {
+            if (auto variable = as<ast::Variable>(node)) {
                 auto iteratorToRecord = varToRecordMap.find(variable->getName());
                 if (iteratorToRecord != varToRecordMap.end()) {
                     return souffle::clone(iteratorToRecord->second);
@@ -131,7 +131,7 @@ bool ResolveAnonymousRecordAliasesTransformer::replaceUnnamedVariable(Clause& cl
             auto isUnnamed = [](Node* node) -> bool { return isA<UnnamedVariable>(node); };
             auto isRecord = [](Node* node) -> bool { return isA<RecordInit>(node); };
 
-            if (auto constraint = dynamic_cast<BinaryConstraint*>(node.get())) {
+            if (auto constraint = as<BinaryConstraint>(node)) {
                 auto left = constraint->getLHS();
                 auto right = constraint->getRHS();
                 bool hasUnnamed = isUnnamed(left) || isUnnamed(right);

--- a/src/ast/transform/ResolveAnonymousRecordAliases.h
+++ b/src/ast/transform/ResolveAnonymousRecordAliases.h
@@ -38,11 +38,11 @@ public:
         return "ResolveAnonymousRecordAliases";
     }
 
-    ResolveAnonymousRecordAliasesTransformer* clone() const override {
+private:
+    ResolveAnonymousRecordAliasesTransformer* cloneImpl() const override {
         return new ResolveAnonymousRecordAliasesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /**

--- a/src/ast/transform/SemanticChecker.cpp
+++ b/src/ast/transform/SemanticChecker.cpp
@@ -652,9 +652,8 @@ static const std::vector<SrcLocation> usesInvalidWitness(
     }
 
     auto aggregateSubclause = mk<Clause>("*");
-    for (const Literal* lit : aggregate.getBodyLiterals()) {
-        aggregateSubclause->addToBody(souffle::clone(lit));
-    }
+    aggregateSubclause->setBodyLiterals(souffle::clone(aggregate.getBodyLiterals()));
+
     struct InnerAggregateMasker : public NodeMapper {
         mutable int numReplaced = 0;
         Own<Node> operator()(Own<Node> node) const override {

--- a/src/ast/transform/SemanticChecker.cpp
+++ b/src/ast/transform/SemanticChecker.cpp
@@ -375,14 +375,14 @@ void SemanticCheckerImpl::checkAggregator(const Aggregator& aggregator) {
 }
 
 void SemanticCheckerImpl::checkArgument(const Argument& arg) {
-    if (const auto* agg = dynamic_cast<const Aggregator*>(&arg)) {
+    if (const auto* agg = as<Aggregator>(arg)) {
         checkAggregator(*agg);
-    } else if (const auto* func = dynamic_cast<const Functor*>(&arg)) {
+    } else if (const auto* func = as<Functor>(arg)) {
         for (auto arg : func->getArguments()) {
             checkArgument(*arg);
         }
 
-        if (auto const* udFunc = dynamic_cast<UserDefinedFunctor const*>(func)) {
+        if (auto const* udFunc = as<UserDefinedFunctor const>(func)) {
             auto const& name = udFunc->getName();
             auto const* udfd = getFunctorDeclaration(program, name);
 
@@ -659,7 +659,7 @@ static const std::vector<SrcLocation> usesInvalidWitness(
     struct InnerAggregateMasker : public NodeMapper {
         mutable int numReplaced = 0;
         Own<Node> operator()(Own<Node> node) const override {
-            if (isA<Aggregator>(node.get())) {
+            if (isA<Aggregator>(node)) {
                 std::string newVariableName = "+aggr_var_" + toString(numReplaced++);
                 return mk<Variable>(newVariableName);
             }

--- a/src/ast/transform/SemanticChecker.cpp
+++ b/src/ast/transform/SemanticChecker.cpp
@@ -343,7 +343,7 @@ bool SemanticCheckerImpl::isDependent(const Clause& agg1, const Clause& agg2) {
 void SemanticCheckerImpl::checkAggregator(const Aggregator& aggregator) {
     auto& report = tu.getErrorReport();
     const Program& program = tu.getProgram();
-    Clause dummyClauseAggregator;
+    Clause dummyClauseAggregator("dummy");
 
     visitDepthFirst(program, [&](const Literal& parentLiteral) {
         visitDepthFirst(parentLiteral, [&](const Aggregator& candidateAggregate) {
@@ -352,15 +352,15 @@ void SemanticCheckerImpl::checkAggregator(const Aggregator& aggregator) {
             }
             // Get the literal containing the aggregator and put it into a dummy clause
             // so we can get information about groundedness
-            dummyClauseAggregator.addToBody(souffle::clone(&parentLiteral));
+            dummyClauseAggregator.addToBody(souffle::clone(parentLiteral));
         });
     });
 
     visitDepthFirst(program, [&](const Literal& parentLiteral) {
         visitDepthFirst(parentLiteral, [&](const Aggregator& /* otherAggregate */) {
             // Create the other aggregate's dummy clause
-            Clause dummyClauseOther;
-            dummyClauseOther.addToBody(souffle::clone(&parentLiteral));
+            Clause dummyClauseOther("dummy");
+            dummyClauseOther.addToBody(souffle::clone(parentLiteral));
             // Check dependency between the aggregator and this one
             if (isDependent(dummyClauseAggregator, dummyClauseOther) &&
                     isDependent(dummyClauseOther, dummyClauseAggregator)) {
@@ -651,8 +651,7 @@ static const std::vector<SrcLocation> usesInvalidWitness(
         return invalidWitnessLocations;  // ie empty result
     }
 
-    auto aggregateSubclause = mk<Clause>();
-    aggregateSubclause->setHead(mk<Atom>("*"));
+    auto aggregateSubclause = mk<Clause>("*");
     for (const Literal* lit : aggregate.getBodyLiterals()) {
         aggregateSubclause->addToBody(souffle::clone(lit));
     }

--- a/src/ast/transform/SemanticChecker.h
+++ b/src/ast/transform/SemanticChecker.h
@@ -30,11 +30,11 @@ public:
         return "SemanticChecker";
     }
 
-    SemanticChecker* clone() const override {
+private:
+    SemanticChecker* cloneImpl() const override {
         return new SemanticChecker();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/SimplifyAggregateTargetExpression.cpp
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.cpp
@@ -23,20 +23,20 @@
 namespace souffle::ast::transform {
 
 Aggregator* SimplifyAggregateTargetExpressionTransformer::simplifyTargetExpression(
-        const TranslationUnit& tu, const Clause* clause, const Aggregator* aggregator) {
-    const auto* origTargetExpression = aggregator->getTargetExpression();
+        const TranslationUnit& tu, const Clause& clause, Aggregator& aggregator) {
+    auto* origTargetExpression = aggregator.getTargetExpression();
     assert(origTargetExpression != nullptr && !isA<Variable>(origTargetExpression) &&
             "aggregator should have complex target expression");
 
     // Create the new simplified target expression
-    auto newTargetExpression = mk<Variable>(analysis::findUniqueVariableName(*clause, "x"));
+    auto newTargetExpression = mk<Variable>(analysis::findUniqueVariableName(clause, "x"));
 
     // Create the new body, with the necessary equality between old and new target expressions
     auto equalityLiteral = std::make_unique<BinaryConstraint>(BinaryConstraintOp::EQ,
             souffle::clone(newTargetExpression), souffle::clone(origTargetExpression));
 
     std::vector<Own<Literal>> newBody;
-    for (const auto* literal : aggregator->getBodyLiterals()) {
+    for (const auto* literal : aggregator.getBodyLiterals()) {
         newBody.push_back(souffle::clone(literal));
     }
     newBody.push_back(std::move(equalityLiteral));
@@ -60,8 +60,8 @@ Aggregator* SimplifyAggregateTargetExpressionTransformer::simplifyTargetExpressi
     //         renamed
 
     // Therefore, variables to rename are non-witness outer scope variables
-    auto witnesses = analysis::getWitnessVariables(tu, *clause, *aggregator);
-    std::set<std::string> varsOutside = analysis::getVariablesOutsideAggregate(*clause, *aggregator);
+    auto witnesses = analysis::getWitnessVariables(tu, clause, aggregator);
+    std::set<std::string> varsOutside = analysis::getVariablesOutsideAggregate(clause, aggregator);
 
     std::set<std::string> varsGroundedOutside;
     for (auto& varName : varsOutside) {
@@ -71,20 +71,20 @@ Aggregator* SimplifyAggregateTargetExpressionTransformer::simplifyTargetExpressi
     }
 
     // Rename the necessary variables in the new aggregator
-    visitDepthFirst(*origTargetExpression, [&](const Variable& v) {
+    visitDepthFirst(*origTargetExpression, [&](Variable& v) {
         if (contains(varsGroundedOutside, v.getName())) {
             // Rename everywhere in the body to fix scoping
-            std::string newVarName = analysis::findUniqueVariableName(*clause, v.getName());
-            visitDepthFirst(newBody, [&](const Variable& literalVar) {
+            std::string newVarName = analysis::findUniqueVariableName(clause, v.getName());
+            visitDepthFirst(newBody, [&](Variable& literalVar) {
                 if (literalVar.getName() == v.getName()) {
-                    const_cast<Variable&>(literalVar).setName(newVarName);
+                    literalVar.setName(newVarName);
                 }
             });
         }
     });
 
     // Create the new simplified aggregator
-    return new Aggregator(aggregator->getBaseOperator(), std::move(newTargetExpression), std::move(newBody));
+    return new Aggregator(aggregator.getBaseOperator(), std::move(newTargetExpression), std::move(newBody));
 }
 
 bool SimplifyAggregateTargetExpressionTransformer::transform(TranslationUnit& translationUnit) {
@@ -109,12 +109,12 @@ bool SimplifyAggregateTargetExpressionTransformer::transform(TranslationUnit& tr
 
     // Generate the necessary simplified forms for each complex aggregator
     std::map<const Aggregator*, Aggregator*> complexToSimple;
-    for (const auto* clause : program.getClauses()) {
-        visitDepthFirst(*clause, [&](const Aggregator& aggregator) {
+    for (auto* clause : program.getClauses()) {
+        visitDepthFirst(*clause, [&](Aggregator& aggregator) {
             const auto* targetExpression = aggregator.getTargetExpression();
             if (targetExpression != nullptr && !isA<Variable>(targetExpression)) {
                 complexToSimple.insert(
-                        {&aggregator, simplifyTargetExpression(translationUnit, clause, &aggregator)});
+                        {&aggregator, simplifyTargetExpression(translationUnit, *clause, aggregator)});
             }
         });
     }

--- a/src/ast/transform/SimplifyAggregateTargetExpression.cpp
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.cpp
@@ -35,10 +35,8 @@ Aggregator* SimplifyAggregateTargetExpressionTransformer::simplifyTargetExpressi
     auto equalityLiteral = mk<BinaryConstraint>(BinaryConstraintOp::EQ, souffle::clone(newTargetExpression),
             souffle::clone(origTargetExpression));
 
-    std::vector<Own<Literal>> newBody;
-    for (const auto* literal : aggregator.getBodyLiterals()) {
-        newBody.push_back(souffle::clone(literal));
-    }
+    VecOwn<Literal> newBody;
+    append(newBody, souffle::cloneRange(aggregator.getBodyLiterals()));
     newBody.push_back(std::move(equalityLiteral));
 
     // Variables in the target expression may have been shadowing variables from the outer scope,

--- a/src/ast/transform/SimplifyAggregateTargetExpression.cpp
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.cpp
@@ -32,8 +32,8 @@ Aggregator* SimplifyAggregateTargetExpressionTransformer::simplifyTargetExpressi
     auto newTargetExpression = mk<Variable>(analysis::findUniqueVariableName(clause, "x"));
 
     // Create the new body, with the necessary equality between old and new target expressions
-    auto equalityLiteral = mk<BinaryConstraint>(BinaryConstraintOp::EQ,
-            souffle::clone(newTargetExpression), souffle::clone(origTargetExpression));
+    auto equalityLiteral = mk<BinaryConstraint>(BinaryConstraintOp::EQ, souffle::clone(newTargetExpression),
+            souffle::clone(origTargetExpression));
 
     std::vector<Own<Literal>> newBody;
     for (const auto* literal : aggregator.getBodyLiterals()) {

--- a/src/ast/transform/SimplifyAggregateTargetExpression.cpp
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.cpp
@@ -97,7 +97,7 @@ bool SimplifyAggregateTargetExpressionTransformer::transform(TranslationUnit& tr
         replace_aggregators(const std::map<const Aggregator*, Aggregator*>& oldToNew) : oldToNew(oldToNew) {}
 
         std::unique_ptr<Node> operator()(std::unique_ptr<Node> node) const override {
-            if (auto* aggregator = dynamic_cast<Aggregator*>(node.get())) {
+            if (auto* aggregator = as<Aggregator>(node)) {
                 if (contains(oldToNew, aggregator)) {
                     return Own<Aggregator>(oldToNew.at(aggregator));
                 }

--- a/src/ast/transform/SimplifyAggregateTargetExpression.cpp
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.cpp
@@ -32,7 +32,7 @@ Aggregator* SimplifyAggregateTargetExpressionTransformer::simplifyTargetExpressi
     auto newTargetExpression = mk<Variable>(analysis::findUniqueVariableName(clause, "x"));
 
     // Create the new body, with the necessary equality between old and new target expressions
-    auto equalityLiteral = std::make_unique<BinaryConstraint>(BinaryConstraintOp::EQ,
+    auto equalityLiteral = mk<BinaryConstraint>(BinaryConstraintOp::EQ,
             souffle::clone(newTargetExpression), souffle::clone(origTargetExpression));
 
     std::vector<Own<Literal>> newBody;

--- a/src/ast/transform/SimplifyAggregateTargetExpression.h
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.h
@@ -43,6 +43,6 @@ private:
      * @return equivalent aggregator with a simple target expression
      */
     static Aggregator* simplifyTargetExpression(
-            const TranslationUnit& tu, const Clause* clause, const Aggregator* aggregator);
+            const TranslationUnit& tu, const Clause& clause, Aggregator& aggregator);
 };
 }  // namespace souffle::ast::transform

--- a/src/ast/transform/SimplifyAggregateTargetExpression.h
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.h
@@ -28,11 +28,11 @@ public:
         return "SimplifyAggregateTargetExpressionTransformer";
     }
 
-    SimplifyAggregateTargetExpressionTransformer* clone() const override {
+private:
+    SimplifyAggregateTargetExpressionTransformer* cloneImpl() const override {
         return new SimplifyAggregateTargetExpressionTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 
     /**

--- a/src/ast/transform/Transformer.h
+++ b/src/ast/transform/Transformer.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "ast/TranslationUnit.h"
+#include "souffle/utility/Types.h"
 #include <string>
 
 namespace souffle::ast::transform {
@@ -32,7 +33,12 @@ public:
 
     virtual std::string getName() const = 0;
 
-    virtual Transformer* clone() const = 0;
+    Own<Transformer> clone() const {
+        return Own<Transformer>(cloneImpl());
+    }
+
+private:
+    virtual Transformer* cloneImpl() const = 0;
 };
 
 }  // namespace souffle::ast::transform

--- a/src/ast/transform/TypeChecker.h
+++ b/src/ast/transform/TypeChecker.h
@@ -35,11 +35,11 @@ public:
     // `apply` but doesn't immediately bail if any errors are found.
     void verify(TranslationUnit& translationUnit);
 
-    TypeChecker* clone() const override {
+private:
+    TypeChecker* cloneImpl() const override {
         return new TypeChecker();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override {
         verify(translationUnit);
         return false;

--- a/src/ast/transform/UniqueAggregationVariables.cpp
+++ b/src/ast/transform/UniqueAggregationVariables.cpp
@@ -35,10 +35,10 @@ bool UniqueAggregationVariablesTransformer::transform(TranslationUnit& translati
     bool changed = false;
 
     // make variables in aggregates unique
-    visitDepthFirst(translationUnit.getProgram(), [&](const Clause& clause) {
+    visitDepthFirst(translationUnit.getProgram(), [&](Clause& clause) {
         // find out if the target expression variable occurs elsewhere in the rule. If so, rename it
         // to avoid naming conflicts
-        visitDepthFirst(clause, [&](const Aggregator& agg) {
+        visitDepthFirst(clause, [&](Aggregator& agg) {
             // get the set of local variables in this aggregate and rename
             // those that occur outside the aggregate
             std::set<std::string> localVariables = analysis::getLocalVariables(translationUnit, clause, agg);
@@ -48,9 +48,9 @@ bool UniqueAggregationVariablesTransformer::transform(TranslationUnit& translati
                 if (variablesOutsideAggregate.find(name) != variablesOutsideAggregate.end()) {
                     // then this MUST be renamed to avoid scoping issues
                     std::string uniqueName = analysis::findUniqueVariableName(clause, name);
-                    visitDepthFirst(agg, [&](const Variable& var) {
+                    visitDepthFirst(agg, [&](Variable& var) {
                         if (var.getName() == name) {
-                            const_cast<Variable&>(var).setName(uniqueName);
+                            var.setName(uniqueName);
                             changed = true;
                         }
                     });

--- a/src/ast/transform/UniqueAggregationVariables.h
+++ b/src/ast/transform/UniqueAggregationVariables.h
@@ -29,11 +29,11 @@ public:
         return "UniqueAggregationVariablesTransformer";
     }
 
-    UniqueAggregationVariablesTransformer* clone() const override {
+private:
+    UniqueAggregationVariablesTransformer* cloneImpl() const override {
         return new UniqueAggregationVariablesTransformer();
     }
 
-private:
     bool transform(TranslationUnit& translationUnit) override;
 };
 

--- a/src/ast/transform/While.h
+++ b/src/ast/transform/While.h
@@ -44,7 +44,7 @@ public:
         return {transformer.get()};
     }
     void setDebugReport() override {
-        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+        if (auto* mt = as<MetaTransformer>(transformer)) {
             mt->setDebugReport();
         } else {
             transformer = mk<DebugReporter>(std::move(transformer));
@@ -53,13 +53,13 @@ public:
 
     void setVerbosity(bool verbose) override {
         this->verbose = verbose;
-        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+        if (auto* mt = as<MetaTransformer>(transformer)) {
             mt->setVerbosity(verbose);
         }
     }
 
     void disableTransformers(const std::set<std::string>& transforms) override {
-        if (auto* mt = dynamic_cast<MetaTransformer*>(transformer.get())) {
+        if (auto* mt = as<MetaTransformer>(transformer)) {
             mt->disableTransformers(transforms);
         } else if (transforms.find(transformer->getName()) != transforms.end()) {
             transformer = mk<NullTransformer>();

--- a/src/ast/transform/While.h
+++ b/src/ast/transform/While.h
@@ -70,13 +70,10 @@ public:
         return "WhileTransformer";
     }
 
-    WhileTransformer* clone() const override {
+private:
+    WhileTransformer* cloneImpl() const override {
         return new WhileTransformer(condition, souffle::clone(transformer));
     }
-
-private:
-    std::function<bool()> condition;
-    Own<Transformer> transformer;
 
     bool transform(TranslationUnit& translationUnit) override {
         bool changed = false;
@@ -85,6 +82,10 @@ private:
         }
         return changed;
     }
+
+private:
+    std::function<bool()> condition;
+    Own<Transformer> transformer;
 };
 
 }  // namespace souffle::ast::transform

--- a/src/ast/utility/BindingStore.cpp
+++ b/src/ast/utility/BindingStore.cpp
@@ -57,7 +57,7 @@ void BindingStore::generateBindingDependencies(const Clause* clause) {
 
 void BindingStore::processEqualityBindings(const Argument* lhs, const Argument* rhs) {
     // Only care about equalities affecting the bound status of variables
-    const auto* var = dynamic_cast<const Variable*>(lhs);
+    const auto* var = as<Variable>(lhs);
     if (var == nullptr) return;
 
     // If all variables on the rhs are bound, then lhs is also bound
@@ -66,9 +66,9 @@ void BindingStore::processEqualityBindings(const Argument* lhs, const Argument* 
     addBindingDependency(var->getName(), depSet);
 
     // If the lhs is bound, then all args in the rec on the rhs are also bound
-    if (const auto* rec = dynamic_cast<const RecordInit*>(rhs)) {
+    if (const auto* rec = as<RecordInit>(rhs)) {
         for (const auto* arg : rec->getArguments()) {
-            const auto* subVar = dynamic_cast<const Variable*>(arg);
+            const auto* subVar = as<Variable>(arg);
             assert(subVar != nullptr && "expected args to be variables");
             addBindingDependency(subVar->getName(), BindingStore::ConjBindingSet({var->getName()}));
         }
@@ -140,9 +140,9 @@ bool BindingStore::reduceDependencies() {
 }
 
 bool BindingStore::isBound(const Argument* arg) const {
-    if (const auto* var = dynamic_cast<const Variable*>(arg)) {
+    if (const auto* var = as<Variable>(arg)) {
         return isBound(var->getName());
-    } else if (const auto* term = dynamic_cast<const Term*>(arg)) {
+    } else if (const auto* term = as<Term>(arg)) {
         for (const auto* subArg : term->getArguments()) {
             if (!isBound(subArg)) {
                 return false;

--- a/src/ast/utility/NodeMapper.h
+++ b/src/ast/utility/NodeMapper.h
@@ -46,8 +46,8 @@ public:
     template <typename T>
     Own<T> operator()(Own<T> node) const {
         Own<Node> resPtr = (*this)(Own<Node>(static_cast<Node*>(node.release())));
-        assert(isA<T>(resPtr.get()) && "Invalid target node!");
-        return Own<T>(dynamic_cast<T*>(resPtr.release()));
+        assert(isA<T>(resPtr) && "Invalid target node!");
+        return Own<T>(as<T>(resPtr.release()));
     }
 };
 

--- a/src/ast/utility/SipsMetric.cpp
+++ b/src/ast/utility/SipsMetric.cpp
@@ -45,7 +45,7 @@ std::vector<unsigned int> SipsMetric::getReordering(const Clause* clause) const 
 
         // set all arguments that are variables as bound
         for (const auto* arg : nextAtom->getArguments()) {
-            if (const auto* var = dynamic_cast<const Variable*>(arg)) {
+            if (const auto* var = as<Variable>(arg)) {
                 bindingStore.bindVariableStrongly(var->getName());
             }
         }

--- a/src/ast/utility/SipsMetric.cpp
+++ b/src/ast/utility/SipsMetric.cpp
@@ -61,28 +61,28 @@ std::vector<unsigned int> SipsMetric::getReordering(const Clause* clause) const 
 /** Create a SIPS metric based on a given heuristic. */
 std::unique_ptr<SipsMetric> SipsMetric::create(const std::string& heuristic, const TranslationUnit& tu) {
     if (heuristic == "strict")
-        return std::make_unique<StrictSips>();
+        return mk<StrictSips>();
     else if (heuristic == "all-bound")
-        return std::make_unique<AllBoundSips>();
+        return mk<AllBoundSips>();
     else if (heuristic == "naive")
-        return std::make_unique<NaiveSips>();
+        return mk<NaiveSips>();
     else if (heuristic == "max-bound")
-        return std::make_unique<MaxBoundSips>();
+        return mk<MaxBoundSips>();
     else if (heuristic == "max-ratio")
-        return std::make_unique<MaxRatioSips>();
+        return mk<MaxRatioSips>();
     else if (heuristic == "least-free")
-        return std::make_unique<LeastFreeSips>();
+        return mk<LeastFreeSips>();
     else if (heuristic == "least-free-vars")
-        return std::make_unique<LeastFreeVarsSips>();
+        return mk<LeastFreeVarsSips>();
     else if (heuristic == "profile-use")
-        return std::make_unique<ProfileUseSips>(*tu.getAnalysis<analysis::ProfileUseAnalysis>());
+        return mk<ProfileUseSips>(*tu.getAnalysis<analysis::ProfileUseAnalysis>());
     else if (heuristic == "delta")
-        return std::make_unique<DeltaSips>();
+        return mk<DeltaSips>();
     else if (heuristic == "input")
-        return std::make_unique<InputSips>(*tu.getAnalysis<analysis::RelationDetailCacheAnalysis>(),
+        return mk<InputSips>(*tu.getAnalysis<analysis::RelationDetailCacheAnalysis>(),
                 *tu.getAnalysis<analysis::IOTypeAnalysis>());
     else if (heuristic == "delta-input")
-        return std::make_unique<DeltaInputSips>(*tu.getAnalysis<analysis::RelationDetailCacheAnalysis>(),
+        return mk<DeltaInputSips>(*tu.getAnalysis<analysis::RelationDetailCacheAnalysis>(),
                 *tu.getAnalysis<analysis::IOTypeAnalysis>());
 
     // default is all-bound

--- a/src/ast/utility/Utils.cpp
+++ b/src/ast/utility/Utils.cpp
@@ -319,9 +319,9 @@ Clause* reorderAtoms(const Clause* clause, const std::vector<unsigned int>& newO
 }
 
 void negateConstraintInPlace(Constraint& constraint) {
-    if (auto* bcstr = dynamic_cast<BooleanConstraint*>(&constraint)) {
+    if (auto* bcstr = as<BooleanConstraint>(constraint)) {
         bcstr->set(!bcstr->isTrue());
-    } else if (auto* cstr = dynamic_cast<BinaryConstraint*>(&constraint)) {
+    } else if (auto* cstr = as<BinaryConstraint>(constraint)) {
         cstr->setBaseOperator(souffle::negatedConstraintOp(cstr->getBaseOperator()));
     } else {
         fatal("Unknown ast-constraint type");
@@ -335,7 +335,7 @@ bool renameAtoms(Node& node, const std::map<QualifiedName, QualifiedName>& oldTo
         rename_atoms(const std::map<QualifiedName, QualifiedName>& oldToNew) : oldToNew(oldToNew) {}
         Own<Node> operator()(Own<Node> node) const override {
             node->apply(*this);
-            if (auto* atom = dynamic_cast<Atom*>(node.get())) {
+            if (auto* atom = as<Atom>(node)) {
                 if (contains(oldToNew, atom->getQualifiedName())) {
                     auto renamedAtom = souffle::clone(atom);
                     renamedAtom->setQualifiedName(oldToNew.at(atom->getQualifiedName()));

--- a/src/ast/utility/Utils.h
+++ b/src/ast/utility/Utils.h
@@ -83,7 +83,7 @@ template <typename T, typename C>
 std::vector<T*> getBodyLiterals(const C& clause) {
     std::vector<T*> res;
     for (auto& lit : clause.getBodyLiterals()) {
-        if (T* t = dynamic_cast<T*>(lit)) {
+        if (T* t = as<T>(lit)) {
             res.push_back(t);
         }
     }

--- a/src/ast/utility/Utils.h
+++ b/src/ast/utility/Utils.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "FunctorOps.h"
+#include "souffle/utility/Types.h"
 #include <cstddef>
 #include <map>
 #include <set>
@@ -249,7 +250,7 @@ bool isDeltaRelation(const QualifiedName& name);
  * @param clause the clause which head to be cloned
  * @return pointer to clause which has head cloned from given clause
  */
-Clause* cloneHead(const Clause* clause);
+Own<Clause> cloneHead(const Clause& clause);
 
 /**
  * Reorders the atoms of a clause to be in the given order.

--- a/src/ast/utility/Visitor.h
+++ b/src/ast/utility/Visitor.h
@@ -284,7 +284,8 @@ struct LambdaVisitor : public Visitor<void, copy_const_t<NodeToVisit, Node>> {
     F lambda;
     LambdaVisitor(F lam) : lambda(std::move(lam)) {}
     void visit(copy_const_t<NodeToVisit, Node>& node) override {
-        if (auto* n = as<NodeToVisit>(node)) {
+        // Don't use as<> to allow cross-casting to mixins
+        if (const auto* n = dynamic_cast<NodeToVisit*>(&node)) {
             lambda(*n);
         }
     }

--- a/src/ast/utility/Visitor.h
+++ b/src/ast/utility/Visitor.h
@@ -285,7 +285,7 @@ struct LambdaVisitor : public Visitor<void, copy_const_t<NodeToVisit, Node>> {
     LambdaVisitor(F lam) : lambda(std::move(lam)) {}
     void visit(copy_const_t<NodeToVisit, Node>& node) override {
         // Don't use as<> to allow cross-casting to mixins
-        if (const auto* n = dynamic_cast<NodeToVisit*>(&node)) {
+        if (auto* n = dynamic_cast<NodeToVisit*>(&node)) {
             lambda(*n);
         }
     }

--- a/src/ast/utility/Visitor.h
+++ b/src/ast/utility/Visitor.h
@@ -146,9 +146,9 @@ struct Visitor : public ast_visitor_tag {
         fatal("unsupported type: %s", typeid(node).name());
     }
 
-#define LINK(Kind, Parent)                                   \
+#define LINK(Kind, Parent)                                                          \
     virtual R visit##Kind(copy_const_t<NodeType, Kind>& n, Params const&... args) { \
-        return visit##Parent(n, args...);                     \
+        return visit##Parent(n, args...);                                           \
     }
 
     // -- types --

--- a/src/ast2ram/provenance/SubproofGenerator.cpp
+++ b/src/ast2ram/provenance/SubproofGenerator.cpp
@@ -95,7 +95,7 @@ Own<ram::Operation> SubproofGenerator::addBodyLiteralConstraints(
     // Add all non-constraints, and then constraints
     std::vector<const ast::Constraint*> constraints;
     for (const auto* lit : clause.getBodyLiterals()) {
-        if (const auto* constraint = dynamic_cast<const ast::Constraint*>(lit)) {
+        if (const auto* constraint = as<ast::Constraint>(lit)) {
             constraints.push_back(constraint);
             continue;
         }
@@ -118,24 +118,24 @@ Own<ram::Operation> SubproofGenerator::addBodyLiteralConstraints(
     size_t levelIndex = clause.getHead()->getArguments().size() - auxiliaryArity;
     for (size_t i = 0; i < head->getArity() - auxiliaryArity; i++) {
         auto arg = headArgs.at(i);
-        if (const auto* var = dynamic_cast<const ast::Variable*>(arg)) {
+        if (const auto* var = as<ast::Variable>(arg)) {
             // FIXME: float equiv (`FEQ`)
             auto lhs = context.translateValue(symbolTable, *valueIndex, var);
             auto constraint = mk<ram::Constraint>(
                     BinaryConstraintOp::EQ, std::move(lhs), mk<ram::SubroutineArgument>(i));
             op = mk<ram::Filter>(std::move(constraint), std::move(op));
-        } else if (const auto* func = dynamic_cast<const ast::Functor*>(arg)) {
+        } else if (const auto* func = as<ast::Functor>(arg)) {
             TypeAttribute returnType = context.getFunctorReturnType(func);
             auto opEq = returnType == TypeAttribute::Float ? BinaryConstraintOp::FEQ : BinaryConstraintOp::EQ;
             auto lhs = context.translateValue(symbolTable, *valueIndex, func);
             auto constraint = mk<ram::Constraint>(opEq, std::move(lhs), mk<ram::SubroutineArgument>(i));
             op = mk<ram::Filter>(std::move(constraint), std::move(op));
-        } else if (const auto* rec = dynamic_cast<const ast::RecordInit*>(arg)) {
+        } else if (const auto* rec = as<ast::RecordInit>(arg)) {
             auto lhs = context.translateValue(symbolTable, *valueIndex, rec);
             auto constraint = mk<ram::Constraint>(
                     BinaryConstraintOp::EQ, std::move(lhs), mk<ram::SubroutineArgument>(i));
             op = mk<ram::Filter>(std::move(constraint), std::move(op));
-        } else if (const auto* adt = dynamic_cast<const ast::BranchInit*>(arg)) {
+        } else if (const auto* adt = as<ast::BranchInit>(arg)) {
             // TODO (azreika): fill this out like record arguments
             assert(false && adt && "unhandled");
         }
@@ -145,7 +145,7 @@ Own<ram::Operation> SubproofGenerator::addBodyLiteralConstraints(
 
     // add level constraints, i.e., that each body literal has height less than that of the head atom
     for (const auto* lit : clause.getBodyLiterals()) {
-        if (const auto* atom = dynamic_cast<const ast::Atom*>(lit)) {
+        if (const auto* atom = as<ast::Atom>(lit)) {
             // arity - 1 is the level number in body atoms
             auto arity = atom->getArity();
             auto atomArgs = atom->getArguments();
@@ -178,11 +178,11 @@ Own<ram::Operation> SubproofGenerator::generateReturnInstantiatedValues(const as
 
     // get all values in the body
     for (ast::Literal* lit : clause.getBodyLiterals()) {
-        if (auto atom = dynamic_cast<ast::Atom*>(lit)) {
+        if (auto atom = as<ast::Atom>(lit)) {
             for (ast::Argument* arg : atom->getArguments()) {
                 values.push_back(context.translateValue(symbolTable, *valueIndex, arg));
             }
-        } else if (auto neg = dynamic_cast<ast::Negation*>(lit)) {
+        } else if (auto neg = as<ast::Negation>(lit)) {
             for (ast::Argument* arg : neg->getAtom()->getArguments()) {
                 values.push_back(context.translateValue(symbolTable, *valueIndex, arg));
             }
@@ -213,23 +213,23 @@ Own<ram::Operation> SubproofGenerator::generateReturnInstantiatedValues(const as
     size_t levelIndex = clause.getHead()->getArguments().size() - auxiliaryArity;
     for (size_t i = 0; i < head->getArity() - auxiliaryArity; i++) {
         auto arg = headArgs.at(i);
-        if (const auto* var = dynamic_cast<const ast::Variable*>(arg)) {
+        if (const auto* var = as<ast::Variable>(arg)) {
             values.push_back(context.translateValue(symbolTable, *valueIndex, var));
             values.push_back(mk<ram::SubroutineArgument>(i));
-        } else if (const auto* func = dynamic_cast<const ast::Functor*>(arg)) {
+        } else if (const auto* func = as<ast::Functor>(arg)) {
             values.push_back(context.translateValue(symbolTable, *valueIndex, func));
             values.push_back(mk<ram::SubroutineArgument>(i));
-        } else if (const auto* rec = dynamic_cast<const ast::RecordInit*>(arg)) {
+        } else if (const auto* rec = as<ast::RecordInit>(arg)) {
             values.push_back(context.translateValue(symbolTable, *valueIndex, rec));
             values.push_back(mk<ram::SubroutineArgument>(i));
-        } else if (const auto* adt = dynamic_cast<const ast::BranchInit*>(arg)) {
+        } else if (const auto* adt = as<ast::BranchInit>(arg)) {
             // TODO (azreika): fill this out like record arguments
             assert(false && adt && "unhandled");
         }
     }
 
     for (const auto* lit : clause.getBodyLiterals()) {
-        if (const auto* atom = dynamic_cast<const ast::Atom*>(lit)) {
+        if (const auto* atom = as<ast::Atom>(lit)) {
             auto arity = atom->getArity();
             auto atomArgs = atom->getArguments();
             values.push_back(context.translateValue(symbolTable, *valueIndex, atomArgs.at(arity - 1)));

--- a/src/ast2ram/provenance/UnitTranslator.cpp
+++ b/src/ast2ram/provenance/UnitTranslator.cpp
@@ -134,7 +134,7 @@ void UnitTranslator::transformVariablesToSubroutineArgs(
         VariablesToArguments(const std::map<int, const ast::Variable*>& idToVar) : idToVar(idToVar) {}
 
         Own<ram::Node> operator()(Own<ram::Node> node) const override {
-            if (const auto* tuple = dynamic_cast<const ram::TupleElement*>(node.get())) {
+            if (const auto* tuple = as<ram::TupleElement>(node)) {
                 const auto* var = idToVar.at(tuple->getTupleId());
                 if (isPrefix("@level_num", var->getName())) {
                     return mk<ram::UndefValue>();
@@ -193,7 +193,7 @@ Own<ram::Statement> UnitTranslator::makeNegationSubproofSubroutine(const ast::Cl
     //     AggregatesToVariables() = default;
 
     //     Own<ast::Node> operator()(Own<ast::Node> node) const override {
-    //         if (dynamic_cast<ast::Aggregator*>(node.get()) != nullptr) {
+    //         if (as<ast::Aggregator>(node) != nullptr) {
     //             return mk<ast::Variable>("agg_" + std::to_string(aggNumber++));
     //         }
 
@@ -231,19 +231,19 @@ Own<ram::Statement> UnitTranslator::makeNegationSubproofSubroutine(const ast::Cl
     // go through each body atom and create a return
     size_t litNumber = 0;
     for (const auto* lit : lits) {
-        if (const auto* atom = dynamic_cast<const ast::Atom*>(lit)) {
+        if (const auto* atom = as<ast::Atom>(lit)) {
             auto existenceCheck = makeRamAtomExistenceCheck(atom, idToVar, *dummyValueIndex);
             transformVariablesToSubroutineArgs(existenceCheck.get(), idToVar);
             auto ifStatement =
                     makeIfStatement(std::move(existenceCheck), makeRamReturnTrue(), makeRamReturnFalse());
             appendStmt(searchSequence, std::move(ifStatement));
-        } else if (const auto* neg = dynamic_cast<const ast::Negation*>(lit)) {
+        } else if (const auto* neg = as<ast::Negation>(lit)) {
             auto existenceCheck = makeRamAtomExistenceCheck(neg->getAtom(), idToVar, *dummyValueIndex);
             transformVariablesToSubroutineArgs(existenceCheck.get(), idToVar);
             auto ifStatement =
                     makeIfStatement(std::move(existenceCheck), makeRamReturnFalse(), makeRamReturnTrue());
             appendStmt(searchSequence, std::move(ifStatement));
-        } else if (const auto* con = dynamic_cast<const ast::Constraint*>(lit)) {
+        } else if (const auto* con = as<ast::Constraint>(lit)) {
             auto condition = context->translateConstraint(*symbolTable, *dummyValueIndex, con);
             transformVariablesToSubroutineArgs(condition.get(), idToVar);
             auto ifStatement =

--- a/src/ast2ram/seminaive/ClauseTranslator.cpp
+++ b/src/ast2ram/seminaive/ClauseTranslator.cpp
@@ -302,13 +302,13 @@ Own<ram::Operation> ClauseTranslator::addVariableIntroductions(
         const ast::Clause& clause, Own<ram::Operation> op) {
     for (int i = operators.size() - 1; i >= 0; i--) {
         const auto* curOp = operators.at(i);
-        if (const auto* atom = dynamic_cast<const ast::Atom*>(curOp)) {
+        if (const auto* atom = as<ast::Atom>(curOp)) {
             // add atom arguments through a scan
             op = addAtomScan(std::move(op), atom, clause, i);
-        } else if (const auto* rec = dynamic_cast<const ast::RecordInit*>(curOp)) {
+        } else if (const auto* rec = as<ast::RecordInit>(curOp)) {
             // add record arguments through an unpack
             op = addRecordUnpack(std::move(op), rec, i);
-        } else if (const auto* adt = dynamic_cast<const ast::BranchInit*>(curOp)) {
+        } else if (const auto* adt = as<ast::BranchInit>(curOp)) {
             // add adt arguments through an unpack
             op = addAdtUnpack(std::move(op), adt, i);
         } else {
@@ -351,7 +351,7 @@ Own<ram::Operation> ClauseTranslator::instantiateAggregator(
 
         // variable bindings are issued differently since we don't want self
         // referential variable bindings
-        if (auto* var = dynamic_cast<const ast::Variable*>(arg)) {
+        if (auto* var = as<ast::Variable>(arg)) {
             for (auto&& loc : valueIndex->getVariableReferences(var->getName())) {
                 if (curLevel != loc.identifier || (int)i != loc.element) {
                     aggCond = addAggEqCondition(std::move(aggCond), makeRamTupleElement(loc), i);
@@ -399,9 +399,9 @@ Own<ram::Operation> ClauseTranslator::addGeneratorLevels(
         Own<ram::Operation> op, const ast::Clause& clause) const {
     size_t curLevel = operators.size() + generators.size() - 1;
     for (const auto* generator : reverse(generators)) {
-        if (auto agg = dynamic_cast<const ast::Aggregator*>(generator)) {
+        if (auto agg = as<ast::Aggregator>(generator)) {
             op = instantiateAggregator(std::move(op), clause, agg, curLevel);
-        } else if (const auto* inf = dynamic_cast<const ast::IntrinsicFunctor*>(generator)) {
+        } else if (const auto* inf = as<ast::IntrinsicFunctor>(generator)) {
             op = instantiateMultiResultFunctor(std::move(op), inf, curLevel);
         } else {
             assert(false && "unhandled generator");
@@ -498,11 +498,11 @@ Own<ram::Condition> ClauseTranslator::createCondition(const ast::Clause& clause)
 
 RamDomain ClauseTranslator::getConstantRamRepresentation(
         SymbolTable& symbolTable, const ast::Constant& constant) const {
-    if (auto strConstant = dynamic_cast<const ast::StringConstant*>(&constant)) {
+    if (auto strConstant = as<ast::StringConstant>(constant)) {
         return symbolTable.lookup(strConstant->getConstant());
     } else if (isA<ast::NilConstant>(&constant)) {
         return 0;
-    } else if (auto* numConstant = dynamic_cast<const ast::NumericConstant*>(&constant)) {
+    } else if (auto* numConstant = as<ast::NumericConstant>(constant)) {
         switch (context.getInferredNumericConstantType(numConstant)) {
             case ast::NumericConstant::Type::Int:
                 return RamSignedFromString(numConstant->getConstant(), nullptr, 0);
@@ -518,7 +518,7 @@ RamDomain ClauseTranslator::getConstantRamRepresentation(
 Own<ram::Expression> ClauseTranslator::translateConstant(
         SymbolTable& symbolTable, const ast::Constant& constant) const {
     auto rawConstant = getConstantRamRepresentation(symbolTable, constant);
-    if (const auto* numericConstant = dynamic_cast<const ast::NumericConstant*>(&constant)) {
+    if (const auto* numericConstant = as<ast::NumericConstant>(constant)) {
         switch (context.getInferredNumericConstantType(numericConstant)) {
             case ast::NumericConstant::Type::Int: return mk<ram::SignedConstant>(rawConstant);
             case ast::NumericConstant::Type::Uint: return mk<ram::UnsignedConstant>(rawConstant);
@@ -540,13 +540,13 @@ Own<ram::Operation> ClauseTranslator::addConstantConstraints(
         size_t curLevel, const std::vector<ast::Argument*>& arguments, Own<ram::Operation> op) const {
     for (size_t i = 0; i < arguments.size(); i++) {
         const auto* argument = arguments.at(i);
-        if (const auto* numericConstant = dynamic_cast<const ast::NumericConstant*>(argument)) {
+        if (const auto* numericConstant = as<ast::NumericConstant>(argument)) {
             bool isFloat = context.getInferredNumericConstantType(numericConstant) ==
                            ast::NumericConstant::Type::Float;
             auto lhs = mk<ram::TupleElement>(curLevel, i);
             auto rhs = translateConstant(symbolTable, *numericConstant);
             op = addEqualityCheck(std::move(op), std::move(lhs), std::move(rhs), isFloat);
-        } else if (const auto* constant = dynamic_cast<const ast::Constant*>(argument)) {
+        } else if (const auto* constant = as<ast::Constant>(argument)) {
             auto lhs = mk<ram::TupleElement>(curLevel, i);
             auto rhs = translateConstant(symbolTable, *constant);
             op = addEqualityCheck(std::move(op), std::move(lhs), std::move(rhs), false);
@@ -660,12 +660,12 @@ void ClauseTranslator::indexNodeArguments(int nodeLevel, const std::vector<ast::
         const auto& arg = nodeArgs.at(i);
 
         // check for variable references
-        if (const auto* var = dynamic_cast<const ast::Variable*>(arg)) {
+        if (const auto* var = as<ast::Variable>(arg)) {
             valueIndex->addVarReference(*var, nodeLevel, i);
         }
 
         // check for nested records
-        if (const auto* rec = dynamic_cast<const ast::RecordInit*>(arg)) {
+        if (const auto* rec = as<ast::RecordInit>(arg)) {
             valueIndex->setRecordDefinition(*rec, nodeLevel, i);
 
             // introduce new nesting level for unpack
@@ -674,7 +674,7 @@ void ClauseTranslator::indexNodeArguments(int nodeLevel, const std::vector<ast::
         }
 
         // check for nested ADT branches
-        if (const auto* adt = dynamic_cast<const ast::BranchInit*>(arg)) {
+        if (const auto* adt = as<ast::BranchInit>(arg)) {
             valueIndex->setAdtDefinition(*adt, nodeLevel, i);
 
             // introduce new nesting level for unpack
@@ -717,7 +717,7 @@ void ClauseTranslator::indexAggregatorBody(const ast::Aggregator& agg) {
     const auto& aggAtomArgs = aggAtom->getArguments();
     for (size_t i = 0; i < aggAtomArgs.size(); i++) {
         const auto* arg = aggAtomArgs.at(i);
-        if (const auto* var = dynamic_cast<const ast::Variable*>(arg)) {
+        if (const auto* var = as<ast::Variable>(arg)) {
             valueIndex->addVarReference(*var, aggLoc.identifier, (int)i);
         }
     }
@@ -733,8 +733,8 @@ void ClauseTranslator::indexAggregators(const ast::Clause& clause) {
     // Add aggregator value introductions
     visitDepthFirst(clause, [&](const ast::BinaryConstraint& bc) {
         if (!isEqConstraint(bc.getBaseOperator())) return;
-        const auto* lhs = dynamic_cast<const ast::Variable*>(bc.getLHS());
-        const auto* rhs = dynamic_cast<const ast::Aggregator*>(bc.getRHS());
+        const auto* lhs = as<ast::Variable>(bc.getLHS());
+        const auto* rhs = as<ast::Aggregator>(bc.getRHS());
         if (lhs == nullptr || rhs == nullptr) return;
         valueIndex->addVarReference(*lhs, valueIndex->getGeneratorLoc(*rhs));
     });
@@ -751,8 +751,8 @@ void ClauseTranslator::indexMultiResultFunctors(const ast::Clause& clause) {
     // Add multi-result functor value introductions
     visitDepthFirst(clause, [&](const ast::BinaryConstraint& bc) {
         if (!isEqConstraint(bc.getBaseOperator())) return;
-        const auto* lhs = dynamic_cast<const ast::Variable*>(bc.getLHS());
-        const auto* rhs = dynamic_cast<const ast::IntrinsicFunctor*>(bc.getRHS());
+        const auto* lhs = as<ast::Variable>(bc.getLHS());
+        const auto* rhs = as<ast::IntrinsicFunctor>(bc.getRHS());
         if (lhs == nullptr || rhs == nullptr) return;
         if (!ast::analysis::FunctorAnalysis::isMultiResult(*rhs)) return;
         valueIndex->addVarReference(*lhs, valueIndex->getGeneratorLoc(*rhs));

--- a/src/ast2ram/seminaive/ClauseTranslator.cpp
+++ b/src/ast2ram/seminaive/ClauseTranslator.cpp
@@ -82,7 +82,7 @@ bool ClauseTranslator::isRecursive() const {
 }
 
 std::string ClauseTranslator::getClauseString(const ast::Clause& clause) const {
-    auto renamedClone = souffle::clone(&clause);
+    auto renamedClone = souffle::clone(clause);
 
     // Update the head atom
     renamedClone->getHead()->setQualifiedName(getClauseAtomName(clause, clause.getHead()));

--- a/src/ast2ram/utility/Utils.cpp
+++ b/src/ast2ram/utility/Utils.cpp
@@ -72,7 +72,7 @@ void nameUnnamedVariables(ast::Clause* clause) {
             node->apply(*this);
 
             // replace unknown variables
-            if (dynamic_cast<ast::UnnamedVariable*>(node.get()) != nullptr) {
+            if (isA<ast::UnnamedVariable>(node)) {
                 auto name = " _unnamed_var" + toString(++counter);
                 return mk<ast::Variable>(name);
             }

--- a/src/include/souffle/CompiledSouffle.h
+++ b/src/include/souffle/CompiledSouffle.h
@@ -111,7 +111,7 @@ private:
 
     protected:
         bool equal(const iterator_base& o) const override {
-            const auto& casted = static_cast<const iterator_wrapper&>(o);
+            const auto& casted = asAssert<iterator_wrapper>(o);
             return it == casted.it;
         }
     };

--- a/src/include/souffle/SouffleInterface.h
+++ b/src/include/souffle/SouffleInterface.h
@@ -61,6 +61,9 @@ protected:
          * Required for identifying type of iterator
          * (NB: LLVM has no typeinfo).
          *
+         * Note: The above statement is not true anymore - should this be made to work the same
+         * as Node::operator==?
+         *
          * TODO (Honghyw) : Provide a clear documentation of what id is used for.
          */
         uint32_t id;

--- a/src/include/souffle/datastructure/BTree.h
+++ b/src/include/souffle/datastructure/BTree.h
@@ -19,6 +19,7 @@
 
 #include "souffle/utility/CacheUtil.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/ParallelUtil.h"
 #include <algorithm>
 #include <cassert>

--- a/src/include/souffle/datastructure/Brie.h
+++ b/src/include/souffle/datastructure/Brie.h
@@ -2738,7 +2738,7 @@ public:
         // conduct a lock-free lazy-creation of nested trees
         if (!nextPtr) {
             // create a sub-tree && register it atomically
-            auto newNested = std::make_unique<nested_trie_type>();
+            auto newNested = mk<nested_trie_type>();
             if (next.compare_exchange_weak(nextPtr, newNested.get())) {
                 nextPtr = newNested.release();  // worked, ownership is acquired by `store`
             }

--- a/src/include/souffle/datastructure/UnionFind.h
+++ b/src/include/souffle/datastructure/UnionFind.h
@@ -18,6 +18,7 @@
 
 #include "souffle/datastructure/LambdaBTree.h"
 #include "souffle/datastructure/PiggyList.h"
+#include "souffle/utility/MiscUtil.h"
 #include <atomic>
 #include <cstddef>
 #include <cstdint>

--- a/src/include/souffle/io/ReadStreamCSV.h
+++ b/src/include/souffle/io/ReadStreamCSV.h
@@ -67,7 +67,7 @@ protected:
             return nullptr;
         }
         std::string line;
-        Own<RamDomain[]> tuple = std::make_unique<RamDomain[]>(typeAttributes.size());
+        Own<RamDomain[]> tuple = mk<RamDomain[]>(typeAttributes.size());
 
         if (!getline(file, line)) {
             return nullptr;

--- a/src/include/souffle/io/ReadStreamJSON.h
+++ b/src/include/souffle/io/ReadStreamJSON.h
@@ -114,7 +114,7 @@ protected:
             return nullptr;
         }
 
-        Own<RamDomain[]> tuple = std::make_unique<RamDomain[]>(typeAttributes.size());
+        Own<RamDomain[]> tuple = mk<RamDomain[]>(typeAttributes.size());
         const Json& jsonObj = jsonSource[pos];
         assert(jsonObj.is_array() && "the input is not json array");
         pos++;
@@ -209,7 +209,7 @@ protected:
             return nullptr;
         }
 
-        Own<RamDomain[]> tuple = std::make_unique<RamDomain[]>(typeAttributes.size());
+        Own<RamDomain[]> tuple = mk<RamDomain[]>(typeAttributes.size());
         const Json& jsonObj = jsonSource[pos];
         assert(jsonObj.is_object() && "the input is not json object");
         pos++;

--- a/src/include/souffle/io/ReadStreamSQLite.h
+++ b/src/include/souffle/io/ReadStreamSQLite.h
@@ -60,7 +60,7 @@ protected:
             return nullptr;
         }
 
-        Own<RamDomain[]> tuple = std::make_unique<RamDomain[]>(arity + auxiliaryArity);
+        Own<RamDomain[]> tuple = mk<RamDomain[]>(arity + auxiliaryArity);
 
         uint32_t column;
         for (column = 0; column < arity; column++) {

--- a/src/include/souffle/profile/ProfileDatabase.h
+++ b/src/include/souffle/profile/ProfileDatabase.h
@@ -379,7 +379,7 @@ public:
         DirectoryEntry* dir = lookupPath(path);
 
         const std::string& key = qualifier.back();
-        Own<TextEntry> entry = std::make_unique<TextEntry>(key, text);
+        Own<TextEntry> entry = mk<TextEntry>(key, text);
         dir->writeEntry(std::move(entry));
     }
 
@@ -390,7 +390,7 @@ public:
         DirectoryEntry* dir = lookupPath(path);
 
         const std::string& key = qualifier.back();
-        Own<DurationEntry> entry = std::make_unique<DurationEntry>(key, start, end);
+        Own<DurationEntry> entry = mk<DurationEntry>(key, start, end);
         dir->writeEntry(std::move(entry));
     }
 
@@ -401,7 +401,7 @@ public:
         DirectoryEntry* dir = lookupPath(path);
 
         const std::string& key = qualifier.back();
-        Own<TimeEntry> entry = std::make_unique<TimeEntry>(key, time);
+        Own<TimeEntry> entry = mk<TimeEntry>(key, time);
         dir->writeEntry(std::move(entry));
     }
 

--- a/src/include/souffle/profile/ProfileDatabase.h
+++ b/src/include/souffle/profile/ProfileDatabase.h
@@ -116,7 +116,7 @@ public:
 
     // read directory
     DirectoryEntry* readDirectoryEntry(const std::string& keyToRead) const {
-        return dynamic_cast<DirectoryEntry*>(readEntry(keyToRead));
+        return as<DirectoryEntry>(readEntry(keyToRead));
     }
 
     // accept visitor
@@ -306,7 +306,7 @@ protected:
             assert(!key.empty() && "Key is empty!");
             DirectoryEntry* newDir = dir->readDirectoryEntry(key);
             if (newDir == nullptr) {
-                newDir = dynamic_cast<DirectoryEntry*>(dir->writeEntry(mk<DirectoryEntry>(key)));
+                newDir = as<DirectoryEntry>(dir->writeEntry(mk<DirectoryEntry>(key)));
             }
             assert(newDir != nullptr && "Attempting to overwrite an existing entry");
             dir = newDir;
@@ -438,13 +438,13 @@ public:
      */
     std::map<std::string, std::string> getStringMap(const std::vector<std::string>& path) const {
         std::map<std::string, std::string> kvps;
-        auto* parent = dynamic_cast<DirectoryEntry*>(lookupEntry(path));
+        auto* parent = as<DirectoryEntry>(lookupEntry(path));
         if (parent == nullptr) {
             return kvps;
         }
 
         for (const auto& key : parent->getKeys()) {
-            auto* text = dynamic_cast<TextEntry*>(parent->readEntry(key));
+            auto* text = as<TextEntry>(parent->readEntry(key));
             if (text != nullptr) {
                 kvps[key] = text->getText();
             }

--- a/src/include/souffle/profile/Reader.h
+++ b/src/include/souffle/profile/Reader.h
@@ -72,8 +72,7 @@ public:
 
         for (auto& key : directory.getKeys()) {
             auto* level = as<SizeEntry>(directory.readDirectoryEntry(key)->readEntry("level"));
-            auto* frequency =
-                    as<SizeEntry>(directory.readDirectoryEntry(key)->readEntry("num-tuples"));
+            auto* frequency = as<SizeEntry>(directory.readDirectoryEntry(key)->readEntry("num-tuples"));
             // Handle older logs
             size_t intFreq = frequency == nullptr ? 0 : frequency->getSize();
             size_t intLevel = level == nullptr ? 0 : level->getSize();

--- a/src/include/souffle/profile/Reader.h
+++ b/src/include/souffle/profile/Reader.h
@@ -71,9 +71,9 @@ public:
         const std::string& clause = directory.getKey();
 
         for (auto& key : directory.getKeys()) {
-            auto* level = dynamic_cast<SizeEntry*>(directory.readDirectoryEntry(key)->readEntry("level"));
+            auto* level = as<SizeEntry>(directory.readDirectoryEntry(key)->readEntry("level"));
             auto* frequency =
-                    dynamic_cast<SizeEntry*>(directory.readDirectoryEntry(key)->readEntry("num-tuples"));
+                    as<SizeEntry>(directory.readDirectoryEntry(key)->readEntry("num-tuples"));
             // Handle older logs
             size_t intFreq = frequency == nullptr ? 0 : frequency->getSize();
             size_t intLevel = level == nullptr ? 0 : level->getSize();
@@ -189,8 +189,8 @@ public:
             }
         }
         if (directory.getKey() == "maxRSS") {
-            auto* preMaxRSS = dynamic_cast<SizeEntry*>(directory.readEntry("pre"));
-            auto* postMaxRSS = dynamic_cast<SizeEntry*>(directory.readEntry("post"));
+            auto* preMaxRSS = as<SizeEntry>(directory.readEntry("pre"));
+            auto* postMaxRSS = as<SizeEntry>(directory.readEntry("post"));
             relation.setPreMaxRSS(preMaxRSS->getSize());
             relation.setPostMaxRSS(postMaxRSS->getSize());
         }
@@ -249,8 +249,8 @@ public:
                 directory.readEntry(key)->accept(rulesVisitor);
             }
         } else if (directory.getKey() == "maxRSS") {
-            auto* preMaxRSS = dynamic_cast<SizeEntry*>(directory.readEntry("pre"));
-            auto* postMaxRSS = dynamic_cast<SizeEntry*>(directory.readEntry("post"));
+            auto* preMaxRSS = as<SizeEntry>(directory.readEntry("pre"));
+            auto* postMaxRSS = as<SizeEntry>(directory.readEntry("post"));
             base.setPreMaxRSS(preMaxRSS->getSize());
             base.setPostMaxRSS(postMaxRSS->getSize());
         }
@@ -298,9 +298,9 @@ public:
     void processFile() {
         rel_id = 0;
         relationMap.clear();
-        auto programDuration = dynamic_cast<DurationEntry*>(db.lookupEntry({"program", "runtime"}));
+        auto programDuration = as<DurationEntry>(db.lookupEntry({"program", "runtime"}));
         if (programDuration == nullptr) {
-            auto startTimeEntry = dynamic_cast<TimeEntry*>(db.lookupEntry({"program", "starttime"}));
+            auto startTimeEntry = as<TimeEntry>(db.lookupEntry({"program", "starttime"}));
             if (startTimeEntry != nullptr) {
                 run->setStarttime(startTimeEntry->getTime());
                 run->setEndtime(std::chrono::duration_cast<microseconds>(now().time_since_epoch()));
@@ -311,13 +311,13 @@ public:
             online = false;
         }
 
-        auto relations = dynamic_cast<DirectoryEntry*>(db.lookupEntry({"program", "relation"}));
+        auto relations = as<DirectoryEntry>(db.lookupEntry({"program", "relation"}));
         if (relations == nullptr) {
             // Souffle hasn't generated any profiling information yet.
             return;
         }
         for (const auto& cur : relations->getKeys()) {
-            auto relation = dynamic_cast<DirectoryEntry*>(db.lookupEntry({"program", "relation", cur}));
+            auto relation = as<DirectoryEntry>(db.lookupEntry({"program", "relation", cur}));
             if (relation != nullptr) {
                 addRelation(*relation);
             }

--- a/src/include/souffle/profile/Tui.h
+++ b/src/include/souffle/profile/Tui.h
@@ -781,16 +781,13 @@ public:
             Usage currentUsage{};
             uint64_t cur = std::stoul(currentKey);
             currentUsage.time = std::chrono::duration<uint64_t, std::micro>(cur);
-            cur = as<SizeEntry>(
-                    usageStats->readDirectoryEntry(currentKey)->readEntry("systemtime"))
+            cur = as<SizeEntry>(usageStats->readDirectoryEntry(currentKey)->readEntry("systemtime"))
                           ->getSize();
             currentUsage.systemtime = std::chrono::duration<uint64_t, std::micro>(cur);
-            cur = as<SizeEntry>(usageStats->readDirectoryEntry(currentKey)->readEntry("usertime"))
-                          ->getSize();
+            cur = as<SizeEntry>(usageStats->readDirectoryEntry(currentKey)->readEntry("usertime"))->getSize();
             currentUsage.usertime = std::chrono::duration<uint64_t, std::micro>(cur);
             currentUsage.maxRSS =
-                    as<SizeEntry>(usageStats->readDirectoryEntry(currentKey)->readEntry("maxRSS"))
-                            ->getSize();
+                    as<SizeEntry>(usageStats->readDirectoryEntry(currentKey)->readEntry("maxRSS"))->getSize();
 
             // Duplicate times are possible
             if (allUsages.find(currentUsage) != allUsages.end()) {
@@ -1022,12 +1019,10 @@ public:
 
     void top() {
         const std::shared_ptr<ProgramRun>& run = out.getProgramRun();
-        auto* totalRelationsEntry =
-                as<TextEntry>(ProfileEventSingleton::instance().getDB().lookupEntry(
-                        {"program", "configuration", "relationCount"}));
-        auto* totalRulesEntry =
-                as<TextEntry>(ProfileEventSingleton::instance().getDB().lookupEntry(
-                        {"program", "configuration", "ruleCount"}));
+        auto* totalRelationsEntry = as<TextEntry>(ProfileEventSingleton::instance().getDB().lookupEntry(
+                {"program", "configuration", "relationCount"}));
+        auto* totalRulesEntry = as<TextEntry>(ProfileEventSingleton::instance().getDB().lookupEntry(
+                {"program", "configuration", "ruleCount"}));
         size_t totalRelations = 0;
         if (totalRelationsEntry != nullptr) {
             totalRelations = std::stoul(totalRelationsEntry->getText());

--- a/src/include/souffle/profile/Tui.h
+++ b/src/include/souffle/profile/Tui.h
@@ -767,7 +767,7 @@ public:
 
     std::set<Usage> getUsageStats(size_t width = size_t(-1)) {
         std::set<Usage> usages;
-        DirectoryEntry* usageStats = dynamic_cast<DirectoryEntry*>(
+        DirectoryEntry* usageStats = as<DirectoryEntry>(
                 ProfileEventSingleton::instance().getDB().lookupEntry({"program", "usage", "timepoint"}));
         if (usageStats == nullptr || usageStats->getKeys().size() < 2) {
             return usages;
@@ -781,15 +781,15 @@ public:
             Usage currentUsage{};
             uint64_t cur = std::stoul(currentKey);
             currentUsage.time = std::chrono::duration<uint64_t, std::micro>(cur);
-            cur = dynamic_cast<SizeEntry*>(
+            cur = as<SizeEntry>(
                     usageStats->readDirectoryEntry(currentKey)->readEntry("systemtime"))
                           ->getSize();
             currentUsage.systemtime = std::chrono::duration<uint64_t, std::micro>(cur);
-            cur = dynamic_cast<SizeEntry*>(usageStats->readDirectoryEntry(currentKey)->readEntry("usertime"))
+            cur = as<SizeEntry>(usageStats->readDirectoryEntry(currentKey)->readEntry("usertime"))
                           ->getSize();
             currentUsage.usertime = std::chrono::duration<uint64_t, std::micro>(cur);
             currentUsage.maxRSS =
-                    dynamic_cast<SizeEntry*>(usageStats->readDirectoryEntry(currentKey)->readEntry("maxRSS"))
+                    as<SizeEntry>(usageStats->readDirectoryEntry(currentKey)->readEntry("maxRSS"))
                             ->getSize();
 
             // Duplicate times are possible
@@ -1023,10 +1023,10 @@ public:
     void top() {
         const std::shared_ptr<ProgramRun>& run = out.getProgramRun();
         auto* totalRelationsEntry =
-                dynamic_cast<TextEntry*>(ProfileEventSingleton::instance().getDB().lookupEntry(
+                as<TextEntry>(ProfileEventSingleton::instance().getDB().lookupEntry(
                         {"program", "configuration", "relationCount"}));
         auto* totalRulesEntry =
-                dynamic_cast<TextEntry*>(ProfileEventSingleton::instance().getDB().lookupEntry(
+                as<TextEntry>(ProfileEventSingleton::instance().getDB().lookupEntry(
                         {"program", "configuration", "ruleCount"}));
         size_t totalRelations = 0;
         if (totalRelationsEntry != nullptr) {

--- a/src/include/souffle/utility/ContainerUtil.h
+++ b/src/include/souffle/utility/ContainerUtil.h
@@ -16,13 +16,13 @@
 
 #pragma once
 
+#include "souffle/utility/Iteration.h"
 #include "souffle/utility/MiscUtil.h"
 
 #include <algorithm>
 #include <functional>
 #include <iterator>
 #include <map>
-#include <memory>
 #include <set>
 #include <type_traits>
 #include <utility>
@@ -33,17 +33,6 @@ namespace souffle {
 // -------------------------------------------------------------------------------
 //                           General Container Utilities
 // -------------------------------------------------------------------------------
-
-template <typename A>
-using Own = std::unique_ptr<A>;
-
-template <typename A>
-using VecOwn = std::vector<Own<A>>;
-
-template <typename A, typename B = A, typename... Args>
-Own<A> mk(Args&&... xs) {
-    return Own<A>(new B(std::forward<Args>(xs)...));
-}
 
 /**
  * Use to range-for iterate in reverse.
@@ -139,7 +128,7 @@ std::vector<T> toVector(const T& first, const R&... rest) {
  * A utility function enabling the creation of a vector of pointers.
  */
 template <typename T>
-std::vector<T*> toPtrVector(const std::vector<std::unique_ptr<T>>& v) {
+std::vector<T*> toPtrVector(const VecOwn<T>& v) {
     std::vector<T*> res;
     for (auto& e : v) {
         res.push_back(e.get());
@@ -152,247 +141,14 @@ std::vector<T*> toPtrVector(const std::vector<std::unique_ptr<T>>& v) {
  */
 template <typename A, typename F /* : A -> B */>
 auto map(const std::vector<A>& xs, F&& f) {
+    // FIXME: We can rewrite this using makeTransformRange now,
+    // or remove the usage of this completely
     std::vector<decltype(f(xs[0]))> ys;
     ys.reserve(xs.size());
     for (auto&& x : xs) {
         ys.emplace_back(f(x));
     }
     return ys;
-}
-
-namespace detail {
-
-// This is a helper in the cases when the lambda is stateless
-template <typename F>
-F const& makeFun() {
-    // Even thought the lambda is stateless, it has no default ctor
-    // Is this gross?  Yes, yes it is.
-    typename std::aligned_storage<sizeof(F)>::type fakeLam;
-    return reinterpret_cast<F const&>(fakeLam);
-}
-}  // namespace detail
-
-// -------------------------------------------------------------
-//                            Iterators
-// -------------------------------------------------------------
-/**
- * A wrapper for an iterator that transforms values returned by
- * the underlying iter.
- *
- * @tparam Iter ... the type of wrapped iterator
- * @tparam F    ... the function to apply
- *
- */
-template <typename Iter, typename F>
-class TransformIterator {
-    using iter_t = std::iterator_traits<Iter>;
-    using difference_type = typename iter_t::difference_type;
-    using result_type = decltype(std::declval<F&>()(*std::declval<Iter>()));
-    static_assert(std::is_empty_v<F>, "Function object must be stateless");
-
-public:
-    // some constructors
-    template <typename It>
-    TransformIterator(It iter, std::enable_if_t<std::is_empty_v<F>, void*> = nullptr)
-            : iter(std::move(iter)), fun(detail::makeFun<F>()) {}
-    TransformIterator(Iter iter, F f) : iter(std::move(iter)), fun(std::move(f)) {}
-
-    // defaulted copy and move constructors
-    TransformIterator(const TransformIterator& other) : iter(other.iter), fun(other.fun) {}
-    TransformIterator(TransformIterator&& other) : iter(std::move(other.iter)), fun(std::move(other.fun)) {}
-
-    // default assignment operators
-    TransformIterator& operator=(const TransformIterator& other) {
-        if (this != &other) {
-            iter = other.iter;
-        }
-        return *this;
-    }
-
-    TransformIterator& operator=(TransformIterator&& other) {
-        if (this != &other) {
-            iter = std::move(other.iter);
-        }
-        return *this;
-    }
-
-    /* The equality operator as required by the iterator concept. */
-    bool operator==(const TransformIterator& other) const {
-        return iter == other.iter;
-    }
-
-    /* The not-equality operator as required by the iterator concept. */
-    bool operator!=(const TransformIterator& other) const {
-        return iter != other.iter;
-    }
-
-    /* The deref operator as required by the iterator concept. */
-    auto operator*() const -> result_type {
-        return fun(*iter);
-    }
-
-    /* Support for the pointer operator. */
-    auto operator->() const {
-        return &**this;
-    }
-
-    /* The increment operator as required by the iterator concept. */
-    TransformIterator& operator++() {
-        ++iter;
-        return *this;
-    }
-
-    TransformIterator operator++(int) {
-        auto res = *this;
-        ++iter;
-        return res;
-    }
-
-    TransformIterator& operator--() {
-        --iter;
-        return *this;
-    }
-
-    TransformIterator operator--(int) {
-        auto res = *this;
-        --iter;
-        return res;
-    }
-
-    auto operator[](difference_type ii) const -> result_type {
-        return f(iter[ii]);
-    }
-
-private:
-    /* The nested iterator. */
-    Iter iter;
-    F fun;
-};
-
-template <typename Iter, typename F>
-auto makeTransformIter(Iter&& iter, F&& f) {
-    return TransformIterator<std::remove_const_t<std::remove_reference_t<Iter>>, std::remove_reference_t<F>>(
-            std::forward<Iter>(iter), std::forward<F>(f));
-}
-
-/**
- * A wrapper for an iterator obtaining pointers of a certain type,
- * dereferencing values before forwarding them to the consumer.
- */
-namespace detail {
-inline auto iterDeref = [](auto& p) -> decltype(*p) { return *p; };
-}
-
-template <typename Iter>
-using IterDerefWrapper = TransformIterator<Iter, decltype(detail::iterDeref)>;
-
-/**
- * A factory function enabling the construction of a dereferencing
- * iterator utilizing the automated deduction of template parameters.
- */
-template <typename Iter>
-auto derefIter(Iter&& iter) {
-    return makeTransformIter(std::forward<Iter>(iter), detail::iterDeref);
-}
-
-// -------------------------------------------------------------
-//                             Ranges
-// -------------------------------------------------------------
-
-/**
- * A utility class enabling representation of ranges by pairing
- * two iterator instances marking lower and upper boundaries.
- */
-template <typename Iter>
-struct range {
-    // the lower and upper boundary
-    Iter a, b;
-
-    // a constructor accepting a lower and upper boundary
-    range(Iter a, Iter b) : a(std::move(a)), b(std::move(b)) {}
-
-    // default copy / move and assignment support
-    range(const range&) = default;
-    range(range&&) = default;
-    range& operator=(const range&) = default;
-
-    // get the lower boundary (for for-all loop)
-    Iter& begin() {
-        return a;
-    }
-    const Iter& begin() const {
-        return a;
-    }
-
-    // get the upper boundary (for for-all loop)
-    Iter& end() {
-        return b;
-    }
-    const Iter& end() const {
-        return b;
-    }
-
-    // emptiness check
-    bool empty() const {
-        return a == b;
-    }
-
-    // splits up this range into the given number of partitions
-    std::vector<range> partition(int np = 100) {
-        // obtain the size
-        int n = 0;
-        for (auto i = a; i != b; ++i) {
-            n++;
-        }
-
-        // split it up
-        auto s = n / np;
-        auto r = n % np;
-        std::vector<range> res;
-        res.reserve(np);
-        auto cur = a;
-        auto last = cur;
-        int i = 0;
-        int p = 0;
-        while (cur != b) {
-            ++cur;
-            i++;
-            if (i >= (s + (p < r ? 1 : 0))) {
-                res.push_back({last, cur});
-                last = cur;
-                p++;
-                i = 0;
-            }
-        }
-        if (cur != last) {
-            res.push_back({last, cur});
-        }
-        return res;
-    }
-};
-
-/**
- * A utility function enabling the construction of ranges
- * without explicitly specifying the iterator type.
- *
- * @tparam Iter .. the iterator type
- * @param a .. the lower boundary
- * @param b .. the upper boundary
- */
-template <typename Iter>
-range<Iter> make_range(const Iter& a, const Iter& b) {
-    return range<Iter>(a, b);
-}
-
-template <typename Iter, typename F>
-auto makeTransformRange(Iter&& begin, Iter&& end, F const& f) {
-    return make_range(
-            makeTransformIter(std::forward<Iter>(begin), f), transformIter(std::forward<Iter>(end), f));
-}
-
-template <typename Iter>
-auto makeDerefRange(Iter&& begin, Iter&& end) {
-    return make_range(derefIter(std::forward<Iter>(begin)), derefIter(std::forward<Iter>(end)));
 }
 
 // -------------------------------------------------------------------------------
@@ -464,8 +220,8 @@ bool equal_targets(const Container<T*>& a, const Container<T*>& b) {
  * targets.
  */
 template <typename T, template <typename...> class Container>
-bool equal_targets(const Container<std::unique_ptr<T>>& a, const Container<std::unique_ptr<T>>& b) {
-    return equal_targets(a, b, comp_deref<std::unique_ptr<T>>());
+bool equal_targets(const Container<Own<T>>& a, const Container<Own<T>>& b) {
+    return equal_targets(a, b, comp_deref<Own<T>>());
 }
 
 /**
@@ -474,8 +230,8 @@ bool equal_targets(const Container<std::unique_ptr<T>>& a, const Container<std::
  */
 template <typename Key, typename Value>
 bool equal_targets(
-        const std::map<Key, std::unique_ptr<Value>>& a, const std::map<Key, std::unique_ptr<Value>>& b) {
-    auto comp = comp_deref<std::unique_ptr<Value>>();
+        const std::map<Key, Own<Value>>& a, const std::map<Key, Own<Value>>& b) {
+    auto comp = comp_deref<Own<Value>>();
     return equal_targets(
             a, b, [&comp](auto& a, auto& b) { return a.first == b.first && comp(a.second, b.second); });
 }
@@ -488,8 +244,8 @@ struct iterator_traits<souffle::TransformIterator<Iter, F>> {
     using iter_t = std::iterator_traits<Iter>;
     using iter_tag = typename iter_t::iterator_category;
     using difference_type = typename iter_t::difference_type;
-    using result_type = decltype(std::declval<F&>()(*std::declval<Iter>()));
-    using value_type = std::remove_cv_t<std::remove_reference_t<result_type>>;
+    using reference = decltype(std::declval<F&>()(*std::declval<Iter>()));
+    using value_type = std::remove_cv_t<std::remove_reference_t<reference>>;
     using iterator_category = std::conditional_t<std::is_base_of_v<std::random_access_iterator_tag, iter_tag>,
             std::random_access_iterator_tag, iter_tag>;
 };

--- a/src/include/souffle/utility/ContainerUtil.h
+++ b/src/include/souffle/utility/ContainerUtil.h
@@ -108,9 +108,21 @@ namespace detail {
 inline auto allOfBool = [](bool b) { return b; };
 }
 
+/**
+ * Return true if all elements (optionally after applying up)
+ * are true
+ */
 template <typename R, typename UnaryP = decltype(detail::allOfBool) const&>
 bool all(R const& range, UnaryP&& up = detail::allOfBool) {
     return std::all_of(range.begin(), range.end(), std::forward<UnaryP>(up));
+}
+
+/**
+ * Append elements to a container
+ */
+template <class C, typename R>
+void append(C& container, R&& range) {
+    container.insert(container.end(), std::begin(range), std::end(range));
 }
 
 /**

--- a/src/include/souffle/utility/ContainerUtil.h
+++ b/src/include/souffle/utility/ContainerUtil.h
@@ -185,115 +185,111 @@ auto clone(const std::vector<std::unique_ptr<A>>& xs) {
 // -------------------------------------------------------------
 //                            Iterators
 // -------------------------------------------------------------
-
 /**
- * A wrapper for an iterator obtaining pointers of a certain type,
- * dereferencing values before forwarding them to the consumer.
+ * A wrapper for an iterator that transforms values returned by
+ * the underlying iter.
  *
  * @tparam Iter ... the type of wrapped iterator
- * @tparam T    ... the value to be accessed by the resulting iterator
+ * @tparam F    ... the function to apply
+ *
  */
-template <typename Iter, typename T = typename std::remove_pointer<typename Iter::value_type>::type>
-struct IterDerefWrapper : public std::iterator<std::forward_iterator_tag, T> {
-    /* The nested iterator. */
-    Iter iter;
+template <typename Iter, typename F>
+class TransformIterator {
+    using iter_t = std::iterator_traits<Iter>;
+    using difference_type = typename iter_t::difference_type;
+    using result_type = decltype(std::declval<F&>()(*std::declval<Iter>()));
 
 public:
     // some constructors
-    IterDerefWrapper() = default;
-    IterDerefWrapper(const Iter& iter) : iter(iter) {}
+    TransformIterator() = default;
+    TransformIterator(Iter iter, F f) : iter(std::move(iter)), fun(std::move(f)) {}
 
     // defaulted copy and move constructors
-    IterDerefWrapper(const IterDerefWrapper&) = default;
-    IterDerefWrapper(IterDerefWrapper&&) = default;
+    TransformIterator(const TransformIterator&) = default;
+    TransformIterator(TransformIterator&&) = default;
 
     // default assignment operators
-    IterDerefWrapper& operator=(const IterDerefWrapper&) = default;
-    IterDerefWrapper& operator=(IterDerefWrapper&&) = default;
+    TransformIterator& operator=(const TransformIterator&) = default;
+    TransformIterator& operator=(TransformIterator&&) = default;
 
     /* The equality operator as required by the iterator concept. */
-    bool operator==(const IterDerefWrapper& other) const {
+    bool operator==(const TransformIterator& other) const {
         return iter == other.iter;
     }
 
     /* The not-equality operator as required by the iterator concept. */
-    bool operator!=(const IterDerefWrapper& other) const {
+    bool operator!=(const TransformIterator& other) const {
         return iter != other.iter;
     }
 
     /* The deref operator as required by the iterator concept. */
-    const T& operator*() const {
-        return **iter;
+    auto operator*() const -> result_type {
+        return fun(*iter);
     }
 
     /* Support for the pointer operator. */
-    const T* operator->() const {
-        return &(**iter);
+    auto operator->() const {
+        return &**this;
     }
 
     /* The increment operator as required by the iterator concept. */
-    IterDerefWrapper& operator++() {
+    TransformIterator& operator++() {
         ++iter;
         return *this;
     }
+
+    TransformIterator operator++(int) {
+        auto res = *this;
+        ++iter;
+        return res;
+    }
+
+    TransformIterator& operator--() {
+        --iter;
+        return *this;
+    }
+
+    TransformIterator operator--(int) {
+        auto res = *this;
+        --iter;
+        return res;
+    }
+
+    auto operator[](difference_type ii) const {
+        return f(iter[ii]);
+    }
+
+private:
+    /* The nested iterator. */
+    Iter iter;
+    F fun;
 };
+
+template <typename Iter, typename F>
+auto makeTransformIter(Iter&& iter, F&& f) {
+    return TransformIterator<std::remove_reference_t<Iter>, std::remove_reference_t<F>>(
+            std::forward<Iter>(iter), std::forward<F>(f));
+}
+
+/**
+ * A wrapper for an iterator obtaining pointers of a certain type,
+ * dereferencing values before forwarding them to the consumer.
+ */
+namespace detail {
+inline auto iterDeref = [](auto& p) -> decltype(*p) { return *p; };
+}
+
+template <typename Iter>
+using IterDerefWrapper = TransformIterator<Iter, decltype(detail::iterDeref)>;
 
 /**
  * A factory function enabling the construction of a dereferencing
  * iterator utilizing the automated deduction of template parameters.
  */
 template <typename Iter>
-IterDerefWrapper<Iter> derefIter(const Iter& iter) {
-    return IterDerefWrapper<Iter>(iter);
+auto derefIter(Iter&& iter) {
+    return makeTransformIter(std::forward<Iter>(iter), detail::iterDeref);
 }
-
-/**
- * An iterator to be utilized if there is only a single element to iterate over.
- */
-template <typename T>
-class SingleValueIterator : public std::iterator<std::forward_iterator_tag, T> {
-    T value;
-
-    bool end = true;
-
-public:
-    SingleValueIterator() = default;
-
-    SingleValueIterator(const T& value) : value(value), end(false) {}
-
-    // a copy constructor
-    SingleValueIterator(const SingleValueIterator& other) = default;
-
-    // an assignment operator
-    SingleValueIterator& operator=(const SingleValueIterator& other) = default;
-
-    // the equality operator as required by the iterator concept
-    bool operator==(const SingleValueIterator& other) const {
-        // only equivalent if pointing to the end
-        return end && other.end;
-    }
-
-    // the not-equality operator as required by the iterator concept
-    bool operator!=(const SingleValueIterator& other) const {
-        return !(*this == other);
-    }
-
-    // the deref operator as required by the iterator concept
-    const T& operator*() const {
-        return value;
-    }
-
-    // support for the pointer operator
-    const T* operator->() const {
-        return &value;
-    }
-
-    // the increment operator as required by the iterator concept
-    SingleValueIterator& operator++() {
-        end = true;
-        return *this;
-    }
-};
 
 // -------------------------------------------------------------
 //                             Ranges
@@ -470,3 +466,16 @@ bool equal_targets(
 }
 
 }  // namespace souffle
+
+namespace std {
+template <typename Iter, typename F>
+struct iterator_traits<souffle::TransformIterator<Iter, F>> {
+    using iter_t = std::iterator_traits<Iter>;
+    using iter_tag = typename iter_t::iterator_category;
+    using difference_type = typename iter_t::difference_type;
+    using result_type = decltype(std::declval<F&>()(*std::declval<Iter>()));
+    using value_type = std::remove_cv_t<std::remove_reference_t<result_type>>;
+    using iterator_category = std::conditional_t<std::is_base_of_v<std::random_access_iterator_tag, iter_tag>,
+            std::random_access_iterator_tag, iter_tag>;
+};
+}  // namespace std

--- a/src/include/souffle/utility/ContainerUtil.h
+++ b/src/include/souffle/utility/ContainerUtil.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "souffle/utility/MiscUtil.h"
+
 #include <algorithm>
 #include <functional>
 #include <iterator>
@@ -154,30 +156,6 @@ auto map(const std::vector<A>& xs, F&& f) {
     ys.reserve(xs.size());
     for (auto&& x : xs) {
         ys.emplace_back(f(x));
-    }
-    return ys;
-}
-
-// -------------------------------------------------------------------------------
-//                             Cloning Utilities
-// -------------------------------------------------------------------------------
-
-template <typename A>
-auto clone(const std::vector<A*>& xs) {
-    std::vector<std::unique_ptr<A>> ys;
-    ys.reserve(xs.size());
-    for (auto&& x : xs) {
-        ys.emplace_back(x ? std::unique_ptr<A>(x->clone()) : nullptr);
-    }
-    return ys;
-}
-
-template <typename A>
-auto clone(const std::vector<std::unique_ptr<A>>& xs) {
-    std::vector<std::unique_ptr<A>> ys;
-    ys.reserve(xs.size());
-    for (auto&& x : xs) {
-        ys.emplace_back(x ? std::unique_ptr<A>(x->clone()) : nullptr);
     }
     return ys;
 }
@@ -429,8 +407,8 @@ auto makeDerefRange(Iter&& begin, Iter&& end) {
  */
 template <typename toType, typename baseType>
 bool castEq(const baseType* left, const baseType* right) {
-    if (auto castedLeft = dynamic_cast<const toType*>(left)) {
-        if (auto castedRight = dynamic_cast<const toType*>(right)) {
+    if (auto castedLeft = as<toType>(left)) {
+        if (auto castedRight = as<toType>(right)) {
             return castedLeft == castedRight;
         }
     }

--- a/src/include/souffle/utility/ContainerUtil.h
+++ b/src/include/souffle/utility/ContainerUtil.h
@@ -104,6 +104,15 @@ typename C::mapped_type const& getOr(
     }
 }
 
+namespace detail {
+inline auto allOfBool = [](bool b) { return b; };
+}
+
+template <typename R, typename UnaryP = decltype(detail::allOfBool) const&>
+bool all(R const& range, UnaryP&& up = detail::allOfBool) {
+    return std::all_of(range.begin(), range.end(), std::forward<UnaryP>(up));
+}
+
 /**
  * A utility function enabling the creation of a vector with a fixed set of
  * elements within a single expression. This is the base case covering empty
@@ -233,6 +242,14 @@ bool equal_targets(const std::map<Key, Own<Value>>& a, const std::map<Key, Own<V
     auto comp = comp_deref<Own<Value>>();
     return equal_targets(
             a, b, [&comp](auto& a, auto& b) { return a.first == b.first && comp(a.second, b.second); });
+}
+
+// -------------------------------------------------------------------------------
+//                             Checking Utilities
+// -------------------------------------------------------------------------------
+template <typename R>
+bool allValidPtrs(R const& range) {
+    return all(makeTransformRange(range, [](auto const& ptr) { return ptr != nullptr; }));
 }
 
 }  // namespace souffle

--- a/src/include/souffle/utility/ContainerUtil.h
+++ b/src/include/souffle/utility/ContainerUtil.h
@@ -229,8 +229,7 @@ bool equal_targets(const Container<Own<T>>& a, const Container<Own<T>>& b) {
  * targets.
  */
 template <typename Key, typename Value>
-bool equal_targets(
-        const std::map<Key, Own<Value>>& a, const std::map<Key, Own<Value>>& b) {
+bool equal_targets(const std::map<Key, Own<Value>>& a, const std::map<Key, Own<Value>>& b) {
     auto comp = comp_deref<Own<Value>>();
     return equal_targets(
             a, b, [&comp](auto& a, auto& b) { return a.first == b.first && comp(a.second, b.second); });

--- a/src/include/souffle/utility/Iteration.h
+++ b/src/include/souffle/utility/Iteration.h
@@ -30,6 +30,7 @@ template <typename F>
 F const& makeFun() {
     // Even thought the lambda is stateless, it has no default ctor
     // Is this gross?  Yes, yes it is.
+    // FIXME: Remove after C++20
     typename std::aligned_storage<sizeof(F)>::type fakeLam;
     return reinterpret_cast<F const&>(fakeLam);
 }
@@ -298,6 +299,11 @@ range<Iter> make_range(const Iter& a, const Iter& b) {
 template <typename Iter, typename F>
 auto makeTransformRange(Iter&& begin, Iter&& end, F const& f) {
     return make_range(transformIter(std::forward<Iter>(begin), f), transformIter(std::forward<Iter>(end), f));
+}
+
+template <typename R, typename F>
+auto makeTransformRange(R&& range, F const& f) {
+    return makeTransformRange(range.begin(), range.end(), f);
 }
 
 template <typename Iter>

--- a/src/include/souffle/utility/Iteration.h
+++ b/src/include/souffle/utility/Iteration.h
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <iterator>
-#include <utility>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace souffle {

--- a/src/include/souffle/utility/Iteration.h
+++ b/src/include/souffle/utility/Iteration.h
@@ -1,0 +1,308 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file Iteration.h
+ *
+ * @brief Utilities for iterators and ranges
+ *
+ ***********************************************************************/
+
+#pragma once
+
+#include <iterator>
+#include <utility>
+#include <type_traits>
+#include <vector>
+
+namespace souffle {
+
+namespace detail {
+
+// This is a helper in the cases when the lambda is stateless
+template <typename F>
+F const& makeFun() {
+    // Even thought the lambda is stateless, it has no default ctor
+    // Is this gross?  Yes, yes it is.
+    typename std::aligned_storage<sizeof(F)>::type fakeLam;
+    return reinterpret_cast<F const&>(fakeLam);
+}
+}  // namespace detail
+
+// -------------------------------------------------------------
+//                            Iterators
+// -------------------------------------------------------------
+/**
+ * A wrapper for an iterator that transforms values returned by
+ * the underlying iter.
+ *
+ * @tparam Iter ... the type of wrapped iterator
+ * @tparam F    ... the function to apply
+ *
+ */
+template <typename Iter, typename F>
+class TransformIterator {
+    using iter_t = std::iterator_traits<Iter>;
+    using difference_type = typename iter_t::difference_type;
+    using reference = decltype(std::declval<F&>()(*std::declval<Iter>()));
+    static_assert(std::is_empty_v<F>, "Function object must be stateless");
+
+public:
+    // some constructors
+    template <typename It>
+    TransformIterator(It iter, std::enable_if_t<std::is_empty_v<F>, void*> = nullptr)
+            : iter(std::move(iter)), fun(detail::makeFun<F>()) {}
+    TransformIterator(Iter iter, F f) : iter(std::move(iter)), fun(std::move(f)) {}
+
+    // defaulted copy and move constructors
+    TransformIterator(const TransformIterator& other) : iter(other.iter), fun(other.fun) {}
+    TransformIterator(TransformIterator&& other) : iter(std::move(other.iter)), fun(std::move(other.fun)) {}
+
+    // default assignment operators
+    TransformIterator& operator=(const TransformIterator& other) {
+        if (this != &other) {
+            iter = other.iter;
+        }
+        return *this;
+    }
+
+    TransformIterator& operator=(TransformIterator&& other) {
+        if (this != &other) {
+            iter = std::move(other.iter);
+        }
+        return *this;
+    }
+
+    /* The equality operator as required by the iterator concept. */
+    bool operator==(const TransformIterator& other) const {
+        return iter == other.iter;
+    }
+
+    /* The not-equality operator as required by the iterator concept. */
+    bool operator!=(const TransformIterator& other) const {
+        return iter != other.iter;
+    }
+
+    bool operator<(TransformIterator const& other) const {
+        return iter < other.iter;
+    }
+
+    bool operator<=(TransformIterator const& other) const {
+        return iter <= other.iter;
+    }
+
+    bool operator>(TransformIterator const& other) const {
+        return iter > other.iter;
+    }
+
+    bool operator>=(TransformIterator const& other) const {
+        return iter >= other.iter;
+    }
+
+    /* The deref operator as required by the iterator concept. */
+    auto operator*() const -> reference {
+        return fun(*iter);
+    }
+
+    /* Support for the pointer operator. */
+    auto operator->() const {
+        return &**this;
+    }
+
+    /* The increment operator as required by the iterator concept. */
+    TransformIterator& operator++() {
+        ++iter;
+        return *this;
+    }
+
+    TransformIterator operator++(int) {
+        auto res = *this;
+        ++iter;
+        return res;
+    }
+
+    TransformIterator& operator--() {
+        --iter;
+        return *this;
+    }
+
+    TransformIterator operator--(int) {
+        auto res = *this;
+        --iter;
+        return res;
+    }
+
+    TransformIterator& operator+=(difference_type n) {
+        iter += n;
+        return *this;
+    }
+
+    TransformIterator operator+(difference_type n) {
+        auto res = *this;
+        res += n;
+        return res;
+    }
+
+    TransformIterator& operator-=(difference_type n) {
+        iter -= n;
+        return *this;
+    }
+
+    TransformIterator operator-(difference_type n) {
+        auto res = *this;
+        res -= n;
+        return res;
+    }
+
+    difference_type operator-(TransformIterator const& other) {
+        return iter - other.iter;
+    }
+
+    auto operator[](difference_type ii) const -> reference {
+        return f(iter[ii]);
+    }
+
+private:
+    /* The nested iterator. */
+    Iter iter;
+    F fun;
+};
+
+template <typename Iter, typename F>
+auto operator+(
+        typename TransformIterator<Iter, F>::difference_type n, TransformIterator<Iter, F> const& iter) {
+    return iter + n;
+}
+
+template <typename Iter, typename F>
+auto transformIter(Iter&& iter, F&& f) {
+    return TransformIterator<std::remove_const_t<std::remove_reference_t<Iter>>, std::remove_reference_t<F>>(
+            std::forward<Iter>(iter), std::forward<F>(f));
+}
+
+/**
+ * A wrapper for an iterator obtaining pointers of a certain type,
+ * dereferencing values before forwarding them to the consumer.
+ */
+namespace detail {
+inline auto iterDeref = [](auto& p) -> decltype(*p) { return *p; };
+}
+
+template <typename Iter>
+using IterDerefWrapper = TransformIterator<Iter, decltype(detail::iterDeref)>;
+
+/**
+ * A factory function enabling the construction of a dereferencing
+ * iterator utilizing the automated deduction of template parameters.
+ */
+template <typename Iter>
+auto derefIter(Iter&& iter) {
+    return transformIter(std::forward<Iter>(iter), detail::iterDeref);
+}
+
+// -------------------------------------------------------------
+//                             Ranges
+// -------------------------------------------------------------
+
+/**
+ * A utility class enabling representation of ranges by pairing
+ * two iterator instances marking lower and upper boundaries.
+ */
+template <typename Iter>
+struct range {
+    // the lower and upper boundary
+    Iter a, b;
+
+    // a constructor accepting a lower and upper boundary
+    range(Iter a, Iter b) : a(std::move(a)), b(std::move(b)) {}
+
+    // default copy / move and assignment support
+    range(const range&) = default;
+    range(range&&) = default;
+    range& operator=(const range&) = default;
+
+    // get the lower boundary (for for-all loop)
+    Iter& begin() {
+        return a;
+    }
+    const Iter& begin() const {
+        return a;
+    }
+
+    // get the upper boundary (for for-all loop)
+    Iter& end() {
+        return b;
+    }
+    const Iter& end() const {
+        return b;
+    }
+
+    // emptiness check
+    bool empty() const {
+        return a == b;
+    }
+
+    // splits up this range into the given number of partitions
+    std::vector<range> partition(int np = 100) {
+        // obtain the size
+        int n = 0;
+        for (auto i = a; i != b; ++i) {
+            n++;
+        }
+
+        // split it up
+        auto s = n / np;
+        auto r = n % np;
+        std::vector<range> res;
+        res.reserve(np);
+        auto cur = a;
+        auto last = cur;
+        int i = 0;
+        int p = 0;
+        while (cur != b) {
+            ++cur;
+            i++;
+            if (i >= (s + (p < r ? 1 : 0))) {
+                res.push_back({last, cur});
+                last = cur;
+                p++;
+                i = 0;
+            }
+        }
+        if (cur != last) {
+            res.push_back({last, cur});
+        }
+        return res;
+    }
+};
+
+/**
+ * A utility function enabling the construction of ranges
+ * without explicitly specifying the iterator type.
+ *
+ * @tparam Iter .. the iterator type
+ * @param a .. the lower boundary
+ * @param b .. the upper boundary
+ */
+template <typename Iter>
+range<Iter> make_range(const Iter& a, const Iter& b) {
+    return range<Iter>(a, b);
+}
+
+template <typename Iter, typename F>
+auto makeTransformRange(Iter&& begin, Iter&& end, F const& f) {
+    return make_range(transformIter(std::forward<Iter>(begin), f), transformIter(std::forward<Iter>(end), f));
+}
+
+template <typename Iter>
+auto makeDerefRange(Iter&& begin, Iter&& end) {
+    return make_range(derefIter(std::forward<Iter>(begin)), derefIter(std::forward<Iter>(end)));
+}
+
+}  // namespace souffle

--- a/src/include/souffle/utility/MiscUtil.h
+++ b/src/include/souffle/utility/MiscUtil.h
@@ -199,3 +199,12 @@ template <typename... Args>
 // HACK:  Workaround to suppress spurious reachability warnings.
 #define UNREACHABLE_BAD_CASE_ANALYSIS fatal("unhandled switch branch");
 }  // namespace souffle
+
+/**
+ * Copy the const qualifier of type T onto type U
+ */
+template <typename T, typename U>
+using copy_const = typename std::conditional<std::is_const_v<T>, U const, U>;
+
+template <typename T, typename U>
+using copy_const_t = typename copy_const<T, U>::type;

--- a/src/include/souffle/utility/MiscUtil.h
+++ b/src/include/souffle/utility/MiscUtil.h
@@ -140,8 +140,14 @@ bool equal_ptr(const std::unique_ptr<T>& a, const std::unique_ptr<T>& b) {
     return equal_ptr(a.get(), b.get());
 }
 
+/**
+ * Copy the const qualifier of type T onto type U
+ */
 template <typename A, typename B>
-using copy_const_t = std::conditional_t<std::is_const_v<A>, const B, B>;
+using copy_const = std::conditional<std::is_const_v<A>, const B, B>;
+
+template <typename A, typename B>
+using copy_const_t = typename copy_const<A, B>::type;
 
 /**
  * Helpers for `dynamic_cast`ing without having to specify redundant type qualifiers.
@@ -199,12 +205,3 @@ template <typename... Args>
 // HACK:  Workaround to suppress spurious reachability warnings.
 #define UNREACHABLE_BAD_CASE_ANALYSIS fatal("unhandled switch branch");
 }  // namespace souffle
-
-/**
- * Copy the const qualifier of type T onto type U
- */
-template <typename T, typename U>
-using copy_const = typename std::conditional<std::is_const_v<T>, U const, U>;
-
-template <typename T, typename U>
-using copy_const_t = typename copy_const<T, U>::type;

--- a/src/include/souffle/utility/Types.h
+++ b/src/include/souffle/utility/Types.h
@@ -1,3 +1,21 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file Types.h
+ *
+ * @brief Shared type definitions
+ *
+ ***********************************************************************/
+
+#pragma once
+
 #include <memory>
 #include <vector>
 

--- a/src/include/souffle/utility/Types.h
+++ b/src/include/souffle/utility/Types.h
@@ -1,0 +1,16 @@
+#include <memory>
+#include <vector>
+
+namespace souffle {
+template <typename A>
+using Own = std::unique_ptr<A>;
+
+template <typename A, typename B = A, typename... Args>
+Own<A> mk(Args&&... xs) {
+    return std::make_unique<B>(std::forward<Args>(xs)...);
+}
+
+template <typename A>
+using VecOwn = std::vector<Own<A>>;
+
+}  // namespace souffle

--- a/src/include/souffle/utility/Types.h
+++ b/src/include/souffle/utility/Types.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 namespace souffle {
@@ -30,5 +31,32 @@ Own<A> mk(Args&&... xs) {
 
 template <typename A>
 using VecOwn = std::vector<Own<A>>;
+
+/**
+ * Copy the const qualifier of type T onto type U
+ */
+template <typename A, typename B>
+using copy_const = std::conditional<std::is_const_v<A>, const B, B>;
+
+template <typename A, typename B>
+using copy_const_t = typename copy_const<A, B>::type;
+
+namespace detail {
+template <typename T, typename U = void>
+struct is_range_impl : std::false_type {};
+
+template <typename T>
+struct is_range_impl<T, std::void_t<decltype(*std::begin(std::declval<T&>()))>> : std::true_type {};
+
+}  // namespace detail
+
+/**
+ * A simple test to check if T is a range (i.e. has std::begin())
+ */
+template <typename T>
+struct is_range : detail::is_range_impl<T> {};
+
+template <typename T>
+inline constexpr bool is_range_v = is_range<T>::value;
 
 }  // namespace souffle

--- a/src/interpreter/Generator.cpp
+++ b/src/interpreter/Generator.cpp
@@ -35,13 +35,13 @@ NodePtr NodeGenerator::generateTree(const ram::Node& root) {
         if (isA<ram::Query>(&node)) {
             newQueryBlock();
         }
-        if (const auto* indexSearch = dynamic_cast<const ram::IndexOperation*>(&node)) {
+        if (const auto* indexSearch = as<ram::IndexOperation>(node)) {
             encodeIndexPos(*indexSearch);
             encodeView(indexSearch);
-        } else if (const auto* exists = dynamic_cast<const ram::ExistenceCheck*>(&node)) {
+        } else if (const auto* exists = as<ram::ExistenceCheck>(node)) {
             encodeIndexPos(*exists);
             encodeView(exists);
-        } else if (const auto* provExists = dynamic_cast<const ram::ProvenanceExistenceCheck*>(&node)) {
+        } else if (const auto* provExists = as<ram::ProvenanceExistenceCheck>(node)) {
             encodeIndexPos(*provExists);
             encodeView(provExists);
         }
@@ -426,7 +426,7 @@ NodePtr NodeGenerator::visitQuery(const ram::Query& query) {
     // do not require a view
     const ram::Operation* next = &query.getOperation();
     std::vector<const ram::Condition*> freeOfView;
-    if (const auto* filter = dynamic_cast<const ram::Filter*>(&query.getOperation())) {
+    if (const auto* filter = as<ram::Filter>(query.getOperation())) {
         next = &filter->getOperation();
         // Check terms of outer filter operation whether they can be pushed before
         // the view-generation for speed improvements
@@ -556,9 +556,9 @@ bool NodeGenerator::requireView(const ram::Node* node) {
 }
 
 const std::string& NodeGenerator::getViewRelation(const ram::Node* node) {
-    if (const auto* exist = dynamic_cast<const ram::AbstractExistenceCheck*>(node)) {
+    if (const auto* exist = as<ram::AbstractExistenceCheck>(node)) {
         return exist->getRelation();
-    } else if (const auto* index = dynamic_cast<const ram::IndexOperation*>(node)) {
+    } else if (const auto* index = as<ram::IndexOperation>(node)) {
         return index->getRelation();
     }
 
@@ -585,13 +585,13 @@ SuperInstruction NodeGenerator::getIndexSuperInstInfo(const ram::IndexOperation&
 
         // Constant
         if (isA<ram::Constant>(low)) {
-            indexOperation.first[i] = dynamic_cast<ram::Constant*>(low)->getConstant();
+            indexOperation.first[i] = as<ram::Constant>(low)->getConstant();
             continue;
         }
 
         // TupleElement
         if (isA<ram::TupleElement>(low)) {
-            auto lowTuple = dynamic_cast<ram::TupleElement*>(low);
+            auto lowTuple = as<ram::TupleElement>(low);
             size_t tupleId = lowTuple->getTupleId();
             size_t elementId = lowTuple->getElement();
             size_t newElementId = orderingContext.mapOrder(tupleId, elementId);
@@ -614,13 +614,13 @@ SuperInstruction NodeGenerator::getIndexSuperInstInfo(const ram::IndexOperation&
 
         // Constant
         if (isA<ram::Constant>(hig)) {
-            indexOperation.second[i] = dynamic_cast<ram::Constant*>(hig)->getConstant();
+            indexOperation.second[i] = as<ram::Constant>(hig)->getConstant();
             continue;
         }
 
         // TupleElement
         if (isA<ram::TupleElement>(hig)) {
-            auto highTuple = dynamic_cast<ram::TupleElement*>(hig);
+            auto highTuple = as<ram::TupleElement>(hig);
             size_t tupleId = highTuple->getTupleId();
             size_t elementId = highTuple->getElement();
             size_t newElementId = orderingContext.mapOrder(tupleId, elementId);
@@ -638,9 +638,9 @@ SuperInstruction NodeGenerator::getExistenceSuperInstInfo(const ram::AbstractExi
     auto interpreterRel = encodeRelation(abstractExist.getRelation());
     size_t indexId = 0;
     if (isA<ram::ExistenceCheck>(&abstractExist)) {
-        indexId = encodeIndexPos(*dynamic_cast<const ram::ExistenceCheck*>(&abstractExist));
+        indexId = encodeIndexPos(*as<ram::ExistenceCheck>(abstractExist));
     } else if (isA<ram::ProvenanceExistenceCheck>(&abstractExist)) {
-        indexId = encodeIndexPos(*dynamic_cast<const ram::ProvenanceExistenceCheck*>(&abstractExist));
+        indexId = encodeIndexPos(*as<ram::ProvenanceExistenceCheck>(abstractExist));
     } else {
         fatal("Unrecognized ram::AbstractExistenceCheck.");
     }
@@ -660,14 +660,14 @@ SuperInstruction NodeGenerator::getExistenceSuperInstInfo(const ram::AbstractExi
 
         // Constant
         if (isA<ram::Constant>(child)) {
-            superOp.first[i] = dynamic_cast<ram::Constant*>(child)->getConstant();
+            superOp.first[i] = as<ram::Constant>(child)->getConstant();
             superOp.second[i] = superOp.first[i];
             continue;
         }
 
         // TupleElement
         if (isA<ram::TupleElement>(child)) {
-            auto tuple = dynamic_cast<ram::TupleElement*>(child);
+            auto tuple = as<ram::TupleElement>(child);
             size_t tupleId = tuple->getTupleId();
             size_t elementId = tuple->getElement();
             size_t newElementId = orderingContext.mapOrder(tupleId, elementId);
@@ -689,13 +689,13 @@ SuperInstruction NodeGenerator::getProjectSuperInstInfo(const ram::Project& exis
         auto& child = children[i];
         // Constant
         if (isA<ram::Constant>(child)) {
-            superOp.first[i] = dynamic_cast<ram::Constant*>(child)->getConstant();
+            superOp.first[i] = as<ram::Constant>(child)->getConstant();
             continue;
         }
 
         // TupleElement
         if (isA<ram::TupleElement>(child)) {
-            auto tuple = dynamic_cast<ram::TupleElement*>(child);
+            auto tuple = as<ram::TupleElement>(child);
             size_t tupleId = tuple->getTupleId();
             size_t elementId = tuple->getElement();
             size_t newElementId = orderingContext.mapOrder(tupleId, elementId);

--- a/src/interpreter/ProgInterface.h
+++ b/src/interpreter/ProgInterface.h
@@ -28,6 +28,7 @@
 #include "souffle/RamTypes.h"
 #include "souffle/SouffleInterface.h"
 #include "souffle/SymbolTable.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -168,12 +169,8 @@ protected:
     protected:
         /** Check equivalence */
         bool equal(const souffle::Relation::iterator_base& o) const override {
-            try {
-                auto& iter = dynamic_cast<const RelInterface::iterator_base&>(o);
-                return ramRelationInterface == iter.ramRelationInterface && it == iter.it;
-            } catch (const std::bad_cast& e) {
-                return false;
-            }
+            auto& iter = asAssert<RelInterface::iterator_base>(o);
+            return ramRelationInterface == iter.ramRelationInterface && it == iter.it;
         }
 
     private:

--- a/src/interpreter/Relation.h
+++ b/src/interpreter/Relation.h
@@ -20,6 +20,7 @@
 #include "ram/analysis/Index.h"
 #include "souffle/RamTypes.h"
 #include "souffle/SouffleInterface.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cstddef>
 #include <cstdint>
 #include <deque>

--- a/src/interpreter/Relation.h
+++ b/src/interpreter/Relation.h
@@ -260,7 +260,7 @@ public:
         }
 
         bool equal(const RelationWrapper::iterator_base& other) const override {
-            if (auto* o = dynamic_cast<const iterator_base*>(&other)) {
+            if (auto* o = as<iterator_base>(other)) {
                 return iter == o->iter;
             }
             return false;

--- a/src/parser/ParserUtils.cpp
+++ b/src/parser/ParserUtils.cpp
@@ -100,11 +100,11 @@ VecOwn<ast::Clause> RuleBody::toClauseBodies() const {
             // negate if necessary
             if (lit.negated) {
                 // negate
-                if (auto* atom = dynamic_cast<ast::Atom*>(&*base)) {
+                if (auto* atom = as<ast::Atom>(*base)) {
                     base.release();
                     base = mk<ast::Negation>(Own<ast::Atom>(atom));
                     base->setSrcLoc(atom->getSrcLoc());
-                } else if (auto* cstr = dynamic_cast<ast::Constraint*>(&*base)) {
+                } else if (auto* cstr = as<ast::Constraint>(*base)) {
                     negateConstraintInPlace(*cstr);
                 }
             }

--- a/src/parser/ParserUtils.cpp
+++ b/src/parser/ParserUtils.cpp
@@ -91,7 +91,7 @@ VecOwn<ast::Clause> RuleBody::toClauseBodies() const {
     // collect clause results
     VecOwn<ast::Clause> bodies;
     for (const clause& cur : dnf) {
-        bodies.push_back(mk<ast::Clause>());
+        bodies.push_back(mk<ast::Clause>("*"));
         ast::Clause& clause = *bodies.back();
 
         for (const literal& lit : cur) {
@@ -102,8 +102,7 @@ VecOwn<ast::Clause> RuleBody::toClauseBodies() const {
                 // negate
                 if (auto* atom = as<ast::Atom>(*base)) {
                     base.release();
-                    base = mk<ast::Negation>(Own<ast::Atom>(atom));
-                    base->setSrcLoc(atom->getSrcLoc());
+                    base = mk<ast::Negation>(Own<ast::Atom>(atom), atom->getSrcLoc());
                 } else if (auto* cstr = as<ast::Constraint>(*base)) {
                     negateConstraintInPlace(*cstr);
                 }

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -473,7 +473,7 @@ relation_decl
             }
 
             for (auto&& fd : $dependency_list) {
-                rel->addDependency(Own<ast::FunctionalConstraint>(fd->clone()));
+                rel->addDependency(souffle::clone(fd));
             }
 
             rel->setAttributes(clone(attributes_list));

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -556,17 +556,17 @@ dependency
 dependency_list_aux
   : dependency { $$.push_back($dependency); }
 
-  | dependency_list_aux[list] COMMA dependency[next] { 
+  | dependency_list_aux[list] COMMA dependency[next] {
     $$ = std::move($list);
     $$.push_back(std::move($next));
   }
   ;
 
 /*  List of functional dependencies on relation */
-dependency_list 
+dependency_list
   : %empty { }
-    
-  | CHOICEDOMAIN dependency_list_aux[list] { 
+
+  | CHOICEDOMAIN dependency_list_aux[list] {
     $$ = std::move($list);
   }
   ;
@@ -752,7 +752,7 @@ arg
   | MINUS arg[nested_arg] %prec NEG {
         // If we have a constant that is not already negated we just negate the constant value.
         auto nested_arg = *$nested_arg;
-        const auto* asNumeric = dynamic_cast<const ast::NumericConstant*>(&*nested_arg);
+        const auto* asNumeric = as<ast::NumericConstant>(*nested_arg);
         if (asNumeric && !isPrefix("-", asNumeric->getConstant())) {
             $$ = mk<ast::NumericConstant>("-" + asNumeric->getConstant(), asNumeric->getFixedType(), @nested_arg);
         } else { // Otherwise, create a functor.
@@ -976,7 +976,7 @@ non_empty_key_value_pairs
 kvp_value
   : STRING  { $$ = $STRING; }
   | IDENT   { $$ = $IDENT; }
-  | NUMBER  { $$ = $NUMBER; } 
+  | NUMBER  { $$ = $NUMBER; }
   | TRUE    { $$ = "true"; }
   | FALSE   { $$ = "false"; }
   ;

--- a/src/ram/AbstractAggregate.h
+++ b/src/ram/AbstractAggregate.h
@@ -19,6 +19,7 @@
 #include "ram/Expression.h"
 #include "ram/Node.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <iosfwd>
 #include <memory>
@@ -88,7 +89,7 @@ protected:
 
 protected:
     bool equal(const Node& node) const {
-        const auto& other = dynamic_cast<const AbstractAggregate&>(node);
+        const auto& other = asAssert<AbstractAggregate, AllowCrossCast>(node);
         return function == other.function && equal_ptr(expression, other.expression) &&
                equal_ptr(condition, other.condition);
     }

--- a/src/ram/AbstractChoice.h
+++ b/src/ram/AbstractChoice.h
@@ -18,6 +18,7 @@
 #include "ram/Node.h"
 #include "ram/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <memory>
 #include <utility>
@@ -53,7 +54,7 @@ public:
 
 protected:
     bool equal(const Node& node) const {
-        const auto& other = dynamic_cast<const AbstractChoice&>(node);
+        const auto& other = asAssert<AbstractChoice, AllowCrossCast>(node);
         return equal_ptr(condition, other.condition);
     }
 

--- a/src/ram/AbstractConditional.h
+++ b/src/ram/AbstractConditional.h
@@ -60,7 +60,7 @@ public:
 
 protected:
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const AbstractConditional&>(node);
+        const auto& other = asAssert<AbstractConditional>(node);
         return NestedOperation::equal(node) && equal_ptr(condition, other.condition);
     }
 

--- a/src/ram/AbstractExistenceCheck.h
+++ b/src/ram/AbstractExistenceCheck.h
@@ -23,6 +23,7 @@
 #include "ram/Relation.h"
 #include "ram/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <cassert>
 #include <memory>
@@ -80,7 +81,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const AbstractExistenceCheck&>(node);
+        const auto& other = asAssert<AbstractExistenceCheck>(node);
         return relation == other.relation && equal_targets(values, other.values);
     }
 

--- a/src/ram/AbstractLog.h
+++ b/src/ram/AbstractLog.h
@@ -18,6 +18,7 @@
 #include "ram/Statement.h"
 #include "ram/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <memory>
 #include <string>
@@ -58,7 +59,7 @@ public:
 
 protected:
     bool equal(const Node& node) const {
-        const auto& other = dynamic_cast<const AbstractLog&>(node);
+        const auto& other = asAssert<AbstractLog, AllowCrossCast>(node);
         return equal_ptr(statement, other.statement) && message == other.message;
     }
 

--- a/src/ram/AbstractOperator.h
+++ b/src/ram/AbstractOperator.h
@@ -20,6 +20,7 @@
 #include "ram/Node.h"
 #include "ram/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <memory>
 #include <utility>
@@ -60,7 +61,7 @@ public:
 
 protected:
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const AbstractOperator&>(node);
+        const auto& other = asAssert<AbstractOperator>(node);
         return equal_targets(arguments, other.arguments);
     }
 

--- a/src/ram/Aggregate.h
+++ b/src/ram/Aggregate.h
@@ -85,7 +85,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Aggregate&>(node);
+        const auto& other = asAssert<Aggregate>(node);
         return RelationOperation::equal(other) && AbstractAggregate::equal(node);
     }
 };

--- a/src/ram/Aggregate.h
+++ b/src/ram/Aggregate.h
@@ -61,7 +61,7 @@ public:
     }
 
     Aggregate* clone() const override {
-        return new Aggregate(souffle::clone(&getOperation()), function, relation, souffle::clone(expression),
+        return new Aggregate(souffle::clone(getOperation()), function, relation, souffle::clone(expression),
                 souffle::clone(condition), getTupleId());
     }
 

--- a/src/ram/BinRelationStatement.h
+++ b/src/ram/BinRelationStatement.h
@@ -19,6 +19,7 @@
 #include "ram/Statement.h"
 #include "ram/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <cstddef>
 #include <memory>
@@ -50,7 +51,7 @@ public:
 
 protected:
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const BinRelationStatement&>(node);
+        const auto& other = asAssert<BinRelationStatement>(node);
         return first == other.first && second == other.second;
     }
 

--- a/src/ram/Break.h
+++ b/src/ram/Break.h
@@ -48,7 +48,7 @@ public:
             : AbstractConditional(std::move(cond), std::move(nested), std::move(profileText)) {}
 
     Break* clone() const override {
-        return new Break(souffle::clone(condition), souffle::clone(&getOperation()), getProfileText());
+        return new Break(souffle::clone(condition), souffle::clone(getOperation()), getProfileText());
     }
 
 protected:

--- a/src/ram/Call.h
+++ b/src/ram/Call.h
@@ -16,6 +16,7 @@
 
 #include "ram/Node.h"
 #include "ram/Statement.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <ostream>
 #include <string>
@@ -54,7 +55,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Call&>(node);
+        const auto& other = asAssert<Call>(node);
         return name == other.name;
     }
 

--- a/src/ram/Choice.h
+++ b/src/ram/Choice.h
@@ -82,7 +82,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Choice&>(node);
+        const auto& other = asAssert<Choice>(node);
         return RelationOperation::equal(other) && AbstractChoice::equal(other);
     }
 };

--- a/src/ram/Choice.h
+++ b/src/ram/Choice.h
@@ -63,7 +63,7 @@ public:
     }
 
     Choice* clone() const override {
-        return new Choice(relation, getTupleId(), souffle::clone(condition), souffle::clone(&getOperation()),
+        return new Choice(relation, getTupleId(), souffle::clone(condition), souffle::clone(getOperation()),
                 getProfileText());
     }
 

--- a/src/ram/Conjunction.h
+++ b/src/ram/Conjunction.h
@@ -80,7 +80,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Conjunction&>(node);
+        const auto& other = asAssert<Conjunction>(node);
         return equal_ptr(lhs, other.lhs) && equal_ptr(rhs, other.rhs);
     }
 

--- a/src/ram/Constant.h
+++ b/src/ram/Constant.h
@@ -19,6 +19,7 @@
 #include "ram/Expression.h"
 #include "ram/Node.h"
 #include "souffle/RamTypes.h"
+#include "souffle/utility/MiscUtil.h"
 
 namespace souffle::ram {
 
@@ -38,7 +39,7 @@ protected:
     explicit Constant(RamDomain constant) : constant(constant) {}
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Constant&>(node);
+        const auto& other = asAssert<Constant>(node);
         return constant == other.constant;
     }
 

--- a/src/ram/Constraint.h
+++ b/src/ram/Constraint.h
@@ -89,7 +89,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Constraint&>(node);
+        const auto& other = asAssert<Constraint>(node);
         return op == other.op && equal_ptr(lhs, other.lhs) && equal_ptr(rhs, other.rhs);
     }
 

--- a/src/ram/EmptinessCheck.h
+++ b/src/ram/EmptinessCheck.h
@@ -62,7 +62,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const EmptinessCheck&>(node);
+        const auto& other = asAssert<EmptinessCheck>(node);
         return relation == other.relation;
     }
 

--- a/src/ram/Exit.h
+++ b/src/ram/Exit.h
@@ -70,7 +70,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Exit&>(node);
+        const auto& other = asAssert<Exit>(node);
         return equal_ptr(condition, other.condition);
     }
 

--- a/src/ram/Filter.h
+++ b/src/ram/Filter.h
@@ -48,7 +48,7 @@ public:
             : AbstractConditional(std::move(cond), std::move(nested), std::move(profileText)) {}
 
     Filter* clone() const override {
-        return new Filter(souffle::clone(condition), souffle::clone(&getOperation()), getProfileText());
+        return new Filter(souffle::clone(condition), souffle::clone(getOperation()), getProfileText());
     }
 
 protected:

--- a/src/ram/GuardedProject.h
+++ b/src/ram/GuardedProject.h
@@ -17,6 +17,7 @@
 #include "ram/ExistenceCheck.h"
 #include "ram/Project.h"
 #include "ram/utility/Utils.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <iosfwd>
 #include <memory>
@@ -84,7 +85,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const GuardedProject&>(node);
+        const auto& other = asAssert<GuardedProject>(node);
         return relation == other.relation && equal_targets(expressions, other.expressions) &&
                equal_ptr(condition, other.condition);
     }

--- a/src/ram/IO.h
+++ b/src/ram/IO.h
@@ -65,7 +65,7 @@ protected:
     };
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const IO&>(node);
+        const auto& other = asAssert<IO>(node);
         return RelationStatement::equal(other) && directives == other.directives;
     }
 

--- a/src/ram/IndexAggregate.h
+++ b/src/ram/IndexAggregate.h
@@ -91,7 +91,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const IndexAggregate&>(node);
+        const auto& other = asAssert<IndexAggregate>(node);
         return IndexOperation::equal(other) && AbstractAggregate::equal(other);
     }
 };

--- a/src/ram/IndexAggregate.h
+++ b/src/ram/IndexAggregate.h
@@ -66,7 +66,7 @@ public:
         for (const auto& i : queryPattern.second) {
             pattern.second.emplace_back(i->clone());
         }
-        return new IndexAggregate(souffle::clone(&getOperation()), function, relation,
+        return new IndexAggregate(souffle::clone(getOperation()), function, relation,
                 souffle::clone(expression), souffle::clone(condition), std::move(pattern), getTupleId());
     }
 

--- a/src/ram/IndexChoice.h
+++ b/src/ram/IndexChoice.h
@@ -87,7 +87,7 @@ public:
             resQueryPattern.second.emplace_back(i->clone());
         }
         auto* res = new IndexChoice(relation, getTupleId(), souffle::clone(condition),
-                std::move(resQueryPattern), souffle::clone(&getOperation()), getProfileText());
+                std::move(resQueryPattern), souffle::clone(getOperation()), getProfileText());
         return res;
     }
 

--- a/src/ram/IndexChoice.h
+++ b/src/ram/IndexChoice.h
@@ -102,7 +102,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const IndexChoice&>(node);
+        const auto& other = asAssert<IndexChoice>(node);
         return IndexOperation::equal(other) && AbstractChoice::equal(other);
     }
 };

--- a/src/ram/IndexOperation.h
+++ b/src/ram/IndexOperation.h
@@ -97,7 +97,7 @@ public:
             resQueryPattern.second.emplace_back(i->clone());
         }
         return new IndexOperation(relation, getTupleId(), std::move(resQueryPattern),
-                souffle::clone(&getOperation()), getProfileText());
+                souffle::clone(getOperation()), getProfileText());
     }
 
     /** @brief Helper method for printing */

--- a/src/ram/IndexOperation.h
+++ b/src/ram/IndexOperation.h
@@ -147,7 +147,7 @@ public:
 
 protected:
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const IndexOperation&>(node);
+        const auto& other = asAssert<IndexOperation>(node);
         return RelationOperation::equal(other) &&
                equal_targets(queryPattern.first, other.queryPattern.first) &&
                equal_targets(queryPattern.second, other.queryPattern.second);

--- a/src/ram/IndexScan.h
+++ b/src/ram/IndexScan.h
@@ -61,7 +61,7 @@ public:
             resQueryPattern.second.emplace_back(i->clone());
         }
         return new IndexScan(relation, getTupleId(), std::move(resQueryPattern),
-                souffle::clone(&getOperation()), getProfileText());
+                souffle::clone(getOperation()), getProfileText());
     }
 
 protected:

--- a/src/ram/IntrinsicOperator.h
+++ b/src/ram/IntrinsicOperator.h
@@ -20,6 +20,7 @@
 #include "ram/AbstractOperator.h"
 #include "ram/Expression.h"
 #include "ram/Node.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include "souffle/utility/tinyformat.h"
 #include <memory>
@@ -64,7 +65,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const IntrinsicOperator&>(node);
+        const auto& other = asAssert<IntrinsicOperator>(node);
         return AbstractOperator::equal(node) && operation == other.operation;
     }
 

--- a/src/ram/ListStatement.h
+++ b/src/ram/ListStatement.h
@@ -18,6 +18,7 @@
 #include "ram/Statement.h"
 #include "ram/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <memory>
 #include <utility>
@@ -64,7 +65,7 @@ public:
 
 protected:
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const ListStatement&>(node);
+        const auto& other = asAssert<ListStatement>(node);
         return equal_targets(statements, other.statements);
     }
 

--- a/src/ram/LogSize.h
+++ b/src/ram/LogSize.h
@@ -53,7 +53,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const LogSize&>(node);
+        const auto& other = asAssert<LogSize>(node);
         return RelationStatement::equal(other) && message == other.message;
     }
 

--- a/src/ram/Loop.h
+++ b/src/ram/Loop.h
@@ -72,7 +72,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Loop&>(node);
+        const auto& other = asAssert<Loop>(node);
         return equal_ptr(body, other.body);
     }
 

--- a/src/ram/Negation.h
+++ b/src/ram/Negation.h
@@ -68,7 +68,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Negation&>(node);
+        const auto& other = asAssert<Negation>(node);
         return equal_ptr(operand, other.operand);
     }
 

--- a/src/ram/NestedIntrinsicOperator.h
+++ b/src/ram/NestedIntrinsicOperator.h
@@ -97,7 +97,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        auto&& other = static_cast<const NestedIntrinsicOperator&>(node);
+        auto&& other = asAssert<NestedIntrinsicOperator>(node);
         return TupleOperation::equal(node) && op == other.op && equal_targets(args, other.args);
     }
 

--- a/src/ram/NestedIntrinsicOperator.h
+++ b/src/ram/NestedIntrinsicOperator.h
@@ -78,7 +78,7 @@ public:
 
     NestedIntrinsicOperator* clone() const override {
         return new NestedIntrinsicOperator(
-                op, souffle::clone(args), souffle::clone(&getOperation()), getTupleId());
+                op, souffle::clone(args), souffle::clone(getOperation()), getTupleId());
     }
 
     void apply(const NodeMapper& map) override {

--- a/src/ram/NestedOperation.h
+++ b/src/ram/NestedOperation.h
@@ -78,7 +78,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const NestedOperation&>(node);
+        const auto& other = asAssert<NestedOperation>(node);
         return equal_ptr(nestedOperation, other.nestedOperation) && profileText == other.profileText;
     }
 

--- a/src/ram/Node.h
+++ b/src/ram/Node.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "ram/utility/LambdaNodeMapper.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <functional>
 #include <iostream>

--- a/src/ram/PackRecord.h
+++ b/src/ram/PackRecord.h
@@ -20,6 +20,7 @@
 #include "ram/Node.h"
 #include "ram/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <cassert>
 #include <memory>
@@ -75,7 +76,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const PackRecord&>(node);
+        const auto& other = asAssert<PackRecord>(node);
         return equal_targets(arguments, other.arguments);
     }
 

--- a/src/ram/ParallelAggregate.h
+++ b/src/ram/ParallelAggregate.h
@@ -53,7 +53,7 @@ public:
             : Aggregate(std::move(nested), fun, rel, std::move(expression), std::move(condition), ident) {}
 
     ParallelAggregate* clone() const override {
-        return new ParallelAggregate(souffle::clone(&getOperation()), function, relation,
+        return new ParallelAggregate(souffle::clone(getOperation()), function, relation,
                 souffle::clone(expression), souffle::clone(condition), identifier);
     }
 

--- a/src/ram/ParallelChoice.h
+++ b/src/ram/ParallelChoice.h
@@ -52,7 +52,7 @@ public:
 
     ParallelChoice* clone() const override {
         return new ParallelChoice(relation, getTupleId(), souffle::clone(condition),
-                souffle::clone(&getOperation()), getProfileText());
+                souffle::clone(getOperation()), getProfileText());
     }
 
 protected:

--- a/src/ram/ParallelIndexAggregate.h
+++ b/src/ram/ParallelIndexAggregate.h
@@ -60,7 +60,7 @@ public:
         for (const auto& i : queryPattern.second) {
             pattern.second.emplace_back(i->clone());
         }
-        return new ParallelIndexAggregate(souffle::clone(&getOperation()), function, relation,
+        return new ParallelIndexAggregate(souffle::clone(getOperation()), function, relation,
                 souffle::clone(expression), souffle::clone(condition), std::move(pattern), getTupleId());
     }
 

--- a/src/ram/ParallelIndexChoice.h
+++ b/src/ram/ParallelIndexChoice.h
@@ -68,7 +68,7 @@ public:
             resQueryPattern.second.emplace_back(i->clone());
         }
         auto* res = new ParallelIndexChoice(relation, getTupleId(), souffle::clone(condition),
-                std::move(resQueryPattern), souffle::clone(&getOperation()), getProfileText());
+                std::move(resQueryPattern), souffle::clone(getOperation()), getProfileText());
         return res;
     }
 

--- a/src/ram/ParallelIndexScan.h
+++ b/src/ram/ParallelIndexScan.h
@@ -66,7 +66,7 @@ public:
             resQueryPattern.second.emplace_back(i->clone());
         }
         return new ParallelIndexScan(relation, getTupleId(), std::move(resQueryPattern),
-                souffle::clone(&getOperation()), getProfileText());
+                souffle::clone(getOperation()), getProfileText());
     }
 
 protected:

--- a/src/ram/ParallelScan.h
+++ b/src/ram/ParallelScan.h
@@ -49,7 +49,7 @@ public:
             : Scan(rel, ident, std::move(nested), profileText) {}
 
     ParallelScan* clone() const override {
-        return new ParallelScan(relation, getTupleId(), souffle::clone(&getOperation()), getProfileText());
+        return new ParallelScan(relation, getTupleId(), souffle::clone(getOperation()), getProfileText());
     }
 
 protected:

--- a/src/ram/Program.h
+++ b/src/ram/Program.h
@@ -143,8 +143,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Program&>(node);
-
+        const auto& other = asAssert<Program>(node);
         return equal_targets(relations, other.relations) && equal_ptr(main, other.main) &&
                equal_targets(subroutines, other.subroutines);
     }

--- a/src/ram/Project.h
+++ b/src/ram/Project.h
@@ -92,7 +92,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Project&>(node);
+        const auto& other = asAssert<Project>(node);
         return relation == other.relation && equal_targets(expressions, other.expressions);
     }
 

--- a/src/ram/Query.h
+++ b/src/ram/Query.h
@@ -73,7 +73,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const Query&>(node);
+        const auto& other = asAssert<Query>(node);
         return equal_ptr(operation, other.operation);
     }
 

--- a/src/ram/Relation.h
+++ b/src/ram/Relation.h
@@ -18,6 +18,7 @@
 #include "RelationTag.h"
 #include "ram/Node.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <cstddef>
 #include <memory>
@@ -116,8 +117,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        assert(isA<Relation>(&node));
-        const auto& other = static_cast<const Relation&>(node);
+        const auto& other = asAssert<Relation>(node);
         return representation == other.representation && name == other.name && arity == other.arity &&
                auxiliaryArity == other.auxiliaryArity && attributeNames == other.attributeNames &&
                attributeTypes == other.attributeTypes;

--- a/src/ram/RelationOperation.h
+++ b/src/ram/RelationOperation.h
@@ -20,6 +20,7 @@
 #include "ram/TupleOperation.h"
 #include "ram/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <memory>
 #include <string>
@@ -48,7 +49,7 @@ public:
 
 protected:
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const RelationOperation&>(node);
+        const auto& other = asAssert<RelationOperation>(node);
         return TupleOperation::equal(other) && relation == other.relation;
     }
 

--- a/src/ram/RelationSize.h
+++ b/src/ram/RelationSize.h
@@ -59,7 +59,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const RelationSize&>(node);
+        const auto& other = asAssert<RelationSize>(node);
         return relation == other.relation;
     }
 

--- a/src/ram/RelationStatement.h
+++ b/src/ram/RelationStatement.h
@@ -19,6 +19,7 @@
 #include "ram/Statement.h"
 #include "ram/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cassert>
 #include <memory>
 #include <utility>
@@ -41,7 +42,7 @@ public:
 
 protected:
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const RelationStatement&>(node);
+        const auto& other = asAssert<RelationStatement>(node);
         return relation == other.relation;
     }
 

--- a/src/ram/Scan.h
+++ b/src/ram/Scan.h
@@ -46,7 +46,7 @@ public:
             : RelationOperation(rel, ident, std::move(nested), std::move(profileText)) {}
 
     Scan* clone() const override {
-        return new Scan(relation, getTupleId(), souffle::clone(&getOperation()), getProfileText());
+        return new Scan(relation, getTupleId(), souffle::clone(getOperation()), getProfileText());
     }
 
 protected:

--- a/src/ram/SubroutineArgument.h
+++ b/src/ram/SubroutineArgument.h
@@ -18,6 +18,7 @@
 
 #include "ram/Expression.h"
 #include "ram/Node.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cstdlib>
 #include <ostream>
 
@@ -50,7 +51,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const SubroutineArgument&>(node);
+        const auto& other = asAssert<SubroutineArgument>(node);
         return number == other.number;
     }
 

--- a/src/ram/SubroutineReturn.h
+++ b/src/ram/SubroutineReturn.h
@@ -19,6 +19,7 @@
 #include "ram/Operation.h"
 #include "ram/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <cassert>
 #include <iosfwd>
@@ -88,7 +89,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const SubroutineReturn&>(node);
+        const auto& other = asAssert<SubroutineReturn>(node);
         return equal_targets(expressions, other.expressions);
     }
 

--- a/src/ram/TranslationUnit.h
+++ b/src/ram/TranslationUnit.h
@@ -74,7 +74,7 @@ public:
                 analyses[name] = std::move(analysis);
             }
         }
-        return dynamic_cast<Analysis*>(analyses[name].get());
+        return as<Analysis>(analyses[name]);
     }
 
     /** @brief Get all alive analyses */

--- a/src/ram/TupleElement.h
+++ b/src/ram/TupleElement.h
@@ -18,6 +18,7 @@
 
 #include "ram/Expression.h"
 #include "ram/Node.h"
+#include "souffle/utility/MiscUtil.h"
 #include <cstdlib>
 #include <ostream>
 
@@ -56,7 +57,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const TupleElement&>(node);
+        const auto& other = asAssert<TupleElement>(node);
         return identifier == other.identifier && element == other.element;
     }
 

--- a/src/ram/TupleOperation.h
+++ b/src/ram/TupleOperation.h
@@ -17,6 +17,7 @@
 #include "ram/NestedOperation.h"
 #include "ram/Node.h"
 #include "ram/Operation.h"
+#include "souffle/utility/MiscUtil.h"
 #include <memory>
 #include <string>
 #include <utility>
@@ -51,7 +52,7 @@ public:
 
 protected:
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const TupleOperation&>(node);
+        const auto& other = asAssert<TupleOperation>(node);
         return NestedOperation::equal(other) && identifier == other.identifier;
     }
 

--- a/src/ram/UnpackRecord.h
+++ b/src/ram/UnpackRecord.h
@@ -70,7 +70,7 @@ public:
 
     UnpackRecord* clone() const override {
         return new UnpackRecord(
-                souffle::clone(&getOperation()), getTupleId(), souffle::clone(&getExpression()), arity);
+                souffle::clone(getOperation()), getTupleId(), souffle::clone(getExpression()), arity);
     }
 
     void apply(const NodeMapper& map) override {

--- a/src/ram/UnpackRecord.h
+++ b/src/ram/UnpackRecord.h
@@ -86,7 +86,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const UnpackRecord&>(node);
+        const auto& other = asAssert<UnpackRecord>(node);
         return TupleOperation::equal(other) && equal_ptr(expression, other.expression) &&
                arity == other.arity;
     }

--- a/src/ram/UserDefinedOperator.h
+++ b/src/ram/UserDefinedOperator.h
@@ -20,6 +20,7 @@
 #include "ram/Expression.h"
 #include "ram/Node.h"
 #include "souffle/TypeAttribute.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <cassert>
 #include <memory>
@@ -84,7 +85,7 @@ protected:
     }
 
     bool equal(const Node& node) const override {
-        const auto& other = static_cast<const UserDefinedOperator&>(node);
+        const auto& other = asAssert<UserDefinedOperator>(node);
         return AbstractOperator::equal(node) && name == other.name && argsTypes == other.argsTypes &&
                returnType == other.returnType && stateful == other.stateful;
     }

--- a/src/ram/analysis/Index.cpp
+++ b/src/ram/analysis/Index.cpp
@@ -393,13 +393,13 @@ void IndexAnalysis::run(const TranslationUnit& translationUnit) {
 
     // visit all nodes to collect searches of each relation
     visitDepthFirst(translationUnit.getProgram(), [&](const Node& node) {
-        if (const auto* indexSearch = dynamic_cast<const IndexOperation*>(&node)) {
+        if (const auto* indexSearch = as<IndexOperation>(node)) {
             relationToSearches[indexSearch->getRelation()].insert(getSearchSignature(indexSearch));
-        } else if (const auto* exists = dynamic_cast<const ExistenceCheck*>(&node)) {
+        } else if (const auto* exists = as<ExistenceCheck>(node)) {
             relationToSearches[exists->getRelation()].insert(getSearchSignature(exists));
-        } else if (const auto* provExists = dynamic_cast<const ProvenanceExistenceCheck*>(&node)) {
+        } else if (const auto* provExists = as<ProvenanceExistenceCheck>(node)) {
             relationToSearches[provExists->getRelation()].insert(getSearchSignature(provExists));
-        } else if (const auto* ramRel = dynamic_cast<const Relation*>(&node)) {
+        } else if (const auto* ramRel = as<Relation>(node)) {
             relationToSearches[ramRel->getName()].insert(getSearchSignature(ramRel));
         }
     });

--- a/src/ram/transform/ChoiceConversion.cpp
+++ b/src/ram/transform/ChoiceConversion.cpp
@@ -54,8 +54,8 @@ Own<Operation> ChoiceConversionTransformer::rewriteScan(const Scan* scan) {
         const auto* filter = as<Filter>(scan->getOperation());
         const int identifier = scan->getTupleId();
 
-        return mk<Choice>(scan->getRelation(), identifier, souffle::clone(&filter->getCondition()),
-                souffle::clone(&filter->getOperation()), scan->getProfileText());
+        return mk<Choice>(scan->getRelation(), identifier, souffle::clone(filter->getCondition()),
+                souffle::clone(filter->getOperation()), scan->getProfileText());
     }
     return nullptr;
 }
@@ -102,8 +102,8 @@ Own<Operation> ChoiceConversionTransformer::rewriteIndexScan(const IndexScan* in
             newValues.second.emplace_back(val);
         }
 
-        return mk<IndexChoice>(rel, identifier, souffle::clone(&filter->getCondition()), std::move(newValues),
-                souffle::clone(&filter->getOperation()), indexScan->getProfileText());
+        return mk<IndexChoice>(rel, identifier, souffle::clone(filter->getCondition()), std::move(newValues),
+                souffle::clone(filter->getOperation()), indexScan->getProfileText());
     }
     return nullptr;
 }

--- a/src/ram/transform/CollapseFilters.cpp
+++ b/src/ram/transform/CollapseFilters.cpp
@@ -32,7 +32,7 @@ bool CollapseFiltersTransformer::collapseFilters(Program& program) {
     bool changed = false;
     visitDepthFirst(program, [&](const Query& query) {
         std::function<Own<Node>(Own<Node>)> filterRewriter = [&](Own<Node> node) -> Own<Node> {
-            if (const Filter* filter = dynamic_cast<Filter*>(node.get())) {
+            if (const Filter* filter = as<Filter>(node)) {
                 // true if two consecutive filters in loop nest found
                 bool canCollapse = false;
 
@@ -41,7 +41,7 @@ bool CollapseFiltersTransformer::collapseFilters(Program& program) {
 
                 const Filter* prevFilter = filter;
                 conditions.emplace_back(filter->getCondition().clone());
-                while (auto* nextFilter = dynamic_cast<Filter*>(&prevFilter->getOperation())) {
+                while (auto* nextFilter = as<Filter>(prevFilter->getOperation())) {
                     canCollapse = true;
                     conditions.emplace_back(nextFilter->getCondition().clone());
                     prevFilter = nextFilter;

--- a/src/ram/transform/CollapseFilters.cpp
+++ b/src/ram/transform/CollapseFilters.cpp
@@ -49,7 +49,7 @@ bool CollapseFiltersTransformer::collapseFilters(Program& program) {
 
                 if (canCollapse) {
                     changed = true;
-                    node = mk<Filter>(toCondition(conditions), souffle::clone(&prevFilter->getOperation()),
+                    node = mk<Filter>(toCondition(conditions), souffle::clone(prevFilter->getOperation()),
                             prevFilter->getProfileText());
                 }
             }

--- a/src/ram/transform/EliminateDuplicates.cpp
+++ b/src/ram/transform/EliminateDuplicates.cpp
@@ -32,7 +32,7 @@ bool EliminateDuplicatesTransformer::eliminateDuplicates(Program& program) {
     bool changed = false;
     visitDepthFirst(program, [&](const Query& query) {
         std::function<Own<Node>(Own<Node>)> filterRewriter = [&](Own<Node> node) -> Own<Node> {
-            if (const Filter* filter = dynamic_cast<Filter*>(node.get())) {
+            if (const Filter* filter = as<Filter>(node)) {
                 const Condition* condition = &filter->getCondition();
                 VecOwn<Condition> conds = toConjunctionList(condition);
                 bool eliminatedDuplicate = false;

--- a/src/ram/transform/EliminateDuplicates.cpp
+++ b/src/ram/transform/EliminateDuplicates.cpp
@@ -49,7 +49,7 @@ bool EliminateDuplicatesTransformer::eliminateDuplicates(Program& program) {
                 if (eliminatedDuplicate) {
                     changed = true;
                     node = mk<Filter>(
-                            Own<Condition>(toCondition(conds)), souffle::clone(&filter->getOperation()));
+                            Own<Condition>(toCondition(conds)), souffle::clone(filter->getOperation()));
                 }
             }
             node->apply(makeLambdaRamMapper(filterRewriter));

--- a/src/ram/transform/ExpandFilter.cpp
+++ b/src/ram/transform/ExpandFilter.cpp
@@ -34,7 +34,7 @@ bool ExpandFilterTransformer::expandFilters(Program& program) {
     bool changed = false;
     visitDepthFirst(program, [&](const Query& query) {
         std::function<Own<Node>(Own<Node>)> filterRewriter = [&](Own<Node> node) -> Own<Node> {
-            if (const Filter* filter = dynamic_cast<Filter*>(node.get())) {
+            if (const Filter* filter = as<Filter>(node)) {
                 const Condition* condition = &filter->getCondition();
                 VecOwn<Condition> conditionList = toConjunctionList(condition);
                 if (conditionList.size() > 1) {

--- a/src/ram/transform/ExpandFilter.cpp
+++ b/src/ram/transform/ExpandFilter.cpp
@@ -42,8 +42,8 @@ bool ExpandFilterTransformer::expandFilters(Program& program) {
                     VecOwn<Filter> filters;
                     for (auto& cond : conditionList) {
                         if (filters.empty()) {
-                            filters.emplace_back(mk<Filter>(
-                                    souffle::clone(cond), souffle::clone(&filter->getOperation())));
+                            filters.emplace_back(
+                                    mk<Filter>(souffle::clone(cond), souffle::clone(filter->getOperation())));
                         } else {
                             filters.emplace_back(mk<Filter>(souffle::clone(cond), std::move(filters.back())));
                         }

--- a/src/ram/transform/HoistAggregate.cpp
+++ b/src/ram/transform/HoistAggregate.cpp
@@ -41,7 +41,7 @@ bool HoistAggregateTransformer::hoistAggregate(Program& program) {
         Own<NestedOperation> newAgg;
         bool priorTupleOp = false;
         std::function<Own<Node>(Own<Node>)> aggRewriter = [&](Own<Node> node) -> Own<Node> {
-            if (isA<Aggregate>(node.get())) {
+            if (isA<Aggregate>(node)) {
                 auto* tupleOp = as<TupleOperation>(node);
                 assert(tupleOp != nullptr && "aggregate conversion to tuple operation failed");
                 if (rla->getLevel(tupleOp) == -1 && !priorTupleOp) {

--- a/src/ram/transform/HoistAggregate.cpp
+++ b/src/ram/transform/HoistAggregate.cpp
@@ -42,7 +42,7 @@ bool HoistAggregateTransformer::hoistAggregate(Program& program) {
         bool priorTupleOp = false;
         std::function<Own<Node>(Own<Node>)> aggRewriter = [&](Own<Node> node) -> Own<Node> {
             if (isA<Aggregate>(node.get())) {
-                auto* tupleOp = dynamic_cast<TupleOperation*>(node.get());
+                auto* tupleOp = as<TupleOperation>(node);
                 assert(tupleOp != nullptr && "aggregate conversion to tuple operation failed");
                 if (rla->getLevel(tupleOp) == -1 && !priorTupleOp) {
                     changed = true;
@@ -50,7 +50,7 @@ bool HoistAggregateTransformer::hoistAggregate(Program& program) {
                     assert(newAgg != nullptr && "failed to make a clone");
                     return souffle::clone(&tupleOp->getOperation());
                 }
-            } else if (isA<TupleOperation>(node.get())) {
+            } else if (isA<TupleOperation>(node)) {
                 // tuple operation that is a non-aggregate
                 priorTupleOp = true;
             }
@@ -71,8 +71,8 @@ bool HoistAggregateTransformer::hoistAggregate(Program& program) {
         int priorOpLevel = -1;
 
         std::function<Own<Node>(Own<Node>)> aggRewriter = [&](Own<Node> node) -> Own<Node> {
-            if (isA<AbstractAggregate>(node.get())) {
-                auto* tupleOp = dynamic_cast<TupleOperation*>(node.get());
+            if (isA<AbstractAggregate>(node)) {
+                auto* tupleOp = as<TupleOperation>(node);
                 assert(tupleOp != nullptr && "aggregate conversion to nested operation failed");
                 int dataDepLevel = rla->getLevel(tupleOp);
                 if (dataDepLevel != -1 && dataDepLevel < tupleOp->getTupleId() - 1) {
@@ -87,11 +87,11 @@ bool HoistAggregateTransformer::hoistAggregate(Program& program) {
                         return souffle::clone(&tupleOp->getOperation());
                     }
                 }
-            } else if (const TupleOperation* tupleOp = dynamic_cast<TupleOperation*>(node.get())) {
+            } else if (const TupleOperation* tupleOp = as<TupleOperation>(node)) {
                 priorOpLevel = tupleOp->getTupleId();
             }
             node->apply(makeLambdaRamMapper(aggRewriter));
-            if (auto* search = dynamic_cast<TupleOperation*>(node.get())) {
+            if (auto* search = as<TupleOperation>(node)) {
                 if (newAgg != nullptr && search->getTupleId() == newLevel) {
                     newAgg->rewrite(&newAgg->getOperation(), souffle::clone(&search->getOperation()));
                     search->rewrite(&search->getOperation(), std::move(newAgg));

--- a/src/ram/transform/HoistAggregate.cpp
+++ b/src/ram/transform/HoistAggregate.cpp
@@ -48,7 +48,7 @@ bool HoistAggregateTransformer::hoistAggregate(Program& program) {
                     changed = true;
                     newAgg = souffle::clone(tupleOp);
                     assert(newAgg != nullptr && "failed to make a clone");
-                    return souffle::clone(&tupleOp->getOperation());
+                    return souffle::clone(tupleOp->getOperation());
                 }
             } else if (isA<TupleOperation>(node)) {
                 // tuple operation that is a non-aggregate
@@ -59,7 +59,7 @@ bool HoistAggregateTransformer::hoistAggregate(Program& program) {
         };
         const_cast<Query*>(&query)->apply(makeLambdaRamMapper(aggRewriter));
         if (newAgg != nullptr) {
-            newAgg->rewrite(&newAgg->getOperation(), souffle::clone(&query.getOperation()));
+            newAgg->rewrite(&newAgg->getOperation(), souffle::clone(query.getOperation()));
             const_cast<Query*>(&query)->rewrite(&query.getOperation(), std::move(newAgg));
         }
     });
@@ -84,7 +84,7 @@ bool HoistAggregateTransformer::hoistAggregate(Program& program) {
                         newLevel = dataDepLevel;
                         newAgg = souffle::clone(tupleOp);
                         assert(newAgg != nullptr && "failed to make a clone");
-                        return souffle::clone(&tupleOp->getOperation());
+                        return souffle::clone(tupleOp->getOperation());
                     }
                 }
             } else if (const TupleOperation* tupleOp = as<TupleOperation>(node)) {
@@ -93,7 +93,7 @@ bool HoistAggregateTransformer::hoistAggregate(Program& program) {
             node->apply(makeLambdaRamMapper(aggRewriter));
             if (auto* search = as<TupleOperation>(node)) {
                 if (newAgg != nullptr && search->getTupleId() == newLevel) {
-                    newAgg->rewrite(&newAgg->getOperation(), souffle::clone(&search->getOperation()));
+                    newAgg->rewrite(&newAgg->getOperation(), souffle::clone(search->getOperation()));
                     search->rewrite(&search->getOperation(), std::move(newAgg));
                 }
             }

--- a/src/ram/transform/HoistConditions.cpp
+++ b/src/ram/transform/HoistConditions.cpp
@@ -50,9 +50,9 @@ bool HoistConditionsTransformer::hoistConditions(Program& program) {
                 // delete the filter operation and collect condition
                 if (rla->getLevel(&condition) == -1) {
                     changed = true;
-                    newCondition = addCondition(std::move(newCondition), souffle::clone(&condition));
+                    newCondition = addCondition(std::move(newCondition), souffle::clone(condition));
                     node->apply(makeLambdaRamMapper(filterRewriter));
-                    return souffle::clone(&filter->getOperation());
+                    return souffle::clone(filter->getOperation());
                 }
             }
             node->apply(makeLambdaRamMapper(filterRewriter));
@@ -78,9 +78,9 @@ bool HoistConditionsTransformer::hoistConditions(Program& program) {
                 // delete the filter operation and collect condition
                 if (rla->getLevel(&condition) == search.getTupleId()) {
                     changed = true;
-                    newCondition = addCondition(std::move(newCondition), souffle::clone(&condition));
+                    newCondition = addCondition(std::move(newCondition), souffle::clone(condition));
                     node->apply(makeLambdaRamMapper(filterRewriter));
-                    return souffle::clone(&filter->getOperation());
+                    return souffle::clone(filter->getOperation());
                 }
             }
             node->apply(makeLambdaRamMapper(filterRewriter));
@@ -92,7 +92,7 @@ bool HoistConditionsTransformer::hoistConditions(Program& program) {
             // insert new filter operation after the search operation
             changed = true;
             tupleOp->rewrite(&tupleOp->getOperation(),
-                    mk<Filter>(std::move(newCondition), souffle::clone(&tupleOp->getOperation())));
+                    mk<Filter>(std::move(newCondition), souffle::clone(tupleOp->getOperation())));
         }
     });
     return changed;

--- a/src/ram/transform/HoistConditions.cpp
+++ b/src/ram/transform/HoistConditions.cpp
@@ -44,7 +44,7 @@ bool HoistConditionsTransformer::hoistConditions(Program& program) {
     visitDepthFirst(program, [&](const Query& query) {
         Own<Condition> newCondition;
         std::function<Own<Node>(Own<Node>)> filterRewriter = [&](Own<Node> node) -> Own<Node> {
-            if (auto* filter = dynamic_cast<Filter*>(node.get())) {
+            if (auto* filter = as<Filter>(node)) {
                 const Condition& condition = filter->getCondition();
                 // if filter condition is independent of any TupleOperation,
                 // delete the filter operation and collect condition
@@ -72,7 +72,7 @@ bool HoistConditionsTransformer::hoistConditions(Program& program) {
     visitDepthFirst(program, [&](const TupleOperation& search) {
         Own<Condition> newCondition;
         std::function<Own<Node>(Own<Node>)> filterRewriter = [&](Own<Node> node) -> Own<Node> {
-            if (auto* filter = dynamic_cast<Filter*>(node.get())) {
+            if (auto* filter = as<Filter>(node)) {
                 const Condition& condition = filter->getCondition();
                 // if filter condition matches level of TupleOperation,
                 // delete the filter operation and collect condition

--- a/src/ram/transform/IfConversion.cpp
+++ b/src/ram/transform/IfConversion.cpp
@@ -61,7 +61,7 @@ Own<Operation> IfConversionTransformer::rewriteIndexScan(const IndexScan* indexS
 
         // check if there is a break statement nested in the Scan - if so, remove it
         Operation* newOp;
-        if (const auto* breakOp = dynamic_cast<const Break*>(&indexScan->getOperation())) {
+        if (const auto* breakOp = as<Break>(indexScan->getOperation())) {
             newOp = breakOp->getOperation().clone();
         } else {
             newOp = indexScan->getOperation().clone();
@@ -77,7 +77,7 @@ bool IfConversionTransformer::convertIndexScans(Program& program) {
     bool changed = false;
     visitDepthFirst(program, [&](const Query& query) {
         std::function<Own<Node>(Own<Node>)> scanRewriter = [&](Own<Node> node) -> Own<Node> {
-            if (const IndexScan* scan = dynamic_cast<IndexScan*>(node.get())) {
+            if (const IndexScan* scan = as<IndexScan>(node)) {
                 if (Own<Operation> op = rewriteIndexScan(scan)) {
                     changed = true;
                     node = std::move(op);

--- a/src/ram/transform/MakeIndex.cpp
+++ b/src/ram/transform/MakeIndex.cpp
@@ -180,10 +180,10 @@ Own<Condition> MakeIndexTransformer::constructPattern(const std::vector<std::str
         if (transformable) {
             // append the weak version of inequality
             toAppend.emplace_back(mk<Constraint>(convertStrictToWeakIneqConstraint(binRelOp->getOperator()),
-                    clone(&binRelOp->getLHS()), clone(&binRelOp->getRHS())));
+                    souffle::clone(binRelOp->getLHS()), souffle::clone(binRelOp->getRHS())));
             // append the != constraint
             toAppend.emplace_back(mk<Constraint>(convertStrictToNotEqualConstraint(binRelOp->getOperator()),
-                    clone(&binRelOp->getLHS()), clone(&binRelOp->getRHS())));
+                    souffle::clone(binRelOp->getLHS()), souffle::clone(binRelOp->getRHS())));
 
             // remove the strict version of inequality
             it = conditionList.erase(it);
@@ -413,8 +413,8 @@ Own<Operation> MakeIndexTransformer::rewriteAggregate(const Aggregate* agg) {
         Own<Condition> condition = constructPattern(rel.getAttributeTypes(), queryPattern, indexable,
                 toConjunctionList(&agg->getCondition()), identifier, rel.getRepresentation());
         if (indexable) {
-            return mk<IndexAggregate>(souffle::clone(&agg->getOperation()), agg->getFunction(),
-                    agg->getRelation(), souffle::clone(&agg->getExpression()), std::move(condition),
+            return mk<IndexAggregate>(souffle::clone(agg->getOperation()), agg->getFunction(),
+                    agg->getRelation(), souffle::clone(agg->getExpression()), std::move(condition),
                     std::move(queryPattern), agg->getTupleId());
         }
     }
@@ -435,7 +435,7 @@ Own<Operation> MakeIndexTransformer::rewriteScan(const Scan* scan) {
         Own<Condition> condition = constructPattern(rel.getAttributeTypes(), queryPattern, indexable,
                 toConjunctionList(&filter->getCondition()), identifier, rel.getRepresentation());
         if (indexable) {
-            Own<Operation> op = souffle::clone(&filter->getOperation());
+            Own<Operation> op = souffle::clone(filter->getOperation());
             if (!isTrue(condition.get())) {
                 op = mk<Filter>(std::move(condition), std::move(op));
             }
@@ -463,7 +463,7 @@ Own<Operation> MakeIndexTransformer::rewriteIndexScan(const IndexScan* iscan) {
         if (indexable) {
             // Merge Index Pattern here
 
-            Own<Operation> op = souffle::clone(&filter->getOperation());
+            Own<Operation> op = souffle::clone(filter->getOperation());
             if (!isTrue(condition.get())) {
                 op = mk<Filter>(std::move(condition), std::move(op));
             }

--- a/src/ram/transform/MakeIndex.cpp
+++ b/src/ram/transform/MakeIndex.cpp
@@ -154,7 +154,7 @@ Own<Condition> MakeIndexTransformer::constructPattern(const std::vector<std::str
     std::vector<Own<Condition>> toAppend;
     auto it = conditionList.begin();
     while (it != conditionList.end()) {
-        auto* binRelOp = as<Constraint>(it->get());
+        auto* binRelOp = as<Constraint>(*it);
         if (binRelOp == nullptr) {
             ++it;
             continue;

--- a/src/ram/transform/Parallel.cpp
+++ b/src/ram/transform/Parallel.cpp
@@ -21,7 +21,9 @@
 #include "ram/Relation.h"
 #include "ram/Statement.h"
 #include "ram/utility/Visitor.h"
+#include "souffle/utility/ContainerUtil.h"
 #include "souffle/utility/MiscUtil.h"
+
 #include <functional>
 #include <memory>
 #include <utility>
@@ -36,7 +38,7 @@ bool ParallelTransformer::parallelizeOperations(Program& program) {
     // most outer loops can be scan/choice/indexScan/indexChoice
     visitDepthFirst(program, [&](const Query& query) {
         std::function<Own<Node>(Own<Node>)> parallelRewriter = [&](Own<Node> node) -> Own<Node> {
-            if (const Scan* scan = dynamic_cast<Scan*>(node.get())) {
+            if (const Scan* scan = as<Scan>(node)) {
                 const Relation& rel = relAnalysis->lookup(scan->getRelation());
                 if (scan->getTupleId() == 0 && rel.getArity() > 0) {
                     if (!isA<Project>(&scan->getOperation())) {
@@ -45,30 +47,30 @@ bool ParallelTransformer::parallelizeOperations(Program& program) {
                                 souffle::clone(&scan->getOperation()), scan->getProfileText());
                     }
                 }
-            } else if (const Choice* choice = dynamic_cast<Choice*>(node.get())) {
+            } else if (const Choice* choice = as<Choice>(node)) {
                 if (choice->getTupleId() == 0) {
                     changed = true;
                     return mk<ParallelChoice>(choice->getRelation(), choice->getTupleId(),
                             souffle::clone(&choice->getCondition()), souffle::clone(&choice->getOperation()),
                             choice->getProfileText());
                 }
-            } else if (const IndexScan* indexScan = dynamic_cast<IndexScan*>(node.get())) {
+            } else if (const IndexScan* indexScan = as<IndexScan>(node)) {
                 if (indexScan->getTupleId() == 0) {
                     changed = true;
-                    RamPattern queryPattern = clone(indexScan->getRangePattern());
+                    RamPattern queryPattern = souffle::clone(indexScan->getRangePattern());
                     return mk<ParallelIndexScan>(indexScan->getRelation(), indexScan->getTupleId(),
                             std::move(queryPattern), souffle::clone(&indexScan->getOperation()),
                             indexScan->getProfileText());
                 }
-            } else if (const IndexChoice* indexChoice = dynamic_cast<IndexChoice*>(node.get())) {
+            } else if (const IndexChoice* indexChoice = as<IndexChoice>(node)) {
                 if (indexChoice->getTupleId() == 0) {
                     changed = true;
-                    RamPattern queryPattern = clone(indexChoice->getRangePattern());
+                    RamPattern queryPattern = souffle::clone(indexChoice->getRangePattern());
                     return mk<ParallelIndexChoice>(indexChoice->getRelation(), indexChoice->getTupleId(),
                             souffle::clone(&indexChoice->getCondition()), std::move(queryPattern),
                             souffle::clone(&indexChoice->getOperation()), indexChoice->getProfileText());
                 }
-            } else if (const Aggregate* aggregate = dynamic_cast<Aggregate*>(node.get())) {
+            } else if (const Aggregate* aggregate = as<Aggregate>(node)) {
                 const Relation& rel = relAnalysis->lookup(aggregate->getRelation());
                 if (aggregate->getTupleId() == 0 && !rel.isNullary()) {
                     changed = true;
@@ -77,11 +79,11 @@ bool ParallelTransformer::parallelizeOperations(Program& program) {
                             Own<Expression>(aggregate->getExpression().clone()),
                             Own<Condition>(aggregate->getCondition().clone()), aggregate->getTupleId());
                 }
-            } else if (const IndexAggregate* indexAggregate = dynamic_cast<IndexAggregate*>(node.get())) {
+            } else if (const IndexAggregate* indexAggregate = as<IndexAggregate>(node)) {
                 const Relation& rel = relAnalysis->lookup(indexAggregate->getRelation());
                 if (indexAggregate->getTupleId() == 0 && !rel.isNullary()) {
                     changed = true;
-                    RamPattern queryPattern = clone(indexAggregate->getRangePattern());
+                    RamPattern queryPattern = souffle::clone(indexAggregate->getRangePattern());
                     return mk<ParallelIndexAggregate>(Own<Operation>(indexAggregate->getOperation().clone()),
                             indexAggregate->getFunction(), indexAggregate->getRelation(),
                             Own<Expression>(indexAggregate->getExpression().clone()),

--- a/src/ram/transform/Parallel.cpp
+++ b/src/ram/transform/Parallel.cpp
@@ -44,14 +44,14 @@ bool ParallelTransformer::parallelizeOperations(Program& program) {
                     if (!isA<Project>(&scan->getOperation())) {
                         changed = true;
                         return mk<ParallelScan>(scan->getRelation(), scan->getTupleId(),
-                                souffle::clone(&scan->getOperation()), scan->getProfileText());
+                                souffle::clone(scan->getOperation()), scan->getProfileText());
                     }
                 }
             } else if (const Choice* choice = as<Choice>(node)) {
                 if (choice->getTupleId() == 0) {
                     changed = true;
                     return mk<ParallelChoice>(choice->getRelation(), choice->getTupleId(),
-                            souffle::clone(&choice->getCondition()), souffle::clone(&choice->getOperation()),
+                            souffle::clone(choice->getCondition()), souffle::clone(choice->getOperation()),
                             choice->getProfileText());
                 }
             } else if (const IndexScan* indexScan = as<IndexScan>(node)) {
@@ -59,7 +59,7 @@ bool ParallelTransformer::parallelizeOperations(Program& program) {
                     changed = true;
                     RamPattern queryPattern = souffle::clone(indexScan->getRangePattern());
                     return mk<ParallelIndexScan>(indexScan->getRelation(), indexScan->getTupleId(),
-                            std::move(queryPattern), souffle::clone(&indexScan->getOperation()),
+                            std::move(queryPattern), souffle::clone(indexScan->getOperation()),
                             indexScan->getProfileText());
                 }
             } else if (const IndexChoice* indexChoice = as<IndexChoice>(node)) {
@@ -67,8 +67,8 @@ bool ParallelTransformer::parallelizeOperations(Program& program) {
                     changed = true;
                     RamPattern queryPattern = souffle::clone(indexChoice->getRangePattern());
                     return mk<ParallelIndexChoice>(indexChoice->getRelation(), indexChoice->getTupleId(),
-                            souffle::clone(&indexChoice->getCondition()), std::move(queryPattern),
-                            souffle::clone(&indexChoice->getOperation()), indexChoice->getProfileText());
+                            souffle::clone(indexChoice->getCondition()), std::move(queryPattern),
+                            souffle::clone(indexChoice->getOperation()), indexChoice->getProfileText());
                 }
             } else if (const Aggregate* aggregate = as<Aggregate>(node)) {
                 const Relation& rel = relAnalysis->lookup(aggregate->getRelation());

--- a/src/ram/transform/ReorderConditions.cpp
+++ b/src/ram/transform/ReorderConditions.cpp
@@ -47,8 +47,8 @@ bool ReorderConditionsTransformer::reorderConditions(Program& program) {
                 if (!std::equal(sortedConds.begin(), sortedConds.end(), condList.begin(),
                             [](Own<Condition>& a, Own<Condition>& b) { return *a == *b; })) {
                     changed = true;
-                    node = mk<Filter>(Own<Condition>(toCondition(sortedConds)),
-                            souffle::clone(&filter->getOperation()));
+                    node = mk<Filter>(
+                            Own<Condition>(toCondition(sortedConds)), souffle::clone(filter->getOperation()));
                 }
             }
             node->apply(makeLambdaRamMapper(filterRewriter));

--- a/src/ram/transform/ReorderConditions.cpp
+++ b/src/ram/transform/ReorderConditions.cpp
@@ -33,7 +33,7 @@ bool ReorderConditionsTransformer::reorderConditions(Program& program) {
     bool changed = false;
     visitDepthFirst(program, [&](const Query& query) {
         std::function<Own<Node>(Own<Node>)> filterRewriter = [&](Own<Node> node) -> Own<Node> {
-            if (const Filter* filter = dynamic_cast<Filter*>(node.get())) {
+            if (const Filter* filter = as<Filter>(node)) {
                 const Condition* condition = &filter->getCondition();
                 VecOwn<Condition> sortedConds;
                 VecOwn<Condition> condList = toConjunctionList(condition);

--- a/src/ram/transform/ReorderFilterBreak.cpp
+++ b/src/ram/transform/ReorderFilterBreak.cpp
@@ -31,8 +31,8 @@ bool ReorderFilterBreak::reorderFilterBreak(Program& program) {
     visitDepthFirst(program, [&](const Query& query) {
         std::function<Own<Node>(Own<Node>)> filterRewriter = [&](Own<Node> node) -> Own<Node> {
             // find filter-break nesting
-            if (const Filter* filter = dynamic_cast<Filter*>(node.get())) {
-                if (const Break* br = dynamic_cast<Break*>(&filter->getOperation())) {
+            if (const Filter* filter = as<Filter>(node)) {
+                if (const Break* br = as<Break>(filter->getOperation())) {
                     changed = true;
                     // convert to break-filter nesting
                     node = mk<Break>(souffle::clone(&br->getCondition()),

--- a/src/ram/transform/ReorderFilterBreak.cpp
+++ b/src/ram/transform/ReorderFilterBreak.cpp
@@ -35,9 +35,9 @@ bool ReorderFilterBreak::reorderFilterBreak(Program& program) {
                 if (const Break* br = as<Break>(filter->getOperation())) {
                     changed = true;
                     // convert to break-filter nesting
-                    node = mk<Break>(souffle::clone(&br->getCondition()),
-                            mk<Filter>(souffle::clone(&filter->getCondition()),
-                                    souffle::clone(&br->getOperation())));
+                    node = mk<Break>(souffle::clone(br->getCondition()),
+                            mk<Filter>(souffle::clone(filter->getCondition()),
+                                    souffle::clone(br->getOperation())));
                 }
             }
             node->apply(makeLambdaRamMapper(filterRewriter));

--- a/src/ram/transform/TupleId.cpp
+++ b/src/ram/transform/TupleId.cpp
@@ -43,7 +43,7 @@ bool TupleIdTransformer::reorderOperations(Program& program) {
         });
 
         std::function<Own<Node>(Own<Node>)> elementRewriter = [&](Own<Node> node) -> Own<Node> {
-            if (auto* element = dynamic_cast<TupleElement*>(node.get())) {
+            if (auto* element = as<TupleElement>(node)) {
                 if (reorder[element->getTupleId()] != element->getTupleId()) {
                     changed = true;
                     node = mk<TupleElement>(reorder[element->getTupleId()], element->getElement());

--- a/src/ram/utility/NodeMapper.h
+++ b/src/ram/utility/NodeMapper.h
@@ -48,8 +48,8 @@ public:
     template <typename T>
     Own<T> operator()(Own<T> node) const {
         Own<Node> resPtr = (*this)(Own<Node>(static_cast<Node*>(node.release())));
-        assert(isA<T>(resPtr.get()) && "Invalid target node!");
-        return Own<T>(dynamic_cast<T*>(resPtr.release()));
+        assert(isA<T>(resPtr) && "Invalid target node!");
+        return Own<T>(as<T>(resPtr.release()));
     }
 };
 

--- a/src/ram/utility/Utils.h
+++ b/src/ram/utility/Utils.h
@@ -56,7 +56,7 @@ inline VecOwn<Condition> toConjunctionList(const Condition* condition) {
         while (!conditionsToProcess.empty()) {
             condition = conditionsToProcess.front();
             conditionsToProcess.pop();
-            if (const auto* ramConj = dynamic_cast<const Conjunction*>(condition)) {
+            if (const auto* ramConj = as<Conjunction>(condition)) {
                 conditionsToProcess.push(&ramConj->getLHS());
                 conditionsToProcess.push(&ramConj->getRHS());
             } else {
@@ -101,7 +101,7 @@ inline std::vector<const ram::Condition*> findConjunctiveTerms(const ram::Condit
         while (!conditionsToProcess.empty()) {
             condition = conditionsToProcess.front();
             conditionsToProcess.pop();
-            if (const auto* ramConj = dynamic_cast<const ram::Conjunction*>(condition)) {
+            if (const auto* ramConj = as<ram::Conjunction>(condition)) {
                 conditionsToProcess.push(&ramConj->getLHS());
                 conditionsToProcess.push(&ramConj->getRHS());
             } else {

--- a/src/ram/utility/Visitor.h
+++ b/src/ram/utility/Visitor.h
@@ -139,7 +139,7 @@ struct Visitor : public ram_visitor_tag {
         // dispatch node processing based on dynamic type
 
 #define FORWARD(Kind) \
-    if (const auto* n = dynamic_cast<const Kind*>(&node)) return visit##Kind(*n, args...);
+    if (const auto* n = as<Kind>(node)) return visit##Kind(*n, args...);
 
         // Relation
         FORWARD(Relation);
@@ -365,6 +365,7 @@ struct LambdaVisitor : public Visitor<void> {
     std::function<R(const N&)> lambda;
     LambdaVisitor(std::function<R(const N&)> lambda) : lambda(std::move(lambda)) {}
     void visit(const Node& node) override {
+        // Don't use as<> to allow cross-casting to mixins
         if (const auto* n = dynamic_cast<const N*>(&node)) {
             lambda(*n);
         }

--- a/src/synthesiser/Relation.cpp
+++ b/src/synthesiser/Relation.cpp
@@ -10,6 +10,7 @@
 #include "RelationTag.h"
 #include "ram/analysis/Index.h"
 #include "souffle/SouffleInterface.h"
+#include "souffle/utility/MiscUtil.h"
 #include "souffle/utility/StreamUtil.h"
 #include <algorithm>
 #include <cassert>

--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -206,15 +206,15 @@ void Synthesiser::generateRelationTypeStruct(std::ostream& out, Own<Relation> re
 std::set<const ram::Relation*> Synthesiser::getReferencedRelations(const Operation& op) {
     std::set<const ram::Relation*> res;
     visitDepthFirst(op, [&](const Node& node) {
-        if (auto scan = dynamic_cast<const RelationOperation*>(&node)) {
+        if (auto scan = as<RelationOperation>(node)) {
             res.insert(lookup(scan->getRelation()));
-        } else if (auto agg = dynamic_cast<const Aggregate*>(&node)) {
+        } else if (auto agg = as<Aggregate>(node)) {
             res.insert(lookup(agg->getRelation()));
-        } else if (auto exists = dynamic_cast<const ExistenceCheck*>(&node)) {
+        } else if (auto exists = as<ExistenceCheck>(node)) {
             res.insert(lookup(exists->getRelation()));
-        } else if (auto provExists = dynamic_cast<const ProvenanceExistenceCheck*>(&node)) {
+        } else if (auto provExists = as<ProvenanceExistenceCheck>(node)) {
             res.insert(lookup(provExists->getRelation()));
-        } else if (auto project = dynamic_cast<const Project*>(&node)) {
+        } else if (auto project = as<Project>(node)) {
             res.insert(lookup(project->getRelation()));
         }
     });
@@ -390,7 +390,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             const Operation* next = &query.getOperation();
             VecOwn<Condition> requireCtx;
             VecOwn<Condition> freeOfCtx;
-            if (const auto* filter = dynamic_cast<const Filter*>(&query.getOperation())) {
+            if (const auto* filter = as<Filter>(query.getOperation())) {
                 next = &filter->getOperation();
                 // Check terms of outer filter operation whether they can be pushed before
                 // the context-generation for speed imrovements
@@ -1141,7 +1141,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             auto keys = isa->getSearchSignature(&aggregate);
             RelationRepresentation repr = synthesiser.lookup(aggregate.getRelation())->getRepresentation();
 
-            const auto* tupleElem = dynamic_cast<const TupleElement*>(&aggregate.getExpression());
+            const auto* tupleElem = as<TupleElement>(aggregate.getExpression());
             return tupleElem && tupleElem->getTupleId() == identifier &&
                    keys[tupleElem->getElement()] != ram::analysis::AttributeConstraint::None &&
                    (repr == RelationRepresentation::BTREE || repr == RelationRepresentation::DEFAULT);


### PR DESCRIPTION
Merge after #1819.

- Established invariants for `ast::Node`-derived classes
- Made head compulsory for `Clause()`; removed most instances of `Clause::setHead()`
- Opportunistically improved ownership semantics where code was touched and easy to do (e.g. `cloneHead`)
- use reference-based `souffle::clone()` ("faster" since we don't need to check for nullptr)
- cleanup up setSrcLoc calls
- Simplified/unified Clause creation
- New utilities
 
Also fixes #1813.