### PR TITLE
Refactor visitor - MERGE FIFTH

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -407,7 +407,8 @@ soufflepublic_HEADERS = \
         include/souffle/SignalHandler.h                    \
         include/souffle/SouffleInterface.h                 \
         include/souffle/SymbolTable.h                      \
-        include/souffle/TypeAttribute.h
+        include/souffle/TypeAttribute.h                    \
+        include/souffle/Visitor.h
 
 souffledatastructuredir = $(soufflepublicdir)/datastructure
 

--- a/src/ast/analysis/Ground.cpp
+++ b/src/ast/analysis/Ground.cpp
@@ -160,7 +160,7 @@ struct GroundednessAnalysis : public ConstraintAnalysis<BoolDisjunctVar> {
             : relCache(*tu.getAnalysis<RelationDetailCacheAnalysis>()) {}
 
     // atoms are producing grounded variables
-    void visit_(type_identity<Atom>,const Atom& cur) override {
+    void visit_(type_identity<Atom>, const Atom& cur) override {
         // some atoms need to be skipped (head or negation)
         if (ignore.find(&cur) != ignore.end()) {
             return;
@@ -173,13 +173,13 @@ struct GroundednessAnalysis : public ConstraintAnalysis<BoolDisjunctVar> {
     }
 
     // negations need to be skipped
-    void visit_(type_identity<Negation>,const Negation& cur) override {
+    void visit_(type_identity<Negation>, const Negation& cur) override {
         // add nested atom to black-list
         ignore.insert(cur.getAtom());
     }
 
     // also skip head if we don't have an inline qualifier
-    void visit_(type_identity<Clause>,const Clause& clause) override {
+    void visit_(type_identity<Clause>, const Clause& clause) override {
         if (auto clauseHead = clause.getHead()) {
             auto relation = relCache.getRelation(clauseHead->getQualifiedName());
             // Only skip the head if the relation ISN'T inline. Keeping the head will ground
@@ -191,7 +191,7 @@ struct GroundednessAnalysis : public ConstraintAnalysis<BoolDisjunctVar> {
     }
 
     // binary equality relations propagates groundness
-    void visit_(type_identity<BinaryConstraint>,const BinaryConstraint& cur) override {
+    void visit_(type_identity<BinaryConstraint>, const BinaryConstraint& cur) override {
         // only target equality
         if (!isEqConstraint(cur.getBaseOperator())) {
             return;

--- a/src/ast/analysis/Ground.cpp
+++ b/src/ast/analysis/Ground.cpp
@@ -160,7 +160,7 @@ struct GroundednessAnalysis : public ConstraintAnalysis<BoolDisjunctVar> {
             : relCache(*tu.getAnalysis<RelationDetailCacheAnalysis>()) {}
 
     // atoms are producing grounded variables
-    void visitAtom(const Atom& cur) override {
+    void visit_(type_identity<Atom>,const Atom& cur) override {
         // some atoms need to be skipped (head or negation)
         if (ignore.find(&cur) != ignore.end()) {
             return;
@@ -173,13 +173,13 @@ struct GroundednessAnalysis : public ConstraintAnalysis<BoolDisjunctVar> {
     }
 
     // negations need to be skipped
-    void visitNegation(const Negation& cur) override {
+    void visit_(type_identity<Negation>,const Negation& cur) override {
         // add nested atom to black-list
         ignore.insert(cur.getAtom());
     }
 
     // also skip head if we don't have an inline qualifier
-    void visitClause(const Clause& clause) override {
+    void visit_(type_identity<Clause>,const Clause& clause) override {
         if (auto clauseHead = clause.getHead()) {
             auto relation = relCache.getRelation(clauseHead->getQualifiedName());
             // Only skip the head if the relation ISN'T inline. Keeping the head will ground
@@ -191,7 +191,7 @@ struct GroundednessAnalysis : public ConstraintAnalysis<BoolDisjunctVar> {
     }
 
     // binary equality relations propagates groundness
-    void visitBinaryConstraint(const BinaryConstraint& cur) override {
+    void visit_(type_identity<BinaryConstraint>,const BinaryConstraint& cur) override {
         // only target equality
         if (!isEqConstraint(cur.getBaseOperator())) {
             return;
@@ -206,7 +206,7 @@ struct GroundednessAnalysis : public ConstraintAnalysis<BoolDisjunctVar> {
     }
 
     // record init nodes
-    void visitRecordInit(const RecordInit& init) override {
+    void visit_(type_identity<RecordInit>, const RecordInit& init) override {
         auto cur = getVar(init);
 
         std::vector<BoolDisjunctVar> vars;
@@ -222,7 +222,7 @@ struct GroundednessAnalysis : public ConstraintAnalysis<BoolDisjunctVar> {
         addConstraint(imply(vars, cur));
     }
 
-    void visitBranchInit(const BranchInit& adt) override {
+    void visit_(type_identity<BranchInit>, const BranchInit& adt) override {
         auto branchVar = getVar(adt);
 
         std::vector<BoolDisjunctVar> argVars;
@@ -239,17 +239,17 @@ struct GroundednessAnalysis : public ConstraintAnalysis<BoolDisjunctVar> {
     }
 
     // Constants are also sources of grounded values
-    void visitConstant(const Constant& constant) override {
+    void visit_(type_identity<Constant>, const Constant& constant) override {
         addConstraint(isTrue(getVar(constant)));
     }
 
     // Aggregators are grounding values
-    void visitAggregator(const Aggregator& aggregator) override {
+    void visit_(type_identity<Aggregator>, const Aggregator& aggregator) override {
         addConstraint(isTrue(getVar(aggregator)));
     }
 
     // Functors with grounded values are grounded values
-    void visitFunctor(const Functor& functor) override {
+    void visit_(type_identity<Functor>, const Functor& functor) override {
         auto var = getVar(functor);
         std::vector<BoolDisjunctVar> varArgs;
         for (const auto& arg : functor.getArguments()) {
@@ -259,7 +259,7 @@ struct GroundednessAnalysis : public ConstraintAnalysis<BoolDisjunctVar> {
     }
 
     // casts propogate groundedness in and out
-    void visitTypeCast(const ast::TypeCast& cast) override {
+    void visit_(type_identity<TypeCast>, const ast::TypeCast& cast) override {
         addConstraint(imply(getVar(cast.getValue()), getVar(cast)));
     }
 };

--- a/src/ast/analysis/TypeConstraints.cpp
+++ b/src/ast/analysis/TypeConstraints.cpp
@@ -397,7 +397,7 @@ void TypeConstraintsAnalysis::visitSink(const Atom& atom) {
     });
 }
 
-void TypeConstraintsAnalysis::visitAtom(const Atom& atom) {
+void TypeConstraintsAnalysis::visit_(type_identity<Atom>, const Atom& atom) {
     if (contains(sinks, &atom)) {
         visitSink(atom);
         return;
@@ -408,15 +408,15 @@ void TypeConstraintsAnalysis::visitAtom(const Atom& atom) {
     });
 }
 
-void TypeConstraintsAnalysis::visitNegation(const Negation& cur) {
+void TypeConstraintsAnalysis::visit_(type_identity<Negation>, const Negation& cur) {
     sinks.insert(cur.getAtom());
 }
 
-void TypeConstraintsAnalysis::visitStringConstant(const StringConstant& cnst) {
+void TypeConstraintsAnalysis::visit_(type_identity<StringConstant>, const StringConstant& cnst) {
     addConstraint(isSubtypeOf(getVar(cnst), typeEnv.getConstantType(TypeAttribute::Symbol)));
 }
 
-void TypeConstraintsAnalysis::visitNumericConstant(const NumericConstant& constant) {
+void TypeConstraintsAnalysis::visit_(type_identity<NumericConstant>, const NumericConstant& constant) {
     TypeSet possibleTypes;
 
     // Check if the type is given.
@@ -476,14 +476,14 @@ void TypeConstraintsAnalysis::visitNumericConstant(const NumericConstant& consta
     addConstraint(hasSuperTypeInSet(getVar(constant), possibleTypes));
 }
 
-void TypeConstraintsAnalysis::visitBinaryConstraint(const BinaryConstraint& rel) {
+void TypeConstraintsAnalysis::visit_(type_identity<BinaryConstraint>, const BinaryConstraint& rel) {
     auto lhs = getVar(rel.getLHS());
     auto rhs = getVar(rel.getRHS());
     addConstraint(isSubtypeOf(lhs, rhs));
     addConstraint(isSubtypeOf(rhs, lhs));
 }
 
-void TypeConstraintsAnalysis::visitFunctor(const Functor& fun) {
+void TypeConstraintsAnalysis::visit_(type_identity<Functor>, const Functor& fun) {
     auto functorVar = getVar(fun);
 
     auto intrFun = as<IntrinsicFunctor>(fun);
@@ -533,11 +533,11 @@ void TypeConstraintsAnalysis::visitFunctor(const Functor& fun) {
     }
 }
 
-void TypeConstraintsAnalysis::visitCounter(const Counter& counter) {
+void TypeConstraintsAnalysis::visit_(type_identity<Counter>, const Counter& counter) {
     addConstraint(isSubtypeOf(getVar(counter), typeEnv.getConstantType(TypeAttribute::Signed)));
 }
 
-void TypeConstraintsAnalysis::visitTypeCast(const ast::TypeCast& typeCast) {
+void TypeConstraintsAnalysis::visit_(type_identity<TypeCast>, const ast::TypeCast& typeCast) {
     auto& typeName = typeCast.getType();
     if (!typeEnv.isType(typeName)) {
         return;
@@ -554,14 +554,14 @@ void TypeConstraintsAnalysis::visitTypeCast(const ast::TypeCast& typeCast) {
     }
 }
 
-void TypeConstraintsAnalysis::visitRecordInit(const RecordInit& record) {
+void TypeConstraintsAnalysis::visit_(type_identity<RecordInit>, const RecordInit& record) {
     auto arguments = record.getArguments();
     for (size_t i = 0; i < arguments.size(); ++i) {
         addConstraint(isSubtypeOfComponent(getVar(arguments[i]), getVar(record), i));
     }
 }
 
-void TypeConstraintsAnalysis::visitBranchInit(const BranchInit& adt) {
+void TypeConstraintsAnalysis::visit_(type_identity<BranchInit>, const BranchInit& adt) {
     auto* correspondingType = sumTypesBranches.getType(adt.getConstructor());
 
     if (correspondingType == nullptr) {
@@ -597,7 +597,7 @@ void TypeConstraintsAnalysis::visitBranchInit(const BranchInit& adt) {
     }
 }
 
-void TypeConstraintsAnalysis::visitAggregator(const Aggregator& agg) {
+void TypeConstraintsAnalysis::visit_(type_identity<Aggregator>, const Aggregator& agg) {
     if (agg.getBaseOperator() == AggregateOp::COUNT) {
         addConstraint(isSubtypeOf(getVar(agg), typeEnv.getConstantType(TypeAttribute::Signed)));
     } else if (agg.getBaseOperator() == AggregateOp::MEAN) {

--- a/src/ast/analysis/TypeConstraints.h
+++ b/src/ast/analysis/TypeConstraints.h
@@ -103,17 +103,17 @@ private:
     /** Visitors */
     void collectConstraints(const Clause& clause) override;
     void visitSink(const Atom& atom);
-    void visitAtom(const Atom& atom) override;
-    void visitNegation(const Negation& cur) override;
-    void visitStringConstant(const StringConstant& cnst) override;
-    void visitNumericConstant(const NumericConstant& constant) override;
-    void visitBinaryConstraint(const BinaryConstraint& rel) override;
-    void visitFunctor(const Functor& fun) override;
-    void visitCounter(const Counter& counter) override;
-    void visitTypeCast(const ast::TypeCast& typeCast) override;
-    void visitRecordInit(const RecordInit& record) override;
-    void visitBranchInit(const BranchInit& adt) override;
-    void visitAggregator(const Aggregator& agg) override;
+    void visit_(type_identity<Atom>, const Atom& atom) override;
+    void visit_(type_identity<Negation>, const Negation& cur) override;
+    void visit_(type_identity<StringConstant>, const StringConstant& cnst) override;
+    void visit_(type_identity<NumericConstant>, const NumericConstant& constant) override;
+    void visit_(type_identity<BinaryConstraint>, const BinaryConstraint& rel) override;
+    void visit_(type_identity<Functor>, const Functor& fun) override;
+    void visit_(type_identity<Counter>, const Counter& counter) override;
+    void visit_(type_identity<TypeCast>, const ast::TypeCast& typeCast) override;
+    void visit_(type_identity<RecordInit>, const RecordInit& record) override;
+    void visit_(type_identity<BranchInit>, const BranchInit& adt) override;
+    void visit_(type_identity<Aggregator>, const Aggregator& agg) override;
 };
 
 }  // namespace souffle::ast::analysis

--- a/src/ast/utility/Visitor.h
+++ b/src/ast/utility/Visitor.h
@@ -53,372 +53,116 @@
 #include "ast/UnnamedVariable.h"
 #include "ast/UserDefinedFunctor.h"
 #include "ast/Variable.h"
+#include "souffle/Visitor.h"
 #include "souffle/utility/FunctionalUtil.h"
 #include "souffle/utility/MiscUtil.h"
-#include <cstddef>
-#include <functional>
-#include <memory>
-#include <type_traits>
-#include <typeinfo>
-#include <vector>
 
 namespace souffle::ast {
-
-/** A tag type required for the is_ast_visitor type trait to identify AstVisitors */
-struct ast_visitor_tag {};
-
 /**
- * The generic base type of all AstVisitors realizing the dispatching of
- * visitor calls. Each visitor may define a return type R and a list of
- * extra parameters to be passed along with the visited Nodes to the
- * corresponding visitor function.
- *
- * @tparam R the result type produced by a visit call
- * @tparam Params extra parameters to be passed to the visit call
+ * The generic base type of all AstVisitors
+ * @see souffle::Visitor
  */
 template <typename R = void, typename NodeType = Node const, typename... Params>
-struct Visitor : public ast_visitor_tag {
-    /** A virtual destructor */
-    virtual ~Visitor() = default;
+struct Visitor : public souffle::Visitor<R, NodeType, Params...> {
+    using souffle::Visitor<R, NodeType, Params...>::visit_;
 
-    /** The main entry for the user allowing visitors to be utilized as functions */
-    R operator()(NodeType& node, Params const&... args) {
-        return visit(node, args...);
-    }
-
-    /**
-     * The main entry for a visit process conducting the dispatching of
-     * a visit to the various sub-types of Nodes. Sub-classes may override
-     * this implementation to conduct pre-visit operations.
-     *
-     * @param node the node to be visited
-     * @param args a list of extra parameters to be forwarded
-     */
-    virtual R visit(NodeType& node, Params const&... args) {
+    virtual R visit(NodeType& node, Params const&... args) override {
         // dispatch node processing based on dynamic type
 
-#define FORWARD(Kind) \
-    if (auto* n = as<Kind>(node)) return visit##Kind(*n, args...);
-
         // types
-        FORWARD(SubsetType);
-        FORWARD(UnionType);
-        FORWARD(RecordType);
-        FORWARD(AlgebraicDataType);
+        SOUFFLE_VISITOR_FORWARD(SubsetType);
+        SOUFFLE_VISITOR_FORWARD(UnionType);
+        SOUFFLE_VISITOR_FORWARD(RecordType);
+        SOUFFLE_VISITOR_FORWARD(AlgebraicDataType);
 
         // arguments
-        FORWARD(Variable)
-        FORWARD(UnnamedVariable)
-        FORWARD(IntrinsicFunctor)
-        FORWARD(UserDefinedFunctor)
-        FORWARD(Counter)
-        FORWARD(NumericConstant)
-        FORWARD(StringConstant)
-        FORWARD(NilConstant)
-        FORWARD(TypeCast)
-        FORWARD(RecordInit)
-        FORWARD(BranchInit)
-        FORWARD(Aggregator)
+        SOUFFLE_VISITOR_FORWARD(Variable)
+        SOUFFLE_VISITOR_FORWARD(UnnamedVariable)
+        SOUFFLE_VISITOR_FORWARD(IntrinsicFunctor)
+        SOUFFLE_VISITOR_FORWARD(UserDefinedFunctor)
+        SOUFFLE_VISITOR_FORWARD(Counter)
+        SOUFFLE_VISITOR_FORWARD(NumericConstant)
+        SOUFFLE_VISITOR_FORWARD(StringConstant)
+        SOUFFLE_VISITOR_FORWARD(NilConstant)
+        SOUFFLE_VISITOR_FORWARD(TypeCast)
+        SOUFFLE_VISITOR_FORWARD(RecordInit)
+        SOUFFLE_VISITOR_FORWARD(BranchInit)
+        SOUFFLE_VISITOR_FORWARD(Aggregator)
 
         // literals
-        FORWARD(Atom)
-        FORWARD(Negation)
-        FORWARD(BooleanConstraint)
-        FORWARD(BinaryConstraint)
-        FORWARD(FunctionalConstraint)
+        SOUFFLE_VISITOR_FORWARD(Atom)
+        SOUFFLE_VISITOR_FORWARD(Negation)
+        SOUFFLE_VISITOR_FORWARD(BooleanConstraint)
+        SOUFFLE_VISITOR_FORWARD(BinaryConstraint)
+        SOUFFLE_VISITOR_FORWARD(FunctionalConstraint)
 
         // components
-        FORWARD(ComponentType);
-        FORWARD(ComponentInit);
-        FORWARD(Component);
+        SOUFFLE_VISITOR_FORWARD(ComponentType);
+        SOUFFLE_VISITOR_FORWARD(ComponentInit);
+        SOUFFLE_VISITOR_FORWARD(Component);
 
         // rest
-        FORWARD(Attribute);
-        FORWARD(Clause);
-        FORWARD(Relation);
-        FORWARD(Program);
-        FORWARD(Pragma);
-
-#undef FORWARD
+        SOUFFLE_VISITOR_FORWARD(Attribute);
+        SOUFFLE_VISITOR_FORWARD(Clause);
+        SOUFFLE_VISITOR_FORWARD(Relation);
+        SOUFFLE_VISITOR_FORWARD(Program);
+        SOUFFLE_VISITOR_FORWARD(Pragma);
 
         // did not work ...
-
         fatal("unsupported type: %s", typeid(node).name());
     }
 
-#define LINK(Kind, Parent)                                                          \
-    virtual R visit##Kind(copy_const_t<NodeType, Kind>& n, Params const&... args) { \
-        return visit##Parent(n, args...);                                           \
-    }
-
     // -- types --
-    LINK(SubsetType, Type);
-    LINK(RecordType, Type);
-    LINK(AlgebraicDataType, Type);
-    LINK(UnionType, Type);
-    LINK(Type, Node);
+    SOUFFLE_VISITOR_LINK(SubsetType, Type);
+    SOUFFLE_VISITOR_LINK(RecordType, Type);
+    SOUFFLE_VISITOR_LINK(AlgebraicDataType, Type);
+    SOUFFLE_VISITOR_LINK(UnionType, Type);
+    SOUFFLE_VISITOR_LINK(Type, Node);
 
     // -- arguments --
-    LINK(Variable, Argument)
-    LINK(UnnamedVariable, Argument)
-    LINK(Counter, Argument)
-    LINK(TypeCast, Argument)
-    LINK(BranchInit, Argument)
+    SOUFFLE_VISITOR_LINK(Variable, Argument)
+    SOUFFLE_VISITOR_LINK(UnnamedVariable, Argument)
+    SOUFFLE_VISITOR_LINK(Counter, Argument)
+    SOUFFLE_VISITOR_LINK(TypeCast, Argument)
+    SOUFFLE_VISITOR_LINK(BranchInit, Argument)
 
-    LINK(NumericConstant, Constant)
-    LINK(StringConstant, Constant)
-    LINK(NilConstant, Constant)
-    LINK(Constant, Argument)
+    SOUFFLE_VISITOR_LINK(NumericConstant, Constant)
+    SOUFFLE_VISITOR_LINK(StringConstant, Constant)
+    SOUFFLE_VISITOR_LINK(NilConstant, Constant)
+    SOUFFLE_VISITOR_LINK(Constant, Argument)
 
-    LINK(IntrinsicFunctor, Functor)
-    LINK(UserDefinedFunctor, Functor)
+    SOUFFLE_VISITOR_LINK(IntrinsicFunctor, Functor)
+    SOUFFLE_VISITOR_LINK(UserDefinedFunctor, Functor)
 
-    LINK(RecordInit, Term)
-    LINK(Functor, Term)
+    SOUFFLE_VISITOR_LINK(RecordInit, Term)
+    SOUFFLE_VISITOR_LINK(Functor, Term)
 
-    LINK(Term, Argument)
+    SOUFFLE_VISITOR_LINK(Term, Argument)
 
-    LINK(Aggregator, Argument)
+    SOUFFLE_VISITOR_LINK(Aggregator, Argument)
 
-    LINK(Argument, Node);
+    SOUFFLE_VISITOR_LINK(Argument, Node);
 
     // literals
-    LINK(Atom, Literal)
-    LINK(Negation, Literal)
-    LINK(Literal, Node);
+    SOUFFLE_VISITOR_LINK(Atom, Literal)
+    SOUFFLE_VISITOR_LINK(Negation, Literal)
+    SOUFFLE_VISITOR_LINK(Literal, Node);
 
-    LINK(BooleanConstraint, Constraint)
-    LINK(BinaryConstraint, Constraint)
-    LINK(FunctionalConstraint, Constraint)
-    LINK(Constraint, Literal)
+    SOUFFLE_VISITOR_LINK(BooleanConstraint, Constraint)
+    SOUFFLE_VISITOR_LINK(BinaryConstraint, Constraint)
+    SOUFFLE_VISITOR_LINK(FunctionalConstraint, Constraint)
+    SOUFFLE_VISITOR_LINK(Constraint, Literal)
 
     // components
-    LINK(ComponentType, Node);
-    LINK(ComponentInit, Node);
-    LINK(Component, Node);
+    SOUFFLE_VISITOR_LINK(ComponentType, Node);
+    SOUFFLE_VISITOR_LINK(ComponentInit, Node);
+    SOUFFLE_VISITOR_LINK(Component, Node);
 
     // -- others --
-    LINK(Program, Node);
-    LINK(Attribute, Node);
-    LINK(Clause, Node);
-    LINK(Relation, Node);
-    LINK(Pragma, Node);
-
-#undef LINK
-
-    /** The base case for all visitors -- if no more specific overload was defined */
-    virtual R visitNode(const Node& /*node*/, Params const&... /*args*/) {
-        return R();
-    }
+    SOUFFLE_VISITOR_LINK(Program, Node);
+    SOUFFLE_VISITOR_LINK(Attribute, Node);
+    SOUFFLE_VISITOR_LINK(Clause, Node);
+    SOUFFLE_VISITOR_LINK(Relation, Node);
+    SOUFFLE_VISITOR_LINK(Pragma, Node);
 };
-
-namespace detail {
-template <typename T>
-using EnableIfNode =
-        std::enable_if_t<std::is_base_of_v<Node, std::remove_const_t<std::remove_reference_t<T>>>>;
-}
-
-/**
- * A utility function visiting all nodes within the ast rooted by the given node
- * recursively in a depth-first pre-order fashion applying the given visitor to each
- * encountered node.
- *
- * @param root the root of the AST to be visited
- * @param visitor the visitor to be applied on each node
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-template <class NodeType, typename... Ts, typename... Args>
-detail::EnableIfNode<NodeType> visitDepthFirstPreOrder(
-        NodeType&& root, Visitor<Ts...>& visitor, Args const&... args) {
-    visitor(root, args...);
-    for (auto* cur : root.getChildNodes()) {
-        if (cur != nullptr) {
-            visitDepthFirstPreOrder(*cur, visitor, args...);
-        }
-    }
-}
-
-/**
- * A utility function visiting all nodes within the ast rooted by the given node
- * recursively in a depth-first post-order fashion applying the given visitor to each
- * encountered node.
- *
- * @param root the root of the AST to be visited
- * @param visitor the visitor to be applied on each node
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-template <class NodeType, typename... Ts, typename... Args>
-detail::EnableIfNode<NodeType> visitDepthFirstPostOrder(
-        NodeType&& root, Visitor<Ts...>& visitor, Args const&... args) {
-    for (auto* cur : root.getChildNodes()) {
-        if (cur != nullptr) {
-            visitDepthFirstPostOrder(*cur, visitor, args...);
-        }
-    }
-    visitor(root, args...);
-}
-
-/**
- * A utility function visiting all nodes within the ast rooted by the given node
- * recursively in a depth-first pre-order fashion applying the given visitor to each
- * encountered node.
- *
- * @param root the root of the AST to be visited
- * @param visitor the visitor to be applied on each node
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-template <class NodeType, typename... Ts, typename... Args>
-detail::EnableIfNode<NodeType> visitDepthFirst(
-        NodeType&& root, Visitor<Ts...>& visitor, Args const&... args) {
-    visitDepthFirstPreOrder(root, visitor, args...);
-}
-
-namespace detail {
-
-/**
- * A specialized visitor wrapping a lambda function -- an auxiliary type required
- * for visitor convenience functions.
- */
-template <class NodeToVisit, typename F = std::function<void(NodeToVisit&)>>
-struct LambdaVisitor : public Visitor<void, copy_const_t<NodeToVisit, Node>> {
-    F lambda;
-    LambdaVisitor(F lam) : lambda(std::move(lam)) {}
-    void visit(copy_const_t<NodeToVisit, Node>& node) override {
-        // Don't use as<> to allow cross-casting to mixins
-        if (auto* n = dynamic_cast<NodeToVisit*>(&node)) {
-            lambda(*n);
-        }
-    }
-};
-
-// Only used for deduction
-template <typename R, typename T>
-T& getNodeTypeHelper(std::function<R(T&)>);
-
-template <typename F>
-typename lambda_traits<F>::arg0_type& getNodeTypeHelper(F const&);
-
-/**
- * A factory function for creating LambdaVisitor instances.
- */
-template <typename F>
-auto makeLambdaVisitor(F&& f) {
-    using NodeToVisit = std::remove_reference_t<decltype(getNodeTypeHelper(f))>;
-    return LambdaVisitor<NodeToVisit, std::remove_reference_t<F>>(std::forward<F>(f));
-}
-
-/**
- * A type trait determining whether a given type is a visitor or not.
- */
-template <typename T>
-struct is_ast_visitor {
-    static constexpr size_t value = std::is_base_of<ast_visitor_tag, T>::value;
-};
-
-template <typename T>
-struct is_ast_visitor<const T> : public is_ast_visitor<T> {};
-
-template <typename T>
-struct is_ast_visitor<T&> : public is_ast_visitor<T> {};
-}  // namespace detail
-
-/**
- * A utility function visiting all nodes within the ast rooted by the given node
- * recursively in a depth-first pre-order fashion applying the given function to each
- * encountered node.
- *
- * @param root the root of the AST to be visited
- * @param fun the function to be applied
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-template <class NodeType, typename F, typename... Args>
-std::enable_if_t<!detail::is_ast_visitor<F>::value> visitDepthFirst(
-        NodeType&& root, F&& fun, Args const&... args) {
-    auto visitor = detail::makeLambdaVisitor(std::forward<F>(fun));
-    visitDepthFirst(root, visitor, args...);
-}
-
-/**
- * A utility function visiting all nodes within the ast rooted by the given node
- * recursively in a depth-first pre-order fashion applying the given function to each
- * encountered node.
- *
- * @param root the root of the AST to be visited
- * @param fun the function to be applied
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-/* FIXME: tomp
-template <typename Lambda, typename R = typename lambda_traits<Lambda>::result_type,
-        typename N = typename lambda_traits<Lambda>::arg0_type>
-typename std::enable_if<!detail::is_ast_visitor<Lambda>::value, void>::type visitDepthFirst(
-        const Node& root, const Lambda& fun) {
-    visitDepthFirst(root, std::function<R(const N&)>(fun));
-}
-*/
-
-/**
- * A utility function visiting all nodes within a given list of AST root nodes
- * recursively in a depth-first pre-order fashion applying the given function to each
- * encountered node.
- *
- * @param list the list of roots of the ASTs to be visited
- * @param fun the function to be applied
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-template <typename T, typename F, typename... Args>
-void visitDepthFirst(const std::vector<T*>& list, F&& fun, Args const&... args) {
-    for (auto&& cur : list) {
-        visitDepthFirst(*cur, std::forward<F>(fun), args...);
-    }
-}
-
-/**
- * A utility function visiting all nodes within a given list of AST root nodes
- * recursively in a depth-first pre-order fashion applying the given function to each
- * encountered node.
- *
- * @param list the list of roots of the ASTs to be visited
- * @param fun the function to be applied
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-template <typename T, typename F, typename... Args>
-void visitDepthFirst(const VecOwn<T>& list, F&& fun, Args const&... args) {
-    for (auto&& cur : list) {
-        visitDepthFirst(*cur, std::forward<F>(fun), args...);
-    }
-}
-
-/**
- * A utility function visiting all nodes within the ast rooted by the given node
- * recursively in a depth-first post-order fashion applying the given function to each
- * encountered node.
- *
- * @param root the root of the AST to be visited
- * @param fun the function to be applied
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-template <class NodeType, typename F, typename... Args>
-detail::EnableIfNode<NodeType> visitDepthFirstPostOrder(NodeType&& root, F&& fun, Args const&... args) {
-    auto visitor = detail::makeLambdaVisitor(std::forward<F>(fun), args...);
-    visitDepthFirstPostOrder(root, visitor);
-}
-
-/**
- * A utility function visiting all nodes within the ast rooted by the given node
- * recursively in a depth-first post-order fashion applying the given function to each
- * encountered node.
- *
- * @param root the root of the AST to be visited
- * @param fun the function to be applied
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-/*
-template <typename Lambda, typename R = typename lambda_traits<Lambda>::result_type,
-        typename N = typename lambda_traits<Lambda>::arg0_type>
-typename std::enable_if<!detail::is_ast_visitor<Lambda>::value, void>::type visitDepthFirstPostOrder(
-        const Node& root, const Lambda& fun) {
-    visitDepthFirstPostOrder(root, std::function<R(const N&)>(fun));
-}
-*/
-
 }  // namespace souffle::ast

--- a/src/ast2ram/seminaive/ConstraintTranslator.cpp
+++ b/src/ast2ram/seminaive/ConstraintTranslator.cpp
@@ -39,7 +39,8 @@ Own<ram::Condition> ConstraintTranslator::visit_(type_identity<ast::Atom>, const
     return nullptr;  // covered already within the scan/lookup generation step
 }
 
-Own<ram::Condition> ConstraintTranslator::visit_(type_identity<ast::BinaryConstraint>, const ast::BinaryConstraint& binRel) {
+Own<ram::Condition> ConstraintTranslator::visit_(
+        type_identity<ast::BinaryConstraint>, const ast::BinaryConstraint& binRel) {
     auto valLHS = context.translateValue(symbolTable, index, binRel.getLHS());
     auto valRHS = context.translateValue(symbolTable, index, binRel.getRHS());
     return mk<ram::Constraint>(

--- a/src/ast2ram/seminaive/ConstraintTranslator.cpp
+++ b/src/ast2ram/seminaive/ConstraintTranslator.cpp
@@ -35,18 +35,18 @@ Own<ram::Condition> ConstraintTranslator::translateConstraint(const ast::Literal
     return ConstraintTranslator(context, symbolTable, index)(*lit);
 }
 
-Own<ram::Condition> ConstraintTranslator::visitAtom(const ast::Atom&) {
+Own<ram::Condition> ConstraintTranslator::visit_(type_identity<ast::Atom>, const ast::Atom&) {
     return nullptr;  // covered already within the scan/lookup generation step
 }
 
-Own<ram::Condition> ConstraintTranslator::visitBinaryConstraint(const ast::BinaryConstraint& binRel) {
+Own<ram::Condition> ConstraintTranslator::visit_(type_identity<ast::BinaryConstraint>, const ast::BinaryConstraint& binRel) {
     auto valLHS = context.translateValue(symbolTable, index, binRel.getLHS());
     auto valRHS = context.translateValue(symbolTable, index, binRel.getRHS());
     return mk<ram::Constraint>(
             context.getOverloadedBinaryConstraintOperator(&binRel), std::move(valLHS), std::move(valRHS));
 }
 
-Own<ram::Condition> ConstraintTranslator::visitNegation(const ast::Negation& neg) {
+Own<ram::Condition> ConstraintTranslator::visit_(type_identity<ast::Negation>, const ast::Negation& neg) {
     const auto* atom = neg.getAtom();
     size_t auxiliaryArity = context.getEvaluationArity(atom);
     assert(auxiliaryArity <= atom->getArity() && "auxiliary arity out of bounds");

--- a/src/ast2ram/seminaive/ConstraintTranslator.h
+++ b/src/ast2ram/seminaive/ConstraintTranslator.h
@@ -47,9 +47,9 @@ public:
     Own<ram::Condition> translateConstraint(const ast::Literal* lit) override;
 
     /** -- Visitors -- */
-    Own<ram::Condition> visitAtom(const ast::Atom&) override;
-    Own<ram::Condition> visitBinaryConstraint(const ast::BinaryConstraint& binRel) override;
-    Own<ram::Condition> visitNegation(const ast::Negation& neg) override;
+    Own<ram::Condition> visit_(type_identity<ast::Atom>, const ast::Atom&) override;
+    Own<ram::Condition> visit_(type_identity<ast::BinaryConstraint>, const ast::BinaryConstraint& binRel) override;
+    Own<ram::Condition> visit_(type_identity<ast::Negation>, const ast::Negation& neg) override;
 };
 
 }  // namespace souffle::ast2ram::seminaive

--- a/src/ast2ram/seminaive/ConstraintTranslator.h
+++ b/src/ast2ram/seminaive/ConstraintTranslator.h
@@ -48,7 +48,8 @@ public:
 
     /** -- Visitors -- */
     Own<ram::Condition> visit_(type_identity<ast::Atom>, const ast::Atom&) override;
-    Own<ram::Condition> visit_(type_identity<ast::BinaryConstraint>, const ast::BinaryConstraint& binRel) override;
+    Own<ram::Condition> visit_(
+            type_identity<ast::BinaryConstraint>, const ast::BinaryConstraint& binRel) override;
     Own<ram::Condition> visit_(type_identity<ast::Negation>, const ast::Negation& neg) override;
 };
 

--- a/src/ast2ram/seminaive/ValueTranslator.cpp
+++ b/src/ast2ram/seminaive/ValueTranslator.cpp
@@ -43,16 +43,16 @@ Own<ram::Expression> ValueTranslator::translateValue(const ast::Argument* arg) {
     return ValueTranslator(context, symbolTable, index)(*arg);
 }
 
-Own<ram::Expression> ValueTranslator::visitVariable(const ast::Variable& var) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::Variable>, const ast::Variable& var) {
     assert(index.isDefined(var) && "variable not grounded");
     return makeRamTupleElement(index.getDefinitionPoint(var));
 }
 
-Own<ram::Expression> ValueTranslator::visitUnnamedVariable(const ast::UnnamedVariable&) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::UnnamedVariable>, const ast::UnnamedVariable&) {
     return mk<ram::UndefValue>();
 }
 
-Own<ram::Expression> ValueTranslator::visitNumericConstant(const ast::NumericConstant& c) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::NumericConstant>, const ast::NumericConstant& c) {
     switch (context.getInferredNumericConstantType(&c)) {
         case ast::NumericConstant::Type::Int:
             return mk<ram::SignedConstant>(RamSignedFromString(c.getConstant(), nullptr, 0));
@@ -65,19 +65,19 @@ Own<ram::Expression> ValueTranslator::visitNumericConstant(const ast::NumericCon
     fatal("unexpected numeric constant type");
 }
 
-Own<ram::Expression> ValueTranslator::visitStringConstant(const ast::StringConstant& c) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::StringConstant>, const ast::StringConstant& c) {
     return mk<ram::SignedConstant>(symbolTable.lookup(c.getConstant()));
 }
 
-Own<ram::Expression> ValueTranslator::visitNilConstant(const ast::NilConstant&) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::NilConstant>, const ast::NilConstant&) {
     return mk<ram::SignedConstant>(0);
 }
 
-Own<ram::Expression> ValueTranslator::visitTypeCast(const ast::TypeCast& typeCast) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::TypeCast>, const ast::TypeCast& typeCast) {
     return translateValue(typeCast.getValue());
 }
 
-Own<ram::Expression> ValueTranslator::visitIntrinsicFunctor(const ast::IntrinsicFunctor& inf) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::IntrinsicFunctor>, const ast::IntrinsicFunctor& inf) {
     VecOwn<ram::Expression> values;
     for (const auto& cur : inf.getArguments()) {
         values.push_back(translateValue(cur));
@@ -90,7 +90,7 @@ Own<ram::Expression> ValueTranslator::visitIntrinsicFunctor(const ast::Intrinsic
     }
 }
 
-Own<ram::Expression> ValueTranslator::visitUserDefinedFunctor(const ast::UserDefinedFunctor& udf) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::UserDefinedFunctor>, const ast::UserDefinedFunctor& udf) {
     VecOwn<ram::Expression> values;
     for (const auto& cur : udf.getArguments()) {
         values.push_back(translateValue(cur));
@@ -101,11 +101,11 @@ Own<ram::Expression> ValueTranslator::visitUserDefinedFunctor(const ast::UserDef
             udf.getName(), argTypes, returnType, context.isStatefulFunctor(&udf), std::move(values));
 }
 
-Own<ram::Expression> ValueTranslator::visitCounter(const ast::Counter&) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::Counter>, const ast::Counter&) {
     return mk<ram::AutoIncrement>();
 }
 
-Own<ram::Expression> ValueTranslator::visitRecordInit(const ast::RecordInit& init) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::RecordInit>, const ast::RecordInit& init) {
     VecOwn<ram::Expression> values;
     for (const auto& cur : init.getArguments()) {
         values.push_back(translateValue(cur));
@@ -113,7 +113,7 @@ Own<ram::Expression> ValueTranslator::visitRecordInit(const ast::RecordInit& ini
     return mk<ram::PackRecord>(std::move(values));
 }
 
-Own<ram::Expression> ValueTranslator::visitBranchInit(const ast::BranchInit& adt) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::BranchInit>, const ast::BranchInit& adt) {
     auto branchId = context.getADTBranchId(&adt);
 
     // Enums are straight forward
@@ -145,7 +145,7 @@ Own<ram::Expression> ValueTranslator::visitBranchInit(const ast::BranchInit& adt
     return mk<ram::PackRecord>(std::move(finalRecordValues));
 }
 
-Own<ram::Expression> ValueTranslator::visitAggregator(const ast::Aggregator& agg) {
+Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::Aggregator>, const ast::Aggregator& agg) {
     // here we look up the location the aggregation result gets bound
     return makeRamTupleElement(index.getGeneratorLoc(agg));
 }

--- a/src/ast2ram/seminaive/ValueTranslator.cpp
+++ b/src/ast2ram/seminaive/ValueTranslator.cpp
@@ -48,11 +48,13 @@ Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::Variable>, const
     return makeRamTupleElement(index.getDefinitionPoint(var));
 }
 
-Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::UnnamedVariable>, const ast::UnnamedVariable&) {
+Own<ram::Expression> ValueTranslator::visit_(
+        type_identity<ast::UnnamedVariable>, const ast::UnnamedVariable&) {
     return mk<ram::UndefValue>();
 }
 
-Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::NumericConstant>, const ast::NumericConstant& c) {
+Own<ram::Expression> ValueTranslator::visit_(
+        type_identity<ast::NumericConstant>, const ast::NumericConstant& c) {
     switch (context.getInferredNumericConstantType(&c)) {
         case ast::NumericConstant::Type::Int:
             return mk<ram::SignedConstant>(RamSignedFromString(c.getConstant(), nullptr, 0));
@@ -65,7 +67,8 @@ Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::NumericConstant>
     fatal("unexpected numeric constant type");
 }
 
-Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::StringConstant>, const ast::StringConstant& c) {
+Own<ram::Expression> ValueTranslator::visit_(
+        type_identity<ast::StringConstant>, const ast::StringConstant& c) {
     return mk<ram::SignedConstant>(symbolTable.lookup(c.getConstant()));
 }
 
@@ -77,7 +80,8 @@ Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::TypeCast>, const
     return translateValue(typeCast.getValue());
 }
 
-Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::IntrinsicFunctor>, const ast::IntrinsicFunctor& inf) {
+Own<ram::Expression> ValueTranslator::visit_(
+        type_identity<ast::IntrinsicFunctor>, const ast::IntrinsicFunctor& inf) {
     VecOwn<ram::Expression> values;
     for (const auto& cur : inf.getArguments()) {
         values.push_back(translateValue(cur));
@@ -90,7 +94,8 @@ Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::IntrinsicFunctor
     }
 }
 
-Own<ram::Expression> ValueTranslator::visit_(type_identity<ast::UserDefinedFunctor>, const ast::UserDefinedFunctor& udf) {
+Own<ram::Expression> ValueTranslator::visit_(
+        type_identity<ast::UserDefinedFunctor>, const ast::UserDefinedFunctor& udf) {
     VecOwn<ram::Expression> values;
     for (const auto& cur : udf.getArguments()) {
         values.push_back(translateValue(cur));

--- a/src/ast2ram/seminaive/ValueTranslator.h
+++ b/src/ast2ram/seminaive/ValueTranslator.h
@@ -55,18 +55,18 @@ public:
     Own<ram::Expression> translateValue(const ast::Argument* arg) override;
 
     /** -- Visitors -- */
-    Own<ram::Expression> visitVariable(const ast::Variable& var) override;
-    Own<ram::Expression> visitUnnamedVariable(const ast::UnnamedVariable& var) override;
-    Own<ram::Expression> visitNumericConstant(const ast::NumericConstant& c) override;
-    Own<ram::Expression> visitStringConstant(const ast::StringConstant& c) override;
-    Own<ram::Expression> visitNilConstant(const ast::NilConstant& c) override;
-    Own<ram::Expression> visitTypeCast(const ast::TypeCast& typeCast) override;
-    Own<ram::Expression> visitIntrinsicFunctor(const ast::IntrinsicFunctor& inf) override;
-    Own<ram::Expression> visitUserDefinedFunctor(const ast::UserDefinedFunctor& udf) override;
-    Own<ram::Expression> visitCounter(const ast::Counter& ctr) override;
-    Own<ram::Expression> visitRecordInit(const ast::RecordInit& init) override;
-    Own<ram::Expression> visitBranchInit(const ast::BranchInit& init) override;
-    Own<ram::Expression> visitAggregator(const ast::Aggregator& agg) override;
+    Own<ram::Expression> visit_(type_identity<ast::Variable>, const ast::Variable& var) override;
+    Own<ram::Expression> visit_(type_identity<ast::UnnamedVariable>, const ast::UnnamedVariable& var) override;
+    Own<ram::Expression> visit_(type_identity<ast::NumericConstant>, const ast::NumericConstant& c) override;
+    Own<ram::Expression> visit_(type_identity<ast::StringConstant>, const ast::StringConstant& c) override;
+    Own<ram::Expression> visit_(type_identity<ast::NilConstant>, const ast::NilConstant& c) override;
+    Own<ram::Expression> visit_(type_identity<ast::TypeCast>, const ast::TypeCast& typeCast) override;
+    Own<ram::Expression> visit_(type_identity<ast::IntrinsicFunctor>, const ast::IntrinsicFunctor& inf) override;
+    Own<ram::Expression> visit_(type_identity<ast::UserDefinedFunctor>, const ast::UserDefinedFunctor& udf) override;
+    Own<ram::Expression> visit_(type_identity<ast::Counter>, const ast::Counter& ctr) override;
+    Own<ram::Expression> visit_(type_identity<ast::RecordInit>, const ast::RecordInit& init) override;
+    Own<ram::Expression> visit_(type_identity<ast::BranchInit>, const ast::BranchInit& init) override;
+    Own<ram::Expression> visit_(type_identity<ast::Aggregator>, const ast::Aggregator& agg) override;
 };
 
 }  // namespace souffle::ast2ram::seminaive

--- a/src/ast2ram/seminaive/ValueTranslator.h
+++ b/src/ast2ram/seminaive/ValueTranslator.h
@@ -56,13 +56,16 @@ public:
 
     /** -- Visitors -- */
     Own<ram::Expression> visit_(type_identity<ast::Variable>, const ast::Variable& var) override;
-    Own<ram::Expression> visit_(type_identity<ast::UnnamedVariable>, const ast::UnnamedVariable& var) override;
+    Own<ram::Expression> visit_(
+            type_identity<ast::UnnamedVariable>, const ast::UnnamedVariable& var) override;
     Own<ram::Expression> visit_(type_identity<ast::NumericConstant>, const ast::NumericConstant& c) override;
     Own<ram::Expression> visit_(type_identity<ast::StringConstant>, const ast::StringConstant& c) override;
     Own<ram::Expression> visit_(type_identity<ast::NilConstant>, const ast::NilConstant& c) override;
     Own<ram::Expression> visit_(type_identity<ast::TypeCast>, const ast::TypeCast& typeCast) override;
-    Own<ram::Expression> visit_(type_identity<ast::IntrinsicFunctor>, const ast::IntrinsicFunctor& inf) override;
-    Own<ram::Expression> visit_(type_identity<ast::UserDefinedFunctor>, const ast::UserDefinedFunctor& udf) override;
+    Own<ram::Expression> visit_(
+            type_identity<ast::IntrinsicFunctor>, const ast::IntrinsicFunctor& inf) override;
+    Own<ram::Expression> visit_(
+            type_identity<ast::UserDefinedFunctor>, const ast::UserDefinedFunctor& udf) override;
     Own<ram::Expression> visit_(type_identity<ast::Counter>, const ast::Counter& ctr) override;
     Own<ram::Expression> visit_(type_identity<ast::RecordInit>, const ast::RecordInit& init) override;
     Own<ram::Expression> visit_(type_identity<ast::BranchInit>, const ast::BranchInit& init) override;

--- a/src/include/souffle/Visitor.h
+++ b/src/include/souffle/Visitor.h
@@ -1,0 +1,293 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file Visitor.h
+ *
+ * Defines a generic visitor pattern for nodes
+ *
+ ***********************************************************************/
+
+#pragma once
+
+#include "souffle/utility/FunctionalUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+namespace souffle {
+
+/** A tag type required for the is_visitor type trait to identify Visitors */
+struct visitor_tag {};
+
+template <class Node>
+struct visitor_with_type : visitor_tag {};
+
+template <class T>
+using is_visitor = std::is_base_of<visitor_tag, T>;
+
+template <typename T>
+inline constexpr bool is_visitor_v = is_visitor<T>::value;
+
+/**
+ * Extension point for visitors.
+ * Can be orderloaded in the namespace of Node
+ */
+template <class Node>
+auto getChildNodes(Node&& node) -> decltype(node.getChildNodes()) {
+    return node.getChildNodes();
+}
+
+namespace detail {
+template <typename T, typename U = void>
+struct is_visitable_impl : std::false_type {};
+
+template <typename T>
+struct is_visitable_impl<T, std::void_t<decltype(getChildNodes(std::declval<T const&>()))>>
+        : is_range<decltype(getChildNodes(std::declval<T&>()))> {};
+}  // namespace detail
+
+template <typename T>
+using is_visitable = detail::is_visitable_impl<T>;
+
+template <typename T>
+inline constexpr bool is_visitable_v = is_visitable<T>::value;
+
+namespace detail {
+template <typename T>
+using node_base_t = std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<decltype(*std::begin(getChildNodes(std::declval<T&>())))>>>;
+
+template <typename T>
+constexpr inline bool ptr_helper_v = is_pointer_like_v<std::remove_const_t<std::remove_reference_t<T>>>;
+}  // namespace detail
+
+/**
+ * The generic base type of all Visitors realizing the dispatching of
+ * visitor calls. Each visitor may define a return type R and a list of
+ * extra parameters to be passed along with the visited Nodes to the
+ * corresponding visitor function.
+ *
+ * @tparam R the result type produced by a visit call
+ * @tparam Node the type of the node being visited (can be const qualified)
+ * @tparam Params extra parameters to be passed to the visit call
+ */
+template <typename R, class NodeType, typename... Params>
+struct Visitor : public visitor_with_type<NodeType> {
+    virtual ~Visitor() = default;
+
+    /** The main entry for the user allowing visitors to be utilized as functions */
+    R operator()(NodeType& node, Params const&... args) {
+        return visit(node, args...);
+    }
+
+    /**
+     * The main entry for a visit process conducting the dispatching of
+     * a visit to the various sub-types of Nodes. Sub-classes may override
+     * this implementation to conduct pre-visit operations.
+     *
+     * @param node the node to be visited
+     * @param args a list of extra parameters to be forwarded
+     */
+    virtual R visit(NodeType& node, Params const&... args) = 0;
+
+    /** The base case for all visitors -- if no more specific overload was defined */
+    virtual R visit_(type_identity<std::remove_const_t<NodeType>>, const NodeType& /*node*/,
+            Params const&... /*args*/) {
+        return R();
+    }
+};
+
+#define SOUFFLE_VISITOR_FORWARD(Kind) \
+    if (auto* n = as<Kind>(node)) return visit_(type_identity<Kind>(), *n, args...);
+
+#define SOUFFLE_VISITOR_LINK(Kind, Parent)                                                         \
+    virtual R visit_(type_identity<Kind>, copy_const_t<NodeType, Kind>& n, Params const&... args) { \
+        return visit_(type_identity<Parent>(), n, args...);                                         \
+    }
+
+/**
+ * A utility function visiting all nodes within the given root
+ * recursively in a depth-first pre-order fashion, applying the given visitor to each
+ * encountered node.
+ *
+ * @param root the root of the structure to be visited
+ * @param visitor the visitor to be applied on each node
+ * @param args a list of extra parameters to be forwarded to the visitor
+ */
+template <class Node, class Visitor, typename... Args>
+std::enable_if_t<is_visitable_v<Node> && is_visitor_v<Visitor>> visitDepthFirstPreOrder(
+        Node&& root, Visitor& visitor, Args const&... args) {
+    visitor(root, args...);
+    for (auto&& cur : getChildNodes(root)) {
+        // FIXME: Remove this once nodes are converted to references
+        if constexpr (detail::ptr_helper_v<decltype(cur)>) {
+            if (cur != nullptr) {
+                visitDepthFirstPreOrder(*cur, visitor, args...);
+            }
+        } else {
+            visitDepthFirstPreOrder(cur, visitor, args...);
+        }
+    }
+}
+
+/**
+ * A utility function visiting all nodes within the given root
+ * recursively in a depth-first post-order fashion applying the given visitor to each
+ * encountered node.
+ *
+ * @param root the root of the structure to be visited
+ * @param visitor the visitor to be applied on each node
+ * @param args a list of extra parameters to be forwarded to the visitor
+ */
+template <class Node, class Visitor, typename... Args>
+std::enable_if_t<is_visitable_v<Node> && is_visitor_v<Visitor>> visitDepthFirstPostOrder(
+        Node&& root, Visitor& visitor, Args const&... args) {
+    for (auto&& cur : getChildNodes(root)) {
+        // FIXME: Remove this once nodes are converted to references
+        if constexpr (detail::ptr_helper_v<decltype(cur)>) {
+            if (cur != nullptr) {
+                visitDepthFirstPostOrder(*cur, visitor, args...);
+            }
+        } else {
+            visitDepthFirstPostOrder(cur, visitor, args...);
+        }
+    }
+    visitor(root, args...);
+}
+
+/**
+ * A utility function visiting all nodes within the given root
+ * recursively in a depth-first pre-order fashion, applying the given visitor to each
+ * encountered node.
+ *
+ * @param root the root of the structure to be visited
+ * @param visitor the visitor to be applied on each node
+ * @param args a list of extra parameters to be forwarded to the visitor
+ */
+template <class Node, class Visitor, typename... Args>
+std::enable_if_t<is_visitable_v<Node> && is_visitor_v<Visitor>> visitDepthFirst(
+        Node&& root, Visitor& visitor, Args const&... args) {
+    visitDepthFirstPreOrder(root, visitor, args...);
+}
+
+namespace detail {
+
+/**
+ * A specialized visitor wrapping a lambda function -- an auxiliary type required
+ * for visitor convenience functions.
+ */
+template <class NodeToVisit, class Node, typename F>
+struct LambdaVisitor : public Visitor<void, copy_const_t<NodeToVisit, Node>> {
+    F lambda;
+    LambdaVisitor(F lam) : lambda(std::move(lam)) {}
+    void visit(copy_const_t<NodeToVisit, Node>& node) override {
+        // Don't use as<> to allow cross-casting to mixins
+        if (auto* n = dynamic_cast<NodeToVisit*>(&node)) {
+            lambda(*n);
+        }
+    }
+};
+
+// Only used for deduction
+template <typename R, typename T>
+T& getNodeHelper(std::function<R(T&)>);
+
+template <typename F>
+typename lambda_traits<F>::arg0_type& getNodeHelper(F const&);
+
+/**
+ * A factory function for creating LambdaVisitor instances.
+ */
+template <class Node, typename F>
+auto makeLambdaVisitor(F&& f) {
+    using NodeToVisit = std::remove_reference_t<decltype(getNodeHelper(f))>;
+    using NodeBase = detail::node_base_t<Node>;
+    return LambdaVisitor<NodeToVisit, copy_const_t<NodeToVisit, NodeBase>, std::remove_reference_t<F>>(
+            std::forward<F>(f));
+}
+}  // namespace detail
+
+/**
+ * A utility function visiting all nodes within the given root
+ * recursively in a depth-first pre-order fashion, applying the given visitor to each
+ * encountered node.
+ *
+ * @param root the root of the structure to be visited
+ * @param visitor the visitor to be applied on each node
+ */
+template <class Node, typename F>
+std::enable_if_t<is_visitable_v<Node> && !is_visitor_v<F>> visitDepthFirst(Node&& root, F&& fun) {
+    auto visitor = detail::makeLambdaVisitor<std::remove_reference_t<Node>>(std::forward<F>(fun));
+    visitDepthFirst(root, visitor);
+}
+
+/**
+ * A utility function visiting all nodes within a given container of root nodes
+ * recursively in a depth-first pre-order fashion applying the given function to each
+ * encountered node.
+ *
+ * @param list the list of roots of the ASTs to be visited
+ * @param fun the function to be applied
+ */
+template <typename R, typename F>
+std::enable_if_t<is_range_v<R>> visitDepthFirst(R const& range, F&& fun) {
+    for (auto&& cur : range) {
+        // NOTE: Can't forward since each visitDepthFirst call could
+        // steal the temporary!
+        // FIXME: Remove this once nodes are converted to references
+        if constexpr (detail::ptr_helper_v<decltype(cur)>) {
+            if (cur != nullptr) {
+                visitDepthFirst(*cur, fun);
+            }
+        } else {
+            visitDepthFirst(cur, fun);
+        }
+    }
+}
+
+/**
+ * A utility function visiting all nodes within the given root
+ * recursively in a depth-first post-order fashion, applying the given visitor to each
+ * encountered node.
+ *
+ * @param root the root of the structure to be visited
+ * @param visitor the visitor to be applied on each node
+ */
+template <class Node, typename F>
+std::enable_if_t<is_visitable_v<Node> && !is_visitor_v<F>> visitDepthFirstPostOrder(Node&& root, F&& fun) {
+    auto visitor = detail::makeLambdaVisitor<std::remove_reference_t<Node>>(std::forward<F>(fun));
+    visitDepthFirstPostOrder(root, visitor);
+}
+
+/**
+ * A utility function visiting all nodes within a given container of root nodes
+ * recursively in a depth-first post-order fashion applying the given function to each
+ * encountered node.
+ *
+ * @param list the list of roots of the ASTs to be visited
+ * @param fun the function to be applied
+ */
+template <typename R, typename F>
+std::enable_if_t<is_range_v<R>> visitDepthFirstPostOrder(R const& range, F&& fun) {
+    for (auto&& cur : range) {
+        // NOTE: Can't forward since each visitDepthFirstPostOrder call could
+        // steal the temporary!
+        // FIXME: Remove this once nodes are converted to references
+        if constexpr (detail::ptr_helper_v<decltype(cur)>) {
+            if (cur != nullptr) {
+                visitDepthFirstPostOrder(*cur, fun);
+            }
+        } else {
+            visitDepthFirstPostOrder(cur, fun);
+        }
+    }
+}
+
+}  // namespace souffle

--- a/src/include/souffle/Visitor.h
+++ b/src/include/souffle/Visitor.h
@@ -62,7 +62,8 @@ inline constexpr bool is_visitable_v = is_visitable<T>::value;
 
 namespace detail {
 template <typename T>
-using node_base_t = std::remove_const_t<std::remove_pointer_t<std::remove_reference_t<decltype(*std::begin(getChildNodes(std::declval<T&>())))>>>;
+using node_base_t = std::remove_const_t<std::remove_pointer_t<
+        std::remove_reference_t<decltype(*std::begin(getChildNodes(std::declval<T&>())))>>>;
 
 template <typename T>
 constexpr inline bool ptr_helper_v = is_pointer_like_v<std::remove_const_t<std::remove_reference_t<T>>>;
@@ -107,7 +108,7 @@ struct Visitor : public visitor_with_type<NodeType> {
 #define SOUFFLE_VISITOR_FORWARD(Kind) \
     if (auto* n = as<Kind>(node)) return visit_(type_identity<Kind>(), *n, args...);
 
-#define SOUFFLE_VISITOR_LINK(Kind, Parent)                                                         \
+#define SOUFFLE_VISITOR_LINK(Kind, Parent)                                                          \
     virtual R visit_(type_identity<Kind>, copy_const_t<NodeType, Kind>& n, Params const&... args) { \
         return visit_(type_identity<Parent>(), n, args...);                                         \
     }

--- a/src/include/souffle/utility/Types.h
+++ b/src/include/souffle/utility/Types.h
@@ -59,4 +59,20 @@ struct is_range : detail::is_range_impl<T> {};
 template <typename T>
 inline constexpr bool is_range_v = is_range<T>::value;
 
+/**
+ * Type identity, remove once on C++20
+ */
+template <typename T>
+struct type_identity {
+    using type = T;
+};
+
+template <typename T>
+struct is_pointer_like : std::is_pointer<T> {};
+
+template <typename T>
+struct is_pointer_like<Own<T>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_pointer_like_v = is_pointer_like<T>::value;
 }  // namespace souffle

--- a/src/interpreter/Engine.cpp
+++ b/src/interpreter/Engine.cpp
@@ -284,7 +284,7 @@ void Engine::executeMain() {
         ProfileEventSingleton::instance().setOutputFile(Global::config().get("profile"));
         // Prepare the frequency table for threaded use
         const ram::Program& program = tUnit.getProgram();
-        ram::visitDepthFirst(program, [&](const ram::TupleOperation& node) {
+        visitDepthFirst(program, [&](const ram::TupleOperation& node) {
             if (!node.getProfileText().empty()) {
                 frequencies.emplace(node.getProfileText(), std::deque<std::atomic<size_t>>());
                 frequencies[node.getProfileText()].emplace_back(0);
@@ -309,7 +309,7 @@ void Engine::executeMain() {
 
         // Store count of rules
         size_t ruleCount = 0;
-        ram::visitDepthFirst(program, [&](const ram::Query&) { ++ruleCount; });
+        visitDepthFirst(program, [&](const ram::Query&) { ++ruleCount; });
         ProfileEventSingleton::instance().makeConfigRecord("ruleCount", std::to_string(ruleCount));
 
         Context ctxt;

--- a/src/interpreter/Generator.cpp
+++ b/src/interpreter/Generator.cpp
@@ -50,92 +50,93 @@ NodePtr NodeGenerator::generateTree(const ram::Node& root) {
     return visit(root);
 }
 
-NodePtr NodeGenerator::visitConstant(const ram::Constant& num) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Constant>, const ram::Constant& num) {
     return mk<Constant>(I_Constant, &num);
 }
 
-NodePtr NodeGenerator::visitTupleElement(const ram::TupleElement& access) {
+NodePtr NodeGenerator::visit_(type_identity<ram::TupleElement>, const ram::TupleElement& access) {
     auto tupleId = access.getTupleId();
     auto elementId = access.getElement();
     auto newElementId = orderingContext.mapOrder(tupleId, elementId);
     return mk<TupleElement>(I_TupleElement, &access, tupleId, newElementId);
 }
 
-NodePtr NodeGenerator::visitAutoIncrement(const ram::AutoIncrement& inc) {
+NodePtr NodeGenerator::visit_(type_identity<ram::AutoIncrement>, const ram::AutoIncrement& inc) {
     return mk<AutoIncrement>(I_AutoIncrement, &inc);
 }
 
-NodePtr NodeGenerator::visitIntrinsicOperator(const ram::IntrinsicOperator& op) {
+NodePtr NodeGenerator::visit_(type_identity<ram::IntrinsicOperator>, const ram::IntrinsicOperator& op) {
     NodePtrVec children;
     for (const auto& arg : op.getArguments()) {
-        children.push_back(visit(arg));
+        children.push_back(visit(*arg));
     }
     return mk<IntrinsicOperator>(I_IntrinsicOperator, &op, std::move(children));
 }
 
-NodePtr NodeGenerator::visitUserDefinedOperator(const ram::UserDefinedOperator& op) {
+NodePtr NodeGenerator::visit_(type_identity<ram::UserDefinedOperator>, const ram::UserDefinedOperator& op) {
     NodePtrVec children;
     for (const auto& arg : op.getArguments()) {
-        children.push_back(visit(arg));
+        children.push_back(visit(*arg));
     }
     return mk<UserDefinedOperator>(I_UserDefinedOperator, &op, std::move(children));
 }
 
-NodePtr NodeGenerator::visitNestedIntrinsicOperator(const ram::NestedIntrinsicOperator& op) {
+NodePtr NodeGenerator::visit_(
+        type_identity<ram::NestedIntrinsicOperator>, const ram::NestedIntrinsicOperator& op) {
     auto arity = op.getArguments().size();
     orderingContext.addNewTuple(op.getTupleId(), arity);
     NodePtrVec children;
     for (auto&& arg : op.getArguments()) {
-        children.push_back(visit(arg));
+        children.push_back(visit(*arg));
     }
-    children.push_back(visitTupleOperation(op));
+    children.push_back(visit_(type_identity<ram::TupleOperation>(), op));
     return mk<NestedIntrinsicOperator>(I_NestedIntrinsicOperator, &op, std::move(children));
 }
 
-NodePtr NodeGenerator::visitPackRecord(const ram::PackRecord& pr) {
+NodePtr NodeGenerator::visit_(type_identity<ram::PackRecord>, const ram::PackRecord& pr) {
     NodePtrVec children;
     for (const auto& arg : pr.getArguments()) {
-        children.push_back(visit(arg));
+        children.push_back(visit(*arg));
     }
     return mk<PackRecord>(I_PackRecord, &pr, std::move(children));
 }
 
-NodePtr NodeGenerator::visitSubroutineArgument(const ram::SubroutineArgument& arg) {
+NodePtr NodeGenerator::visit_(type_identity<ram::SubroutineArgument>, const ram::SubroutineArgument& arg) {
     return mk<SubroutineArgument>(I_SubroutineArgument, &arg);
 }
 
 // -- connectors operators --
-NodePtr NodeGenerator::visitTrue(const ram::True& ltrue) {
+NodePtr NodeGenerator::visit_(type_identity<ram::True>, const ram::True& ltrue) {
     return mk<True>(I_True, &ltrue);
 }
 
-NodePtr NodeGenerator::visitFalse(const ram::False& lfalse) {
+NodePtr NodeGenerator::visit_(type_identity<ram::False>, const ram::False& lfalse) {
     return mk<False>(I_False, &lfalse);
 }
 
-NodePtr NodeGenerator::visitConjunction(const ram::Conjunction& conj) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Conjunction>, const ram::Conjunction& conj) {
     return mk<Conjunction>(I_Conjunction, &conj, visit(conj.getLHS()), visit(conj.getRHS()));
 }
 
-NodePtr NodeGenerator::visitNegation(const ram::Negation& neg) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Negation>, const ram::Negation& neg) {
     return mk<Negation>(I_Negation, &neg, visit(neg.getOperand()));
 }
 
-NodePtr NodeGenerator::visitEmptinessCheck(const ram::EmptinessCheck& emptiness) {
+NodePtr NodeGenerator::visit_(type_identity<ram::EmptinessCheck>, const ram::EmptinessCheck& emptiness) {
     size_t relId = encodeRelation(emptiness.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("EmptinessCheck", lookup(emptiness.getRelation()));
     return mk<EmptinessCheck>(type, &emptiness, rel);
 }
 
-NodePtr NodeGenerator::visitRelationSize(const ram::RelationSize& size) {
+NodePtr NodeGenerator::visit_(type_identity<ram::RelationSize>, const ram::RelationSize& size) {
     size_t relId = encodeRelation(size.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("RelationSize", lookup(size.getRelation()));
     return mk<RelationSize>(type, &size, rel);
 }
 
-NodePtr NodeGenerator::visitExistenceCheck(const ram::ExistenceCheck& exists) {
+NodePtr NodeGenerator::visit_(type_identity<ram::ExistenceCheck>, const ram::ExistenceCheck& exists) {
     SuperInstruction superOp = getExistenceSuperInstInfo(exists);
     // Check if the search signature is a total signature
     bool isTotal = true;
@@ -150,94 +151,98 @@ NodePtr NodeGenerator::visitExistenceCheck(const ram::ExistenceCheck& exists) {
             ramRelation.isTemp(), ramRelation.getName());
 }
 
-NodePtr NodeGenerator::visitProvenanceExistenceCheck(const ram::ProvenanceExistenceCheck& provExists) {
+NodePtr NodeGenerator::visit_(
+        type_identity<ram::ProvenanceExistenceCheck>, const ram::ProvenanceExistenceCheck& provExists) {
     SuperInstruction superOp = getExistenceSuperInstInfo(provExists);
     NodeType type = constructNodeType("ProvenanceExistenceCheck", lookup(provExists.getRelation()));
-    return mk<ProvenanceExistenceCheck>(type, &provExists, visit(provExists.getChildNodes().back()),
+    return mk<ProvenanceExistenceCheck>(type, &provExists, visit(*provExists.getChildNodes().back()),
             encodeView(&provExists), std::move(superOp));
 }
 
-NodePtr NodeGenerator::visitConstraint(const ram::Constraint& relOp) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Constraint>, const ram::Constraint& relOp) {
     return mk<Constraint>(I_Constraint, &relOp, visit(relOp.getLHS()), visit(relOp.getRHS()));
 }
 
-NodePtr NodeGenerator::visitNestedOperation(const ram::NestedOperation& nested) {
+NodePtr NodeGenerator::visit_(type_identity<ram::NestedOperation>, const ram::NestedOperation& nested) {
     return visit(nested.getOperation());
 }
 
-NodePtr NodeGenerator::visitTupleOperation(const ram::TupleOperation& search) {
+NodePtr NodeGenerator::visit_(type_identity<ram::TupleOperation>, const ram::TupleOperation& search) {
     if (engine.profileEnabled && engine.frequencyCounterEnabled && !search.getProfileText().empty()) {
         return mk<TupleOperation>(I_TupleOperation, &search, visit(search.getOperation()));
     }
     return visit(search.getOperation());
 }
 
-NodePtr NodeGenerator::visitScan(const ram::Scan& scan) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Scan>, const ram::Scan& scan) {
     orderingContext.addTupleWithDefaultOrder(scan.getTupleId(), scan);
     size_t relId = encodeRelation(scan.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("Scan", lookup(scan.getRelation()));
-    return mk<Scan>(type, &scan, rel, visitTupleOperation(scan));
+    return mk<Scan>(type, &scan, rel, visit_(type_identity<ram::TupleOperation>(), scan));
 }
 
-NodePtr NodeGenerator::visitParallelScan(const ram::ParallelScan& pScan) {
+NodePtr NodeGenerator::visit_(type_identity<ram::ParallelScan>, const ram::ParallelScan& pScan) {
     orderingContext.addTupleWithDefaultOrder(pScan.getTupleId(), pScan);
     size_t relId = encodeRelation(pScan.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("ParallelScan", lookup(pScan.getRelation()));
-    auto res = mk<ParallelScan>(type, &pScan, rel, visitTupleOperation(pScan));
+    auto res = mk<ParallelScan>(type, &pScan, rel, visit_(type_identity<ram::TupleOperation>(), pScan));
     res->setViewContext(parentQueryViewContext);
     return res;
 }
 
-NodePtr NodeGenerator::visitIndexScan(const ram::IndexScan& iScan) {
+NodePtr NodeGenerator::visit_(type_identity<ram::IndexScan>, const ram::IndexScan& iScan) {
     orderingContext.addTupleWithIndexOrder(iScan.getTupleId(), iScan);
     SuperInstruction indexOperation = getIndexSuperInstInfo(iScan);
     NodeType type = constructNodeType("IndexScan", lookup(iScan.getRelation()));
-    return mk<IndexScan>(
-            type, &iScan, nullptr, visitTupleOperation(iScan), encodeView(&iScan), std::move(indexOperation));
+    return mk<IndexScan>(type, &iScan, nullptr, visit_(type_identity<ram::TupleOperation>(), iScan),
+            encodeView(&iScan), std::move(indexOperation));
 }
 
-NodePtr NodeGenerator::visitParallelIndexScan(const ram::ParallelIndexScan& piscan) {
+NodePtr NodeGenerator::visit_(type_identity<ram::ParallelIndexScan>, const ram::ParallelIndexScan& piscan) {
     orderingContext.addTupleWithIndexOrder(piscan.getTupleId(), piscan);
     SuperInstruction indexOperation = getIndexSuperInstInfo(piscan);
     size_t relId = encodeRelation(piscan.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("ParallelIndexScan", lookup(piscan.getRelation()));
-    auto res = mk<ParallelIndexScan>(type, &piscan, rel, visitTupleOperation(piscan), encodeIndexPos(piscan),
-            std::move(indexOperation));
+    auto res = mk<ParallelIndexScan>(type, &piscan, rel, visit_(type_identity<ram::TupleOperation>(), piscan),
+            encodeIndexPos(piscan), std::move(indexOperation));
     res->setViewContext(parentQueryViewContext);
     return res;
 }
 
-NodePtr NodeGenerator::visitChoice(const ram::Choice& choice) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Choice>, const ram::Choice& choice) {
     orderingContext.addTupleWithDefaultOrder(choice.getTupleId(), choice);
     size_t relId = encodeRelation(choice.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("Choice", lookup(choice.getRelation()));
-    return mk<Choice>(type, &choice, rel, visit(choice.getCondition()), visitTupleOperation(choice));
+    return mk<Choice>(type, &choice, rel, visit(choice.getCondition()),
+            visit_(type_identity<ram::TupleOperation>(), choice));
 }
 
-NodePtr NodeGenerator::visitParallelChoice(const ram::ParallelChoice& pChoice) {
+NodePtr NodeGenerator::visit_(type_identity<ram::ParallelChoice>, const ram::ParallelChoice& pChoice) {
     orderingContext.addTupleWithDefaultOrder(pChoice.getTupleId(), pChoice);
     size_t relId = encodeRelation(pChoice.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("ParallelChoice", lookup(pChoice.getRelation()));
-    auto res = mk<ParallelChoice>(
-            type, &pChoice, rel, visit(pChoice.getCondition()), visitTupleOperation(pChoice));
+    auto res = mk<ParallelChoice>(type, &pChoice, rel, visit(pChoice.getCondition()),
+            visit_(type_identity<ram::TupleOperation>(), pChoice));
     res->setViewContext(parentQueryViewContext);
     return res;
 }
 
-NodePtr NodeGenerator::visitIndexChoice(const ram::IndexChoice& iChoice) {
+NodePtr NodeGenerator::visit_(type_identity<ram::IndexChoice>, const ram::IndexChoice& iChoice) {
     orderingContext.addTupleWithIndexOrder(iChoice.getTupleId(), iChoice);
     SuperInstruction indexOperation = getIndexSuperInstInfo(iChoice);
     NodeType type = constructNodeType("IndexChoice", lookup(iChoice.getRelation()));
     return mk<IndexChoice>(type, &iChoice, nullptr, visit(iChoice.getCondition()),
-            visitTupleOperation(iChoice), encodeView(&iChoice), std::move(indexOperation));
+            visit_(type_identity<ram::TupleOperation>(), iChoice), encodeView(&iChoice),
+            std::move(indexOperation));
 }
 
-NodePtr NodeGenerator::visitParallelIndexChoice(const ram::ParallelIndexChoice& piChoice) {
+NodePtr NodeGenerator::visit_(
+        type_identity<ram::ParallelIndexChoice>, const ram::ParallelIndexChoice& piChoice) {
     orderingContext.addTupleWithIndexOrder(piChoice.getTupleId(), piChoice);
     SuperInstruction indexOperation = getIndexSuperInstInfo(piChoice);
     size_t relId = encodeRelation(piChoice.getRelation());
@@ -249,13 +254,14 @@ NodePtr NodeGenerator::visitParallelIndexChoice(const ram::ParallelIndexChoice& 
     return res;
 }
 
-NodePtr NodeGenerator::visitUnpackRecord(const ram::UnpackRecord& unpack) {  // get reference
+NodePtr NodeGenerator::visit_(
+        type_identity<ram::UnpackRecord>, const ram::UnpackRecord& unpack) {  // get reference
     orderingContext.addNewTuple(unpack.getTupleId(), unpack.getArity());
-    return mk<UnpackRecord>(
-            I_UnpackRecord, &unpack, visit(unpack.getExpression()), visitTupleOperation(unpack));
+    return mk<UnpackRecord>(I_UnpackRecord, &unpack, visit(unpack.getExpression()),
+            visit_(type_identity<ram::TupleOperation>(), unpack));
 }
 
-NodePtr NodeGenerator::visitAggregate(const ram::Aggregate& aggregate) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Aggregate>, const ram::Aggregate& aggregate) {
     // Notice: Aggregate is sensitive to the visiting order of the subexprs in order to make
     // orderCtxt consistent. The order of visiting should be the same as the order of execution during
     // runtime.
@@ -263,19 +269,20 @@ NodePtr NodeGenerator::visitAggregate(const ram::Aggregate& aggregate) {
     NodePtr expr = visit(aggregate.getExpression());
     NodePtr cond = visit(aggregate.getCondition());
     orderingContext.addNewTuple(aggregate.getTupleId(), 1);
-    NodePtr nested = visitTupleOperation(aggregate);
+    NodePtr nested = visit_(type_identity<ram::TupleOperation>(), aggregate);
     size_t relId = encodeRelation(aggregate.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("Aggregate", lookup(aggregate.getRelation()));
     return mk<Aggregate>(type, &aggregate, rel, std::move(expr), std::move(cond), std::move(nested));
 }
 
-NodePtr NodeGenerator::visitParallelAggregate(const ram::ParallelAggregate& pAggregate) {
+NodePtr NodeGenerator::visit_(
+        type_identity<ram::ParallelAggregate>, const ram::ParallelAggregate& pAggregate) {
     orderingContext.addTupleWithDefaultOrder(pAggregate.getTupleId(), pAggregate);
     NodePtr expr = visit(pAggregate.getExpression());
     NodePtr cond = visit(pAggregate.getCondition());
     orderingContext.addNewTuple(pAggregate.getTupleId(), 1);
-    NodePtr nested = visitTupleOperation(pAggregate);
+    NodePtr nested = visit_(type_identity<ram::TupleOperation>(), pAggregate);
     size_t relId = encodeRelation(pAggregate.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("ParallelAggregate", lookup(pAggregate.getRelation()));
@@ -286,13 +293,13 @@ NodePtr NodeGenerator::visitParallelAggregate(const ram::ParallelAggregate& pAgg
     return res;
 }
 
-NodePtr NodeGenerator::visitIndexAggregate(const ram::IndexAggregate& iAggregate) {
+NodePtr NodeGenerator::visit_(type_identity<ram::IndexAggregate>, const ram::IndexAggregate& iAggregate) {
     orderingContext.addTupleWithIndexOrder(iAggregate.getTupleId(), iAggregate);
     SuperInstruction indexOperation = getIndexSuperInstInfo(iAggregate);
     NodePtr expr = visit(iAggregate.getExpression());
     NodePtr cond = visit(iAggregate.getCondition());
     orderingContext.addNewTuple(iAggregate.getTupleId(), 1);
-    NodePtr nested = visitTupleOperation(iAggregate);
+    NodePtr nested = visit_(type_identity<ram::TupleOperation>(), iAggregate);
     size_t relId = encodeRelation(iAggregate.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("IndexAggregate", lookup(iAggregate.getRelation()));
@@ -300,13 +307,14 @@ NodePtr NodeGenerator::visitIndexAggregate(const ram::IndexAggregate& iAggregate
             encodeView(&iAggregate), std::move(indexOperation));
 }
 
-NodePtr NodeGenerator::visitParallelIndexAggregate(const ram::ParallelIndexAggregate& piAggregate) {
+NodePtr NodeGenerator::visit_(
+        type_identity<ram::ParallelIndexAggregate>, const ram::ParallelIndexAggregate& piAggregate) {
     orderingContext.addTupleWithIndexOrder(piAggregate.getTupleId(), piAggregate);
     SuperInstruction indexOperation = getIndexSuperInstInfo(piAggregate);
     NodePtr expr = visit(piAggregate.getExpression());
     NodePtr cond = visit(piAggregate.getCondition());
     orderingContext.addNewTuple(piAggregate.getTupleId(), 1);
-    NodePtr nested = visitTupleOperation(piAggregate);
+    NodePtr nested = visit_(type_identity<ram::TupleOperation>(), piAggregate);
     size_t relId = encodeRelation(piAggregate.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("ParallelIndexAggregate", lookup(piAggregate.getRelation()));
@@ -316,24 +324,24 @@ NodePtr NodeGenerator::visitParallelIndexAggregate(const ram::ParallelIndexAggre
     return res;
 }
 
-NodePtr NodeGenerator::visitBreak(const ram::Break& breakOp) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Break>, const ram::Break& breakOp) {
     return mk<Break>(I_Break, &breakOp, visit(breakOp.getCondition()), visit(breakOp.getOperation()));
 }
 
-NodePtr NodeGenerator::visitFilter(const ram::Filter& filter) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Filter>, const ram::Filter& filter) {
     return mk<Filter>(I_Filter, &filter, visit(filter.getCondition()), visit(filter.getOperation()));
 }
 
-NodePtr NodeGenerator::visitGuardedProject(const ram::GuardedProject& guardedProject) {
+NodePtr NodeGenerator::visit_(type_identity<ram::GuardedProject>, const ram::GuardedProject& guardedProject) {
     SuperInstruction superOp = getProjectSuperInstInfo(guardedProject);
     size_t relId = encodeRelation(guardedProject.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("GuardedProject", lookup(guardedProject.getRelation()));
     auto condition = guardedProject.getCondition();
-    return mk<GuardedProject>(type, &guardedProject, rel, std::move(superOp), visit(condition));
+    return mk<GuardedProject>(type, &guardedProject, rel, std::move(superOp), visit(*condition));
 }
 
-NodePtr NodeGenerator::visitProject(const ram::Project& project) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Project>, const ram::Project& project) {
     SuperInstruction superOp = getProjectSuperInstInfo(project);
     size_t relId = encodeRelation(project.getRelation());
     auto rel = getRelationHandle(relId);
@@ -341,40 +349,40 @@ NodePtr NodeGenerator::visitProject(const ram::Project& project) {
     return mk<Project>(type, &project, rel, std::move(superOp));
 }
 
-NodePtr NodeGenerator::visitSubroutineReturn(const ram::SubroutineReturn& ret) {
+NodePtr NodeGenerator::visit_(type_identity<ram::SubroutineReturn>, const ram::SubroutineReturn& ret) {
     NodePtrVec children;
     for (const auto& value : ret.getValues()) {
-        children.push_back(visit(value));
+        children.push_back(visit(*value));
     }
     return mk<SubroutineReturn>(I_SubroutineReturn, &ret, std::move(children));
 }
 
-NodePtr NodeGenerator::visitSequence(const ram::Sequence& seq) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Sequence>, const ram::Sequence& seq) {
     NodePtrVec children;
     for (const auto& value : seq.getStatements()) {
-        children.push_back(visit(value));
+        children.push_back(visit(*value));
     }
     return mk<Sequence>(I_Sequence, &seq, std::move(children));
 }
 
-NodePtr NodeGenerator::visitParallel(const ram::Parallel& parallel) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Parallel>, const ram::Parallel& parallel) {
     // Parallel statements are executed in sequence for now.
     NodePtrVec children;
     for (const auto& value : parallel.getStatements()) {
-        children.push_back(visit(value));
+        children.push_back(visit(*value));
     }
     return mk<Parallel>(I_Parallel, &parallel, std::move(children));
 }
 
-NodePtr NodeGenerator::visitLoop(const ram::Loop& loop) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Loop>, const ram::Loop& loop) {
     return mk<Loop>(I_Loop, &loop, visit(loop.getBody()));
 }
 
-NodePtr NodeGenerator::visitExit(const ram::Exit& exit) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Exit>, const ram::Exit& exit) {
     return mk<Exit>(I_Exit, &exit, visit(exit.getCondition()));
 }
 
-NodePtr NodeGenerator::visitCall(const ram::Call& call) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Call>, const ram::Call& call) {
     // translate a subroutine name to an index
     // the index is used to identify the subroutine
     // in the interpreter. The index is stored in the
@@ -385,40 +393,40 @@ NodePtr NodeGenerator::visitCall(const ram::Call& call) {
     return mk<Call>(I_Call, &call, subroutineId);
 }
 
-NodePtr NodeGenerator::visitLogRelationTimer(const ram::LogRelationTimer& timer) {
+NodePtr NodeGenerator::visit_(type_identity<ram::LogRelationTimer>, const ram::LogRelationTimer& timer) {
     size_t relId = encodeRelation(timer.getRelation());
     auto rel = getRelationHandle(relId);
     return mk<LogRelationTimer>(I_LogRelationTimer, &timer, visit(timer.getStatement()), rel);
 }
 
-NodePtr NodeGenerator::visitLogTimer(const ram::LogTimer& timer) {
+NodePtr NodeGenerator::visit_(type_identity<ram::LogTimer>, const ram::LogTimer& timer) {
     return mk<LogTimer>(I_LogTimer, &timer, visit(timer.getStatement()));
 }
 
-NodePtr NodeGenerator::visitDebugInfo(const ram::DebugInfo& dbg) {
+NodePtr NodeGenerator::visit_(type_identity<ram::DebugInfo>, const ram::DebugInfo& dbg) {
     return mk<DebugInfo>(I_DebugInfo, &dbg, visit(dbg.getStatement()));
 }
 
-NodePtr NodeGenerator::visitClear(const ram::Clear& clear) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Clear>, const ram::Clear& clear) {
     size_t relId = encodeRelation(clear.getRelation());
     auto rel = getRelationHandle(relId);
     NodeType type = constructNodeType("Clear", lookup(clear.getRelation()));
     return mk<Clear>(type, &clear, rel);
 }
 
-NodePtr NodeGenerator::visitLogSize(const ram::LogSize& size) {
+NodePtr NodeGenerator::visit_(type_identity<ram::LogSize>, const ram::LogSize& size) {
     size_t relId = encodeRelation(size.getRelation());
     auto rel = getRelationHandle(relId);
     return mk<LogSize>(I_LogSize, &size, rel);
 }
 
-NodePtr NodeGenerator::visitIO(const ram::IO& io) {
+NodePtr NodeGenerator::visit_(type_identity<ram::IO>, const ram::IO& io) {
     size_t relId = encodeRelation(io.getRelation());
     auto rel = getRelationHandle(relId);
     return mk<IO>(I_IO, &io, rel);
 }
 
-NodePtr NodeGenerator::visitQuery(const ram::Query& query) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Query>, const ram::Query& query) {
     std::shared_ptr<ViewContext> viewContext = std::make_shared<ViewContext>();
     parentQueryViewContext = viewContext;
     // split terms of conditions of outer-most filter operation
@@ -464,23 +472,23 @@ NodePtr NodeGenerator::visitQuery(const ram::Query& query) {
     return res;
 }
 
-NodePtr NodeGenerator::visitExtend(const ram::Extend& extend) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Extend>, const ram::Extend& extend) {
     size_t src = encodeRelation(extend.getFirstRelation());
     size_t target = encodeRelation(extend.getSecondRelation());
     return mk<Extend>(I_Extend, &extend, src, target);
 }
 
-NodePtr NodeGenerator::visitSwap(const ram::Swap& swap) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Swap>, const ram::Swap& swap) {
     size_t src = encodeRelation(swap.getFirstRelation());
     size_t target = encodeRelation(swap.getSecondRelation());
     return mk<Swap>(I_Swap, &swap, src, target);
 }
 
-NodePtr NodeGenerator::visitUndefValue(const ram::UndefValue&) {
+NodePtr NodeGenerator::visit_(type_identity<ram::UndefValue>, const ram::UndefValue&) {
     return nullptr;
 }
 
-NodePtr NodeGenerator::visitNode(const ram::Node& node) {
+NodePtr NodeGenerator::visit_(type_identity<ram::Node>, const ram::Node& node) {
     fatal("unsupported node type: %s", typeid(node).name());
 }
 
@@ -600,7 +608,7 @@ SuperInstruction NodeGenerator::getIndexSuperInstInfo(const ram::IndexOperation&
         }
 
         // Generic expression
-        indexOperation.exprFirst.push_back(std::pair<size_t, Own<Node>>(i, visit(low)));
+        indexOperation.exprFirst.push_back(std::pair<size_t, Own<Node>>(i, visit(*low)));
     }
     const auto& second = ramIndex.getRangePattern().second;
     for (size_t i = 0; i < arity; ++i) {
@@ -629,7 +637,7 @@ SuperInstruction NodeGenerator::getIndexSuperInstInfo(const ram::IndexOperation&
         }
 
         // Generic expression
-        indexOperation.exprSecond.push_back(std::pair<size_t, Own<Node>>(i, visit(hig)));
+        indexOperation.exprSecond.push_back(std::pair<size_t, Own<Node>>(i, visit(*hig)));
     }
     return indexOperation;
 }
@@ -676,7 +684,7 @@ SuperInstruction NodeGenerator::getExistenceSuperInstInfo(const ram::AbstractExi
         }
 
         // Generic expression
-        superOp.exprFirst.push_back(std::pair<size_t, Own<Node>>(i, visit(child)));
+        superOp.exprFirst.push_back(std::pair<size_t, Own<Node>>(i, visit(*child)));
     }
     return superOp;
 }
@@ -704,7 +712,7 @@ SuperInstruction NodeGenerator::getProjectSuperInstInfo(const ram::Project& exis
         }
 
         // Generic expression
-        superOp.exprFirst.push_back(std::pair<size_t, Own<Node>>(i, visit(child)));
+        superOp.exprFirst.push_back(std::pair<size_t, Own<Node>>(i, visit(*child)));
     }
     return superOp;
 }

--- a/src/interpreter/Generator.h
+++ b/src/interpreter/Generator.h
@@ -123,111 +123,111 @@ public:
      */
     NodePtr generateTree(const ram::Node& root);
 
-    NodePtr visitConstant(const ram::Constant& num) override;
+    NodePtr visit_(type_identity<ram::Constant>,const ram::Constant& num) override;
 
-    NodePtr visitTupleElement(const ram::TupleElement& access) override;
+    NodePtr visit_(type_identity<ram::TupleElement>,const ram::TupleElement& access) override;
 
-    NodePtr visitAutoIncrement(const ram::AutoIncrement& inc) override;
+    NodePtr visit_(type_identity<ram::AutoIncrement>,const ram::AutoIncrement& inc) override;
 
-    NodePtr visitIntrinsicOperator(const ram::IntrinsicOperator& op) override;
+    NodePtr visit_(type_identity<ram::IntrinsicOperator>,const ram::IntrinsicOperator& op) override;
 
-    NodePtr visitUserDefinedOperator(const ram::UserDefinedOperator& op) override;
+    NodePtr visit_(type_identity<ram::UserDefinedOperator>,const ram::UserDefinedOperator& op) override;
 
-    NodePtr visitNestedIntrinsicOperator(const ram::NestedIntrinsicOperator& op) override;
+    NodePtr visit_(type_identity<ram::NestedIntrinsicOperator>,const ram::NestedIntrinsicOperator& op) override;
 
-    NodePtr visitPackRecord(const ram::PackRecord& pr) override;
+    NodePtr visit_(type_identity<ram::PackRecord>,const ram::PackRecord& pr) override;
 
-    NodePtr visitSubroutineArgument(const ram::SubroutineArgument& arg) override;
+    NodePtr visit_(type_identity<ram::SubroutineArgument>,const ram::SubroutineArgument& arg) override;
 
-    NodePtr visitTrue(const ram::True& ltrue) override;
+    NodePtr visit_(type_identity<ram::True>,const ram::True& ltrue) override;
 
-    NodePtr visitFalse(const ram::False& lfalse) override;
+    NodePtr visit_(type_identity<ram::False>,const ram::False& lfalse) override;
 
-    NodePtr visitConjunction(const ram::Conjunction& conj) override;
+    NodePtr visit_(type_identity<ram::Conjunction>,const ram::Conjunction& conj) override;
 
-    NodePtr visitNegation(const ram::Negation& neg) override;
+    NodePtr visit_(type_identity<ram::Negation>,const ram::Negation& neg) override;
 
-    NodePtr visitEmptinessCheck(const ram::EmptinessCheck& emptiness) override;
+    NodePtr visit_(type_identity<ram::EmptinessCheck>,const ram::EmptinessCheck& emptiness) override;
 
-    NodePtr visitRelationSize(const ram::RelationSize& size) override;
+    NodePtr visit_(type_identity<ram::RelationSize>,const ram::RelationSize& size) override;
 
-    NodePtr visitExistenceCheck(const ram::ExistenceCheck& exists) override;
+    NodePtr visit_(type_identity<ram::ExistenceCheck>,const ram::ExistenceCheck& exists) override;
 
-    NodePtr visitProvenanceExistenceCheck(const ram::ProvenanceExistenceCheck& provExists) override;
+    NodePtr visit_(type_identity<ram::ProvenanceExistenceCheck>,const ram::ProvenanceExistenceCheck& provExists) override;
 
-    NodePtr visitConstraint(const ram::Constraint& relOp) override;
+    NodePtr visit_(type_identity<ram::Constraint>,const ram::Constraint& relOp) override;
 
-    NodePtr visitNestedOperation(const ram::NestedOperation& nested) override;
+    NodePtr visit_(type_identity<ram::NestedOperation>,const ram::NestedOperation& nested) override;
 
-    NodePtr visitTupleOperation(const ram::TupleOperation& search) override;
+    NodePtr visit_(type_identity<ram::TupleOperation>,const ram::TupleOperation& search) override;
 
-    NodePtr visitScan(const ram::Scan& scan) override;
+    NodePtr visit_(type_identity<ram::Scan>,const ram::Scan& scan) override;
 
-    NodePtr visitParallelScan(const ram::ParallelScan& pScan) override;
+    NodePtr visit_(type_identity<ram::ParallelScan>,const ram::ParallelScan& pScan) override;
 
-    NodePtr visitIndexScan(const ram::IndexScan& iScan) override;
+    NodePtr visit_(type_identity<ram::IndexScan>,const ram::IndexScan& iScan) override;
 
-    NodePtr visitParallelIndexScan(const ram::ParallelIndexScan& piscan) override;
+    NodePtr visit_(type_identity<ram::ParallelIndexScan>,const ram::ParallelIndexScan& piscan) override;
 
-    NodePtr visitChoice(const ram::Choice& choice) override;
+    NodePtr visit_(type_identity<ram::Choice>,const ram::Choice& choice) override;
 
-    NodePtr visitParallelChoice(const ram::ParallelChoice& pChoice) override;
+    NodePtr visit_(type_identity<ram::ParallelChoice>,const ram::ParallelChoice& pChoice) override;
 
-    NodePtr visitIndexChoice(const ram::IndexChoice& iChoice) override;
+    NodePtr visit_(type_identity<ram::IndexChoice>,const ram::IndexChoice& iChoice) override;
 
-    NodePtr visitParallelIndexChoice(const ram::ParallelIndexChoice& piChoice) override;
+    NodePtr visit_(type_identity<ram::ParallelIndexChoice>,const ram::ParallelIndexChoice& piChoice) override;
 
-    NodePtr visitUnpackRecord(const ram::UnpackRecord& unpack) override;
+    NodePtr visit_(type_identity<ram::UnpackRecord>,const ram::UnpackRecord& unpack) override;
 
-    NodePtr visitAggregate(const ram::Aggregate& aggregate) override;
+    NodePtr visit_(type_identity<ram::Aggregate>,const ram::Aggregate& aggregate) override;
 
-    NodePtr visitParallelAggregate(const ram::ParallelAggregate& pAggregate) override;
+    NodePtr visit_(type_identity<ram::ParallelAggregate>,const ram::ParallelAggregate& pAggregate) override;
 
-    NodePtr visitIndexAggregate(const ram::IndexAggregate& iAggregate) override;
+    NodePtr visit_(type_identity<ram::IndexAggregate>,const ram::IndexAggregate& iAggregate) override;
 
-    NodePtr visitParallelIndexAggregate(const ram::ParallelIndexAggregate& piAggregate) override;
+    NodePtr visit_(type_identity<ram::ParallelIndexAggregate>,const ram::ParallelIndexAggregate& piAggregate) override;
 
-    NodePtr visitBreak(const ram::Break& breakOp) override;
+    NodePtr visit_(type_identity<ram::Break>,const ram::Break& breakOp) override;
 
-    NodePtr visitFilter(const ram::Filter& filter) override;
+    NodePtr visit_(type_identity<ram::Filter>,const ram::Filter& filter) override;
 
-    NodePtr visitGuardedProject(const ram::GuardedProject& guardedPorject) override;
+    NodePtr visit_(type_identity<ram::GuardedProject>,const ram::GuardedProject& guardedPorject) override;
 
-    NodePtr visitProject(const ram::Project& project) override;
+    NodePtr visit_(type_identity<ram::Project>,const ram::Project& project) override;
 
-    NodePtr visitSubroutineReturn(const ram::SubroutineReturn& ret) override;
+    NodePtr visit_(type_identity<ram::SubroutineReturn>,const ram::SubroutineReturn& ret) override;
 
-    NodePtr visitSequence(const ram::Sequence& seq) override;
+    NodePtr visit_(type_identity<ram::Sequence>,const ram::Sequence& seq) override;
 
-    NodePtr visitParallel(const ram::Parallel& parallel) override;
+    NodePtr visit_(type_identity<ram::Parallel>,const ram::Parallel& parallel) override;
 
-    NodePtr visitLoop(const ram::Loop& loop) override;
+    NodePtr visit_(type_identity<ram::Loop>,const ram::Loop& loop) override;
 
-    NodePtr visitExit(const ram::Exit& exit) override;
+    NodePtr visit_(type_identity<ram::Exit>,const ram::Exit& exit) override;
 
-    NodePtr visitCall(const ram::Call& call) override;
+    NodePtr visit_(type_identity<ram::Call>,const ram::Call& call) override;
 
-    NodePtr visitLogRelationTimer(const ram::LogRelationTimer& timer) override;
+    NodePtr visit_(type_identity<ram::LogRelationTimer>,const ram::LogRelationTimer& timer) override;
 
-    NodePtr visitLogTimer(const ram::LogTimer& timer) override;
+    NodePtr visit_(type_identity<ram::LogTimer>,const ram::LogTimer& timer) override;
 
-    NodePtr visitDebugInfo(const ram::DebugInfo& dbg) override;
+    NodePtr visit_(type_identity<ram::DebugInfo>,const ram::DebugInfo& dbg) override;
 
-    NodePtr visitClear(const ram::Clear& clear) override;
+    NodePtr visit_(type_identity<ram::Clear>,const ram::Clear& clear) override;
 
-    NodePtr visitLogSize(const ram::LogSize& size) override;
+    NodePtr visit_(type_identity<ram::LogSize>,const ram::LogSize& size) override;
 
-    NodePtr visitIO(const ram::IO& io) override;
+    NodePtr visit_(type_identity<ram::IO>,const ram::IO& io) override;
 
-    NodePtr visitQuery(const ram::Query& query) override;
+    NodePtr visit_(type_identity<ram::Query>,const ram::Query& query) override;
 
-    NodePtr visitExtend(const ram::Extend& extend) override;
+    NodePtr visit_(type_identity<ram::Extend>,const ram::Extend& extend) override;
 
-    NodePtr visitSwap(const ram::Swap& swap) override;
+    NodePtr visit_(type_identity<ram::Swap>,const ram::Swap& swap) override;
 
-    NodePtr visitUndefValue(const ram::UndefValue&) override;
+    NodePtr visit_(type_identity<ram::UndefValue>,const ram::UndefValue&) override;
 
-    NodePtr visitNode(const ram::Node& node) override;
+    NodePtr visit_(type_identity<ram::Node>,const ram::Node& node) override;
 
 private:
     /**

--- a/src/interpreter/Generator.h
+++ b/src/interpreter/Generator.h
@@ -123,111 +123,115 @@ public:
      */
     NodePtr generateTree(const ram::Node& root);
 
-    NodePtr visit_(type_identity<ram::Constant>,const ram::Constant& num) override;
+    NodePtr visit_(type_identity<ram::Constant>, const ram::Constant& num) override;
 
-    NodePtr visit_(type_identity<ram::TupleElement>,const ram::TupleElement& access) override;
+    NodePtr visit_(type_identity<ram::TupleElement>, const ram::TupleElement& access) override;
 
-    NodePtr visit_(type_identity<ram::AutoIncrement>,const ram::AutoIncrement& inc) override;
+    NodePtr visit_(type_identity<ram::AutoIncrement>, const ram::AutoIncrement& inc) override;
 
-    NodePtr visit_(type_identity<ram::IntrinsicOperator>,const ram::IntrinsicOperator& op) override;
+    NodePtr visit_(type_identity<ram::IntrinsicOperator>, const ram::IntrinsicOperator& op) override;
 
-    NodePtr visit_(type_identity<ram::UserDefinedOperator>,const ram::UserDefinedOperator& op) override;
+    NodePtr visit_(type_identity<ram::UserDefinedOperator>, const ram::UserDefinedOperator& op) override;
 
-    NodePtr visit_(type_identity<ram::NestedIntrinsicOperator>,const ram::NestedIntrinsicOperator& op) override;
+    NodePtr visit_(
+            type_identity<ram::NestedIntrinsicOperator>, const ram::NestedIntrinsicOperator& op) override;
 
-    NodePtr visit_(type_identity<ram::PackRecord>,const ram::PackRecord& pr) override;
+    NodePtr visit_(type_identity<ram::PackRecord>, const ram::PackRecord& pr) override;
 
-    NodePtr visit_(type_identity<ram::SubroutineArgument>,const ram::SubroutineArgument& arg) override;
+    NodePtr visit_(type_identity<ram::SubroutineArgument>, const ram::SubroutineArgument& arg) override;
 
-    NodePtr visit_(type_identity<ram::True>,const ram::True& ltrue) override;
+    NodePtr visit_(type_identity<ram::True>, const ram::True& ltrue) override;
 
-    NodePtr visit_(type_identity<ram::False>,const ram::False& lfalse) override;
+    NodePtr visit_(type_identity<ram::False>, const ram::False& lfalse) override;
 
-    NodePtr visit_(type_identity<ram::Conjunction>,const ram::Conjunction& conj) override;
+    NodePtr visit_(type_identity<ram::Conjunction>, const ram::Conjunction& conj) override;
 
-    NodePtr visit_(type_identity<ram::Negation>,const ram::Negation& neg) override;
+    NodePtr visit_(type_identity<ram::Negation>, const ram::Negation& neg) override;
 
-    NodePtr visit_(type_identity<ram::EmptinessCheck>,const ram::EmptinessCheck& emptiness) override;
+    NodePtr visit_(type_identity<ram::EmptinessCheck>, const ram::EmptinessCheck& emptiness) override;
 
-    NodePtr visit_(type_identity<ram::RelationSize>,const ram::RelationSize& size) override;
+    NodePtr visit_(type_identity<ram::RelationSize>, const ram::RelationSize& size) override;
 
-    NodePtr visit_(type_identity<ram::ExistenceCheck>,const ram::ExistenceCheck& exists) override;
+    NodePtr visit_(type_identity<ram::ExistenceCheck>, const ram::ExistenceCheck& exists) override;
 
-    NodePtr visit_(type_identity<ram::ProvenanceExistenceCheck>,const ram::ProvenanceExistenceCheck& provExists) override;
+    NodePtr visit_(type_identity<ram::ProvenanceExistenceCheck>,
+            const ram::ProvenanceExistenceCheck& provExists) override;
 
-    NodePtr visit_(type_identity<ram::Constraint>,const ram::Constraint& relOp) override;
+    NodePtr visit_(type_identity<ram::Constraint>, const ram::Constraint& relOp) override;
 
-    NodePtr visit_(type_identity<ram::NestedOperation>,const ram::NestedOperation& nested) override;
+    NodePtr visit_(type_identity<ram::NestedOperation>, const ram::NestedOperation& nested) override;
 
-    NodePtr visit_(type_identity<ram::TupleOperation>,const ram::TupleOperation& search) override;
+    NodePtr visit_(type_identity<ram::TupleOperation>, const ram::TupleOperation& search) override;
 
-    NodePtr visit_(type_identity<ram::Scan>,const ram::Scan& scan) override;
+    NodePtr visit_(type_identity<ram::Scan>, const ram::Scan& scan) override;
 
-    NodePtr visit_(type_identity<ram::ParallelScan>,const ram::ParallelScan& pScan) override;
+    NodePtr visit_(type_identity<ram::ParallelScan>, const ram::ParallelScan& pScan) override;
 
-    NodePtr visit_(type_identity<ram::IndexScan>,const ram::IndexScan& iScan) override;
+    NodePtr visit_(type_identity<ram::IndexScan>, const ram::IndexScan& iScan) override;
 
-    NodePtr visit_(type_identity<ram::ParallelIndexScan>,const ram::ParallelIndexScan& piscan) override;
+    NodePtr visit_(type_identity<ram::ParallelIndexScan>, const ram::ParallelIndexScan& piscan) override;
 
-    NodePtr visit_(type_identity<ram::Choice>,const ram::Choice& choice) override;
+    NodePtr visit_(type_identity<ram::Choice>, const ram::Choice& choice) override;
 
-    NodePtr visit_(type_identity<ram::ParallelChoice>,const ram::ParallelChoice& pChoice) override;
+    NodePtr visit_(type_identity<ram::ParallelChoice>, const ram::ParallelChoice& pChoice) override;
 
-    NodePtr visit_(type_identity<ram::IndexChoice>,const ram::IndexChoice& iChoice) override;
+    NodePtr visit_(type_identity<ram::IndexChoice>, const ram::IndexChoice& iChoice) override;
 
-    NodePtr visit_(type_identity<ram::ParallelIndexChoice>,const ram::ParallelIndexChoice& piChoice) override;
+    NodePtr visit_(
+            type_identity<ram::ParallelIndexChoice>, const ram::ParallelIndexChoice& piChoice) override;
 
-    NodePtr visit_(type_identity<ram::UnpackRecord>,const ram::UnpackRecord& unpack) override;
+    NodePtr visit_(type_identity<ram::UnpackRecord>, const ram::UnpackRecord& unpack) override;
 
-    NodePtr visit_(type_identity<ram::Aggregate>,const ram::Aggregate& aggregate) override;
+    NodePtr visit_(type_identity<ram::Aggregate>, const ram::Aggregate& aggregate) override;
 
-    NodePtr visit_(type_identity<ram::ParallelAggregate>,const ram::ParallelAggregate& pAggregate) override;
+    NodePtr visit_(type_identity<ram::ParallelAggregate>, const ram::ParallelAggregate& pAggregate) override;
 
-    NodePtr visit_(type_identity<ram::IndexAggregate>,const ram::IndexAggregate& iAggregate) override;
+    NodePtr visit_(type_identity<ram::IndexAggregate>, const ram::IndexAggregate& iAggregate) override;
 
-    NodePtr visit_(type_identity<ram::ParallelIndexAggregate>,const ram::ParallelIndexAggregate& piAggregate) override;
+    NodePtr visit_(type_identity<ram::ParallelIndexAggregate>,
+            const ram::ParallelIndexAggregate& piAggregate) override;
 
-    NodePtr visit_(type_identity<ram::Break>,const ram::Break& breakOp) override;
+    NodePtr visit_(type_identity<ram::Break>, const ram::Break& breakOp) override;
 
-    NodePtr visit_(type_identity<ram::Filter>,const ram::Filter& filter) override;
+    NodePtr visit_(type_identity<ram::Filter>, const ram::Filter& filter) override;
 
-    NodePtr visit_(type_identity<ram::GuardedProject>,const ram::GuardedProject& guardedPorject) override;
+    NodePtr visit_(type_identity<ram::GuardedProject>, const ram::GuardedProject& guardedPorject) override;
 
-    NodePtr visit_(type_identity<ram::Project>,const ram::Project& project) override;
+    NodePtr visit_(type_identity<ram::Project>, const ram::Project& project) override;
 
-    NodePtr visit_(type_identity<ram::SubroutineReturn>,const ram::SubroutineReturn& ret) override;
+    NodePtr visit_(type_identity<ram::SubroutineReturn>, const ram::SubroutineReturn& ret) override;
 
-    NodePtr visit_(type_identity<ram::Sequence>,const ram::Sequence& seq) override;
+    NodePtr visit_(type_identity<ram::Sequence>, const ram::Sequence& seq) override;
 
-    NodePtr visit_(type_identity<ram::Parallel>,const ram::Parallel& parallel) override;
+    NodePtr visit_(type_identity<ram::Parallel>, const ram::Parallel& parallel) override;
 
-    NodePtr visit_(type_identity<ram::Loop>,const ram::Loop& loop) override;
+    NodePtr visit_(type_identity<ram::Loop>, const ram::Loop& loop) override;
 
-    NodePtr visit_(type_identity<ram::Exit>,const ram::Exit& exit) override;
+    NodePtr visit_(type_identity<ram::Exit>, const ram::Exit& exit) override;
 
-    NodePtr visit_(type_identity<ram::Call>,const ram::Call& call) override;
+    NodePtr visit_(type_identity<ram::Call>, const ram::Call& call) override;
 
-    NodePtr visit_(type_identity<ram::LogRelationTimer>,const ram::LogRelationTimer& timer) override;
+    NodePtr visit_(type_identity<ram::LogRelationTimer>, const ram::LogRelationTimer& timer) override;
 
-    NodePtr visit_(type_identity<ram::LogTimer>,const ram::LogTimer& timer) override;
+    NodePtr visit_(type_identity<ram::LogTimer>, const ram::LogTimer& timer) override;
 
-    NodePtr visit_(type_identity<ram::DebugInfo>,const ram::DebugInfo& dbg) override;
+    NodePtr visit_(type_identity<ram::DebugInfo>, const ram::DebugInfo& dbg) override;
 
-    NodePtr visit_(type_identity<ram::Clear>,const ram::Clear& clear) override;
+    NodePtr visit_(type_identity<ram::Clear>, const ram::Clear& clear) override;
 
-    NodePtr visit_(type_identity<ram::LogSize>,const ram::LogSize& size) override;
+    NodePtr visit_(type_identity<ram::LogSize>, const ram::LogSize& size) override;
 
-    NodePtr visit_(type_identity<ram::IO>,const ram::IO& io) override;
+    NodePtr visit_(type_identity<ram::IO>, const ram::IO& io) override;
 
-    NodePtr visit_(type_identity<ram::Query>,const ram::Query& query) override;
+    NodePtr visit_(type_identity<ram::Query>, const ram::Query& query) override;
 
-    NodePtr visit_(type_identity<ram::Extend>,const ram::Extend& extend) override;
+    NodePtr visit_(type_identity<ram::Extend>, const ram::Extend& extend) override;
 
-    NodePtr visit_(type_identity<ram::Swap>,const ram::Swap& swap) override;
+    NodePtr visit_(type_identity<ram::Swap>, const ram::Swap& swap) override;
 
-    NodePtr visit_(type_identity<ram::UndefValue>,const ram::UndefValue&) override;
+    NodePtr visit_(type_identity<ram::UndefValue>, const ram::UndefValue&) override;
 
-    NodePtr visit_(type_identity<ram::Node>,const ram::Node& node) override;
+    NodePtr visit_(type_identity<ram::Node>, const ram::Node& node) override;
 
 private:
     /**

--- a/src/ram/analysis/Complexity.cpp
+++ b/src/ram/analysis/Complexity.cpp
@@ -36,33 +36,33 @@ int ComplexityAnalysis::getComplexity(const Node* node) const {
         ValueComplexityVisitor(RelationAnalysis* relAnalysis) : ra(relAnalysis) {}
 
         // conjunction
-        int visitConjunction(const Conjunction& conj) override {
+        int visit_(type_identity<Conjunction>, const Conjunction& conj) override {
             return visit(conj.getLHS()) + visit(conj.getRHS());
         }
 
         // negation
-        int visitNegation(const Negation& neg) override {
+        int visit_(type_identity<Negation>, const Negation& neg) override {
             return visit(neg.getOperand());
         }
 
         // existence check
-        int visitExistenceCheck(const ExistenceCheck&) override {
+        int visit_(type_identity<ExistenceCheck>, const ExistenceCheck&) override {
             return 2;
         }
 
         // provenance existence check
-        int visitProvenanceExistenceCheck(const ProvenanceExistenceCheck&) override {
+        int visit_(type_identity<ProvenanceExistenceCheck>, const ProvenanceExistenceCheck&) override {
             return 2;
         }
 
         // emptiness check
-        int visitEmptinessCheck(const EmptinessCheck& emptiness) override {
+        int visit_(type_identity<EmptinessCheck>, const EmptinessCheck& emptiness) override {
             // emptiness check for nullary relations is for free; others have weight one
             return (ra->lookup(emptiness.getRelation()).getArity() > 0) ? 1 : 0;
         }
 
         // default rule
-        int visitNode(const Node&) override {
+        int visit_(type_identity<Node>, const Node&) override {
             return 0;
         }
 
@@ -71,7 +71,7 @@ int ComplexityAnalysis::getComplexity(const Node* node) const {
     };
 
     assert((isA<Expression>(node) || isA<Condition>(node)) && "not an expression/condition/operation");
-    return ValueComplexityVisitor(ra).visit(node);
+    return ValueComplexityVisitor(ra).visit(*node);
 }
 
 }  // namespace souffle::ram::analysis

--- a/src/ram/analysis/Level.cpp
+++ b/src/ram/analysis/Level.cpp
@@ -60,7 +60,7 @@ int LevelAnalysis::getLevel(const Node* node) const {
     class ValueLevelVisitor : public Visitor<int> {
     public:
         // number
-        int visit_(type_identity<Constant>,const Constant&) override {
+        int visit_(type_identity<Constant>, const Constant&) override {
             return -1;
         }
 
@@ -241,7 +241,8 @@ int LevelAnalysis::getLevel(const Node* node) const {
         }
 
         // provenance existence check
-        int visit_(type_identity<ProvenanceExistenceCheck>, const ProvenanceExistenceCheck& provExists) override {
+        int visit_(type_identity<ProvenanceExistenceCheck>,
+                const ProvenanceExistenceCheck& provExists) override {
             int level = -1;
             for (const auto& cur : provExists.getValues()) {
                 level = std::max(level, visit(*cur));

--- a/src/ram/analysis/Level.cpp
+++ b/src/ram/analysis/Level.cpp
@@ -60,209 +60,209 @@ int LevelAnalysis::getLevel(const Node* node) const {
     class ValueLevelVisitor : public Visitor<int> {
     public:
         // number
-        int visitConstant(const Constant&) override {
+        int visit_(type_identity<Constant>,const Constant&) override {
             return -1;
         }
 
         // true
-        int visitTrue(const True&) override {
+        int visit_(type_identity<True>, const True&) override {
             return -1;
         }
 
         // false
-        int visitFalse(const False&) override {
+        int visit_(type_identity<False>, const False&) override {
             return -1;
         }
 
         // tuple element access
-        int visitTupleElement(const TupleElement& elem) override {
+        int visit_(type_identity<TupleElement>, const TupleElement& elem) override {
             return elem.getTupleId();
         }
 
         // scan
-        int visitScan(const Scan&) override {
+        int visit_(type_identity<Scan>, const Scan&) override {
             return -1;
         }
 
         // index scan
-        int visitIndexScan(const IndexScan& indexScan) override {
+        int visit_(type_identity<IndexScan>, const IndexScan& indexScan) override {
             int level = -1;
             for (auto& index : indexScan.getRangePattern().first) {
-                level = std::max(level, visit(index));
+                level = std::max(level, visit(*index));
             }
             for (auto& index : indexScan.getRangePattern().second) {
-                level = std::max(level, visit(index));
+                level = std::max(level, visit(*index));
             }
             return level;
         }
 
         // choice
-        int visitChoice(const Choice& choice) override {
+        int visit_(type_identity<Choice>, const Choice& choice) override {
             return std::max(-1, visit(choice.getCondition()));
         }
 
         // index choice
-        int visitIndexChoice(const IndexChoice& indexChoice) override {
+        int visit_(type_identity<IndexChoice>, const IndexChoice& indexChoice) override {
             int level = -1;
             for (auto& index : indexChoice.getRangePattern().first) {
-                level = std::max(level, visit(index));
+                level = std::max(level, visit(*index));
             }
             for (auto& index : indexChoice.getRangePattern().second) {
-                level = std::max(level, visit(index));
+                level = std::max(level, visit(*index));
             }
             return std::max(level, visit(indexChoice.getCondition()));
         }
 
         // aggregate
-        int visitAggregate(const Aggregate& aggregate) override {
+        int visit_(type_identity<Aggregate>, const Aggregate& aggregate) override {
             return std::max(visit(aggregate.getExpression()), visit(aggregate.getCondition()));
         }
 
         // index aggregate
-        int visitIndexAggregate(const IndexAggregate& indexAggregate) override {
+        int visit_(type_identity<IndexAggregate>, const IndexAggregate& indexAggregate) override {
             int level = -1;
             for (auto& index : indexAggregate.getRangePattern().first) {
-                level = std::max(level, visit(index));
+                level = std::max(level, visit(*index));
             }
             for (auto& index : indexAggregate.getRangePattern().second) {
-                level = std::max(level, visit(index));
+                level = std::max(level, visit(*index));
             }
             level = std::max(visit(indexAggregate.getExpression()), level);
             return std::max(level, visit(indexAggregate.getCondition()));
         }
 
         // unpack record
-        int visitUnpackRecord(const UnpackRecord& unpack) override {
+        int visit_(type_identity<UnpackRecord>, const UnpackRecord& unpack) override {
             return visit(unpack.getExpression());
         }
 
         // filter
-        int visitFilter(const Filter& filter) override {
+        int visit_(type_identity<Filter>, const Filter& filter) override {
             return visit(filter.getCondition());
         }
 
         // break
-        int visitBreak(const Break& b) override {
+        int visit_(type_identity<Break>, const Break& b) override {
             return visit(b.getCondition());
         }
 
         // guarded project
-        int visitGuardedProject(const GuardedProject& guardedProject) override {
+        int visit_(type_identity<GuardedProject>, const GuardedProject& guardedProject) override {
             int level = -1;
             for (auto& exp : guardedProject.getValues()) {
-                level = std::max(level, visit(exp));
+                level = std::max(level, visit(*exp));
             }
-            level = std::max(level, visit(guardedProject.getCondition()));
+            level = std::max(level, visit(*guardedProject.getCondition()));
             return level;
         }
 
         // project
-        int visitProject(const Project& project) override {
+        int visit_(type_identity<Project>, const Project& project) override {
             int level = -1;
             for (auto& exp : project.getValues()) {
-                level = std::max(level, visit(exp));
+                level = std::max(level, visit(*exp));
             }
             return level;
         }
 
         // return
-        int visitSubroutineReturn(const SubroutineReturn& ret) override {
+        int visit_(type_identity<SubroutineReturn>, const SubroutineReturn& ret) override {
             int level = -1;
             for (auto& exp : ret.getValues()) {
-                level = std::max(level, visit(exp));
+                level = std::max(level, visit(*exp));
             }
             return level;
         }
 
         // auto increment
-        int visitAutoIncrement(const AutoIncrement&) override {
+        int visit_(type_identity<AutoIncrement>, const AutoIncrement&) override {
             return -1;
         }
 
         // undef value
-        int visitUndefValue(const UndefValue&) override {
+        int visit_(type_identity<UndefValue>, const UndefValue&) override {
             return -1;
         }
 
         // intrinsic functors
-        int visitIntrinsicOperator(const IntrinsicOperator& op) override {
+        int visit_(type_identity<IntrinsicOperator>, const IntrinsicOperator& op) override {
             int level = -1;
             for (const auto& arg : op.getArguments()) {
-                level = std::max(level, visit(arg));
+                level = std::max(level, visit(*arg));
             }
             return level;
         }
 
         // pack operator
-        int visitPackRecord(const PackRecord& pack) override {
+        int visit_(type_identity<PackRecord>, const PackRecord& pack) override {
             int level = -1;
             for (const auto& arg : pack.getArguments()) {
-                level = std::max(level, visit(arg));
+                level = std::max(level, visit(*arg));
             }
             return level;
         }
 
         // argument
-        int visitSubroutineArgument(const SubroutineArgument&) override {
+        int visit_(type_identity<SubroutineArgument>, const SubroutineArgument&) override {
             return -1;
         }
 
         // user defined operator
-        int visitUserDefinedOperator(const UserDefinedOperator& op) override {
+        int visit_(type_identity<UserDefinedOperator>, const UserDefinedOperator& op) override {
             int level = -1;
             for (const auto& arg : op.getArguments()) {
-                level = std::max(level, visit(arg));
+                level = std::max(level, visit(*arg));
             }
             return level;
         }
 
         // conjunction
-        int visitConjunction(const Conjunction& conj) override {
+        int visit_(type_identity<Conjunction>, const Conjunction& conj) override {
             return std::max(visit(conj.getLHS()), visit(conj.getRHS()));
         }
 
         // negation
-        int visitNegation(const Negation& neg) override {
+        int visit_(type_identity<Negation>, const Negation& neg) override {
             return visit(neg.getOperand());
         }
 
         // constraint
-        int visitConstraint(const Constraint& binRel) override {
+        int visit_(type_identity<Constraint>, const Constraint& binRel) override {
             return std::max(visit(binRel.getLHS()), visit(binRel.getRHS()));
         }
 
         // existence check
-        int visitExistenceCheck(const ExistenceCheck& exists) override {
+        int visit_(type_identity<ExistenceCheck>, const ExistenceCheck& exists) override {
             int level = -1;
             for (const auto& cur : exists.getValues()) {
-                level = std::max(level, visit(cur));
+                level = std::max(level, visit(*cur));
             }
             return level;
         }
 
         // provenance existence check
-        int visitProvenanceExistenceCheck(const ProvenanceExistenceCheck& provExists) override {
+        int visit_(type_identity<ProvenanceExistenceCheck>, const ProvenanceExistenceCheck& provExists) override {
             int level = -1;
             for (const auto& cur : provExists.getValues()) {
-                level = std::max(level, visit(cur));
+                level = std::max(level, visit(*cur));
             }
             return level;
         }
 
         // emptiness check
-        int visitEmptinessCheck(const EmptinessCheck&) override {
+        int visit_(type_identity<EmptinessCheck>, const EmptinessCheck&) override {
             return -1;  // can be in the top level
         }
 
         // default rule
-        int visitNode(const Node&) override {
+        int visit_(type_identity<Node>, const Node&) override {
             fatal("Node not implemented!");
         }
     };
 
     assert((isA<Expression>(node) || isA<Condition>(node) || isA<Operation>(node)) &&
             "not an expression/condition/operation");
-    return ValueLevelVisitor().visit(node);
+    return ValueLevelVisitor().visit(*node);
 }
 
 }  // namespace souffle::ram::analysis

--- a/src/ram/utility/Visitor.h
+++ b/src/ram/utility/Visitor.h
@@ -87,9 +87,9 @@
 #include "ram/UnpackRecord.h"
 #include "ram/UnsignedConstant.h"
 #include "ram/UserDefinedOperator.h"
+#include "souffle/Visitor.h"
 #include "souffle/utility/FunctionalUtil.h"
 #include "souffle/utility/MiscUtil.h"
-#include "souffle/Visitor.h"
 #include <cstddef>
 #include <functional>
 #include <type_traits>

--- a/src/ram/utility/Visitor.h
+++ b/src/ram/utility/Visitor.h
@@ -89,6 +89,7 @@
 #include "ram/UserDefinedOperator.h"
 #include "souffle/utility/FunctionalUtil.h"
 #include "souffle/utility/MiscUtil.h"
+#include "souffle/Visitor.h"
 #include <cstddef>
 #include <functional>
 #include <type_traits>
@@ -96,334 +97,176 @@
 #include <vector>
 
 namespace souffle::ram {
-
-/** A tag type required for the is_ram_visitor type trait to identify RamVisitors */
-struct ram_visitor_tag {};
-
 /**
- * The generic base type of all RamVisitors realizing the dispatching of
- * visitor calls. Each visitor may define a return type R and a list of
- * extra parameters to be passed along with the visited Nodes to the
- * corresponding visitor function.
- *
- * @tparam R the result type produced by a visit call
- * @tparam Params extra parameters to be passed to the visit call
+ * The generic base type of all RamVisitors
+ * @see souffle::Visitor
  */
-template <typename R = void, typename... Params>
-struct Visitor : public ram_visitor_tag {
-    /** A virtual destructor */
-    virtual ~Visitor() = default;
+template <typename R = void, typename NodeType = Node const, typename... Params>
+struct Visitor : public souffle::Visitor<R, NodeType, Params...> {
+    using souffle::Visitor<R, NodeType, Params...>::visit_;
 
-    /** The main entry for the user allowing visitors to be utilized as functions */
-    R operator()(const Node& node, Params... args) {
-        return visit(node, args...);
-    }
-
-    /** The main entry for the user allowing visitors to be utilized as functions */
-    R operator()(const Node* node, Params... args) {
-        return visit(*node, args...);
-    }
-
-    /**
-     * The main entry for a visit process conducting the dispatching of
-     * a visit to the various sub-types of Nodes. Sub-classes may override
-     * this implementation to conduct pre-visit operations.
-     *
-     * Note that the order of this list is important. Sub-classes must be listed
-     * before their super-classes; otherwise sub-classes cannot be visited.
-     *
-     * @param node the node to be visited
-     * @param args a list of extra parameters to be forwarded
-     */
-    virtual R visit(const Node& node, Params... args) {
+    virtual R visit(const Node& node, Params... args) override {
         // dispatch node processing based on dynamic type
 
-#define FORWARD(Kind) \
-    if (const auto* n = as<Kind>(node)) return visit##Kind(*n, args...);
-
         // Relation
-        FORWARD(Relation);
+        SOUFFLE_VISITOR_FORWARD(Relation);
 
         // Expressions
-        FORWARD(TupleElement);
-        FORWARD(SignedConstant);
-        FORWARD(UnsignedConstant);
-        FORWARD(FloatConstant);
-        FORWARD(Constant);
-        FORWARD(IntrinsicOperator);
-        FORWARD(UserDefinedOperator);
-        FORWARD(AutoIncrement);
-        FORWARD(PackRecord);
-        FORWARD(SubroutineArgument);
-        FORWARD(UndefValue);
-        FORWARD(RelationSize);
+        SOUFFLE_VISITOR_FORWARD(TupleElement);
+        SOUFFLE_VISITOR_FORWARD(SignedConstant);
+        SOUFFLE_VISITOR_FORWARD(UnsignedConstant);
+        SOUFFLE_VISITOR_FORWARD(FloatConstant);
+        SOUFFLE_VISITOR_FORWARD(Constant);
+        SOUFFLE_VISITOR_FORWARD(IntrinsicOperator);
+        SOUFFLE_VISITOR_FORWARD(UserDefinedOperator);
+        SOUFFLE_VISITOR_FORWARD(AutoIncrement);
+        SOUFFLE_VISITOR_FORWARD(PackRecord);
+        SOUFFLE_VISITOR_FORWARD(SubroutineArgument);
+        SOUFFLE_VISITOR_FORWARD(UndefValue);
+        SOUFFLE_VISITOR_FORWARD(RelationSize);
 
         // Conditions
-        FORWARD(True);
-        FORWARD(False);
-        FORWARD(EmptinessCheck);
-        FORWARD(ProvenanceExistenceCheck);
-        FORWARD(ExistenceCheck);
-        FORWARD(Conjunction);
-        FORWARD(Negation);
-        FORWARD(Constraint);
+        SOUFFLE_VISITOR_FORWARD(True);
+        SOUFFLE_VISITOR_FORWARD(False);
+        SOUFFLE_VISITOR_FORWARD(EmptinessCheck);
+        SOUFFLE_VISITOR_FORWARD(ProvenanceExistenceCheck);
+        SOUFFLE_VISITOR_FORWARD(ExistenceCheck);
+        SOUFFLE_VISITOR_FORWARD(Conjunction);
+        SOUFFLE_VISITOR_FORWARD(Negation);
+        SOUFFLE_VISITOR_FORWARD(Constraint);
 
         // Operations
-        FORWARD(Filter);
-        FORWARD(Break);
-        FORWARD(GuardedProject);
-        FORWARD(Project);
-        FORWARD(SubroutineReturn);
-        FORWARD(UnpackRecord);
-        FORWARD(NestedIntrinsicOperator);
-        FORWARD(ParallelScan);
-        FORWARD(Scan);
-        FORWARD(ParallelIndexScan);
-        FORWARD(IndexScan);
-        FORWARD(ParallelChoice);
-        FORWARD(Choice);
-        FORWARD(ParallelIndexChoice);
-        FORWARD(IndexChoice);
-        FORWARD(ParallelAggregate);
-        FORWARD(Aggregate);
-        FORWARD(ParallelIndexAggregate);
-        FORWARD(IndexAggregate);
+        SOUFFLE_VISITOR_FORWARD(Filter);
+        SOUFFLE_VISITOR_FORWARD(Break);
+        SOUFFLE_VISITOR_FORWARD(GuardedProject);
+        SOUFFLE_VISITOR_FORWARD(Project);
+        SOUFFLE_VISITOR_FORWARD(SubroutineReturn);
+        SOUFFLE_VISITOR_FORWARD(UnpackRecord);
+        SOUFFLE_VISITOR_FORWARD(NestedIntrinsicOperator);
+        SOUFFLE_VISITOR_FORWARD(ParallelScan);
+        SOUFFLE_VISITOR_FORWARD(Scan);
+        SOUFFLE_VISITOR_FORWARD(ParallelIndexScan);
+        SOUFFLE_VISITOR_FORWARD(IndexScan);
+        SOUFFLE_VISITOR_FORWARD(ParallelChoice);
+        SOUFFLE_VISITOR_FORWARD(Choice);
+        SOUFFLE_VISITOR_FORWARD(ParallelIndexChoice);
+        SOUFFLE_VISITOR_FORWARD(IndexChoice);
+        SOUFFLE_VISITOR_FORWARD(ParallelAggregate);
+        SOUFFLE_VISITOR_FORWARD(Aggregate);
+        SOUFFLE_VISITOR_FORWARD(ParallelIndexAggregate);
+        SOUFFLE_VISITOR_FORWARD(IndexAggregate);
 
         // Statements
-        FORWARD(IO);
-        FORWARD(Query);
-        FORWARD(Clear);
-        FORWARD(LogSize);
+        SOUFFLE_VISITOR_FORWARD(IO);
+        SOUFFLE_VISITOR_FORWARD(Query);
+        SOUFFLE_VISITOR_FORWARD(Clear);
+        SOUFFLE_VISITOR_FORWARD(LogSize);
 
-        FORWARD(Swap);
-        FORWARD(Extend);
+        SOUFFLE_VISITOR_FORWARD(Swap);
+        SOUFFLE_VISITOR_FORWARD(Extend);
 
         // Control-flow
-        FORWARD(Program);
-        FORWARD(Sequence);
-        FORWARD(Loop);
-        FORWARD(Parallel);
-        FORWARD(Exit);
-        FORWARD(LogTimer);
-        FORWARD(LogRelationTimer);
-        FORWARD(DebugInfo);
-        FORWARD(Call);
-
-#undef FORWARD
+        SOUFFLE_VISITOR_FORWARD(Program);
+        SOUFFLE_VISITOR_FORWARD(Sequence);
+        SOUFFLE_VISITOR_FORWARD(Loop);
+        SOUFFLE_VISITOR_FORWARD(Parallel);
+        SOUFFLE_VISITOR_FORWARD(Exit);
+        SOUFFLE_VISITOR_FORWARD(LogTimer);
+        SOUFFLE_VISITOR_FORWARD(LogRelationTimer);
+        SOUFFLE_VISITOR_FORWARD(DebugInfo);
+        SOUFFLE_VISITOR_FORWARD(Call);
 
         // did not work ...
         fatal("unsupported type: %s", typeid(node).name());
     }
 
-    virtual R visit(const Node* node, Params... args) {
-        return visit(*node, args...);
-    }
-
 protected:
-#define LINK(Node, Parent)                                 \
-    virtual R visit##Node(const Node& n, Params... args) { \
-        return visit##Parent(n, args...);                  \
-    }
-
     // -- statements --
-    LINK(IO, RelationStatement);
-    LINK(Query, Statement);
-    LINK(Clear, RelationStatement);
-    LINK(LogSize, RelationStatement);
+    SOUFFLE_VISITOR_LINK(IO, RelationStatement);
+    SOUFFLE_VISITOR_LINK(Query, Statement);
+    SOUFFLE_VISITOR_LINK(Clear, RelationStatement);
+    SOUFFLE_VISITOR_LINK(LogSize, RelationStatement);
 
-    LINK(RelationStatement, Statement);
+    SOUFFLE_VISITOR_LINK(RelationStatement, Statement);
 
-    LINK(Swap, BinRelationStatement);
-    LINK(Extend, BinRelationStatement);
-    LINK(BinRelationStatement, Statement);
+    SOUFFLE_VISITOR_LINK(Swap, BinRelationStatement);
+    SOUFFLE_VISITOR_LINK(Extend, BinRelationStatement);
+    SOUFFLE_VISITOR_LINK(BinRelationStatement, Statement);
 
-    LINK(Sequence, ListStatement);
-    LINK(Loop, Statement);
-    LINK(Parallel, ListStatement);
-    LINK(ListStatement, Statement);
-    LINK(Exit, Statement);
-    LINK(LogTimer, Statement);
-    LINK(LogRelationTimer, Statement);
-    LINK(DebugInfo, Statement);
-    LINK(Call, Statement);
+    SOUFFLE_VISITOR_LINK(Sequence, ListStatement);
+    SOUFFLE_VISITOR_LINK(Loop, Statement);
+    SOUFFLE_VISITOR_LINK(Parallel, ListStatement);
+    SOUFFLE_VISITOR_LINK(ListStatement, Statement);
+    SOUFFLE_VISITOR_LINK(Exit, Statement);
+    SOUFFLE_VISITOR_LINK(LogTimer, Statement);
+    SOUFFLE_VISITOR_LINK(LogRelationTimer, Statement);
+    SOUFFLE_VISITOR_LINK(DebugInfo, Statement);
+    SOUFFLE_VISITOR_LINK(Call, Statement);
 
-    LINK(Statement, Node);
+    SOUFFLE_VISITOR_LINK(Statement, Node);
 
     // -- operations --
-    LINK(GuardedProject, Project);
-    LINK(Project, Operation);
-    LINK(SubroutineReturn, Operation);
-    LINK(UnpackRecord, TupleOperation);
-    LINK(NestedIntrinsicOperator, TupleOperation)
-    LINK(Scan, RelationOperation);
-    LINK(ParallelScan, Scan);
-    LINK(IndexScan, IndexOperation);
-    LINK(ParallelIndexScan, IndexScan);
-    LINK(Choice, RelationOperation);
-    LINK(ParallelChoice, Choice);
-    LINK(IndexChoice, IndexOperation);
-    LINK(ParallelIndexChoice, IndexChoice);
-    LINK(RelationOperation, TupleOperation);
-    LINK(Aggregate, RelationOperation);
-    LINK(ParallelAggregate, Aggregate);
-    LINK(IndexAggregate, IndexOperation);
-    LINK(ParallelIndexAggregate, IndexAggregate);
-    LINK(IndexOperation, RelationOperation);
-    LINK(TupleOperation, NestedOperation);
-    LINK(Filter, AbstractConditional);
-    LINK(Break, AbstractConditional);
-    LINK(AbstractConditional, NestedOperation);
-    LINK(NestedOperation, Operation);
+    SOUFFLE_VISITOR_LINK(GuardedProject, Project);
+    SOUFFLE_VISITOR_LINK(Project, Operation);
+    SOUFFLE_VISITOR_LINK(SubroutineReturn, Operation);
+    SOUFFLE_VISITOR_LINK(UnpackRecord, TupleOperation);
+    SOUFFLE_VISITOR_LINK(NestedIntrinsicOperator, TupleOperation)
+    SOUFFLE_VISITOR_LINK(Scan, RelationOperation);
+    SOUFFLE_VISITOR_LINK(ParallelScan, Scan);
+    SOUFFLE_VISITOR_LINK(IndexScan, IndexOperation);
+    SOUFFLE_VISITOR_LINK(ParallelIndexScan, IndexScan);
+    SOUFFLE_VISITOR_LINK(Choice, RelationOperation);
+    SOUFFLE_VISITOR_LINK(ParallelChoice, Choice);
+    SOUFFLE_VISITOR_LINK(IndexChoice, IndexOperation);
+    SOUFFLE_VISITOR_LINK(ParallelIndexChoice, IndexChoice);
+    SOUFFLE_VISITOR_LINK(RelationOperation, TupleOperation);
+    SOUFFLE_VISITOR_LINK(Aggregate, RelationOperation);
+    SOUFFLE_VISITOR_LINK(ParallelAggregate, Aggregate);
+    SOUFFLE_VISITOR_LINK(IndexAggregate, IndexOperation);
+    SOUFFLE_VISITOR_LINK(ParallelIndexAggregate, IndexAggregate);
+    SOUFFLE_VISITOR_LINK(IndexOperation, RelationOperation);
+    SOUFFLE_VISITOR_LINK(TupleOperation, NestedOperation);
+    SOUFFLE_VISITOR_LINK(Filter, AbstractConditional);
+    SOUFFLE_VISITOR_LINK(Break, AbstractConditional);
+    SOUFFLE_VISITOR_LINK(AbstractConditional, NestedOperation);
+    SOUFFLE_VISITOR_LINK(NestedOperation, Operation);
 
-    LINK(Operation, Node);
+    SOUFFLE_VISITOR_LINK(Operation, Node);
 
     // -- conditions --
-    LINK(True, Condition);
-    LINK(False, Condition);
-    LINK(Conjunction, Condition);
-    LINK(Negation, Condition);
-    LINK(Constraint, Condition);
-    LINK(ProvenanceExistenceCheck, AbstractExistenceCheck);
-    LINK(ExistenceCheck, AbstractExistenceCheck);
-    LINK(EmptinessCheck, Condition);
-    LINK(AbstractExistenceCheck, Condition);
+    SOUFFLE_VISITOR_LINK(True, Condition);
+    SOUFFLE_VISITOR_LINK(False, Condition);
+    SOUFFLE_VISITOR_LINK(Conjunction, Condition);
+    SOUFFLE_VISITOR_LINK(Negation, Condition);
+    SOUFFLE_VISITOR_LINK(Constraint, Condition);
+    SOUFFLE_VISITOR_LINK(ProvenanceExistenceCheck, AbstractExistenceCheck);
+    SOUFFLE_VISITOR_LINK(ExistenceCheck, AbstractExistenceCheck);
+    SOUFFLE_VISITOR_LINK(EmptinessCheck, Condition);
+    SOUFFLE_VISITOR_LINK(AbstractExistenceCheck, Condition);
 
-    LINK(Condition, Node);
+    SOUFFLE_VISITOR_LINK(Condition, Node);
 
     // -- values --
-    LINK(SignedConstant, Constant);
-    LINK(UnsignedConstant, Constant);
-    LINK(FloatConstant, Constant);
-    LINK(Constant, Expression);
-    LINK(UndefValue, Expression);
-    LINK(TupleElement, Expression);
-    LINK(IntrinsicOperator, AbstractOperator);
-    LINK(UserDefinedOperator, AbstractOperator);
-    LINK(AbstractOperator, Expression);
-    LINK(AutoIncrement, Expression);
-    LINK(PackRecord, Expression);
-    LINK(SubroutineArgument, Expression);
-    LINK(RelationSize, Expression);
+    SOUFFLE_VISITOR_LINK(SignedConstant, Constant);
+    SOUFFLE_VISITOR_LINK(UnsignedConstant, Constant);
+    SOUFFLE_VISITOR_LINK(FloatConstant, Constant);
+    SOUFFLE_VISITOR_LINK(Constant, Expression);
+    SOUFFLE_VISITOR_LINK(UndefValue, Expression);
+    SOUFFLE_VISITOR_LINK(TupleElement, Expression);
+    SOUFFLE_VISITOR_LINK(IntrinsicOperator, AbstractOperator);
+    SOUFFLE_VISITOR_LINK(UserDefinedOperator, AbstractOperator);
+    SOUFFLE_VISITOR_LINK(AbstractOperator, Expression);
+    SOUFFLE_VISITOR_LINK(AutoIncrement, Expression);
+    SOUFFLE_VISITOR_LINK(PackRecord, Expression);
+    SOUFFLE_VISITOR_LINK(SubroutineArgument, Expression);
+    SOUFFLE_VISITOR_LINK(RelationSize, Expression);
 
-    LINK(Expression, Node);
+    SOUFFLE_VISITOR_LINK(Expression, Node);
 
     // -- program --
-    LINK(Program, Node);
+    SOUFFLE_VISITOR_LINK(Program, Node);
 
     // -- relation
-    LINK(Relation, Node);
-
-#undef LINK
-
-    /** The base case for all visitors -- if no more specific overload was defined */
-    virtual R visitNode(const Node& /*node*/, Params... /*args*/) {
-        return R();
-    }
+    SOUFFLE_VISITOR_LINK(Relation, Node);
 };
-
-/**
- * A utility function visiting all nodes within the RAM fragment rooted by the given node
- * recursively in a depth-first pre-order fashion applying the given visitor to each
- * encountered node.
- *
- * @param root the root of the RAM fragment to be visited
- * @param visitor the visitor to be applied on each node
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-template <typename R, typename... Ps, typename... Args>
-void visitDepthFirstPreOrder(const Node& root, Visitor<R, Ps...>& visitor, Args&... args) {
-    visitor(root, args...);
-    for (const Node* cur : root.getChildNodes()) {
-        if (cur != nullptr) {
-            visitDepthFirstPreOrder(*cur, visitor, args...);
-        }
-    }
-}
-
-/**
- * A utility function visiting all nodes within the RAM fragments rooted by the given node
- * recursively in a depth-first pre-order fashion applying the given visitor to each
- * encountered node.
- *
- * @param root the root of the RAM fragments to be visited
- * @param visitor the visitor to be applied on each node
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-template <typename R, typename... Ps, typename... Args>
-void visitDepthFirst(const Node& root, Visitor<R, Ps...>& visitor, Args&... args) {
-    visitDepthFirstPreOrder(root, visitor, args...);
-}
-
-namespace detail {
-
-/**
- * A specialized visitor wrapping a lambda function -- an auxiliary type required
- * for visitor convenience functions.
- */
-template <typename R, typename N>
-struct LambdaVisitor : public Visitor<void> {
-    std::function<R(const N&)> lambda;
-    LambdaVisitor(std::function<R(const N&)> lambda) : lambda(std::move(lambda)) {}
-    void visit(const Node& node) override {
-        // Don't use as<> to allow cross-casting to mixins
-        if (const auto* n = dynamic_cast<const N*>(&node)) {
-            lambda(*n);
-        }
-    }
-};
-
-/**
- * A factory function for creating LambdaVisitor instances.
- */
-template <typename R, typename N>
-LambdaVisitor<R, N> makeLambdaVisitor(const std::function<R(const N&)>& fun) {
-    return LambdaVisitor<R, N>(fun);
-}
-
-/**
- * A type trait determining whether a given type is a visitor or not.
- */
-template <typename T>
-struct is_ram_visitor {
-    static constexpr size_t value = std::is_base_of<ram_visitor_tag, T>::value;
-};
-
-template <typename T>
-struct is_ram_visitor<const T> : public is_ram_visitor<T> {};
-
-template <typename T>
-struct is_ram_visitor<T&> : public is_ram_visitor<T> {};
-}  // namespace detail
-
-/**
- * A utility function visiting all nodes within the RAM fragment rooted by the given node
- * recursively in a depth-first pre-order fashion applying the given function to each
- * encountered node.
- *
- * @param root the root of the RAM fragment to be visited
- * @param fun the function to be applied
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-template <typename R, typename N>
-void visitDepthFirst(const Node& root, const std::function<R(const N&)>& fun) {
-    auto visitor = detail::makeLambdaVisitor(fun);
-    visitDepthFirst<void>(root, visitor);
-}
-
-/**
- * A utility function visiting all nodes within the RAM fragment rooted by the given node
- * recursively in a depth-first pre-order fashion applying the given function to each
- * encountered node.
- *
- * @param root the root of the RAM fragment to be visited
- * @param fun the function to be applied
- * @param args a list of extra parameters to be forwarded to the visitor
- */
-template <typename Lambda, typename R = typename lambda_traits<Lambda>::result_type,
-        typename N = typename lambda_traits<Lambda>::arg0_type>
-typename std::enable_if<!detail::is_ram_visitor<Lambda>::value, void>::type visitDepthFirst(
-        const Node& root, const Lambda& fun) {
-    visitDepthFirst(root, std::function<R(const N&)>(fun));
-}
-
 }  // namespace souffle::ram

--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -222,7 +222,7 @@ std::set<const ram::Relation*> Synthesiser::getReferencedRelations(const Operati
 }
 
 void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
-    class CodeEmitter : public Visitor<void, std::ostream&> {
+    class CodeEmitter : public ram::Visitor<void, Node const, std::ostream&> {
     private:
         Synthesiser& synthesiser;
         IndexAnalysis* const isa = synthesiser.getTranslationUnit().getAnalysis<IndexAnalysis>();
@@ -304,7 +304,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                     low << supremum;
                 } else {
                     low << "ramBitCast(";
-                    visit(rangePatternLower[column], low);
+                    visit(*rangePatternLower[column], low);
                     low << ")";
                 }
 
@@ -312,7 +312,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                     high << infimum;
                 } else {
                     high << "ramBitCast(";
-                    visit(rangePatternUpper[column], high);
+                    visit(*rangePatternUpper[column], high);
                     high << ")";
                 }
             }
@@ -324,7 +324,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
         // -- relation statements --
 
-        void visitIO(const IO& io, std::ostream& out) override {
+        void visit_(type_identity<IO>, const IO& io, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
 
             // print directives as C++ initializers
@@ -381,7 +381,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitQuery(const Query& query, std::ostream& out) override {
+        void visit_(type_identity<Query>, const Query& query, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
 
             // split terms of conditions of outer filter operation
@@ -472,7 +472,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitClear(const Clear& clear, std::ostream& out) override {
+        void visit_(type_identity<Clear>, const Clear& clear, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
 
             if (!synthesiser.lookup(clear.getRelation())->isTemp()) {
@@ -484,7 +484,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitLogSize(const LogSize& size, std::ostream& out) override {
+        void visit_(type_identity<LogSize>, const LogSize& size, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "ProfileEventSingleton::instance().makeQuantityEvent( R\"(";
             out << size.getMessage() << ")\",";
@@ -494,15 +494,15 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
         // -- control flow statements --
 
-        void visitSequence(const Sequence& seq, std::ostream& out) override {
+        void visit_(type_identity<Sequence>, const Sequence& seq, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             for (const auto& cur : seq.getStatements()) {
-                visit(cur, out);
+                visit(*cur, out);
             }
             PRINT_END_COMMENT(out);
         }
 
-        void visitParallel(const Parallel& parallel, std::ostream& out) override {
+        void visit_(type_identity<Parallel>, const Parallel& parallel, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             auto stmts = parallel.getStatements();
 
@@ -514,7 +514,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
             // a single statement => save the overhead
             if (stmts.size() == 1) {
-                visit(stmts[0], out);
+                visit(*stmts[0], out);
                 PRINT_END_COMMENT(out);
                 return;
             }
@@ -527,7 +527,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             // put each thread in another section
             for (const auto& cur : stmts) {
                 out << "SECTION_START;\n";
-                visit(cur, out);
+                visit(*cur, out);
                 out << "SECTION_END\n";
             }
 
@@ -536,7 +536,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitLoop(const Loop& loop, std::ostream& out) override {
+        void visit_(type_identity<Loop>, const Loop& loop, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "iter = 0;\n";
             out << "for(;;) {\n";
@@ -547,7 +547,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitSwap(const Swap& swap, std::ostream& out) override {
+        void visit_(type_identity<Swap>, const Swap& swap, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             const std::string& deltaKnowledge =
                     synthesiser.getRelationName(synthesiser.lookup(swap.getFirstRelation()));
@@ -558,7 +558,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitExtend(const Extend& extend, std::ostream& out) override {
+        void visit_(type_identity<Extend>, const Extend& extend, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << synthesiser.getRelationName(synthesiser.lookup(extend.getSourceRelation())) << "->"
                 << "extend("
@@ -567,7 +567,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitExit(const Exit& exit, std::ostream& out) override {
+        void visit_(type_identity<Exit>, const Exit& exit, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "if(";
             visit(exit.getCondition(), out);
@@ -575,7 +575,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitCall(const Call& call, std::ostream& out) override {
+        void visit_(type_identity<Call>, const Call& call, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             const Program& prog = synthesiser.getTranslationUnit().getProgram();
             const auto& subs = prog.getSubroutines();
@@ -586,7 +586,8 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitLogRelationTimer(const LogRelationTimer& timer, std::ostream& out) override {
+        void visit_(
+                type_identity<LogRelationTimer>, const LogRelationTimer& timer, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             // create local scope for name resolution
             out << "{\n";
@@ -606,7 +607,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitLogTimer(const LogTimer& timer, std::ostream& out) override {
+        void visit_(type_identity<LogTimer>, const LogTimer& timer, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             // create local scope for name resolution
             out << "{\n";
@@ -623,7 +624,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitDebugInfo(const DebugInfo& dbg, std::ostream& out) override {
+        void visit_(type_identity<DebugInfo>, const DebugInfo& dbg, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "signalHandler->setMsg(R\"_(";
             out << dbg.getMessage();
@@ -636,7 +637,8 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
         // -- operations --
 
-        void visitNestedOperation(const NestedOperation& nested, std::ostream& out) override {
+        void visit_(
+                type_identity<NestedOperation>, const NestedOperation& nested, std::ostream& out) override {
             visit(nested.getOperation(), out);
             if (Global::config().has("profile") && Global::config().has("profile-frequency") &&
                     !nested.getProfileText().empty()) {
@@ -644,13 +646,13 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             }
         }
 
-        void visitTupleOperation(const TupleOperation& search, std::ostream& out) override {
+        void visit_(type_identity<TupleOperation>, const TupleOperation& search, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
-            visitNestedOperation(search, out);
+            visit_(type_identity<NestedOperation>(), search, out);
             PRINT_END_COMMENT(out);
         }
 
-        void visitParallelScan(const ParallelScan& pscan, std::ostream& out) override {
+        void visit_(type_identity<ParallelScan>, const ParallelScan& pscan, std::ostream& out) override {
             const auto* rel = synthesiser.lookup(pscan.getRelation());
             const auto& relName = synthesiser.getRelationName(rel);
 
@@ -670,7 +672,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             out << "try{\n";
             out << "for(const auto& env0 : *it) {\n";
 
-            visitTupleOperation(pscan, out);
+            visit_(type_identity<TupleOperation>(), pscan, out);
 
             out << "}\n";
             out << "} catch(std::exception &e) { signalHandler->error(e.what());}\n";
@@ -679,7 +681,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitScan(const Scan& scan, std::ostream& out) override {
+        void visit_(type_identity<Scan>, const Scan& scan, std::ostream& out) override {
             const auto* rel = synthesiser.lookup(scan.getRelation());
             auto relName = synthesiser.getRelationName(rel);
             auto id = scan.getTupleId();
@@ -691,14 +693,14 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             out << "for(const auto& env" << id << " : "
                 << "*" << relName << ") {\n";
 
-            visitTupleOperation(scan, out);
+            visit_(type_identity<TupleOperation>(), scan, out);
 
             out << "}\n";
 
             PRINT_END_COMMENT(out);
         }
 
-        void visitChoice(const Choice& choice, std::ostream& out) override {
+        void visit_(type_identity<Choice>, const Choice& choice, std::ostream& out) override {
             const auto* rel = synthesiser.lookup(choice.getRelation());
             auto relName = synthesiser.getRelationName(rel);
             auto identifier = choice.getTupleId();
@@ -715,7 +717,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
             out << ") {\n";
 
-            visitTupleOperation(choice, out);
+            visit_(type_identity<TupleOperation>(), choice, out);
 
             out << "break;\n";
             out << "}\n";
@@ -724,7 +726,8 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitParallelChoice(const ParallelChoice& pchoice, std::ostream& out) override {
+        void visit_(
+                type_identity<ParallelChoice>, const ParallelChoice& pchoice, std::ostream& out) override {
             const auto* rel = synthesiser.lookup(pchoice.getRelation());
             auto relName = synthesiser.getRelationName(rel);
 
@@ -749,7 +752,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
             out << ") {\n";
 
-            visitTupleOperation(pchoice, out);
+            visit_(type_identity<TupleOperation>(), pchoice, out);
 
             out << "break;\n";
             out << "}\n";
@@ -760,7 +763,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitIndexScan(const IndexScan& iscan, std::ostream& out) override {
+        void visit_(type_identity<IndexScan>, const IndexScan& iscan, std::ostream& out) override {
             const auto* rel = synthesiser.lookup(iscan.getRelation());
             auto relName = synthesiser.getRelationName(rel);
             auto identifier = iscan.getTupleId();
@@ -781,13 +784,14 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                 << rangeBounds.second.str() << "," << ctxName << ");\n";
             out << "for(const auto& env" << identifier << " : range) {\n";
 
-            visitTupleOperation(iscan, out);
+            visit_(type_identity<TupleOperation>(), iscan, out);
 
             out << "}\n";
             PRINT_END_COMMENT(out);
         }
 
-        void visitParallelIndexScan(const ParallelIndexScan& piscan, std::ostream& out) override {
+        void visit_(type_identity<ParallelIndexScan>, const ParallelIndexScan& piscan,
+                std::ostream& out) override {
             const auto* rel = synthesiser.lookup(piscan.getRelation());
             auto relName = synthesiser.getRelationName(rel);
             auto arity = rel->getArity();
@@ -817,7 +821,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             out << "try{\n";
             out << "for(const auto& env0 : *it) {\n";
 
-            visitTupleOperation(piscan, out);
+            visit_(type_identity<TupleOperation>(), piscan, out);
 
             out << "}\n";
             out << "} catch(std::exception &e) { signalHandler->error(e.what());}\n";
@@ -826,7 +830,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitIndexChoice(const IndexChoice& ichoice, std::ostream& out) override {
+        void visit_(type_identity<IndexChoice>, const IndexChoice& ichoice, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             const auto* rel = synthesiser.lookup(ichoice.getRelation());
             auto relName = synthesiser.getRelationName(rel);
@@ -851,7 +855,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
             out << ") {\n";
 
-            visitTupleOperation(ichoice, out);
+            visit_(type_identity<TupleOperation>(), ichoice, out);
 
             out << "break;\n";
             out << "}\n";
@@ -860,7 +864,8 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitParallelIndexChoice(const ParallelIndexChoice& pichoice, std::ostream& out) override {
+        void visit_(type_identity<ParallelIndexChoice>, const ParallelIndexChoice& pichoice,
+                std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             const auto* rel = synthesiser.lookup(pichoice.getRelation());
             auto relName = synthesiser.getRelationName(rel);
@@ -895,7 +900,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
             out << ") {\n";
 
-            visitTupleOperation(pichoice, out);
+            visit_(type_identity<TupleOperation>(), pichoice, out);
 
             out << "break;\n";
             out << "}\n";
@@ -906,7 +911,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitUnpackRecord(const UnpackRecord& unpack, std::ostream& out) override {
+        void visit_(type_identity<UnpackRecord>, const UnpackRecord& unpack, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             auto arity = unpack.getArity();
 
@@ -927,14 +932,14 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             out << "{\n";
 
             // continue with condition checks and nested body
-            visitTupleOperation(unpack, out);
+            visit_(type_identity<TupleOperation>(), unpack, out);
 
             out << "}\n";
             PRINT_END_COMMENT(out);
         }
 
-        void visitParallelIndexAggregate(
-                const ParallelIndexAggregate& aggregate, std::ostream& out) override {
+        void visit_(type_identity<ParallelIndexAggregate>, const ParallelIndexAggregate& aggregate,
+                std::ostream& out) override {
             assert(aggregate.getTupleId() == 0 && "not outer-most loop");
             assert(!preambleIssued && "only first loop can be made parallel");
             preambleIssued = true;
@@ -963,7 +968,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                     << "size();\n";
                 out << "{\n";  // to match PARALLEL_END closing bracket
                 out << preamble.str();
-                visitTupleOperation(aggregate, out);
+                visit_(type_identity<TupleOperation>(), aggregate, out);
                 PRINT_END_COMMENT(out);
                 return;
             }
@@ -1129,7 +1134,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
             // check whether there exists a min/max first before next loop
             out << "if (shouldRunNested) {\n";
-            visitTupleOperation(aggregate, out);
+            visit_(type_identity<TupleOperation>(), aggregate, out);
             out << "}\n";
             // end single-threaded section
             out << "}\n";
@@ -1147,7 +1152,8 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                    (repr == RelationRepresentation::BTREE || repr == RelationRepresentation::DEFAULT);
         }
 
-        void visitIndexAggregate(const IndexAggregate& aggregate, std::ostream& out) override {
+        void visit_(
+                type_identity<IndexAggregate>, const IndexAggregate& aggregate, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             // get some properties
             const auto* rel = synthesiser.lookup(aggregate.getRelation());
@@ -1171,7 +1177,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                 // shortcut: use relation size
                 out << "env" << identifier << "[0] = " << relName << "->"
                     << "size();\n";
-                visitTupleOperation(aggregate, out);
+                visit_(type_identity<TupleOperation>(), aggregate, out);
                 PRINT_END_COMMENT(out);
                 return;
             }
@@ -1295,13 +1301,14 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
             // check whether there exists a min/max first before next loop
             out << "if (shouldRunNested) {\n";
-            visitTupleOperation(aggregate, out);
+            visit_(type_identity<TupleOperation>(), aggregate, out);
             out << "}\n";
 
             PRINT_END_COMMENT(out);
         }
 
-        void visitParallelAggregate(const ParallelAggregate& aggregate, std::ostream& out) override {
+        void visit_(type_identity<ParallelAggregate>, const ParallelAggregate& aggregate,
+                std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             // get some properties
             const auto* rel = synthesiser.lookup(aggregate.getRelation());
@@ -1323,7 +1330,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                     << "size();\n";
                 out << "PARALLEL_START\n";
                 out << preamble.str();
-                visitTupleOperation(aggregate, out);
+                visit_(type_identity<TupleOperation>(), aggregate, out);
                 PRINT_END_COMMENT(out);
                 return;
             }
@@ -1472,12 +1479,12 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
             // check whether there exists a min/max first before next loop
             out << "if (shouldRunNested) {\n";
-            visitTupleOperation(aggregate, out);
+            visit_(type_identity<TupleOperation>(), aggregate, out);
             out << "}\n";
             out << "}\n";  // to close off pragma omp single section
             PRINT_END_COMMENT(out);
         }
-        void visitAggregate(const Aggregate& aggregate, std::ostream& out) override {
+        void visit_(type_identity<Aggregate>, const Aggregate& aggregate, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             // get some properties
             const auto* rel = synthesiser.lookup(aggregate.getRelation());
@@ -1493,7 +1500,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                 // shortcut: use relation size
                 out << "env" << identifier << "[0] = " << relName << "->"
                     << "size();\n";
-                visitTupleOperation(aggregate, out);
+                visit_(type_identity<TupleOperation>(), aggregate, out);
                 PRINT_END_COMMENT(out);
                 return;
             }
@@ -1601,32 +1608,33 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
             // check whether there exists a min/max first before next loop
             out << "if (shouldRunNested) {\n";
-            visitTupleOperation(aggregate, out);
+            visit_(type_identity<TupleOperation>(), aggregate, out);
             out << "}\n";
 
             PRINT_END_COMMENT(out);
         }
 
-        void visitFilter(const Filter& filter, std::ostream& out) override {
+        void visit_(type_identity<Filter>, const Filter& filter, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "if( ";
             visit(filter.getCondition(), out);
             out << ") {\n";
-            visitNestedOperation(filter, out);
+            visit_(type_identity<NestedOperation>(), filter, out);
             out << "}\n";
             PRINT_END_COMMENT(out);
         }
 
-        void visitBreak(const Break& breakOp, std::ostream& out) override {
+        void visit_(type_identity<Break>, const Break& breakOp, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "if( ";
             visit(breakOp.getCondition(), out);
             out << ") break;\n";
-            visitNestedOperation(breakOp, out);
+            visit_(type_identity<NestedOperation>(), breakOp, out);
             PRINT_END_COMMENT(out);
         }
 
-        void visitGuardedProject(const GuardedProject& guardedProject, std::ostream& out) override {
+        void visit_(type_identity<GuardedProject>, const GuardedProject& guardedProject,
+                std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             const auto* rel = synthesiser.lookup(guardedProject.getRelation());
             auto arity = rel->getArity();
@@ -1636,7 +1644,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             auto condition = guardedProject.getCondition();
             // guarded conditions
             out << "if( ";
-            visit(condition, out);
+            visit(*condition, out);
             out << ") {\n";
 
             // create projected tuple
@@ -1653,7 +1661,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitProject(const Project& project, std::ostream& out) override {
+        void visit_(type_identity<Project>, const Project& project, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             const auto* rel = synthesiser.lookup(project.getRelation());
             auto arity = rel->getArity();
@@ -1673,19 +1681,19 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
         // -- conditions --
 
-        void visitTrue(const True&, std::ostream& out) override {
+        void visit_(type_identity<True>, const True&, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "true";
             PRINT_END_COMMENT(out);
         }
 
-        void visitFalse(const False&, std::ostream& out) override {
+        void visit_(type_identity<False>, const False&, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "false";
             PRINT_END_COMMENT(out);
         }
 
-        void visitConjunction(const Conjunction& conj, std::ostream& out) override {
+        void visit_(type_identity<Conjunction>, const Conjunction& conj, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             visit(conj.getLHS(), out);
             out << " && ";
@@ -1693,7 +1701,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitNegation(const Negation& neg, std::ostream& out) override {
+        void visit_(type_identity<Negation>, const Negation& neg, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "!(";
             visit(neg.getOperand(), out);
@@ -1701,7 +1709,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitConstraint(const Constraint& rel, std::ostream& out) override {
+        void visit_(type_identity<Constraint>, const Constraint& rel, std::ostream& out) override {
             // clang-format off
 #define EVAL_CHILD(ty, idx)        \
     out << "ramBitCast<" #ty ">("; \
@@ -1786,14 +1794,15 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 #undef COMPARE_EQ_NE
         }
 
-        void visitEmptinessCheck(const EmptinessCheck& emptiness, std::ostream& out) override {
+        void visit_(
+                type_identity<EmptinessCheck>, const EmptinessCheck& emptiness, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << synthesiser.getRelationName(synthesiser.lookup(emptiness.getRelation())) << "->"
                 << "empty()";
             PRINT_END_COMMENT(out);
         }
 
-        void visitRelationSize(const RelationSize& size, std::ostream& out) override {
+        void visit_(type_identity<RelationSize>, const RelationSize& size, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "(RamDomain)" << synthesiser.getRelationName(synthesiser.lookup(size.getRelation()))
                 << "->"
@@ -1801,7 +1810,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitExistenceCheck(const ExistenceCheck& exists, std::ostream& out) override {
+        void visit_(type_identity<ExistenceCheck>, const ExistenceCheck& exists, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             // get some details
             const auto* rel = synthesiser.lookup(exists.getRelation());
@@ -1838,8 +1847,8 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_END_COMMENT(out);
         }
 
-        void visitProvenanceExistenceCheck(
-                const ProvenanceExistenceCheck& provExists, std::ostream& out) override {
+        void visit_(type_identity<ProvenanceExistenceCheck>, const ProvenanceExistenceCheck& provExists,
+                std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             // get some details
             const auto* rel = synthesiser.lookup(provExists.getRelation());
@@ -1894,43 +1903,46 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
         }
 
         // -- values --
-        void visitUnsignedConstant(const UnsignedConstant& constant, std::ostream& out) override {
+        void visit_(type_identity<UnsignedConstant>, const UnsignedConstant& constant,
+                std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "RamUnsigned(" << constant.getValue() << ")";
             PRINT_END_COMMENT(out);
         }
 
-        void visitFloatConstant(const FloatConstant& constant, std::ostream& out) override {
+        void visit_(type_identity<FloatConstant>, const FloatConstant& constant, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "RamFloat(" << constant.getValue() << ")";
             PRINT_END_COMMENT(out);
         }
 
-        void visitSignedConstant(const SignedConstant& constant, std::ostream& out) override {
+        void visit_(
+                type_identity<SignedConstant>, const SignedConstant& constant, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "RamSigned(" << constant.getConstant() << ")";
             PRINT_END_COMMENT(out);
         }
 
-        void visitTupleElement(const TupleElement& access, std::ostream& out) override {
+        void visit_(type_identity<TupleElement>, const TupleElement& access, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "env" << access.getTupleId() << "[" << access.getElement() << "]";
             PRINT_END_COMMENT(out);
         }
 
-        void visitAutoIncrement(const AutoIncrement& /*inc*/, std::ostream& out) override {
+        void visit_(type_identity<AutoIncrement>, const AutoIncrement& /*inc*/, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
             out << "(ctr++)";
             PRINT_END_COMMENT(out);
         }
 
-        void visitIntrinsicOperator(const IntrinsicOperator& op, std::ostream& out) override {
+        void visit_(
+                type_identity<IntrinsicOperator>, const IntrinsicOperator& op, std::ostream& out) override {
 #define MINMAX_SYMBOL(op)                   \
     {                                       \
         out << "symTable.lookup(" #op "({"; \
         for (auto& cur : args) {            \
             out << "symTable.resolve(";     \
-            visit(cur, out);                \
+            visit(*cur, out);                \
             out << "), ";                   \
         }                                   \
         out << "}))";                       \
@@ -1943,7 +1955,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 #define UNARY_OP(opcode, ty, op)                \
     case FunctorOp::opcode: {                   \
         out << "(" #op "(ramBitCast<" #ty ">("; \
-        visit(args[0], out);                    \
+        visit(*args[0], out);                    \
         out << ")))";                           \
         break;                                  \
     }
@@ -1958,9 +1970,9 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 #define BINARY_OP_EXPR_EX(ty, op, rhs_post)      \
     {                                            \
         out << "(ramBitCast<" #ty ">(";          \
-        visit(args[0], out);                     \
+        visit(*args[0], out);                     \
         out << ") " #op " ramBitCast<" #ty ">("; \
-        visit(args[1], out);                     \
+        visit(*args[1], out);                     \
         out << rhs_post "))";                    \
         break;                                   \
     }
@@ -1987,9 +1999,9 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 #define BINARY_OP_EXP(opcode, ty, tyTemp)                                                     \
     case FunctorOp::opcode: {                                                                 \
         out << "static_cast<" #ty ">(static_cast<" #tyTemp ">(std::pow(ramBitCast<" #ty ">("; \
-        visit(args[0], out);                                                                  \
+        visit(*args[0], out);                                                                  \
         out << "), ramBitCast<" #ty ">(";                                                     \
-        visit(args[1], out);                                                                  \
+        visit(*args[1], out);                                                                  \
         out << "))))";                                                                        \
         break;                                                                                \
     }
@@ -1999,7 +2011,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
         out << #op "({";                   \
         for (auto& cur : args) {           \
             out << "ramBitCast<" #ty ">("; \
-            visit(cur, out);               \
+            visit(*cur, out);               \
             out << "), ";                  \
         }                                  \
         out << "})";                       \
@@ -2014,13 +2026,13 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 #define CONV_TO_STRING(opcode, ty)                \
     case FunctorOp::opcode: {                     \
         out << "symTable.lookup(std::to_string("; \
-        visit(args[0], out);                      \
+        visit(*args[0], out);                      \
         out << "))";                              \
     } break;
 #define CONV_FROM_STRING(opcode, ty)                                            \
     case FunctorOp::opcode: {                                                   \
         out << "souffle::evaluator::symbol2numeric<" #ty ">(symTable.resolve("; \
-        visit(args[0], out);                                                    \
+        visit(*args[0], out);                                                    \
         out << "))";                                                            \
     } break;
             // clang-format on
@@ -2029,13 +2041,13 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             switch (op.getOperator()) {
                 /** Unary Functor Operators */
                 case FunctorOp::ORD: {
-                    visit(args[0], out);
+                    visit(*args[0], out);
                     break;
                 }
                 // TODO: change the signature of `STRLEN` to return an unsigned?
                 case FunctorOp::STRLEN: {
                     out << "static_cast<RamSigned>(symTable.resolve(";
-                    visit(args[0], out);
+                    visit(*args[0], out);
                     out << ").size())";
                     break;
                 }
@@ -2053,7 +2065,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                 case FunctorOp::I2I:
                 case FunctorOp::U2U:
                 case FunctorOp::S2S: {
-                    visit(args[0], out);
+                    visit(*args[0], out);
                     break;
                 }
 
@@ -2123,12 +2135,12 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                     size_t i = 0;
                     while (i < args.size() - 1) {
                         out << "symTable.resolve(";
-                        visit(args[i], out);
+                        visit(*args[i], out);
                         out << ") + ";
                         i++;
                     }
                     out << "symTable.resolve(";
-                    visit(args[i], out);
+                    visit(*args[i], out);
                     out << "))";
                     break;
                 }
@@ -2137,11 +2149,11 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                 case FunctorOp::SUBSTR: {
                     out << "symTable.lookup(";
                     out << "substr_wrapper(symTable.resolve(";
-                    visit(args[0], out);
+                    visit(*args[0], out);
                     out << "),(";
-                    visit(args[1], out);
+                    visit(*args[1], out);
                     out << "),(";
-                    visit(args[2], out);
+                    visit(*args[2], out);
                     out << ")))";
                     break;
                 }
@@ -2156,14 +2168,15 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 #undef MINMAX_SYMBOL
         }
 
-        void visitNestedIntrinsicOperator(const NestedIntrinsicOperator& op, std::ostream& out) override {
+        void visit_(type_identity<NestedIntrinsicOperator>, const NestedIntrinsicOperator& op,
+                std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
 
             auto emitHelper = [&](auto&& func) {
                 tfm::format(out, "%s(%s, [&](auto&& env%d) {\n", func,
-                        join(op.getArguments(), ",", [&](auto& os, auto* arg) { return visit(arg, os); }),
+                        join(op.getArguments(), ",", [&](auto& os, auto* arg) { return visit(*arg, os); }),
                         op.getTupleId());
-                visitTupleOperation(op, out);
+                visit_(type_identity<TupleOperation>(), op, out);
                 out << "});\n";
 
                 PRINT_END_COMMENT(out);
@@ -2182,7 +2195,8 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             UNREACHABLE_BAD_CASE_ANALYSIS
         }
 
-        void visitUserDefinedOperator(const UserDefinedOperator& op, std::ostream& out) override {
+        void visit_(type_identity<UserDefinedOperator>, const UserDefinedOperator& op,
+                std::ostream& out) override {
             const std::string& name = op.getName();
 
             auto args = op.getArguments();
@@ -2190,7 +2204,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                 out << name << "(&symTable, &recordTable";
                 for (auto& arg : args) {
                     out << ",";
-                    visit(arg, out);
+                    visit(*arg, out);
                 }
                 out << ")";
             } else {
@@ -2208,22 +2222,22 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                     switch (argTypes[i]) {
                         case TypeAttribute::Signed:
                             out << "((RamSigned)";
-                            visit(args[i], out);
+                            visit(*args[i], out);
                             out << ")";
                             break;
                         case TypeAttribute::Unsigned:
                             out << "((RamUnsigned)";
-                            visit(args[i], out);
+                            visit(*args[i], out);
                             out << ")";
                             break;
                         case TypeAttribute::Float:
                             out << "((RamFloat)";
-                            visit(args[i], out);
+                            visit(*args[i], out);
                             out << ")";
                             break;
                         case TypeAttribute::Symbol:
                             out << "symTable.resolve(";
-                            visit(args[i], out);
+                            visit(*args[i], out);
                             out << ").c_str()";
                             break;
                         case TypeAttribute::ADT:
@@ -2239,7 +2253,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
         // -- records --
 
-        void visitPackRecord(const PackRecord& pack, std::ostream& out) override {
+        void visit_(type_identity<PackRecord>, const PackRecord& pack, std::ostream& out) override {
             PRINT_BEGIN_COMMENT(out);
 
             out << "pack(recordTable,"
@@ -2256,20 +2270,22 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
         // -- subroutine argument --
 
-        void visitSubroutineArgument(const SubroutineArgument& arg, std::ostream& out) override {
+        void visit_(type_identity<SubroutineArgument>, const SubroutineArgument& arg,
+                std::ostream& out) override {
             out << "(args)[" << arg.getArgument() << "]";
         }
 
         // -- subroutine return --
 
-        void visitSubroutineReturn(const SubroutineReturn& ret, std::ostream& out) override {
+        void visit_(
+                type_identity<SubroutineReturn>, const SubroutineReturn& ret, std::ostream& out) override {
             out << "std::lock_guard<std::mutex> guard(lock);\n";
             for (auto val : ret.getValues()) {
                 if (isUndefValue(val)) {
                     out << "ret.push_back(0);\n";
                 } else {
                     out << "ret.push_back(";
-                    visit(val, out);
+                    visit(*val, out);
                     out << ");\n";
                 }
             }
@@ -2277,11 +2293,11 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
         // -- safety net --
 
-        void visitUndefValue(const UndefValue&, std::ostream& /*out*/) override {
+        void visit_(type_identity<UndefValue>, const UndefValue&, std::ostream& /*out*/) override {
             fatal("Compilation error");
         }
 
-        void visitNode(const Node& node, std::ostream& /*out*/) override {
+        void visit_(type_identity<Node>, const Node& node, std::ostream& /*out*/) override {
             fatal("Unsupported node type: %s", typeid(node).name());
         }
     };

--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -1942,7 +1942,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
         out << "symTable.lookup(" #op "({"; \
         for (auto& cur : args) {            \
             out << "symTable.resolve(";     \
-            visit(*cur, out);                \
+            visit(*cur, out);               \
             out << "), ";                   \
         }                                   \
         out << "}))";                       \

--- a/src/synthesiser/Synthesiser.h
+++ b/src/synthesiser/Synthesiser.h
@@ -97,7 +97,7 @@ protected:
 
 public:
     explicit Synthesiser(ram::TranslationUnit& tUnit) : translationUnit(tUnit) {
-        ram::visitDepthFirst(tUnit.getProgram(),
+        visitDepthFirst(tUnit.getProgram(),
                 [&](const ram::Relation& relation) { relationMap[relation.getName()] = &relation; });
     }
 


### PR DESCRIPTION
Merge this PR after #1820.  It may be a good idea to also merge after @azreika's #1822, since this touches ram/synth code, too (unless their PR is still not ready).

I will let Christopher Lambert summarize this PR: https://www.youtube.com/watch?v=sqcLjcSloXs

This unifies both the ast and ram visitors into a single, generic framework.  

Main changes:

1) All the visitor functions are now defined just once and work for all visitors
2) The action of "getting children" is abstracted into an overloadable function `getChildren` which can be found by ADL.
3) The former ram::LambdaVisitor now also gets the lambda optimization (meaning no longer uses std::function<> internally)
4) Support for references and pointers
5) Support for traversing generic ranges (not just vectors of pointers/`Own<>`s)
6) `LambdaVisitor<>` is no longer derived from `ast/ram::Visitor`, since it doesn't (and can't!) dispatch back into it; hence there is no point in the inheritance
7) `visitX(X&)` (as previously generated by e.g. by the macro `FORWARD(X)` has been renamed and changed to `visit_(type_identity<X>, X&)`