### PR TITLE
Children references and cleanups - MERGE SIXTH

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -89,12 +89,19 @@ souffle_sources = \
         ast/SubsetType.h                                   \
         ast/Term.cpp                                       \
         ast/Term.h                                         \
+        ast/TranslationUnit.cpp                            \
         ast/TranslationUnit.h                              \
+        ast/Type.cpp                                       \
         ast/Type.h                                         \
+        ast/TypeCast.cpp                                   \
         ast/TypeCast.h                                     \
+        ast/UnionType.cpp                                  \
         ast/UnionType.h                                    \
+        ast/UnnamedVariable.cpp                            \
         ast/UnnamedVariable.h                              \
+        ast/UserDefinedFunctor.cpp                         \
         ast/UserDefinedFunctor.h                           \
+        ast/Variable.cpp                                   \
         ast/Variable.h                                     \
         ast/analysis/Aggregate.cpp                         \
         ast/analysis/Aggregate.h                           \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,6 +38,7 @@ souffle_sources = \
         ast/BranchInit.h                                   \
         ast/Clause.cpp                                     \
         ast/Clause.h                                       \
+        ast/Component.cpp                                  \
         ast/Component.h                                    \
         ast/ComponentInit.h                                \
         ast/ComponentType.h                                \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,14 +49,17 @@ souffle_sources = \
         ast/Constraint.h                                   \
         ast/Counter.cpp                                    \
         ast/Counter.h                                      \
+        ast/Directive.cpp                                  \
+        ast/Directive.h                                    \
         ast/ExecutionOrder.cpp                             \
         ast/ExecutionOrder.h                               \
         ast/ExecutionPlan.cpp                              \
         ast/ExecutionPlan.h                                \
         ast/Functor.h                                      \
+        ast/FunctorDeclaration.cpp                         \
         ast/FunctorDeclaration.h                           \
+        ast/FunctionalConstraint.cpp                       \
         ast/FunctionalConstraint.h                         \
-        ast/Directive.h                                    \
         ast/IntrinsicFunctor.h                             \
         ast/Literal.h                                      \
         ast/Negation.h                                     \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,12 +19,14 @@ souffle_sources = \
         GraphUtils.h                                       \
         LogStatement.h                                     \
         RelationTag.h                                      \
-        ast/Aggregator.h                                   \
         ast/Aggregator.cpp                                 \
-        ast/AlgebraicDataType.h                            \
+        ast/Aggregator.h                                   \
         ast/AlgebraicDataType.cpp                          \
+        ast/AlgebraicDataType.h                            \
         ast/Argument.h                                     \
+        ast/Atom.cpp                                       \
         ast/Atom.h                                         \
+        ast/Attribute.cpp                                  \
         ast/Attribute.h                                    \
         ast/BinaryConstraint.h                             \
         ast/BooleanConstraint.h                            \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,11 +40,16 @@ souffle_sources = \
         ast/Clause.h                                       \
         ast/Component.cpp                                  \
         ast/Component.h                                    \
+        ast/ComponentInit.cpp                              \
         ast/ComponentInit.h                                \
+        ast/ComponentType.cpp                              \
         ast/ComponentType.h                                \
+        ast/Constant.cpp                                   \
         ast/Constant.h                                     \
         ast/Constraint.h                                   \
+        ast/Counter.cpp                                    \
         ast/Counter.h                                      \
+        ast/ExecutionOrder.cpp                             \
         ast/ExecutionOrder.h                               \
         ast/ExecutionPlan.h                                \
         ast/Functor.h                                      \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -51,6 +51,7 @@ souffle_sources = \
         ast/Counter.h                                      \
         ast/ExecutionOrder.cpp                             \
         ast/ExecutionOrder.h                               \
+        ast/ExecutionPlan.cpp                              \
         ast/ExecutionPlan.h                                \
         ast/Functor.h                                      \
         ast/FunctorDeclaration.h                           \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,9 +28,13 @@ souffle_sources = \
         ast/Atom.h                                         \
         ast/Attribute.cpp                                  \
         ast/Attribute.h                                    \
+        ast/BinaryConstraint.cpp                           \
         ast/BinaryConstraint.h                             \
+        ast/BooleanConstraint.cpp                          \
         ast/BooleanConstraint.h                            \
+        ast/BranchDeclaration.cpp                          \
         ast/BranchDeclaration.h                            \
+        ast/BranchInit.cpp                                 \
         ast/BranchInit.h                                   \
         ast/Clause.cpp                                     \
         ast/Clause.h                                       \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,6 +47,7 @@ souffle_sources = \
         ast/Negation.h                                     \
         ast/NilConstant.h                                  \
         ast/Node.h                                         \
+        ast/Node.cpp                                       \
         ast/NumericConstant.h                              \
         ast/Pragma.h                                       \
         ast/Program.cpp                                    \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -60,13 +60,18 @@ souffle_sources = \
         ast/FunctorDeclaration.h                           \
         ast/FunctionalConstraint.cpp                       \
         ast/FunctionalConstraint.h                         \
+        ast/IntrinsicFunctor.cpp                           \
         ast/IntrinsicFunctor.h                             \
         ast/Literal.h                                      \
+        ast/Negation.cpp                                   \
         ast/Negation.h                                     \
+        ast/NilConstant.cpp                                \
         ast/NilConstant.h                                  \
         ast/Node.h                                         \
         ast/Node.cpp                                       \
+        ast/NumericConstant.cpp                            \
         ast/NumericConstant.h                              \
+        ast/Pragma.cpp                                     \
         ast/Pragma.h                                       \
         ast/Program.cpp                                    \
         ast/Program.h                                      \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,12 +75,19 @@ souffle_sources = \
         ast/Pragma.h                                       \
         ast/Program.cpp                                    \
         ast/Program.h                                      \
+        ast/QualifiedName.cpp                              \
         ast/QualifiedName.h                                \
+        ast/RecordInit.cpp                                 \
         ast/RecordInit.h                                   \
+        ast/RecordType.cpp                                 \
         ast/RecordType.h                                   \
+        ast/Relation.cpp                                   \
         ast/Relation.h                                     \
+        ast/StringConstant.cpp                             \
         ast/StringConstant.h                               \
+        ast/SubsetType.cpp                                 \
         ast/SubsetType.h                                   \
+        ast/Term.cpp                                       \
         ast/Term.h                                         \
         ast/TranslationUnit.h                              \
         ast/Type.h                                         \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,7 +20,9 @@ souffle_sources = \
         LogStatement.h                                     \
         RelationTag.h                                      \
         ast/Aggregator.h                                   \
+        ast/Aggregator.cpp                                 \
         ast/AlgebraicDataType.h                            \
+        ast/AlgebraicDataType.cpp                          \
         ast/Argument.h                                     \
         ast/Atom.h                                         \
         ast/Attribute.h                                    \

--- a/src/ast/Aggregator.cpp
+++ b/src/ast/Aggregator.cpp
@@ -1,0 +1,73 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Aggregator.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+Aggregator::Aggregator(AggregateOp baseOperator, Own<Argument> expr, VecOwn<Literal> body, SrcLocation loc)
+        : Argument(std::move(loc)), baseOperator(baseOperator), targetExpression(std::move(expr)),
+          body(std::move(body)) {
+    // NOTE: targetExpression can be nullptr - it's used e.g. when aggregator
+    // has no parameters, such as count: { body }
+    assert(allValidPtrs(this->body));
+}
+
+std::vector<Literal*> Aggregator::getBodyLiterals() const {
+    return toPtrVector(body);
+}
+
+void Aggregator::setBody(VecOwn<Literal> bodyLiterals) {
+    assert(allValidPtrs(body));
+    body = std::move(bodyLiterals);
+}
+
+void Aggregator::apply(const NodeMapper& map) {
+    if (targetExpression) {
+        targetExpression = map(std::move(targetExpression));
+    }
+
+    for (auto& cur : body) {
+        cur = map(std::move(cur));
+    }
+}
+
+void Aggregator::print(std::ostream& os) const {
+    os << baseOperator;
+    if (targetExpression) {
+        os << " " << *targetExpression;
+    }
+    os << " : { " << join(body) << " }";
+}
+
+bool Aggregator::equal(const Node& node) const {
+    const auto& other = asAssert<Aggregator>(node);
+    return baseOperator == other.baseOperator && equal_ptr(targetExpression, other.targetExpression) &&
+           equal_targets(body, other.body);
+}
+
+Aggregator* Aggregator::cloneImpl() const {
+    return new Aggregator(baseOperator, souffle::clone(targetExpression), souffle::clone(body), getSrcLoc());
+}
+
+Node::NodeVec Aggregator::getChildNodesImpl() const {
+    auto res = Argument::getChildNodesImpl();
+    if (targetExpression) {
+        res.push_back(targetExpression.get());
+    }
+    append(res, makePtrRange(body));
+    return res;
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Aggregator.cpp
+++ b/src/ast/Aggregator.cpp
@@ -38,9 +38,7 @@ void Aggregator::apply(const NodeMapper& map) {
         targetExpression = map(std::move(targetExpression));
     }
 
-    for (auto& cur : body) {
-        cur = map(std::move(cur));
-    }
+    mapAll(body, map);
 }
 
 void Aggregator::print(std::ostream& os) const {

--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -1,6 +1,6 @@
 /*
  * Souffle - A Datalog Compiler
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved
  * Licensed under the Universal Permissive License v 1.0 as shown at:
  * - https://opensource.org/licenses/UPL
  * - <souffle root>/licenses/SOUFFLE-UPL.txt
@@ -19,17 +19,9 @@
 #include "AggregateOp.h"
 #include "ast/Argument.h"
 #include "ast/Literal.h"
-#include "ast/Node.h"
-#include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <memory>
-#include <optional>
-#include <ostream>
-#include <string>
-#include <utility>
+#include "souffle/utility/Types.h"
+#include <iosfwd>
 #include <vector>
 
 namespace souffle::ast {
@@ -47,13 +39,7 @@ namespace souffle::ast {
 class Aggregator : public Argument {
 public:
     Aggregator(AggregateOp baseOperator, Own<Argument> expr = {}, VecOwn<Literal> body = {},
-            SrcLocation loc = {})
-            : Argument(std::move(loc)), baseOperator(baseOperator), targetExpression(std::move(expr)),
-              body(std::move(body)) {
-        // targetExpression can be nullptr - it's used e.g. when aggregator
-        // has no parameters, such as count: { body }
-        assert(allValidPtrs(this->body));
-    }
+            SrcLocation loc = {});
 
     /** Return the (base type) operator of the aggregator */
     AggregateOp getBaseOperator() const {
@@ -70,56 +56,20 @@ public:
     }
 
     /** Return body literals */
-    std::vector<Literal*> getBodyLiterals() const {
-        return toPtrVector(body);
-    }
+    std::vector<Literal*> getBodyLiterals() const;
 
     /** Set body */
-    void setBody(VecOwn<Literal> bodyLiterals) {
-        assert(allValidPtrs(body));
-        body = std::move(bodyLiterals);
-    }
+    void setBody(VecOwn<Literal> bodyLiterals);
 
-    NodeVec getChildNodesImpl() const override {
-        auto res = Argument::getChildNodesImpl();
-        if (targetExpression) {
-            res.push_back(targetExpression.get());
-        }
-        for (auto& cur : body) {
-            res.push_back(cur.get());
-        }
-        return res;
-    }
-
-    void apply(const NodeMapper& map) override {
-        if (targetExpression) {
-            targetExpression = map(std::move(targetExpression));
-        }
-        for (auto& cur : body) {
-            cur = map(std::move(cur));
-        }
-    }
+    void apply(const NodeMapper& map) override;
 
 protected:
-    void print(std::ostream& os) const override {
-        os << baseOperator;
-        if (targetExpression) {
-            os << " " << *targetExpression;
-        }
-        os << " : { " << join(body) << " }";
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Aggregator>(node);
-        return baseOperator == other.baseOperator && equal_ptr(targetExpression, other.targetExpression) &&
-               equal_targets(body, other.body);
-    }
+    void print(std::ostream& os) const override;
+    bool equal(const Node& node) const override;
 
 private:
-    Aggregator* cloneImpl() const override {
-        return new Aggregator(
-                baseOperator, souffle::clone(targetExpression), souffle::clone(body), getSrcLoc());
-    }
+    Aggregator* cloneImpl() const override;
+    NodeVec getChildNodesImpl() const override;
 
 private:
     /** Aggregate (base type) operator */

--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -80,7 +80,7 @@ public:
         body = std::move(bodyLiterals);
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         auto res = Argument::getChildNodesImpl();
         if (targetExpression) {
             res.push_back(targetExpression.get());

--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -65,11 +65,13 @@ public:
 
 protected:
     void print(std::ostream& os) const override;
-    bool equal(const Node& node) const override;
+
+    NodeVec getChildNodesImpl() const override;
 
 private:
+    bool equal(const Node& node) const override;
+
     Aggregator* cloneImpl() const override;
-    NodeVec getChildNodesImpl() const override;
 
 private:
     /** Aggregate (base type) operator */

--- a/src/ast/AlgebraicDataType.cpp
+++ b/src/ast/AlgebraicDataType.cpp
@@ -1,0 +1,41 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020 The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/AlgebraicDataType.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include "souffle/utility/tinyformat.h"
+#include <cassert>
+
+namespace souffle::ast {
+
+AlgebraicDataType::AlgebraicDataType(QualifiedName name, VecOwn<BranchDeclaration> branches, SrcLocation loc)
+        : Type(std::move(name), std::move(loc)), branches(std::move(branches)) {
+    assert(!this->branches.empty());
+    assert(allValidPtrs(this->branches));
+}
+
+std::vector<BranchDeclaration*> AlgebraicDataType::getBranches() const {
+    return toPtrVector(branches);
+}
+
+void AlgebraicDataType::print(std::ostream& os) const {
+    os << tfm::format(".type %s = %s", getQualifiedName(), join(branches, " | "));
+}
+
+bool AlgebraicDataType::equal(const Node& node) const {
+    const auto& other = asAssert<AlgebraicDataType>(node);
+    return getQualifiedName() == other.getQualifiedName() && branches == other.branches;
+}
+
+AlgebraicDataType* AlgebraicDataType::cloneImpl() const {
+    return new AlgebraicDataType(getQualifiedName(), souffle::clone(branches), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/AlgebraicDataType.h
+++ b/src/ast/AlgebraicDataType.h
@@ -17,19 +17,10 @@
 #pragma once
 
 #include "ast/BranchDeclaration.h"
-#include "ast/Node.h"
 #include "ast/QualifiedName.h"
 #include "ast/Type.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include "souffle/utility/tinyformat.h"
-#include <cassert>
 #include <iosfwd>
-#include <memory>
-#include <string>
-#include <utility>
 #include <vector>
 
 namespace souffle::ast {
@@ -49,30 +40,17 @@ namespace souffle::ast {
  */
 class AlgebraicDataType : public Type {
 public:
-    AlgebraicDataType(QualifiedName name, VecOwn<BranchDeclaration> branches, SrcLocation loc = {})
-            : Type(std::move(name), std::move(loc)), branches(std::move(branches)) {
-        assert(!this->branches.empty());
-        assert(allValidPtrs(this->branches));
-    };
+    AlgebraicDataType(QualifiedName name, VecOwn<BranchDeclaration> branches, SrcLocation loc = {});
 
-    std::vector<BranchDeclaration*> getBranches() const {
-        return toPtrVector(branches);
-    }
-
-    void print(std::ostream& os) const override {
-        os << tfm::format(".type %s = %s", getQualifiedName(), join(branches, " | "));
-    }
+    std::vector<BranchDeclaration*> getBranches() const;
 
 protected:
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<AlgebraicDataType>(node);
-        return getQualifiedName() == other.getQualifiedName() && branches == other.branches;
-    }
+    void print(std::ostream& os) const override;
+
+    bool equal(const Node& node) const override;
 
 private:
-    AlgebraicDataType* cloneImpl() const override {
-        return new AlgebraicDataType(getQualifiedName(), souffle::clone(branches), getSrcLoc());
-    }
+    AlgebraicDataType* cloneImpl() const override;
 
 private:
     /** The list of branches for this sum type. */

--- a/src/ast/AlgebraicDataType.h
+++ b/src/ast/AlgebraicDataType.h
@@ -47,9 +47,9 @@ public:
 protected:
     void print(std::ostream& os) const override;
 
+private:
     bool equal(const Node& node) const override;
 
-private:
     AlgebraicDataType* cloneImpl() const override;
 
 private:

--- a/src/ast/Atom.cpp
+++ b/src/ast/Atom.cpp
@@ -1,0 +1,70 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Atom.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+/**
+ * @class Atom
+ * @brief An atom class
+ *
+ * An atom representing the use of a relation
+ * either in the head or in the body of a clause,
+ * e.g., parent(x,y), !parent(x,y), ...
+ */
+Atom::Atom(QualifiedName name, VecOwn<Argument> args, SrcLocation loc)
+        : Literal(std::move(loc)), name(std::move(name)), arguments(std::move(args)) {
+    assert(allValidPtrs(arguments));
+}
+
+void Atom::setQualifiedName(QualifiedName n) {
+    name = std::move(n);
+}
+
+void Atom::addArgument(Own<Argument> arg) {
+    assert(arg != nullptr);
+    arguments.push_back(std::move(arg));
+}
+
+std::vector<Argument*> Atom::getArguments() const {
+    return toPtrVector(arguments);
+}
+
+void Atom::apply(const NodeMapper& map) {
+    for (auto& arg : arguments) {
+        arg = map(std::move(arg));
+    }
+}
+
+Node::NodeVec Atom::getChildNodesImpl() const {
+    auto cn = makePtrRange(arguments);
+    return {cn.begin(), cn.end()};
+}
+
+void Atom::print(std::ostream& os) const {
+    os << getQualifiedName() << "(" << join(arguments) << ")";
+}
+
+bool Atom::equal(const Node& node) const {
+    const auto& other = asAssert<Atom>(node);
+    return name == other.name && equal_targets(arguments, other.arguments);
+}
+
+Atom* Atom::cloneImpl() const {
+    return new Atom(name, souffle::clone(arguments), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Atom.cpp
+++ b/src/ast/Atom.cpp
@@ -44,9 +44,7 @@ std::vector<Argument*> Atom::getArguments() const {
 }
 
 void Atom::apply(const NodeMapper& map) {
-    for (auto& arg : arguments) {
-        arg = map(std::move(arg));
-    }
+    mapAll(arguments, map);
 }
 
 Node::NodeVec Atom::getChildNodesImpl() const {

--- a/src/ast/Atom.h
+++ b/src/ast/Atom.h
@@ -18,20 +18,11 @@
 
 #include "ast/Argument.h"
 #include "ast/Literal.h"
-#include "ast/Node.h"
 #include "ast/QualifiedName.h"
-#include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <algorithm>
-#include <cassert>
+#include "souffle/utility/Types.h"
 #include <cstddef>
-#include <iostream>
-#include <memory>
-#include <string>
-#include <utility>
+#include <iosfwd>
 #include <vector>
 
 namespace souffle::ast {
@@ -46,10 +37,7 @@ namespace souffle::ast {
  */
 class Atom : public Literal {
 public:
-    Atom(QualifiedName name = {}, VecOwn<Argument> args = {}, SrcLocation loc = {})
-            : Literal(std::move(loc)), name(std::move(name)), arguments(std::move(args)) {
-        assert(allValidPtrs(arguments));
-    }
+    Atom(QualifiedName name = {}, VecOwn<Argument> args = {}, SrcLocation loc = {});
 
     /** Return qualified name */
     const QualifiedName& getQualifiedName() const {
@@ -57,54 +45,30 @@ public:
     }
 
     /** Return arity of the atom */
-    size_t getArity() const {
+    std::size_t getArity() const {
         return arguments.size();
     }
 
     /** Set qualified name */
-    void setQualifiedName(QualifiedName n) {
-        name = std::move(n);
-    }
+    void setQualifiedName(QualifiedName n);
 
     /** Add argument to the atom */
-    void addArgument(Own<Argument> arg) {
-        assert(arg != nullptr);
-        arguments.push_back(std::move(arg));
-    }
+    void addArgument(Own<Argument> arg);
 
     /** Return arguments */
-    std::vector<Argument*> getArguments() const {
-        return toPtrVector(arguments);
-    }
+    std::vector<Argument*> getArguments() const;
 
-    void apply(const NodeMapper& map) override {
-        for (auto& arg : arguments) {
-            arg = map(std::move(arg));
-        }
-    }
-
-    NodeVec getChildNodesImpl() const override {
-        std::vector<const Node*> res;
-        for (auto& cur : arguments) {
-            res.push_back(cur.get());
-        }
-        return res;
-    }
+    void apply(const NodeMapper& map) override;
 
 protected:
-    void print(std::ostream& os) const override {
-        os << getQualifiedName() << "(" << join(arguments) << ")";
-    }
+    void print(std::ostream& os) const override;
 
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Atom>(node);
-        return name == other.name && equal_targets(arguments, other.arguments);
-    }
+    NodeVec getChildNodesImpl() const override;
 
 private:
-    Atom* cloneImpl() const override {
-        return new Atom(name, souffle::clone(arguments), getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    Atom* cloneImpl() const override;
 
 private:
     /** Name of atom */

--- a/src/ast/Atom.h
+++ b/src/ast/Atom.h
@@ -83,7 +83,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (auto& cur : arguments) {
             res.push_back(cur.get());

--- a/src/ast/Attribute.cpp
+++ b/src/ast/Attribute.cpp
@@ -1,0 +1,37 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Attribute.h"
+#include "souffle/utility/MiscUtil.h"
+
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+Attribute::Attribute(std::string n, QualifiedName t, SrcLocation loc)
+        : Node(std::move(loc)), name(std::move(n)), typeName(std::move(t)) {}
+
+void Attribute::setTypeName(QualifiedName name) {
+    typeName = std::move(name);
+}
+
+void Attribute::print(std::ostream& os) const {
+    os << name << ":" << typeName;
+}
+
+bool Attribute::equal(const Node& node) const {
+    const auto& other = asAssert<Attribute>(node);
+    return name == other.name && typeName == other.typeName;
+}
+
+Attribute* Attribute::cloneImpl() const {
+    return new Attribute(name, typeName, getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Attribute.h
+++ b/src/ast/Attribute.h
@@ -19,11 +19,8 @@
 #include "ast/Node.h"
 #include "ast/QualifiedName.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/MiscUtil.h"
-
-#include <ostream>
+#include <iosfwd>
 #include <string>
-#include <utility>
 
 namespace souffle::ast {
 
@@ -37,8 +34,7 @@ namespace souffle::ast {
  */
 class Attribute : public Node {
 public:
-    Attribute(std::string n, QualifiedName t, SrcLocation loc = {})
-            : Node(std::move(loc)), name(std::move(n)), typeName(std::move(t)) {}
+    Attribute(std::string n, QualifiedName t, SrcLocation loc = {});
 
     /** Return attribute name */
     const std::string& getName() const {
@@ -51,24 +47,15 @@ public:
     }
 
     /** Set type name */
-    void setTypeName(QualifiedName name) {
-        typeName = std::move(name);
-    }
+    void setTypeName(QualifiedName name);
 
 protected:
-    void print(std::ostream& os) const override {
-        os << name << ":" << typeName;
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Attribute>(node);
-        return name == other.name && typeName == other.typeName;
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    Attribute* cloneImpl() const override {
-        return new Attribute(name, typeName, getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    Attribute* cloneImpl() const override;
 
 private:
     /** Attribute name */

--- a/src/ast/BinaryConstraint.cpp
+++ b/src/ast/BinaryConstraint.cpp
@@ -1,0 +1,50 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/BinaryConstraint.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/MiscUtil.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+BinaryConstraint::BinaryConstraint(BinaryConstraintOp o, Own<Argument> ls, Own<Argument> rs, SrcLocation loc)
+        : Constraint(std::move(loc)), operation(o), lhs(std::move(ls)), rhs(std::move(rs)) {
+    assert(lhs != nullptr);
+    assert(rhs != nullptr);
+}
+
+void BinaryConstraint::apply(const NodeMapper& map) {
+    lhs = map(std::move(lhs));
+    rhs = map(std::move(rhs));
+}
+
+Node::NodeVec BinaryConstraint::getChildNodesImpl() const {
+    return {lhs.get(), rhs.get()};
+}
+
+void BinaryConstraint::print(std::ostream& os) const {
+    if (isInfixFunctorOp(operation)) {
+        os << *lhs << " " << operation << " " << *rhs;
+    } else {
+        os << operation << "(" << *lhs << ", " << *rhs << ")";
+    }
+}
+
+bool BinaryConstraint::equal(const Node& node) const {
+    const auto& other = asAssert<BinaryConstraint>(node);
+    return operation == other.operation && equal_ptr(lhs, other.lhs) && equal_ptr(rhs, other.rhs);
+}
+
+BinaryConstraint* BinaryConstraint::cloneImpl() const {
+    return new BinaryConstraint(operation, souffle::clone(lhs), souffle::clone(rhs), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/BinaryConstraint.h
+++ b/src/ast/BinaryConstraint.h
@@ -77,7 +77,7 @@ public:
         rhs = map(std::move(rhs));
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         return {lhs.get(), rhs.get()};
     }
 

--- a/src/ast/BinaryConstraint.h
+++ b/src/ast/BinaryConstraint.h
@@ -18,19 +18,10 @@
 
 #include "ast/Argument.h"
 #include "ast/Constraint.h"
-#include "ast/Node.h"
-#include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
 #include "souffle/BinaryConstraintOps.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include <cassert>
-#include <iostream>
-#include <memory>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include "souffle/utility/Types.h"
+#include <iosfwd>
 
 namespace souffle::ast {
 
@@ -46,11 +37,7 @@ namespace souffle::ast {
  */
 class BinaryConstraint : public Constraint {
 public:
-    BinaryConstraint(BinaryConstraintOp o, Own<Argument> ls, Own<Argument> rs, SrcLocation loc = {})
-            : Constraint(std::move(loc)), operation(o), lhs(std::move(ls)), rhs(std::move(rs)) {
-        assert(lhs != nullptr);
-        assert(rhs != nullptr);
-    }
+    BinaryConstraint(BinaryConstraintOp o, Own<Argument> ls, Own<Argument> rs, SrcLocation loc = {});
 
     /** Return left-hand side argument */
     Argument* getLHS() const {
@@ -72,33 +59,17 @@ public:
         operation = op;
     }
 
-    void apply(const NodeMapper& map) override {
-        lhs = map(std::move(lhs));
-        rhs = map(std::move(rhs));
-    }
-
-    NodeVec getChildNodesImpl() const override {
-        return {lhs.get(), rhs.get()};
-    }
+    void apply(const NodeMapper& map) override;
 
 protected:
-    void print(std::ostream& os) const override {
-        if (isInfixFunctorOp(operation)) {
-            os << *lhs << " " << operation << " " << *rhs;
-        } else {
-            os << operation << "(" << *lhs << ", " << *rhs << ")";
-        }
-    }
+    void print(std::ostream& os) const override;
 
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<BinaryConstraint>(node);
-        return operation == other.operation && equal_ptr(lhs, other.lhs) && equal_ptr(rhs, other.rhs);
-    }
+    NodeVec getChildNodesImpl() const override;
 
 private:
-    BinaryConstraint* cloneImpl() const override {
-        return new BinaryConstraint(operation, souffle::clone(lhs), souffle::clone(rhs), getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    BinaryConstraint* cloneImpl() const override;
 
 private:
     /** Constraint (base) operator */

--- a/src/ast/BooleanConstraint.cpp
+++ b/src/ast/BooleanConstraint.cpp
@@ -1,0 +1,42 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020 The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/BooleanConstraint.h"
+#include "souffle/utility/MiscUtil.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+/**
+ * @class BooleanConstraint
+ * @brief Boolean constraint class
+ *
+ * Example:
+ *       true
+ *
+ * Boolean constraint representing either the 'true' or the 'false' value
+ */
+BooleanConstraint::BooleanConstraint(bool truthValue, SrcLocation loc)
+        : Constraint(std::move(loc)), truthValue(truthValue) {}
+
+void BooleanConstraint::print(std::ostream& os) const {
+    os << (truthValue ? "true" : "false");
+}
+
+bool BooleanConstraint::equal(const Node& node) const {
+    const auto& other = asAssert<BooleanConstraint>(node);
+    return truthValue == other.truthValue;
+}
+
+BooleanConstraint* BooleanConstraint::cloneImpl() const {
+    return new BooleanConstraint(truthValue, getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/BooleanConstraint.h
+++ b/src/ast/BooleanConstraint.h
@@ -17,13 +17,8 @@
 #pragma once
 
 #include "ast/Constraint.h"
-#include "ast/Node.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/MiscUtil.h"
-#include <cassert>
-#include <iostream>
-#include <string>
-#include <utility>
+#include <iosfwd>
 
 namespace souffle::ast {
 
@@ -38,8 +33,7 @@ namespace souffle::ast {
  */
 class BooleanConstraint : public Constraint {
 public:
-    BooleanConstraint(bool truthValue, SrcLocation loc = {})
-            : Constraint(std::move(loc)), truthValue(truthValue) {}
+    BooleanConstraint(bool truthValue, SrcLocation loc = {});
 
     /** Check whether constraint holds */
     bool isTrue() const {
@@ -52,19 +46,12 @@ public:
     }
 
 protected:
-    void print(std::ostream& os) const override {
-        os << (truthValue ? "true" : "false");
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<BooleanConstraint>(node);
-        return truthValue == other.truthValue;
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    BooleanConstraint* cloneImpl() const override {
-        return new BooleanConstraint(truthValue, getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    BooleanConstraint* cloneImpl() const override;
 
 private:
     /** Truth value of Boolean constraint */

--- a/src/ast/BranchDeclaration.cpp
+++ b/src/ast/BranchDeclaration.cpp
@@ -1,0 +1,35 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020 The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/BranchDeclaration.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include "souffle/utility/tinyformat.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+BranchDeclaration::BranchDeclaration(std::string constructor, VecOwn<Attribute> fields, SrcLocation loc)
+        : Node(std::move(loc)), constructor(std::move(constructor)), fields(std::move(fields)) {
+    assert(allValidPtrs(this->fields));
+}
+
+std::vector<Attribute*> BranchDeclaration::getFields() {
+    return toPtrVector(fields);
+}
+
+void BranchDeclaration::print(std::ostream& os) const {
+    os << tfm::format("%s {%s}", constructor, join(fields, ", "));
+}
+
+BranchDeclaration* BranchDeclaration::cloneImpl() const {
+    return new BranchDeclaration(constructor, souffle::clone(fields), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/BranchDeclaration.h
+++ b/src/ast/BranchDeclaration.h
@@ -19,12 +19,9 @@
 #include "ast/Attribute.h"
 #include "ast/Node.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include "souffle/utility/tinyformat.h"
+#include "souffle/utility/Types.h"
 #include <iosfwd>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace souffle::ast {
@@ -41,28 +38,19 @@ namespace souffle::ast {
  */
 class BranchDeclaration : public Node {
 public:
-    BranchDeclaration(std::string constructor, VecOwn<Attribute> fields, SrcLocation loc = {})
-            : Node(std::move(loc)), constructor(std::move(constructor)), fields(std::move(fields)) {
-        assert(allValidPtrs(this->fields));
-    }
+    BranchDeclaration(std::string constructor, VecOwn<Attribute> fields, SrcLocation loc = {});
 
     const std::string& getConstructor() const {
         return constructor;
     }
 
-    std::vector<Attribute*> getFields() {
-        return toPtrVector(fields);
-    }
+    std::vector<Attribute*> getFields();
 
 protected:
-    void print(std::ostream& os) const override {
-        os << tfm::format("%s {%s}", constructor, join(fields, ", "));
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    BranchDeclaration* cloneImpl() const override {
-        return new BranchDeclaration(constructor, souffle::clone(fields), getSrcLoc());
-    }
+    BranchDeclaration* cloneImpl() const override;
 
 private:
     std::string constructor;

--- a/src/ast/BranchInit.cpp
+++ b/src/ast/BranchInit.cpp
@@ -1,0 +1,35 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020 The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/BranchInit.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include "souffle/utility/tinyformat.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+BranchInit::BranchInit(std::string constructor, VecOwn<Argument> args, SrcLocation loc)
+        : Term(std::move(args), std::move(loc)), constructor(std::move(constructor)) {}
+
+void BranchInit::print(std::ostream& os) const {
+    os << tfm::format("$%s(%s)", constructor, join(args, ", "));
+}
+
+bool BranchInit::equal(const Node& node) const {
+    const auto& other = asAssert<BranchInit>(node);
+    return (constructor == other.constructor) && equal_targets(args, other.args);
+}
+
+BranchInit* BranchInit::cloneImpl() const {
+    return new BranchInit(constructor, souffle::clone(args), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/BranchInit.h
+++ b/src/ast/BranchInit.h
@@ -17,17 +17,10 @@
 #pragma once
 
 #include "ast/Argument.h"
-#include "ast/Node.h"
 #include "ast/Term.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include "souffle/utility/tinyformat.h"
 #include <iosfwd>
 #include <string>
-#include <utility>
-#include <vector>
 
 namespace souffle::ast {
 
@@ -43,28 +36,20 @@ namespace souffle::ast {
  */
 class BranchInit : public Term {
 public:
-    BranchInit(std::string constructor, VecOwn<Argument> args, SrcLocation loc = {})
-            : Term(std::move(args), std::move(loc)), constructor(std::move(constructor)) {}
+    BranchInit(std::string constructor, VecOwn<Argument> args, SrcLocation loc = {});
 
     const std::string& getConstructor() const {
         return constructor;
     }
 
 protected:
-    void print(std::ostream& os) const override {
-        os << tfm::format("$%s(%s)", constructor, join(args, ", "));
-    }
-
-    /** Implements the node comparison for this node type */
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<BranchInit>(node);
-        return (constructor == other.constructor) && equal_targets(args, other.args);
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    BranchInit* cloneImpl() const override {
-        return new BranchInit(constructor, souffle::clone(args), getSrcLoc());
-    }
+    /** Implements the node comparison for this node type */
+    bool equal(const Node& node) const override;
+
+    BranchInit* cloneImpl() const override;
 
 private:
     /** The adt branch constructor */

--- a/src/ast/Clause.cpp
+++ b/src/ast/Clause.cpp
@@ -1,10 +1,96 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020 The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
 #include "ast/Clause.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
 
 namespace souffle::ast {
 
+Clause::Clause(Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan, SrcLocation loc)
+        : Node(std::move(loc)), head(std::move(head)), bodyLiterals(std::move(bodyLiterals)),
+          plan(std::move(plan)) {
+    assert(this->head != nullptr);
+    assert(allValidPtrs(this->bodyLiterals));
+    // Execution plan can be null
+}
+
+Clause::Clause(Own<Atom> head, SrcLocation loc) : Clause(std::move(head), {}, {}, std::move(loc)) {}
+
+Clause::Clause(QualifiedName name, SrcLocation loc) : Clause(mk<Atom>(name), std::move(loc)) {}
+
+void Clause::addToBody(Own<Literal> literal) {
+    assert(literal != nullptr);
+    bodyLiterals.push_back(std::move(literal));
+}
 void Clause::addToBody(VecOwn<Literal>&& literals) {
     assert(allValidPtrs(literals));
     bodyLiterals.insert(bodyLiterals.end(), std::make_move_iterator(literals.begin()),
             std::make_move_iterator(literals.end()));
 }
+
+void Clause::setHead(Own<Atom> h) {
+    assert(h != nullptr);
+    head = std::move(h);
+}
+
+void Clause::setBodyLiterals(VecOwn<Literal> body) {
+    assert(allValidPtrs(body));
+    bodyLiterals = std::move(body);
+}
+
+std::vector<Literal*> Clause::getBodyLiterals() const {
+    return toPtrVector(bodyLiterals);
+}
+
+void Clause::setExecutionPlan(Own<ExecutionPlan> plan) {
+    this->plan = std::move(plan);
+}
+
+void Clause::apply(const NodeMapper& map) {
+    head = map(std::move(head));
+    for (auto& lit : bodyLiterals) {
+        lit = map(std::move(lit));
+    }
+}
+
+Node::NodeVec Clause::getChildNodesImpl() const {
+    std::vector<const Node*> res = {head.get()};
+    append(res, makePtrRange(bodyLiterals));
+    return res;
+}
+
+void Clause::print(std::ostream& os) const {
+    if (head != nullptr) {
+        os << *head;
+    }
+    if (!bodyLiterals.empty()) {
+        os << " :- \n   " << join(bodyLiterals, ",\n   ");
+    }
+    os << ".";
+    if (plan != nullptr) {
+        os << *plan;
+    }
+}
+
+bool Clause::equal(const Node& node) const {
+    const auto& other = asAssert<Clause>(node);
+    return equal_ptr(head, other.head) && equal_targets(bodyLiterals, other.bodyLiterals) &&
+           equal_ptr(plan, other.plan);
+}
+
+Clause* Clause::cloneImpl() const {
+    return new Clause(souffle::clone(head), souffle::clone(bodyLiterals), souffle::clone(plan), getSrcLoc());
+}
+
 }  // namespace souffle::ast

--- a/src/ast/Clause.cpp
+++ b/src/ast/Clause.cpp
@@ -59,9 +59,7 @@ void Clause::setExecutionPlan(Own<ExecutionPlan> plan) {
 
 void Clause::apply(const NodeMapper& map) {
     head = map(std::move(head));
-    for (auto& lit : bodyLiterals) {
-        lit = map(std::move(lit));
-    }
+    mapAll(bodyLiterals, map);
 }
 
 Node::NodeVec Clause::getChildNodesImpl() const {

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -20,16 +20,8 @@
 #include "ast/ExecutionPlan.h"
 #include "ast/Literal.h"
 #include "ast/Node.h"
-#include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <algorithm>
-#include <memory>
-#include <ostream>
-#include <string>
-#include <utility>
+#include <iosfwd>
 #include <vector>
 
 namespace souffle::ast {
@@ -44,38 +36,23 @@ namespace souffle::ast {
  */
 class Clause : public Node {
 public:
-    Clause(Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan = {}, SrcLocation loc = {})
-            : Node(std::move(loc)), head(std::move(head)), bodyLiterals(std::move(bodyLiterals)),
-              plan(std::move(plan)) {
-        assert(this->head != nullptr);
-        assert(allValidPtrs(this->bodyLiterals));
-        // Execution plan can be null
-    }
+    Clause(Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan = {}, SrcLocation loc = {});
 
-    Clause(Own<Atom> head, SrcLocation loc = {}) : Clause(std::move(head), {}, {}, std::move(loc)) {}
+    Clause(Own<Atom> head, SrcLocation loc = {});
 
-    Clause(QualifiedName name, SrcLocation loc = {}) : Clause(mk<Atom>(name), std::move(loc)) {}
+    Clause(QualifiedName name, SrcLocation loc = {});
 
     /** Add a literal to the body of the clause */
-    void addToBody(Own<Literal> literal) {
-        assert(literal != nullptr);
-        bodyLiterals.push_back(std::move(literal));
-    }
+    void addToBody(Own<Literal> literal);
 
     /** Add a collection of literals to the body of the clause */
     void addToBody(VecOwn<Literal>&& literals);
 
     /** Set the head of clause to @p h */
-    void setHead(Own<Atom> h) {
-        assert(h != nullptr);
-        head = std::move(h);
-    }
+    void setHead(Own<Atom> h);
 
     /** Set the bodyLiterals of clause to @p body */
-    void setBodyLiterals(VecOwn<Literal> body) {
-        assert(allValidPtrs(body));
-        bodyLiterals = std::move(body);
-    }
+    void setBodyLiterals(VecOwn<Literal> body);
 
     /** Return the atom that represents the head of the clause */
     Atom* getHead() const {
@@ -83,9 +60,7 @@ public:
     }
 
     /** Obtains a copy of the internally maintained body literals */
-    std::vector<Literal*> getBodyLiterals() const {
-        return toPtrVector(bodyLiterals);
-    }
+    std::vector<Literal*> getBodyLiterals() const;
 
     /** Obtains the execution plan associated to this clause or null if there is none */
     const ExecutionPlan* getExecutionPlan() const {
@@ -93,55 +68,24 @@ public:
     }
 
     /** Updates the execution plan associated to this clause */
-    void setExecutionPlan(Own<ExecutionPlan> plan) {
-        this->plan = std::move(plan);
-    }
+    void setExecutionPlan(Own<ExecutionPlan> plan);
 
     /** Resets the execution plan */
     void clearExecutionPlan() {
         plan = nullptr;
     }
 
-    void apply(const NodeMapper& map) override {
-        head = map(std::move(head));
-        for (auto& lit : bodyLiterals) {
-            lit = map(std::move(lit));
-        }
-    }
-
-    NodeVec getChildNodesImpl() const override {
-        std::vector<const Node*> res = {head.get()};
-        for (auto& cur : bodyLiterals) {
-            res.push_back(cur.get());
-        }
-        return res;
-    }
+    void apply(const NodeMapper& map) override;
 
 protected:
-    void print(std::ostream& os) const override {
-        if (head != nullptr) {
-            os << *head;
-        }
-        if (!bodyLiterals.empty()) {
-            os << " :- \n   " << join(bodyLiterals, ",\n   ");
-        }
-        os << ".";
-        if (plan != nullptr) {
-            os << *plan;
-        }
-    }
+    void print(std::ostream& os) const override;
 
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Clause>(node);
-        return equal_ptr(head, other.head) && equal_targets(bodyLiterals, other.bodyLiterals) &&
-               equal_ptr(plan, other.plan);
-    }
+    NodeVec getChildNodesImpl() const override;
 
 private:
-    Clause* cloneImpl() const override {
-        return new Clause(
-                souffle::clone(head), souffle::clone(bodyLiterals), souffle::clone(plan), getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    Clause* cloneImpl() const override;
 
 private:
     /** Head of the clause */

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -109,7 +109,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         std::vector<const Node*> res = {head.get()};
         for (auto& cur : bodyLiterals) {
             res.push_back(cur.get());

--- a/src/ast/Component.cpp
+++ b/src/ast/Component.cpp
@@ -1,0 +1,181 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Component.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+void Component::setComponentType(Own<ComponentType> other) {
+    assert(other != nullptr);
+    componentType = std::move(other);
+}
+
+const std::vector<ComponentType*> Component::getBaseComponents() const {
+    return toPtrVector(baseComponents);
+}
+
+void Component::addBaseComponent(Own<ComponentType> component) {
+    assert(component != nullptr);
+    baseComponents.push_back(std::move(component));
+}
+
+void Component::addType(Own<Type> t) {
+    assert(t != nullptr);
+    types.push_back(std::move(t));
+}
+
+std::vector<Type*> Component::getTypes() const {
+    return toPtrVector(types);
+}
+
+void Component::copyBaseComponents(const Component& other) {
+    baseComponents = souffle::clone(other.baseComponents);
+}
+
+void Component::addRelation(Own<Relation> r) {
+    assert(r != nullptr);
+    relations.push_back(std::move(r));
+}
+
+std::vector<Relation*> Component::getRelations() const {
+    return toPtrVector(relations);
+}
+
+void Component::addClause(Own<Clause> c) {
+    assert(c != nullptr);
+    clauses.push_back(std::move(c));
+}
+
+std::vector<Clause*> Component::getClauses() const {
+    return toPtrVector(clauses);
+}
+
+void Component::addDirective(Own<Directive> directive) {
+    assert(directive != nullptr);
+    directives.push_back(std::move(directive));
+}
+
+std::vector<Directive*> Component::getDirectives() const {
+    return toPtrVector(directives);
+}
+
+void Component::addComponent(Own<Component> c) {
+    assert(c != nullptr);
+    components.push_back(std::move(c));
+}
+
+std::vector<Component*> Component::getComponents() const {
+    return toPtrVector(components);
+}
+
+void Component::addInstantiation(Own<ComponentInit> i) {
+    assert(i != nullptr);
+    instantiations.push_back(std::move(i));
+}
+
+std::vector<ComponentInit*> Component::getInstantiations() const {
+    return toPtrVector(instantiations);
+}
+
+void Component::apply(const NodeMapper& mapper) {
+    componentType = mapper(std::move(componentType));
+    mapAll(baseComponents, mapper);
+    mapAll(components, mapper);
+    mapAll(instantiations, mapper);
+    mapAll(types, mapper);
+    mapAll(relations, mapper);
+    mapAll(clauses, mapper);
+    mapAll(directives, mapper);
+}
+
+Node::NodeVec Component::getChildNodesImpl() const {
+    std::vector<const Node*> res;
+    res.push_back(componentType.get());
+    append(res, makePtrRange(baseComponents));
+    append(res, makePtrRange(components));
+    append(res, makePtrRange(instantiations));
+    append(res, makePtrRange(types));
+    append(res, makePtrRange(relations));
+    append(res, makePtrRange(clauses));
+    append(res, makePtrRange(directives));
+    return res;
+}
+
+void Component::print(std::ostream& os) const {
+    auto show = [&](auto&& xs, char const* sep = "\n", char const* prefix = "") {
+        if (xs.empty()) return;
+        os << prefix << join(xs, sep) << "\n";
+    };
+
+    os << ".comp " << *componentType << " ";
+    show(baseComponents, ",", ": ");
+    os << "{\n";
+    show(components);
+    show(instantiations);
+    show(types);
+    show(relations);
+    show(overrideRules, ",", ".");
+    show(clauses, "\n\n");
+    show(directives, "\n\n");
+    os << "}\n";
+}
+
+bool Component::equal(const Node& node) const {
+    const auto& other = asAssert<Component>(node);
+
+    if (equal_ptr(componentType, other.componentType)) {
+        return true;
+    }
+    if (!equal_targets(baseComponents, other.baseComponents)) {
+        return false;
+    }
+    if (!equal_targets(components, other.components)) {
+        return false;
+    }
+    if (!equal_targets(instantiations, other.instantiations)) {
+        return false;
+    }
+    if (!equal_targets(types, other.types)) {
+        return false;
+    }
+    if (!equal_targets(relations, other.relations)) {
+        return false;
+    }
+    if (!equal_targets(clauses, other.clauses)) {
+        return false;
+    }
+    if (!equal_targets(directives, other.directives)) {
+        return false;
+    }
+    if (overrideRules != other.overrideRules) {
+        return false;
+    }
+    return true;
+}
+
+Component* Component::cloneImpl() const {
+    auto* res = new Component();
+    res->componentType = souffle::clone(componentType);
+    res->baseComponents = souffle::clone(baseComponents);
+    res->components = souffle::clone(components);
+    res->instantiations = souffle::clone(instantiations);
+    res->types = souffle::clone(types);
+    res->relations = souffle::clone(relations);
+    res->clauses = souffle::clone(clauses);
+    res->directives = souffle::clone(directives);
+    res->overrideRules = overrideRules;
+    return res;
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Component.cpp
+++ b/src/ast/Component.cpp
@@ -134,34 +134,20 @@ void Component::print(std::ostream& os) const {
 bool Component::equal(const Node& node) const {
     const auto& other = asAssert<Component>(node);
 
-    if (equal_ptr(componentType, other.componentType)) {
-        return true;
-    }
-    if (!equal_targets(baseComponents, other.baseComponents)) {
-        return false;
-    }
-    if (!equal_targets(components, other.components)) {
-        return false;
-    }
-    if (!equal_targets(instantiations, other.instantiations)) {
-        return false;
-    }
-    if (!equal_targets(types, other.types)) {
-        return false;
-    }
-    if (!equal_targets(relations, other.relations)) {
-        return false;
-    }
-    if (!equal_targets(clauses, other.clauses)) {
-        return false;
-    }
-    if (!equal_targets(directives, other.directives)) {
-        return false;
-    }
-    if (overrideRules != other.overrideRules) {
-        return false;
-    }
-    return true;
+    // FIXME (?): This pointer comparison is either irrelevant or should
+    // be moved to operator== in Node. (Since e.g. Program doesn't check pointer
+    // equlity)
+    return (&componentType == &other.componentType) ||
+           // clang-format off
+           (equal_targets(baseComponents, other.baseComponents) &&
+            equal_targets(components, other.components) &&
+            equal_targets(instantiations, other.instantiations) &&
+            equal_targets(types, other.types) &&
+            equal_targets(relations, other.relations) &&
+            equal_targets(clauses, other.clauses) &&
+            equal_targets(directives, other.directives) &&
+            overrideRules != other.overrideRules);
+           // clang-format off
 }
 
 Component* Component::cloneImpl() const {

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -23,17 +23,9 @@
 #include "ast/Node.h"
 #include "ast/Relation.h"
 #include "ast/Type.h"
-#include "ast/utility/NodeMapper.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <algorithm>
-#include <cassert>
-#include <memory>
-#include <ostream>
+#include <iosfwd>
 #include <set>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace souffle::ast {
@@ -58,92 +50,52 @@ public:
     }
 
     /** Set component type */
-    void setComponentType(Own<ComponentType> other) {
-        assert(other != nullptr);
-        componentType = std::move(other);
-    }
+    void setComponentType(Own<ComponentType> other);
 
     /** Get base components */
-    const std::vector<ComponentType*> getBaseComponents() const {
-        return toPtrVector(baseComponents);
-    }
+    const std::vector<ComponentType*> getBaseComponents() const;
 
     /** Add base components */
-    void addBaseComponent(Own<ComponentType> component) {
-        assert(component != nullptr);
-        baseComponents.push_back(std::move(component));
-    }
+    void addBaseComponent(Own<ComponentType> component);
 
     /** Add type */
-    void addType(Own<Type> t) {
-        assert(t != nullptr);
-        types.push_back(std::move(t));
-    }
+    void addType(Own<Type> t);
 
     /** Get types */
-    std::vector<Type*> getTypes() const {
-        return toPtrVector(types);
-    }
+    std::vector<Type*> getTypes() const;
 
     /** Copy base components */
-    void copyBaseComponents(const Component& other) {
-        baseComponents = souffle::clone(other.baseComponents);
-    }
+    void copyBaseComponents(const Component& other);
 
     /** Add relation */
-    void addRelation(Own<Relation> r) {
-        assert(r != nullptr);
-        relations.push_back(std::move(r));
-    }
+    void addRelation(Own<Relation> r);
 
     /** Get relations */
-    std::vector<Relation*> getRelations() const {
-        return toPtrVector(relations);
-    }
+    std::vector<Relation*> getRelations() const;
 
     /** Add clause */
-    void addClause(Own<Clause> c) {
-        assert(c != nullptr);
-        clauses.push_back(std::move(c));
-    }
+    void addClause(Own<Clause> c);
 
     /** Get clauses */
-    std::vector<Clause*> getClauses() const {
-        return toPtrVector(clauses);
-    }
+    std::vector<Clause*> getClauses() const;
 
     /** Add directive */
-    void addDirective(Own<Directive> directive) {
-        assert(directive != nullptr);
-        directives.push_back(std::move(directive));
-    }
+    void addDirective(Own<Directive> directive);
 
     /** Get directive statements */
-    std::vector<Directive*> getDirectives() const {
-        return toPtrVector(directives);
-    }
+    std::vector<Directive*> getDirectives() const;
 
     /** Add components */
-    void addComponent(Own<Component> c) {
-        assert(c != nullptr);
-        components.push_back(std::move(c));
-    }
+    void addComponent(Own<Component> c);
 
     /** Get components */
-    std::vector<Component*> getComponents() const {
-        return toPtrVector(components);
-    }
+    std::vector<Component*> getComponents() const;
 
     /** Add instantiation */
-    void addInstantiation(Own<ComponentInit> i) {
-        assert(i != nullptr);
-        instantiations.push_back(std::move(i));
-    }
+    void addInstantiation(Own<ComponentInit> i);
 
     /** Get instantiation */
-    std::vector<ComponentInit*> getInstantiations() const {
-        return toPtrVector(instantiations);
-    }
+    std::vector<ComponentInit*> getInstantiations() const;
 
     /** Add override */
     void addOverride(const std::string& name) {
@@ -155,126 +107,17 @@ public:
         return overrideRules;
     }
 
-    void apply(const NodeMapper& mapper) override {
-        componentType = mapper(std::move(componentType));
-        for (auto& cur : baseComponents) {
-            cur = mapper(std::move(cur));
-        }
-        for (auto& cur : components) {
-            cur = mapper(std::move(cur));
-        }
-        for (auto& cur : instantiations) {
-            cur = mapper(std::move(cur));
-        }
-        for (auto& cur : types) {
-            cur = mapper(std::move(cur));
-        }
-        for (auto& cur : relations) {
-            cur = mapper(std::move(cur));
-        }
-        for (auto& cur : clauses) {
-            cur = mapper(std::move(cur));
-        }
-        for (auto& cur : directives) {
-            cur = mapper(std::move(cur));
-        }
-    }
-
-    NodeVec getChildNodesImpl() const override {
-        std::vector<const Node*> res;
-
-        res.push_back(componentType.get());
-        for (const auto& cur : baseComponents) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : components) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : instantiations) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : types) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : relations) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : clauses) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : directives) {
-            res.push_back(cur.get());
-        }
-        return res;
-    }
+    void apply(const NodeMapper& mapper) override;
 
 protected:
-    void print(std::ostream& os) const override {
-        auto show = [&](auto&& xs, char const* sep = "\n", char const* prefix = "") {
-            if (xs.empty()) return;
-            os << prefix << join(xs, sep) << "\n";
-        };
+    void print(std::ostream& os) const override;
 
-        os << ".comp " << *componentType << " ";
-        show(baseComponents, ",", ": ");
-        os << "{\n";
-        show(components);
-        show(instantiations);
-        show(types);
-        show(relations);
-        show(overrideRules, ",", ".override ");
-        show(clauses, "\n\n");
-        show(directives, "\n\n");
-        os << "}\n";
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Component>(node);
-
-        if (equal_ptr(componentType, other.componentType)) {
-            return true;
-        }
-        if (!equal_targets(baseComponents, other.baseComponents)) {
-            return false;
-        }
-        if (!equal_targets(components, other.components)) {
-            return false;
-        }
-        if (!equal_targets(instantiations, other.instantiations)) {
-            return false;
-        }
-        if (!equal_targets(types, other.types)) {
-            return false;
-        }
-        if (!equal_targets(relations, other.relations)) {
-            return false;
-        }
-        if (!equal_targets(clauses, other.clauses)) {
-            return false;
-        }
-        if (!equal_targets(directives, other.directives)) {
-            return false;
-        }
-        if (overrideRules != other.overrideRules) {
-            return false;
-        }
-        return true;
-    }
+    NodeVec getChildNodesImpl() const override;
 
 private:
-    Component* cloneImpl() const override {
-        auto* res = new Component();
-        res->componentType = souffle::clone(componentType);
-        res->baseComponents = souffle::clone(baseComponents);
-        res->components = souffle::clone(components);
-        res->instantiations = souffle::clone(instantiations);
-        res->types = souffle::clone(types);
-        res->relations = souffle::clone(relations);
-        res->clauses = souffle::clone(clauses);
-        res->directives = souffle::clone(directives);
-        res->overrideRules = overrideRules;
-        return res;
-    }
+    bool equal(const Node& node) const override;
+
+    Component* cloneImpl() const override;
 
 private:
     /** Name of component and its formal component arguments. */

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -180,7 +180,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         std::vector<const Node*> res;
 
         res.push_back(componentType.get());

--- a/src/ast/ComponentInit.cpp
+++ b/src/ast/ComponentInit.cpp
@@ -1,0 +1,52 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/ComponentInit.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/MiscUtil.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+ComponentInit::ComponentInit(std::string name, Own<ComponentType> type, SrcLocation loc)
+        : Node(std::move(loc)), instanceName(std::move(name)), componentType(std::move(type)) {
+    assert(componentType);
+}
+
+void ComponentInit::setInstanceName(std::string name) {
+    instanceName = std::move(name);
+}
+
+void ComponentInit::setComponentType(Own<ComponentType> type) {
+    assert(type != nullptr);
+    componentType = std::move(type);
+}
+
+void ComponentInit::apply(const NodeMapper& mapper) {
+    componentType = mapper(std::move(componentType));
+}
+
+Node::NodeVec ComponentInit::getChildNodesImpl() const {
+    return {componentType.get()};
+}
+
+void ComponentInit::print(std::ostream& os) const {
+    os << ".init " << instanceName << " = " << *componentType;
+}
+
+bool ComponentInit::equal(const Node& node) const {
+    const auto& other = asAssert<ComponentInit>(node);
+    return instanceName == other.instanceName && *componentType == *other.componentType;
+}
+
+ComponentInit* ComponentInit::cloneImpl() const {
+    return new ComponentInit(instanceName, souffle::clone(componentType), getSrcLoc());
+}
+}  // namespace souffle::ast

--- a/src/ast/ComponentInit.h
+++ b/src/ast/ComponentInit.h
@@ -71,7 +71,7 @@ public:
         componentType = mapper(std::move(componentType));
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         return {componentType.get()};
     }
 

--- a/src/ast/ComponentInit.h
+++ b/src/ast/ComponentInit.h
@@ -18,15 +18,9 @@
 
 #include "ast/ComponentType.h"
 #include "ast/Node.h"
-#include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/MiscUtil.h"
-#include <cassert>
-#include <memory>
-#include <ostream>
+#include <iosfwd>
 #include <string>
-#include <utility>
-#include <vector>
 
 namespace souffle::ast {
 
@@ -41,10 +35,7 @@ namespace souffle::ast {
  */
 class ComponentInit : public Node {
 public:
-    ComponentInit(std::string name, Own<ComponentType> type, SrcLocation loc = {})
-            : Node(std::move(loc)), instanceName(std::move(name)), componentType(std::move(type)) {
-        assert(componentType);
-    }
+    ComponentInit(std::string name, Own<ComponentType> type, SrcLocation loc = {});
 
     /** Return instance name */
     const std::string& getInstanceName() const {
@@ -52,9 +43,7 @@ public:
     }
 
     /** Set instance name */
-    void setInstanceName(std::string name) {
-        instanceName = std::move(name);
-    }
+    void setInstanceName(std::string name);
 
     /** Return component type */
     const ComponentType* getComponentType() const {
@@ -62,33 +51,19 @@ public:
     }
 
     /** Set component type */
-    void setComponentType(Own<ComponentType> type) {
-        assert(type != nullptr);
-        componentType = std::move(type);
-    }
+    void setComponentType(Own<ComponentType> type);
 
-    void apply(const NodeMapper& mapper) override {
-        componentType = mapper(std::move(componentType));
-    }
-
-    NodeVec getChildNodesImpl() const override {
-        return {componentType.get()};
-    }
+    void apply(const NodeMapper& mapper) override;
 
 protected:
-    void print(std::ostream& os) const override {
-        os << ".init " << instanceName << " = " << *componentType;
-    }
+    void print(std::ostream& os) const override;
 
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<ComponentInit>(node);
-        return instanceName == other.instanceName && *componentType == *other.componentType;
-    }
+    bool equal(const Node& node) const override;
 
 private:
-    ComponentInit* cloneImpl() const override {
-        return new ComponentInit(instanceName, souffle::clone(componentType), getSrcLoc());
-    }
+    NodeVec getChildNodesImpl() const override;
+
+    ComponentInit* cloneImpl() const override;
 
 private:
     /** Instance name */

--- a/src/ast/ComponentType.cpp
+++ b/src/ast/ComponentType.cpp
@@ -1,0 +1,36 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/ComponentType.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+ComponentType::ComponentType(std::string name, std::vector<QualifiedName> params, SrcLocation loc)
+        : Node(std::move(loc)), name(std::move(name)), typeParams(std::move(params)) {}
+
+void ComponentType::print(std::ostream& os) const {
+    os << name;
+    if (!typeParams.empty()) {
+        os << "<" << join(typeParams) << ">";
+    }
+}
+
+bool ComponentType::equal(const Node& node) const {
+    const auto& other = asAssert<ComponentType>(node);
+    return name == other.name && typeParams == other.typeParams;
+}
+
+ComponentType* ComponentType::cloneImpl() const {
+    return new ComponentType(name, typeParams, getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/ComponentType.h
+++ b/src/ast/ComponentType.h
@@ -19,11 +19,8 @@
 #include "ast/Node.h"
 #include "ast/QualifiedName.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <ostream>
+#include <iosfwd>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace souffle::ast {

--- a/src/ast/ComponentType.h
+++ b/src/ast/ComponentType.h
@@ -39,8 +39,7 @@ namespace souffle::ast {
  */
 class ComponentType : public Node {
 public:
-    ComponentType(std::string name = "", std::vector<QualifiedName> params = {}, SrcLocation loc = {})
-            : Node(std::move(loc)), name(std::move(name)), typeParams(std::move(params)) {}
+    ComponentType(std::string name = "", std::vector<QualifiedName> params = {}, SrcLocation loc = {});
 
     /** Return component name */
     const std::string& getName() const {
@@ -48,9 +47,7 @@ public:
     }
 
     /** Set component name */
-    void setName(std::string n) {
-        name = std::move(n);
-    }
+    void setName(std::string n);
 
     /** Return component type parameters */
     const std::vector<QualifiedName>& getTypeParameters() const {
@@ -63,22 +60,12 @@ public:
     }
 
 protected:
-    void print(std::ostream& os) const override {
-        os << name;
-        if (!typeParams.empty()) {
-            os << "<" << join(typeParams) << ">";
-        }
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<ComponentType>(node);
-        return name == other.name && typeParams == other.typeParams;
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    ComponentType* cloneImpl() const override {
-        return new ComponentType(name, typeParams, getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    ComponentType* cloneImpl() const override;
 
 private:
     /** Component name */

--- a/src/ast/Constant.cpp
+++ b/src/ast/Constant.cpp
@@ -1,0 +1,27 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Constant.h"
+#include "souffle/utility/MiscUtil.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+Constant::Constant(std::string value, SrcLocation loc)
+        : Argument(std::move(loc)), constant(std::move(value)){};
+
+void Constant::print(std::ostream& os) const {
+    os << getConstant();
+}
+
+bool Constant::equal(const Node& node) const {
+    const auto& other = asAssert<Constant>(node);
+    return constant == other.constant;
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Constant.h
+++ b/src/ast/Constant.h
@@ -17,12 +17,9 @@
 #pragma once
 
 #include "ast/Argument.h"
-#include "ast/Node.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/MiscUtil.h"
-#include <ostream>
+#include <iosfwd>
 #include <string>
-#include <utility>
 
 namespace souffle::ast {
 
@@ -38,17 +35,11 @@ public:
     }
 
 protected:
-    void print(std::ostream& os) const override {
-        os << getConstant();
-    }
+    Constant(std::string value, SrcLocation loc = {});
 
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Constant>(node);
-        return constant == other.constant;
-    }
+    void print(std::ostream& os) const override;
 
-    Constant(std::string value, SrcLocation loc = {})
-            : Argument(std::move(loc)), constant(std::move(value)){};
+    bool equal(const Node& node) const override;
 
 private:
     /** String representation of constant */

--- a/src/ast/Counter.cpp
+++ b/src/ast/Counter.cpp
@@ -1,0 +1,22 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Counter.h"
+#include <ostream>
+
+namespace souffle::ast {
+
+void Counter::print(std::ostream& os) const {
+    os << "$";
+}
+
+Counter* Counter::cloneImpl() const {
+    return new Counter(getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Counter.h
+++ b/src/ast/Counter.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "ast/Argument.h"
-#include <ostream>
+#include <iosfwd>
 
 namespace souffle::ast {
 
@@ -30,14 +30,10 @@ public:
     using Argument::Argument;
 
 protected:
-    void print(std::ostream& os) const override {
-        os << "$";
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    Counter* cloneImpl() const override {
-        return new Counter(getSrcLoc());
-    }
+    Counter* cloneImpl() const override;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Directive.cpp
+++ b/src/ast/Directive.cpp
@@ -1,0 +1,59 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Directive.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+std::ostream& operator<<(std::ostream& os, DirectiveType e) {
+    switch (e) {
+        case DirectiveType::input: return os << "input";
+        case DirectiveType::output: return os << "output";
+        case DirectiveType::printsize: return os << "printsize";
+        case DirectiveType::limitsize: return os << "limitsize";
+    }
+
+    UNREACHABLE_BAD_CASE_ANALYSIS
+}
+
+Directive::Directive(DirectiveType type, QualifiedName name, SrcLocation loc)
+        : Node(std::move(loc)), type(type), name(std::move(name)) {}
+
+void Directive::setQualifiedName(QualifiedName name) {
+    this->name = std::move(name);
+}
+
+void Directive::addParameter(const std::string& key, std::string value) {
+    parameters[key] = std::move(value);
+}
+
+void Directive::print(std::ostream& os) const {
+    os << "." << type << " " << name;
+    if (!parameters.empty()) {
+        os << "(" << join(parameters, ",", [](std::ostream& out, const auto& arg) {
+            out << arg.first << "=\"" << arg.second << "\"";
+        }) << ")";
+    }
+}
+
+bool Directive::equal(const Node& node) const {
+    const auto& other = asAssert<Directive>(node);
+    return other.type == type && other.name == name && other.parameters == parameters;
+}
+
+Directive* Directive::cloneImpl() const {
+    auto res = new Directive(type, name, getSrcLoc());
+    res->parameters = parameters;
+    return res;
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Directive.h
+++ b/src/ast/Directive.h
@@ -19,28 +19,16 @@
 #include "ast/Node.h"
 #include "ast/QualifiedName.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
+#include <iosfwd>
 #include <map>
-#include <ostream>
 #include <string>
-#include <utility>
 
 namespace souffle::ast {
 
 enum class DirectiveType { input, output, printsize, limitsize };
 
 // FIXME: I'm going crazy defining these. There has to be a library that does this boilerplate for us.
-inline std::ostream& operator<<(std::ostream& os, DirectiveType e) {
-    switch (e) {
-        case DirectiveType::input: return os << "input";
-        case DirectiveType::output: return os << "output";
-        case DirectiveType::printsize: return os << "printsize";
-        case DirectiveType::limitsize: return os << "limitsize";
-    }
-
-    UNREACHABLE_BAD_CASE_ANALYSIS
-}
+std::ostream& operator<<(std::ostream& os, DirectiveType e);
 
 /**
  * @class Directive
@@ -49,8 +37,7 @@ inline std::ostream& operator<<(std::ostream& os, DirectiveType e) {
  */
 class Directive : public Node {
 public:
-    Directive(DirectiveType type, QualifiedName name, SrcLocation loc = {})
-            : Node(std::move(loc)), type(type), name(std::move(name)) {}
+    Directive(DirectiveType type, QualifiedName name, SrcLocation loc = {});
 
     /** Get directive type */
     DirectiveType getType() const {
@@ -68,9 +55,7 @@ public:
     }
 
     /** Set relation name */
-    void setQualifiedName(QualifiedName name) {
-        this->name = std::move(name);
-    }
+    void setQualifiedName(QualifiedName name);
 
     /** Get parameter */
     const std::string& getParameter(const std::string& key) const {
@@ -78,9 +63,7 @@ public:
     }
 
     /** Add new parameter */
-    void addParameter(const std::string& key, std::string value) {
-        parameters[key] = std::move(value);
-    }
+    void addParameter(const std::string& key, std::string value);
 
     /** Check for a parameter */
     bool hasParameter(const std::string& key) const {
@@ -93,26 +76,12 @@ public:
     }
 
 protected:
-    void print(std::ostream& os) const override {
-        os << "." << type << " " << name;
-        if (!parameters.empty()) {
-            os << "(" << join(parameters, ",", [](std::ostream& out, const auto& arg) {
-                out << arg.first << "=\"" << arg.second << "\"";
-            }) << ")";
-        }
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Directive>(node);
-        return other.type == type && other.name == name && other.parameters == parameters;
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    Directive* cloneImpl() const override {
-        auto res = new Directive(type, name, getSrcLoc());
-        res->parameters = parameters;
-        return res;
-    }
+    bool equal(const Node& node) const override;
+
+    Directive* cloneImpl() const override;
 
 private:
     /** Type of directive */

--- a/src/ast/ExecutionOrder.cpp
+++ b/src/ast/ExecutionOrder.cpp
@@ -1,0 +1,33 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/ExecutionOrder.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+ExecutionOrder::ExecutionOrder(ExecOrder order, SrcLocation loc)
+        : Node(std::move(loc)), order(std::move(order)) {}
+
+void ExecutionOrder::print(std::ostream& out) const {
+    out << "(" << join(order) << ")";
+}
+
+bool ExecutionOrder::equal(const Node& node) const {
+    const auto& other = asAssert<ExecutionOrder>(node);
+    return order == other.order;
+}
+
+ExecutionOrder* ExecutionOrder::cloneImpl() const {
+    return new ExecutionOrder(order, getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/ExecutionOrder.h
+++ b/src/ast/ExecutionOrder.h
@@ -18,11 +18,7 @@
 
 #include "ast/Node.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <ostream>
-#include <string>
-#include <utility>
+#include <iosfwd>
 #include <vector>
 
 namespace souffle::ast {
@@ -36,8 +32,7 @@ class ExecutionOrder : public Node {
 public:
     using ExecOrder = std::vector<unsigned int>;
 
-    ExecutionOrder(ExecOrder order = {}, SrcLocation loc = {})
-            : Node(std::move(loc)), order(std::move(order)) {}
+    ExecutionOrder(ExecOrder order = {}, SrcLocation loc = {});
 
     /** Get order */
     const ExecOrder& getOrder() const {
@@ -45,19 +40,12 @@ public:
     }
 
 protected:
-    void print(std::ostream& out) const override {
-        out << "(" << join(order) << ")";
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<ExecutionOrder>(node);
-        return order == other.order;
-    }
+    void print(std::ostream& out) const override;
 
 private:
-    ExecutionOrder* cloneImpl() const override {
-        return new ExecutionOrder(order, getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    ExecutionOrder* cloneImpl() const override;
 
 private:
     /** Literal order of body (starting from 1) */

--- a/src/ast/ExecutionPlan.cpp
+++ b/src/ast/ExecutionPlan.cpp
@@ -1,0 +1,65 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/ExecutionPlan.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+/** Set execution order for a given rule version */
+void ExecutionPlan::setOrderFor(int version, Own<ExecutionOrder> plan) {
+    assert(plan != nullptr);
+    plans[version] = std::move(plan);
+}
+
+/** Get orders */
+std::map<int, const ExecutionOrder*> ExecutionPlan::getOrders() const {
+    std::map<int, const ExecutionOrder*> result;
+    for (auto& plan : plans) {
+        result.insert(std::make_pair(plan.first, plan.second.get()));
+    }
+    return result;
+}
+
+void ExecutionPlan::apply(const NodeMapper& map) {
+    for (auto& plan : plans) {
+        plan.second = map(std::move(plan.second));
+    }
+}
+
+Node::NodeVec ExecutionPlan::getChildNodesImpl() const {
+    auto ran = makeTransformRange(plan, [](auto const& pair) { return pair.second.get() });
+    return {ran.begin(), ran.end()};
+}
+
+void ExecutionPlan::print(std::ostream& out) const {
+    if (!plans.empty()) {
+        out << " .plan ";
+        out << join(plans, ", ",
+                [](std::ostream& os, const auto& arg) { os << arg.first << ":" << *arg.second; });
+    }
+}
+
+bool ExecutionPlan::equal(const Node& node) const {
+    const auto& other = asAssert<ExecutionPlan>(node);
+    return equal_targets(plans, other.plans);
+}
+
+ExecutionPlan* ExecutionPlan::cloneImpl() const {
+    auto res = mk<ExecutionPlan>(getSrcLoc());
+    for (auto& plan : plans) {
+        res->setOrderFor(plan.first, souffle::clone(plan.second));
+    }
+    return res.release();
+}
+}  // namespace souffle::ast

--- a/src/ast/ExecutionPlan.cpp
+++ b/src/ast/ExecutionPlan.cpp
@@ -38,7 +38,7 @@ void ExecutionPlan::apply(const NodeMapper& map) {
 }
 
 Node::NodeVec ExecutionPlan::getChildNodesImpl() const {
-    auto ran = makeTransformRange(plan, [](auto const& pair) { return pair.second.get() });
+    auto ran = makeTransformRange(plans, [](auto const& pair) { return pair.second.get(); });
     return {ran.begin(), ran.end()};
 }
 

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -68,7 +68,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         std::vector<const Node*> childNodes;
         for (auto& plan : plans) {
             childNodes.push_back(plan.second.get());

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -18,16 +18,8 @@
 
 #include "ast/ExecutionOrder.h"
 #include "ast/Node.h"
-#include "ast/utility/NodeMapper.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <algorithm>
+#include <iosfwd>
 #include <map>
-#include <memory>
-#include <ostream>
-#include <utility>
-#include <vector>
 
 namespace souffle::ast {
 
@@ -48,56 +40,22 @@ public:
     using Node::Node;
 
     /** Set execution order for a given rule version */
-    void setOrderFor(int version, Own<ExecutionOrder> plan) {
-        assert(plan != nullptr);
-        plans[version] = std::move(plan);
-    }
+    void setOrderFor(int version, Own<ExecutionOrder> plan);
 
     /** Get orders */
-    std::map<int, const ExecutionOrder*> getOrders() const {
-        std::map<int, const ExecutionOrder*> result;
-        for (auto& plan : plans) {
-            result.insert(std::make_pair(plan.first, plan.second.get()));
-        }
-        return result;
-    }
+    std::map<int, const ExecutionOrder*> getOrders() const;
 
-    void apply(const NodeMapper& map) override {
-        for (auto& plan : plans) {
-            plan.second = map(std::move(plan.second));
-        }
-    }
+    void apply(const NodeMapper& map) override;
 
-    NodeVec getChildNodesImpl() const override {
-        std::vector<const Node*> childNodes;
-        for (auto& plan : plans) {
-            childNodes.push_back(plan.second.get());
-        }
-        return childNodes;
-    }
+    NodeVec getChildNodesImpl() const override;
 
 protected:
-    void print(std::ostream& out) const override {
-        if (!plans.empty()) {
-            out << " .plan ";
-            out << join(plans, ", ",
-                    [](std::ostream& os, const auto& arg) { os << arg.first << ":" << *arg.second; });
-        }
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<ExecutionPlan>(node);
-        return equal_targets(plans, other.plans);
-    }
+    void print(std::ostream& out) const override;
 
 private:
-    ExecutionPlan* cloneImpl() const override {
-        auto res = mk<ExecutionPlan>(getSrcLoc());
-        for (auto& plan : plans) {
-            res->setOrderFor(plan.first, souffle::clone(plan.second));
-        }
-        return res.release();
-    }
+    bool equal(const Node& node) const override;
+
+    ExecutionPlan* cloneImpl() const override;
 
 private:
     /** Mapping versions of clauses to execution orders */

--- a/src/ast/FunctionalConstraint.cpp
+++ b/src/ast/FunctionalConstraint.cpp
@@ -1,0 +1,84 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020 The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/FunctionalConstraint.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <utility>
+
+namespace souffle::ast {
+
+FunctionalConstraint::FunctionalConstraint(VecOwn<Variable> keys, SrcLocation loc)
+        : Constraint(std::move(loc)), keys(std::move(keys)) {
+    assert(allValidPtrs(this->keys));
+}
+
+FunctionalConstraint::FunctionalConstraint(Own<Variable> key, SrcLocation loc) : Constraint(std::move(loc)) {
+    assert(key != nullptr);
+    keys.push_back(std::move(key));
+}
+
+std::vector<Variable*> FunctionalConstraint::getKeys() const {
+    return toPtrVector(keys);
+}
+
+Node::NodeVec FunctionalConstraint::getChildNodesImpl() const {
+    auto rn = makePtrRange(keys);
+    return {rn.begin(), rn.end()};
+}
+
+void FunctionalConstraint::print(std::ostream& os) const {
+    os << "keys ";
+    if (keys.size() > 1) {
+        os << "(";
+    }
+    os << join(keys, ",", print_deref<Own<ast::Variable>>());
+    if (keys.size() > 1) {
+        os << ")";
+    }
+}
+
+bool FunctionalConstraint::equal(const Node& node) const {
+    const auto& other = asAssert<FunctionalConstraint>(node);
+    if (keys.size() != other.keys.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < keys.size(); i++) {
+        if (!equal_ptr(keys.at(i), other.keys.at(i))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool FunctionalConstraint::equivalentConstraint(const FunctionalConstraint& other) const {
+    if (this->getArity() != other.getArity()) {
+        return false;
+    }
+    std::set<std::string> keyNames;
+    for (const auto& key : keys) {
+        keyNames.insert(key->getName());
+    }
+    for (const auto& key : other.keys) {
+        if (keyNames.find(key->getName()) == keyNames.end()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+FunctionalConstraint* FunctionalConstraint::cloneImpl() const {
+    return new FunctionalConstraint(souffle::clone(keys), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/FunctionalConstraint.h
+++ b/src/ast/FunctionalConstraint.h
@@ -71,7 +71,7 @@ public:
         return keys.size();
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (auto& cur : keys) {
             res.push_back(cur.get());

--- a/src/ast/Functor.h
+++ b/src/ast/Functor.h
@@ -17,8 +17,6 @@
 #pragma once
 
 #include "ast/Term.h"
-#include "souffle/TypeAttribute.h"
-#include <cstddef>
 
 namespace souffle::ast {
 

--- a/src/ast/FunctorDeclaration.cpp
+++ b/src/ast/FunctorDeclaration.cpp
@@ -1,0 +1,57 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020 The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/FunctorDeclaration.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include "souffle/utility/tinyformat.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+FunctorDeclaration::FunctorDeclaration(std::string name, std::vector<TypeAttribute> argsTypes,
+        TypeAttribute returnType, bool stateful, SrcLocation loc)
+        : Node(std::move(loc)), name(std::move(name)), argsTypes(std::move(argsTypes)),
+          returnType(returnType), stateful(stateful) {
+    assert(this->name.length() > 0 && "functor name is empty");
+}
+
+void FunctorDeclaration::print(std::ostream& out) const {
+    auto convert = [&](TypeAttribute type) {
+        switch (type) {
+            case TypeAttribute::Signed: return "number";
+            case TypeAttribute::Symbol: return "symbol";
+            case TypeAttribute::Float: return "float";
+            case TypeAttribute::Unsigned: return "unsigned";
+            case TypeAttribute::Record: break;
+            case TypeAttribute::ADT: break;
+        }
+        fatal("unhandled `TypeAttribute`");
+    };
+
+    tfm::format(out, ".declfun %s(%s): %s", name, join(map(argsTypes, convert), ","), convert(returnType));
+    if (stateful) {
+        out << " stateful";
+    }
+    out << std::endl;
+}
+
+bool FunctorDeclaration::equal(const Node& node) const {
+    const auto& other = asAssert<FunctorDeclaration>(node);
+    return name == other.name && argsTypes == other.argsTypes && returnType == other.returnType &&
+           stateful == other.stateful;
+}
+
+FunctorDeclaration* FunctorDeclaration::cloneImpl() const {
+    return new FunctorDeclaration(name, argsTypes, returnType, stateful, getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/FunctorDeclaration.h
+++ b/src/ast/FunctorDeclaration.h
@@ -19,15 +19,8 @@
 #include "ast/Node.h"
 #include "parser/SrcLocation.h"
 #include "souffle/TypeAttribute.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include "souffle/utility/tinyformat.h"
-#include <cassert>
-#include <cstdlib>
-#include <ostream>
+#include <iosfwd>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace souffle::ast {
@@ -43,11 +36,7 @@ namespace souffle::ast {
 class FunctorDeclaration : public Node {
 public:
     FunctorDeclaration(std::string name, std::vector<TypeAttribute> argsTypes, TypeAttribute returnType,
-            bool stateful, SrcLocation loc = {})
-            : Node(std::move(loc)), name(std::move(name)), argsTypes(std::move(argsTypes)),
-              returnType(returnType), stateful(stateful) {
-        assert(this->name.length() > 0 && "functor name is empty");
-    }
+            bool stateful, SrcLocation loc = {});
 
     /** Return name */
     const std::string& getName() const {
@@ -75,38 +64,14 @@ public:
     }
 
 protected:
-    void print(std::ostream& out) const override {
-        auto convert = [&](TypeAttribute type) {
-            switch (type) {
-                case TypeAttribute::Signed: return "number";
-                case TypeAttribute::Symbol: return "symbol";
-                case TypeAttribute::Float: return "float";
-                case TypeAttribute::Unsigned: return "unsigned";
-                case TypeAttribute::Record: break;
-                case TypeAttribute::ADT: break;
-            }
-            fatal("unhandled `TypeAttribute`");
-        };
-
-        tfm::format(
-                out, ".declfun %s(%s): %s", name, join(map(argsTypes, convert), ","), convert(returnType));
-        if (stateful) {
-            out << " stateful";
-        }
-        out << std::endl;
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<FunctorDeclaration>(node);
-        return name == other.name && argsTypes == other.argsTypes && returnType == other.returnType &&
-               stateful == other.stateful;
-    }
+    void print(std::ostream& out) const override;
 
 private:
-    FunctorDeclaration* cloneImpl() const override {
-        return new FunctorDeclaration(name, argsTypes, returnType, stateful, getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
 
+    FunctorDeclaration* cloneImpl() const override;
+
+private:
     /** Name of functor */
     const std::string name;
 

--- a/src/ast/IntrinsicFunctor.cpp
+++ b/src/ast/IntrinsicFunctor.cpp
@@ -1,0 +1,44 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020 The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/IntrinsicFunctor.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <cassert>
+#include <ostream>
+
+namespace souffle::ast {
+
+IntrinsicFunctor::IntrinsicFunctor(std::string op, VecOwn<Argument> args, SrcLocation loc)
+        : Functor(std::move(args), std::move(loc)), function(std::move(op)) {}
+
+void IntrinsicFunctor::print(std::ostream& os) const {
+    if (isInfixFunctorOp(function)) {
+        os << "(" << join(args, function) << ")";
+    } else {
+        // Negation is handled differently to all other functors so we need a special case.
+        if (function == FUNCTOR_INTRINSIC_PREFIX_NEGATE_NAME) {
+            os << "-";
+        } else {
+            os << function;
+        }
+        os << "(" << join(args) << ")";
+    }
+}
+
+bool IntrinsicFunctor::equal(const Node& node) const {
+    const auto& other = asAssert<IntrinsicFunctor>(node);
+    return function == other.function && Functor::equal(node);
+}
+
+IntrinsicFunctor* IntrinsicFunctor::cloneImpl() const {
+    return new IntrinsicFunctor(function, souffle::clone(args), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/IntrinsicFunctor.h
+++ b/src/ast/IntrinsicFunctor.h
@@ -19,19 +19,10 @@
 #include "FunctorOps.h"
 #include "ast/Argument.h"
 #include "ast/Functor.h"
-#include "ast/Node.h"
 #include "parser/SrcLocation.h"
-#include "souffle/TypeAttribute.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <cassert>
-#include <cstddef>
-#include <optional>
-#include <ostream>
+#include <iosfwd>
 #include <string>
 #include <utility>
-#include <vector>
 
 namespace souffle::ast {
 
@@ -49,8 +40,7 @@ public:
     IntrinsicFunctor(SrcLocation loc, std::string op, Operands&&... operands)
             : Functor(std::move(loc), std::forward<Operands>(operands)...), function(std::move(op)) {}
 
-    IntrinsicFunctor(std::string op, VecOwn<Argument> args, SrcLocation loc = {})
-            : Functor(std::move(args), std::move(loc)), function(std::move(op)) {}
+    IntrinsicFunctor(std::string op, VecOwn<Argument> args, SrcLocation loc = {});
 
     /** Get (base type) function */
     const std::string& getBaseFunctionOp() const {
@@ -63,29 +53,12 @@ public:
     }
 
 protected:
-    void print(std::ostream& os) const override {
-        if (isInfixFunctorOp(function)) {
-            os << "(" << join(args, function) << ")";
-        } else {
-            // Negation is handled differently to all other functors so we need a special case.
-            if (function == FUNCTOR_INTRINSIC_PREFIX_NEGATE_NAME) {
-                os << "-";
-            } else {
-                os << function;
-            }
-            os << "(" << join(args) << ")";
-        }
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<IntrinsicFunctor>(node);
-        return function == other.function && Functor::equal(node);
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    IntrinsicFunctor* cloneImpl() const override {
-        return new IntrinsicFunctor(function, souffle::clone(args), getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    IntrinsicFunctor* cloneImpl() const override;
 
 private:
     /** Function */

--- a/src/ast/Negation.cpp
+++ b/src/ast/Negation.cpp
@@ -1,0 +1,43 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Negation.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/MiscUtil.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+Negation::Negation(Own<Atom> atom, SrcLocation loc) : Literal(std::move(loc)), atom(std::move(atom)) {
+    assert(this->atom != nullptr);
+}
+
+void Negation::apply(const NodeMapper& map) {
+    atom = map(std::move(atom));
+}
+
+Node::NodeVec Negation::getChildNodesImpl() const {
+    return {atom.get()};
+}
+
+void Negation::print(std::ostream& os) const {
+    os << "!" << *atom;
+}
+
+bool Negation::equal(const Node& node) const {
+    const auto& other = asAssert<Negation>(node);
+    return equal_ptr(atom, other.atom);
+}
+
+Negation* Negation::cloneImpl() const {
+    return new Negation(souffle::clone(atom), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Negation.h
+++ b/src/ast/Negation.h
@@ -18,17 +18,8 @@
 
 #include "ast/Atom.h"
 #include "ast/Literal.h"
-#include "ast/Node.h"
-#include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include <cassert>
-#include <iostream>
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
+#include <iosfwd>
 
 namespace souffle::ast {
 
@@ -43,37 +34,24 @@ namespace souffle::ast {
  */
 class Negation : public Literal {
 public:
-    Negation(Own<Atom> atom, SrcLocation loc = {}) : Literal(std::move(loc)), atom(std::move(atom)) {
-        assert(this->atom != nullptr);
-    }
+    Negation(Own<Atom> atom, SrcLocation loc = {});
 
     /** Get negated atom */
     Atom* getAtom() const {
         return atom.get();
     }
 
-    void apply(const NodeMapper& map) override {
-        atom = map(std::move(atom));
-    }
-
-    NodeVec getChildNodesImpl() const override {
-        return {atom.get()};
-    }
+    void apply(const NodeMapper& map) override;
 
 protected:
-    void print(std::ostream& os) const override {
-        os << "!" << *atom;
-    }
+    void print(std::ostream& os) const override;
 
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Negation>(node);
-        return equal_ptr(atom, other.atom);
-    }
+    NodeVec getChildNodesImpl() const override;
 
 private:
-    Negation* cloneImpl() const override {
-        return new Negation(souffle::clone(atom), getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    Negation* cloneImpl() const override;
 
 private:
     /** Negated atom */

--- a/src/ast/Negation.h
+++ b/src/ast/Negation.h
@@ -56,7 +56,7 @@ public:
         atom = map(std::move(atom));
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         return {atom.get()};
     }
 

--- a/src/ast/NilConstant.cpp
+++ b/src/ast/NilConstant.cpp
@@ -1,0 +1,19 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/NilConstant.h"
+
+namespace souffle::ast {
+
+NilConstant::NilConstant(SrcLocation loc) : Constant("nil", std::move(loc)) {}
+
+NilConstant* NilConstant::cloneImpl() const {
+    return new NilConstant(getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/NilConstant.h
+++ b/src/ast/NilConstant.h
@@ -29,12 +29,10 @@ namespace souffle::ast {
  */
 class NilConstant : public Constant {
 public:
-    NilConstant(SrcLocation loc = {}) : Constant("nil", std::move(loc)) {}
+    NilConstant(SrcLocation loc = {});
 
 private:
-    NilConstant* cloneImpl() const override {
-        return new NilConstant(getSrcLoc());
-    }
+    NilConstant* cloneImpl() const override;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Node.cpp
+++ b/src/ast/Node.cpp
@@ -1,3 +1,10 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
 #include "ast/Node.h"
 #include <typeinfo>
 #include <utility>

--- a/src/ast/Node.cpp
+++ b/src/ast/Node.cpp
@@ -26,11 +26,11 @@ Own<Node> Node::clone() const {
 void Node::apply(const NodeMapper& /* mapper */) {}
 
 Node::ConstChildNodes Node::getChildNodes() const {
-    return ConstChildNodes(getChildNodesImpl(), detail::refCaster);
+    return ConstChildNodes(getChildNodesImpl(), detail::RefCaster());
 }
 
 Node::ChildNodes Node::getChildNodes() {
-    return ChildNodes(getChildNodesImpl(), detail::constCaster);
+    return ChildNodes(getChildNodesImpl(), detail::ConstCaster());
 }
 
 std::ostream& operator<<(std::ostream& out, const Node& node) {

--- a/src/ast/Node.cpp
+++ b/src/ast/Node.cpp
@@ -1,0 +1,50 @@
+#include "ast/Node.h"
+#include <typeinfo>
+#include <utility>
+
+namespace souffle::ast {
+Node::Node(SrcLocation loc) : location(std::move(loc)) {}
+
+/** Set source location for the Node */
+void Node::setSrcLoc(SrcLocation l) {
+    location = std::move(l);
+}
+
+bool Node::operator==(const Node& other) const {
+    if (this == &other) {
+        return true;
+    }
+
+    return typeid(*this) == typeid(*&other) && equal(other);
+}
+
+Own<Node> Node::clone() const {
+    return Own<Node>(cloneImpl());
+}
+
+/** Apply the mapper to all child nodes */
+void Node::apply(const NodeMapper& /* mapper */) {}
+
+Node::ConstChildNodes Node::getChildNodes() const {
+    return ConstChildNodes(getChildNodesImpl(), detail::refCaster);
+}
+
+Node::ChildNodes Node::getChildNodes() {
+    return ChildNodes(getChildNodesImpl(), detail::constCaster);
+}
+
+std::ostream& operator<<(std::ostream& out, const Node& node) {
+    node.print(out);
+    return out;
+}
+
+bool Node::equal(const Node&) const {
+    // FIXME: Change to this == &other?
+    return true;
+}
+
+Node::NodeVec Node::getChildNodesImpl() const {
+    return {};
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Node.h
+++ b/src/ast/Node.h
@@ -73,8 +73,6 @@ public:
     /** Apply the mapper to all child nodes */
     virtual void apply(const NodeMapper& /* mapper */);
 
-private:
-public:
     using NodeVec = std::vector<Node const*>;  // std::reference_wrapper<Node const>>;
 
     using ConstChildNodes = OwningTransformRange<NodeVec, decltype(detail::refCaster)>;
@@ -95,12 +93,12 @@ protected:
     /** Output to a given output stream */
     virtual void print(std::ostream& os) const = 0;
 
-    /** Abstract equality check for two AST nodes */
-    virtual bool equal(const Node& /* other */) const;
-
     virtual NodeVec getChildNodesImpl() const;
 
 private:
+    /** Abstract equality check for two AST nodes */
+    virtual bool equal(const Node& /* other */) const;
+
     virtual Node* cloneImpl() const = 0;
 
 private:

--- a/src/ast/Node.h
+++ b/src/ast/Node.h
@@ -17,17 +17,22 @@
 #pragma once
 
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/Iteration.h"
+#include "souffle/utility/Types.h"
+#include <functional>
 #include <iosfwd>
 #include <string>
-#include <typeinfo>
-#include <utility>
 #include <vector>
 
 namespace souffle::ast {
 
 class NodeMapper;
+class Node;
+
+namespace detail {
+inline auto refCaster = [](Node const* node) -> Node const& { return *node; };
+inline auto constCaster = [](Node const* node) -> Node& { return *const_cast<Node*>(node); };
+}  // namespace detail
 
 /**
  *  @class Node
@@ -35,8 +40,11 @@ class NodeMapper;
  */
 class Node {
 public:
-    Node(SrcLocation loc = {}) : location(std::move(loc)){};
+    Node(SrcLocation loc = {});
     virtual ~Node() = default;
+    // Make sure we don't accidentally copy/slice
+    Node(Node const&) = delete;
+    Node& operator=(Node const&) = delete;
 
     /** Return source location of the Node */
     const SrcLocation& getSrcLoc() const {
@@ -44,9 +52,7 @@ public:
     }
 
     /** Set source location for the Node */
-    void setSrcLoc(SrcLocation l) {
-        location = std::move(l);
-    }
+    void setSrcLoc(SrcLocation l);
 
     /** Return source location of the syntactic element */
     std::string extloc() const {
@@ -54,14 +60,7 @@ public:
     }
 
     /** Equivalence check for two AST nodes */
-    bool operator==(const Node& other) const {
-        if (this == &other) {
-            return true;
-        } else if (typeid(*this) == typeid(*&other)) {
-            return equal(other);
-        }
-        return false;
-    }
+    bool operator==(const Node& other) const;
 
     /** Inequality check for two AST nodes */
     bool operator!=(const Node& other) const {
@@ -69,84 +68,37 @@ public:
     }
 
     /** Create a clone (i.e. deep copy) of this node */
-    Own<Node> clone() const {
-        return Own<Node>(cloneImpl());
-    }
+    Own<Node> clone() const;
 
     /** Apply the mapper to all child nodes */
-    virtual void apply(const NodeMapper& /* mapper */) {}
+    virtual void apply(const NodeMapper& /* mapper */);
 
-    using ConstChildNodes = std::vector<Node const*>;
-    /**
-     * This wraps the ChildNodes container, and does the const-casting
-     * in place.  This allows us to move all the uses to be const-correct,
-     * while it's confined to a single location.
-     * It also saves the user from having to write getChildNodes()
-     * and getChildNodes() const
-     */
-    class ChildNodes {
-    private:
-        auto caster() const {
-            return [](Node const* node) { return const_cast<Node*>(node); };
-        }
+private:
+public:
+    using NodeVec = std::vector<Node const*>;  // std::reference_wrapper<Node const>>;
 
-    public:
-        ChildNodes(ConstChildNodes&& cn) : childNodes(std::move(cn)) {}
-
-        auto begin() const {
-            return transformIter(childNodes.begin(), caster());
-        }
-
-        auto cbegin() const {
-            return transformIter(childNodes.cbegin(), caster());
-        }
-
-        auto end() const {
-            return transformIter(childNodes.end(), caster());
-        }
-
-        auto cend() const {
-            return transformIter(childNodes.cend(), caster());
-        }
-
-        auto size() const {
-            return childNodes.size();
-        }
-        auto operator[](std::size_t ii) const {
-            return childNodes[ii];
-        }
-
-    private:
-        ConstChildNodes childNodes;
-    };
-
+    using ConstChildNodes = OwningTransformRange<NodeVec, decltype(detail::refCaster)>;
     /** Obtain a list of all embedded AST child nodes */
-    ConstChildNodes getChildNodes() const {
-        return getChildNodesImpl();
-    }
+    ConstChildNodes getChildNodes() const;
 
-    ChildNodes getChildNodes() {
-        return ChildNodes(getChildNodesImpl());
-    }
+    /*
+     * Using the ConstCastRange saves the user from having to write
+     * getChildNodes() and getChildNodes() const
+     */
+    using ChildNodes = OwningTransformRange<NodeVec, decltype(detail::constCaster)>;
+    ChildNodes getChildNodes();
 
     /** Print node onto an output stream */
-    friend std::ostream& operator<<(std::ostream& out, const Node& node) {
-        node.print(out);
-        return out;
-    }
+    friend std::ostream& operator<<(std::ostream& out, const Node& node);
 
 protected:
     /** Output to a given output stream */
     virtual void print(std::ostream& os) const = 0;
 
     /** Abstract equality check for two AST nodes */
-    virtual bool equal(const Node& /* other */) const {
-        return true;
-    }
+    virtual bool equal(const Node& /* other */) const;
 
-    virtual ConstChildNodes getChildNodesImpl() const {
-        return {};
-    }
+    virtual NodeVec getChildNodesImpl() const;
 
 private:
     virtual Node* cloneImpl() const = 0;
@@ -154,6 +106,6 @@ private:
 private:
     /** Source location of a syntactic element */
     SrcLocation location;
-};  // namespace souffle::ast
+};
 
 }  // namespace souffle::ast

--- a/src/ast/NumericConstant.cpp
+++ b/src/ast/NumericConstant.cpp
@@ -1,0 +1,33 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/NumericConstant.h"
+#include "souffle/utility/MiscUtil.h"
+#include <cassert>
+#include <utility>
+
+namespace souffle::ast {
+
+NumericConstant::NumericConstant(RamSigned value) : Constant(std::to_string(value)), fixedType(Type::Int) {}
+
+NumericConstant::NumericConstant(std::string constant, SrcLocation loc)
+        : Constant(std::move(constant), std::move(loc)) {}
+
+NumericConstant::NumericConstant(std::string constant, std::optional<Type> fixedType, SrcLocation loc)
+        : Constant(std::move(constant), std::move(loc)), fixedType(fixedType) {}
+
+bool NumericConstant::equal(const Node& node) const {
+    const auto& other = asAssert<NumericConstant>(node);
+    return Constant::equal(node) && fixedType == other.fixedType;
+}
+
+NumericConstant* NumericConstant::cloneImpl() const {
+    return new NumericConstant(getConstant(), getFixedType(), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/NumericConstant.h
+++ b/src/ast/NumericConstant.h
@@ -17,14 +17,10 @@
 #pragma once
 
 #include "ast/Constant.h"
-#include "ast/Node.h"
 #include "parser/SrcLocation.h"
 #include "souffle/RamTypes.h"
-#include "souffle/utility/MiscUtil.h"
-#include <cassert>
 #include <optional>
 #include <string>
-#include <utility>
 
 namespace souffle::ast {
 
@@ -39,27 +35,20 @@ class NumericConstant : public Constant {
 public:
     enum class Type { Int, Uint, Float };
 
-    NumericConstant(RamSigned value) : Constant(std::to_string(value)), fixedType(Type::Int) {}
+    NumericConstant(RamSigned value);
 
-    NumericConstant(std::string constant, SrcLocation loc) : Constant(std::move(constant), std::move(loc)) {}
+    NumericConstant(std::string constant, SrcLocation loc);
 
-    NumericConstant(std::string constant, std::optional<Type> fixedType = std::nullopt, SrcLocation loc = {})
-            : Constant(std::move(constant), std::move(loc)), fixedType(fixedType) {}
+    NumericConstant(std::string constant, std::optional<Type> fixedType = std::nullopt, SrcLocation loc = {});
 
     const std::optional<Type>& getFixedType() const {
         return fixedType;
     }
 
-protected:
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<NumericConstant>(node);
-        return Constant::equal(node) && fixedType == other.fixedType;
-    }
-
 private:
-    NumericConstant* cloneImpl() const override {
-        return new NumericConstant(getConstant(), getFixedType(), getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    NumericConstant* cloneImpl() const override;
 
 private:
     std::optional<Type> fixedType;

--- a/src/ast/Pragma.cpp
+++ b/src/ast/Pragma.cpp
@@ -1,0 +1,32 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved.
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Pragma.h"
+#include "souffle/utility/MiscUtil.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+Pragma::Pragma(std::string key, std::string value, SrcLocation loc)
+        : Node(std::move(loc)), key(std::move(key)), value(std::move(value)) {}
+
+void Pragma::print(std::ostream& os) const {
+    os << ".pragma " << key << " " << value << "\n";
+}
+
+bool Pragma::equal(const Node& node) const {
+    const auto& other = asAssert<Pragma>(node);
+    return other.key == key && other.value == value;
+}
+
+Pragma* Pragma::cloneImpl() const {
+    return new Pragma(key, value, getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Pragma.h
+++ b/src/ast/Pragma.h
@@ -18,8 +18,7 @@
 
 #include "ast/Node.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/MiscUtil.h"
-#include <ostream>
+#include <iosfwd>
 #include <string>
 #include <utility>
 
@@ -31,29 +30,22 @@ namespace souffle::ast {
  */
 class Pragma : public Node {
 public:
-    Pragma(std::string key, std::string value, SrcLocation loc = {})
-            : Node(std::move(loc)), key(std::move(key)), value(std::move(value)) {}
+    Pragma(std::string key, std::string value, SrcLocation loc = {});
 
     /* Get kvp */
     std::pair<std::string, std::string> getkvp() const {
-        return std::pair<std::string, std::string>(key, value);
+        return std::make_pair(key, value);
     }
 
 protected:
-    void print(std::ostream& os) const override {
-        os << ".pragma " << key << " " << value << "\n";
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Pragma>(node);
-        return other.key == key && other.value == value;
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    Pragma* cloneImpl() const override {
-        return new Pragma(key, value, getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
 
+    Pragma* cloneImpl() const override;
+
+private:
     /** Name of the key */
     std::string key;
 

--- a/src/ast/Program.cpp
+++ b/src/ast/Program.cpp
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 #include "ast/Program.h"
+#include "ast/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
 #include <cassert>
 #include <utility>

--- a/src/ast/Program.cpp
+++ b/src/ast/Program.cpp
@@ -9,6 +9,7 @@
 #include "ast/Program.h"
 #include "ast/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/StreamUtil.h"
 #include <cassert>
 #include <utility>
 

--- a/src/ast/Program.cpp
+++ b/src/ast/Program.cpp
@@ -6,16 +6,6 @@
  * - <souffle root>/licenses/SOUFFLE-UPL.txt
  */
 
-/************************************************************************
- *
- * @file Program.cpp
- *
- * Defines the program class
- *
- * TODO(b-scholz): Remove ast/utility/Utils.h dependency!
- *
- ***********************************************************************/
-
 #include "ast/Program.h"
 #include "ast/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -152,7 +152,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (const auto& cur : pragmas) {
             res.push_back(cur.get());

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -26,16 +26,7 @@
 #include "ast/QualifiedName.h"
 #include "ast/Relation.h"
 #include "ast/Type.h"
-#include "ast/utility/NodeMapper.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <algorithm>
-#include <cassert>
 #include <iosfwd>
-#include <memory>
-#include <ostream>
-#include <utility>
 #include <vector>
 
 namespace souffle {
@@ -53,35 +44,22 @@ class ComponentInstantiationTransformer;
 class Program : public Node {
 public:
     /** Return types */
-    std::vector<Type*> getTypes() const {
-        return toPtrVector(types);
-    }
+    std::vector<Type*> getTypes() const;
 
     /** Return relations */
-    std::vector<Relation*> getRelations() const {
-        return toPtrVector(relations);
-    }
+    std::vector<Relation*> getRelations() const;
 
     /** Return clauses */
-    std::vector<Clause*> getClauses() const {
-        return toPtrVector(clauses);
-    }
+    std::vector<Clause*> getClauses() const;
 
     /** Return functor declarations */
-    std::vector<FunctorDeclaration*> getFunctorDeclarations() const {
-        return toPtrVector(functors);
-    }
+    std::vector<FunctorDeclaration*> getFunctorDeclarations() const;
 
     /** Return relation directives */
-    std::vector<Directive*> getDirectives() const {
-        return toPtrVector(directives);
-    }
+    std::vector<Directive*> getDirectives() const;
 
     /** Add relation directive */
-    void addDirective(Own<Directive> directive) {
-        assert(directive && "NULL directive");
-        directives.push_back(std::move(directive));
-    }
+    void addDirective(Own<Directive> directive);
 
     /** Return pragma directives */
     const VecOwn<Pragma>& getPragmaDirectives() const {
@@ -95,10 +73,7 @@ public:
     bool removeRelationDecl(const QualifiedName& name);
 
     /** Set clauses */
-    void setClauses(VecOwn<Clause> newClauses) {
-        assert(allValidPtrs(newClauses));
-        clauses = std::move(newClauses);
-    }
+    void setClauses(VecOwn<Clause> newClauses);
 
     /** Add a clause */
     void addClause(Own<Clause> clause);
@@ -113,120 +88,21 @@ public:
     bool removeDirective(const Directive* directive);
 
     /** Return components */
-    std::vector<Component*> getComponents() const {
-        return toPtrVector(components);
-    }
+    std::vector<Component*> getComponents() const;
 
     /** Return component instantiation */
-    std::vector<ComponentInit*> getComponentInstantiations() const {
-        return toPtrVector(instantiations);
-    }
+    std::vector<ComponentInit*> getComponentInstantiations() const;
 
     /** Remove components and components' instantiations */
     void clearComponents();
 
-    void apply(const NodeMapper& map) override {
-        for (auto& cur : pragmas) {
-            cur = map(std::move(cur));
-        }
-        for (auto& cur : components) {
-            cur = map(std::move(cur));
-        }
-        for (auto& cur : instantiations) {
-            cur = map(std::move(cur));
-        }
-        for (auto& cur : functors) {
-            cur = map(std::move(cur));
-        }
-        for (auto& cur : types) {
-            cur = map(std::move(cur));
-        }
-        for (auto& cur : relations) {
-            cur = map(std::move(cur));
-        }
-        for (auto& cur : clauses) {
-            cur = map(std::move(cur));
-        }
-        for (auto& cur : directives) {
-            cur = map(std::move(cur));
-        }
-    }
-
-    NodeVec getChildNodesImpl() const override {
-        std::vector<const Node*> res;
-        for (const auto& cur : pragmas) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : components) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : instantiations) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : functors) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : types) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : relations) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : clauses) {
-            res.push_back(cur.get());
-        }
-        for (const auto& cur : directives) {
-            res.push_back(cur.get());
-        }
-        return res;
-    }
+    void apply(const NodeMapper& map) override;
 
 protected:
-    void print(std::ostream& os) const override {
-        auto show = [&](auto&& xs, char const* sep = "\n") {
-            if (!xs.empty()) os << join(xs, sep) << "\n";
-        };
+    void print(std::ostream& os) const override;
 
-        show(pragmas, "\n\n");
-        show(components);
-        show(instantiations);
-        show(types);
-        show(functors);
-        show(relations);
-        show(clauses, "\n\n");
-        show(directives, "\n\n");
-    }
+    NodeVec getChildNodesImpl() const override;
 
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Program>(node);
-        if (!equal_targets(pragmas, other.pragmas)) {
-            return false;
-        }
-        if (!equal_targets(components, other.components)) {
-            return false;
-        }
-        if (!equal_targets(instantiations, other.instantiations)) {
-            return false;
-        }
-        if (!equal_targets(functors, other.functors)) {
-            return false;
-        }
-        if (!equal_targets(types, other.types)) {
-            return false;
-        }
-        if (!equal_targets(relations, other.relations)) {
-            return false;
-        }
-        if (!equal_targets(clauses, other.clauses)) {
-            return false;
-        }
-        if (!equal_targets(directives, other.directives)) {
-            return false;
-        }
-        return true;
-    }
-
-protected:
     friend class souffle::ParserDriver;
 
     void addPragma(Own<Pragma> pragma);
@@ -234,31 +110,17 @@ protected:
     void addFunctorDeclaration(Own<FunctorDeclaration> functor);
 
     /** Add component */
-    void addComponent(Own<Component> component) {
-        assert(component && "NULL component");
-        components.push_back(std::move(component));
-    }
+    void addComponent(Own<Component> component);
 
     /** Add component instantiation */
-    void addInstantiation(Own<ComponentInit> instantiation) {
-        assert(instantiation && "NULL instantiation");
-        instantiations.push_back(std::move(instantiation));
-    }
+    void addInstantiation(Own<ComponentInit> instantiation);
 
 private:
-    Program* cloneImpl() const override {
-        auto res = new Program();
-        res->pragmas = souffle::clone(pragmas);
-        res->components = souffle::clone(components);
-        res->instantiations = souffle::clone(instantiations);
-        res->types = souffle::clone(types);
-        res->functors = souffle::clone(functors);
-        res->relations = souffle::clone(relations);
-        res->clauses = souffle::clone(clauses);
-        res->directives = souffle::clone(directives);
-        return res;
-    }
+    bool equal(const Node& node) const override;
 
+    Program* cloneImpl() const override;
+
+private:
     /** Program types  */
     VecOwn<Type> types;
 

--- a/src/ast/QualifiedName.cpp
+++ b/src/ast/QualifiedName.cpp
@@ -1,0 +1,54 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/QualifiedName.h"
+#include "souffle/utility/StreamUtil.h"
+#include <algorithm>
+#include <ostream>
+#include <sstream>
+#include <utility>
+
+namespace souffle::ast {
+
+QualifiedName::QualifiedName() {}
+QualifiedName::QualifiedName(std::string name) {
+    qualifiers.emplace_back(std::move(name));
+}
+QualifiedName::QualifiedName(const char* name) : QualifiedName(std::string(name)) {}
+QualifiedName::QualifiedName(std::vector<std::string> qualifiers) : qualifiers(std::move(qualifiers)) {}
+
+void QualifiedName::append(std::string name) {
+    qualifiers.push_back(std::move(name));
+}
+
+void QualifiedName::prepend(std::string name) {
+    qualifiers.insert(qualifiers.begin(), std::move(name));
+}
+
+/** convert to a string separated by fullstop */
+std::string QualifiedName::toString() const {
+    std::stringstream ss;
+    print(ss);
+    return ss.str();
+}
+
+bool QualifiedName::operator<(const QualifiedName& other) const {
+    return std::lexicographical_compare(
+            qualifiers.begin(), qualifiers.end(), other.qualifiers.begin(), other.qualifiers.end());
+}
+
+void QualifiedName::print(std::ostream& out) const {
+    out << join(qualifiers, ".");
+}
+
+std::ostream& operator<<(std::ostream& out, const QualifiedName& id) {
+    id.print(out);
+    return out;
+}
+
+}  // namespace souffle::ast

--- a/src/ast/QualifiedName.h
+++ b/src/ast/QualifiedName.h
@@ -16,11 +16,8 @@
 
 #pragma once
 
-#include "souffle/utility/StreamUtil.h"
-#include <algorithm>
-#include <sstream>
+#include <iosfwd>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace souffle::ast {
@@ -32,24 +29,20 @@ namespace souffle::ast {
  */
 class QualifiedName {
 public:
-    QualifiedName() : qualifiers() {}
-    QualifiedName(const std::string& name) : qualifiers({name}) {}
-    QualifiedName(const char* name) : QualifiedName(std::string(name)) {}
-    QualifiedName(const std::vector<std::string> qualifiers) : qualifiers(qualifiers) {}
+    QualifiedName();
+    QualifiedName(std::string name);
+    QualifiedName(const char* name);
+    QualifiedName(std::vector<std::string> qualifiers);
     QualifiedName(const QualifiedName&) = default;
     QualifiedName(QualifiedName&&) = default;
     QualifiedName& operator=(const QualifiedName&) = default;
     QualifiedName& operator=(QualifiedName&&) = default;
 
     /** append qualifiers */
-    void append(std::string name) {
-        qualifiers.push_back(std::move(name));
-    }
+    void append(std::string name);
 
     /** prepend qualifiers */
-    void prepend(std::string name) {
-        qualifiers.insert(qualifiers.begin(), std::move(name));
-    }
+    void prepend(std::string name);
 
     /** check for emptiness */
     bool empty() const {
@@ -62,11 +55,7 @@ public:
     }
 
     /** convert to a string separated by fullstop */
-    std::string toString() const {
-        std::stringstream ss;
-        ss << join(qualifiers, ".");
-        return ss.str();
-    }
+    std::string toString() const;
 
     bool operator==(const QualifiedName& other) const {
         return qualifiers == other.qualifiers;
@@ -76,20 +65,12 @@ public:
         return !(*this == other);
     }
 
-    bool operator<(const QualifiedName& other) const {
-        return std::lexicographical_compare(
-                qualifiers.begin(), qualifiers.end(), other.qualifiers.begin(), other.qualifiers.end());
-    }
+    bool operator<(const QualifiedName& other) const;
 
     /** print qualified name */
-    void print(std::ostream& out) const {
-        out << join(qualifiers, ".");
-    }
+    void print(std::ostream& out) const;
 
-    friend std::ostream& operator<<(std::ostream& out, const QualifiedName& id) {
-        id.print(out);
-        return out;
-    }
+    friend std::ostream& operator<<(std::ostream& out, const QualifiedName& id);
 
 private:
     /* array of name qualifiers */

--- a/src/ast/RecordInit.cpp
+++ b/src/ast/RecordInit.cpp
@@ -1,0 +1,26 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/RecordInit.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+RecordInit::RecordInit(VecOwn<Argument> operands, SrcLocation loc)
+        : Term(std::move(operands), std::move(loc)) {}
+
+void RecordInit::print(std::ostream& os) const {
+    os << "[" << join(args) << "]";
+}
+
+RecordInit* RecordInit::cloneImpl() const {
+    return new RecordInit(souffle::clone(args), getSrcLoc());
+}
+}  // namespace souffle::ast

--- a/src/ast/RecordInit.h
+++ b/src/ast/RecordInit.h
@@ -17,15 +17,10 @@
 #pragma once
 
 #include "ast/Argument.h"
-#include "ast/Node.h"
 #include "ast/Term.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <ostream>
+#include <iostream>
 #include <string>
-#include <utility>
-#include <vector>
 
 namespace souffle::ast {
 
@@ -35,18 +30,13 @@ namespace souffle::ast {
  */
 class RecordInit : public Term {
 public:
-    RecordInit(VecOwn<Argument> operands = {}, SrcLocation loc = {})
-            : Term(std::move(operands), std::move(loc)) {}
+    RecordInit(VecOwn<Argument> operands = {}, SrcLocation loc = {});
 
 protected:
-    void print(std::ostream& os) const override {
-        os << "[" << join(args) << "]";
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    RecordInit* cloneImpl() const override {
-        return new RecordInit(souffle::clone(args), getSrcLoc());
-    }
+    RecordInit* cloneImpl() const override;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/RecordType.cpp
+++ b/src/ast/RecordType.cpp
@@ -1,0 +1,49 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/RecordType.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include "souffle/utility/tinyformat.h"
+#include <ostream>
+#include <string>
+#include <utility>
+
+namespace souffle::ast {
+RecordType::RecordType(QualifiedName name, VecOwn<Attribute> fields, SrcLocation loc)
+        : Type(std::move(name), std::move(loc)), fields(std::move(fields)) {
+    assert(allValidPtrs(this->fields));
+}
+
+void RecordType::add(std::string name, QualifiedName type) {
+    fields.push_back(mk<Attribute>(std::move(name), std::move(type)));
+}
+
+std::vector<Attribute*> RecordType::getFields() const {
+    return toPtrVector(fields);
+}
+
+void RecordType::setFieldType(size_t idx, QualifiedName type) {
+    fields.at(idx)->setTypeName(std::move(type));
+}
+
+void RecordType::print(std::ostream& os) const {
+    os << tfm::format(".type %s = [%s]", getQualifiedName(), join(fields, ", "));
+}
+
+bool RecordType::equal(const Node& node) const {
+    const auto& other = asAssert<RecordType>(node);
+    return getQualifiedName() == other.getQualifiedName() && equal_targets(fields, other.fields);
+}
+
+RecordType* RecordType::cloneImpl() const {
+    return new RecordType(getQualifiedName(), souffle::clone(fields), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/RecordType.h
+++ b/src/ast/RecordType.h
@@ -17,20 +17,10 @@
 #pragma once
 
 #include "ast/Attribute.h"
-#include "ast/Node.h"
 #include "ast/QualifiedName.h"
 #include "ast/Type.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include "souffle/utility/tinyformat.h"
-#include <algorithm>
-#include <cstddef>
-#include <iostream>
-#include <memory>
-#include <string>
-#include <utility>
+#include <iosfwd>
 #include <vector>
 
 namespace souffle::ast {
@@ -44,40 +34,24 @@ namespace souffle::ast {
  */
 class RecordType : public Type {
 public:
-    RecordType(QualifiedName name, VecOwn<Attribute> fields, SrcLocation loc = {})
-            : Type(std::move(name), std::move(loc)), fields(std::move(fields)) {
-        assert(allValidPtrs(this->fields));
-    }
+    RecordType(QualifiedName name, VecOwn<Attribute> fields, SrcLocation loc = {});
 
     /** Add field to record type */
-    void add(std::string name, QualifiedName type) {
-        fields.push_back(mk<Attribute>(std::move(name), std::move(type)));
-    }
+    void add(std::string name, QualifiedName type);
 
     /** Get fields of record */
-    std::vector<Attribute*> getFields() const {
-        return toPtrVector(fields);
-    }
+    std::vector<Attribute*> getFields() const;
 
     /** Set field type */
-    void setFieldType(size_t idx, QualifiedName type) {
-        fields.at(idx)->setTypeName(std::move(type));
-    }
+    void setFieldType(size_t idx, QualifiedName type);
 
 protected:
-    void print(std::ostream& os) const override {
-        os << tfm::format(".type %s = [%s]", getQualifiedName(), join(fields, ", "));
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<RecordType>(node);
-        return getQualifiedName() == other.getQualifiedName() && equal_targets(fields, other.fields);
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    RecordType* cloneImpl() const override {
-        return new RecordType(getQualifiedName(), souffle::clone(fields), getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    RecordType* cloneImpl() const override;
 
 private:
     /** record fields */

--- a/src/ast/Relation.cpp
+++ b/src/ast/Relation.cpp
@@ -1,0 +1,76 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Relation.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+Relation::Relation(QualifiedName name, SrcLocation loc) : Node(std::move(loc)), name(std::move(name)) {}
+
+void Relation::setQualifiedName(QualifiedName n) {
+    name = std::move(n);
+}
+
+void Relation::addAttribute(Own<Attribute> attr) {
+    assert(attr && "Undefined attribute");
+    attributes.push_back(std::move(attr));
+}
+
+void Relation::setAttributes(VecOwn<Attribute> attrs) {
+    assert(allValidPtrs(attrs));
+    attributes = std::move(attrs);
+}
+
+std::vector<Attribute*> Relation::getAttributes() const {
+    return toPtrVector(attributes);
+}
+
+void Relation::addDependency(Own<FunctionalConstraint> fd) {
+    assert(fd != nullptr);
+    functionalDependencies.push_back(std::move(fd));
+}
+
+std::vector<FunctionalConstraint*> Relation::getFunctionalDependencies() const {
+    return toPtrVector(functionalDependencies);
+}
+
+void Relation::apply(const NodeMapper& map) {
+    mapAll(attributes, map);
+}
+
+Node::NodeVec Relation::getChildNodesImpl() const {
+    auto rn = makePtrRange(attributes);
+    return {rn.begin(), rn.end()};
+}
+
+void Relation::print(std::ostream& os) const {
+    os << ".decl " << getQualifiedName() << "(" << join(attributes, ", ") << ")" << join(qualifiers, " ")
+       << " " << representation;
+}
+
+bool Relation::equal(const Node& node) const {
+    const auto& other = asAssert<Relation>(node);
+    return name == other.name && equal_targets(attributes, other.attributes);
+}
+
+Relation* Relation::cloneImpl() const {
+    auto res = new Relation(name, getSrcLoc());
+    res->attributes = souffle::clone(attributes);
+    res->qualifiers = qualifiers;
+    res->representation = representation;
+    return res;
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Relation.h
+++ b/src/ast/Relation.h
@@ -125,7 +125,7 @@ public:
         }
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         std::vector<const Node*> res;
         for (const auto& cur : attributes) {
             res.push_back(cur.get());

--- a/src/ast/Relation.h
+++ b/src/ast/Relation.h
@@ -21,19 +21,10 @@
 #include "ast/FunctionalConstraint.h"
 #include "ast/Node.h"
 #include "ast/QualifiedName.h"
-#include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <algorithm>
-#include <cassert>
 #include <cstddef>
-#include <memory>
-#include <ostream>
+#include <iosfwd>
 #include <set>
-#include <string>
-#include <utility>
 #include <vector>
 
 namespace souffle::ast {
@@ -45,7 +36,7 @@ namespace souffle::ast {
 class Relation : public Node {
 public:
     Relation() = default;
-    Relation(QualifiedName name, SrcLocation loc = {}) : Node(std::move(loc)), name(std::move(name)) {}
+    Relation(QualifiedName name, SrcLocation loc = {});
 
     /** Get qualified relation name */
     const QualifiedName& getQualifiedName() const {
@@ -53,31 +44,21 @@ public:
     }
 
     /** Set name for this relation */
-    void setQualifiedName(QualifiedName n) {
-        name = std::move(n);
-    }
+    void setQualifiedName(QualifiedName n);
 
     /** Add a new used type to this relation */
-    void addAttribute(Own<Attribute> attr) {
-        assert(attr && "Undefined attribute");
-        attributes.push_back(std::move(attr));
-    }
+    void addAttribute(Own<Attribute> attr);
 
     /** Return the arity of this relation */
-    size_t getArity() const {
+    std::size_t getArity() const {
         return attributes.size();
     }
 
     /** Set relation attributes */
-    void setAttributes(VecOwn<Attribute> attrs) {
-        assert(allValidPtrs(attrs));
-        attributes = std::move(attrs);
-    }
+    void setAttributes(VecOwn<Attribute> attrs);
 
     /** Get relation attributes */
-    std::vector<Attribute*> getAttributes() const {
-        return toPtrVector(attributes);
-    }
+    std::vector<Attribute*> getAttributes() const;
 
     /** Get relation qualifiers */
     const std::set<RelationQualifier>& getQualifiers() const {
@@ -110,48 +91,21 @@ public:
     }
 
     /** Add functional dependency to this relation */
-    void addDependency(Own<FunctionalConstraint> fd) {
-        assert(fd != nullptr);
-        functionalDependencies.push_back(std::move(fd));
-    }
+    void addDependency(Own<FunctionalConstraint> fd);
 
-    std::vector<FunctionalConstraint*> getFunctionalDependencies() const {
-        return toPtrVector(functionalDependencies);
-    }
+    std::vector<FunctionalConstraint*> getFunctionalDependencies() const;
 
-    void apply(const NodeMapper& map) override {
-        for (auto& cur : attributes) {
-            cur = map(std::move(cur));
-        }
-    }
-
-    NodeVec getChildNodesImpl() const override {
-        std::vector<const Node*> res;
-        for (const auto& cur : attributes) {
-            res.push_back(cur.get());
-        }
-        return res;
-    }
+    void apply(const NodeMapper& map) override;
 
 protected:
-    void print(std::ostream& os) const override {
-        os << ".decl " << getQualifiedName() << "(" << join(attributes, ", ") << ")" << join(qualifiers, " ")
-           << " " << representation;
-    }
+    void print(std::ostream& os) const override;
 
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Relation>(node);
-        return name == other.name && equal_targets(attributes, other.attributes);
-    }
+    NodeVec getChildNodesImpl() const override;
 
 private:
-    Relation* cloneImpl() const override {
-        auto res = new Relation(name, getSrcLoc());
-        res->attributes = souffle::clone(attributes);
-        res->qualifiers = qualifiers;
-        res->representation = representation;
-        return res;
-    }
+    bool equal(const Node& node) const override;
+
+    Relation* cloneImpl() const override;
 
 private:
     /** Name of relation */

--- a/src/ast/StringConstant.cpp
+++ b/src/ast/StringConstant.cpp
@@ -1,0 +1,26 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/StringConstant.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+StringConstant::StringConstant(std::string value, SrcLocation loc)
+        : Constant(std::move(value), std::move(loc)) {}
+
+void StringConstant::print(std::ostream& os) const {
+    os << "\"" << getConstant() << "\"";
+}
+
+StringConstant* StringConstant::cloneImpl() const {
+    return new StringConstant(getConstant(), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/StringConstant.h
+++ b/src/ast/StringConstant.h
@@ -18,9 +18,8 @@
 
 #include "ast/Constant.h"
 #include "parser/SrcLocation.h"
-#include <ostream>
+#include <iosfwd>
 #include <string>
-#include <utility>
 
 namespace souffle::ast {
 
@@ -30,18 +29,13 @@ namespace souffle::ast {
  */
 class StringConstant : public Constant {
 public:
-    explicit StringConstant(std::string value, SrcLocation loc = {})
-            : Constant(std::move(value), std::move(loc)) {}
+    explicit StringConstant(std::string value, SrcLocation loc = {});
 
 protected:
-    void print(std::ostream& os) const override {
-        os << "\"" << getConstant() << "\"";
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    StringConstant* cloneImpl() const override {
-        return new StringConstant(getConstant(), getSrcLoc());
-    }
+    StringConstant* cloneImpl() const override;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/SubsetType.cpp
+++ b/src/ast/SubsetType.cpp
@@ -1,0 +1,32 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020 The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/SubsetType.h"
+#include "souffle/utility/MiscUtil.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+SubsetType::SubsetType(QualifiedName name, QualifiedName baseTypeName, SrcLocation loc)
+        : Type(std::move(name), std::move(loc)), baseType(std::move(baseTypeName)) {}
+
+void SubsetType::print(std::ostream& os) const {
+    os << ".type " << getQualifiedName() << " <: " << getBaseType();
+}
+
+bool SubsetType::equal(const Node& node) const {
+    const auto& other = asAssert<SubsetType>(node);
+    return getQualifiedName() == other.getQualifiedName() && baseType == other.baseType;
+}
+
+SubsetType* SubsetType::cloneImpl() const {
+    return new SubsetType(getQualifiedName(), getBaseType(), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/SubsetType.h
+++ b/src/ast/SubsetType.h
@@ -16,14 +16,10 @@
 
 #pragma once
 
-#include "ast/Node.h"
 #include "ast/QualifiedName.h"
 #include "ast/Type.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/MiscUtil.h"
-#include <iostream>
-#include <string>
-#include <utility>
+#include <iosfwd>
 
 namespace souffle::ast {
 
@@ -36,8 +32,7 @@ namespace souffle::ast {
  */
 class SubsetType : public Type {
 public:
-    SubsetType(QualifiedName name, QualifiedName baseTypeName, SrcLocation loc = {})
-            : Type(std::move(name), std::move(loc)), baseType(std::move(baseTypeName)) {}
+    SubsetType(QualifiedName name, QualifiedName baseTypeName, SrcLocation loc = {});
 
     /** Return base type */
     const QualifiedName& getBaseType() const {
@@ -45,19 +40,12 @@ public:
     }
 
 protected:
-    void print(std::ostream& os) const override {
-        os << ".type " << getQualifiedName() << " <: " << getBaseType();
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<SubsetType>(node);
-        return getQualifiedName() == other.getQualifiedName() && baseType == other.baseType;
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    SubsetType* cloneImpl() const override {
-        return new SubsetType(getQualifiedName(), getBaseType(), getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    SubsetType* cloneImpl() const override;
 
 private:
     /** Base type */

--- a/src/ast/Term.cpp
+++ b/src/ast/Term.cpp
@@ -1,0 +1,46 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Term.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include <cassert>
+
+namespace souffle::ast {
+
+Term::Term(VecOwn<Argument> operands, SrcLocation loc) : Argument(std::move(loc)), args(std::move(operands)) {
+    assert(allValidPtrs(args));
+}
+
+std::vector<Argument*> Term::getArguments() const {
+    return toPtrVector(args);
+}
+
+/** Add argument to argument list */
+void Term::addArgument(Own<Argument> arg) {
+    assert(arg != nullptr);
+    args.push_back(std::move(arg));
+}
+
+Node::NodeVec Term::getChildNodesImpl() const {
+    auto res = Argument::getChildNodesImpl();
+    append(res, makePtrRange(args));
+    return res;
+}
+
+void Term::apply(const NodeMapper& map) {
+    mapAll(args, map);
+}
+
+bool Term::equal(const Node& node) const {
+    const auto& other = asAssert<Term>(node);
+    return equal_targets(args, other.args);
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Term.h
+++ b/src/ast/Term.h
@@ -17,13 +17,8 @@
 #pragma once
 
 #include "ast/Argument.h"
-#include "ast/Node.h"
-#include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
 #include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include <algorithm>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -37,53 +32,28 @@ namespace souffle::ast {
 class Term : public Argument {
 protected:
     template <typename... Operands>
-    Term(Operands&&... operands) : Term(asVec(std::forward<Operands>(operands)...)) {}
+    Term(Operands&&... operands) : Term({}, std::forward<Operands>(operands)...) {}
 
     template <typename... Operands>
     Term(SrcLocation loc, Operands&&... operands)
             : Term(asVec(std::forward<Operands>(operands)...), std::move(loc)) {}
 
-    Term(VecOwn<Argument> operands, SrcLocation loc = {})
-            : Argument(std::move(loc)), args(std::move(operands)) {
-        assert(allValidPtrs(args));
-    }
+    Term(VecOwn<Argument> operands, SrcLocation loc = {});
 
 public:
     /** Get arguments */
-    std::vector<Argument*> getArguments() const {
-        return toPtrVector(args);
-    }
+    std::vector<Argument*> getArguments() const;
 
     /** Add argument to argument list */
-    void addArgument(Own<Argument> arg) {
-        assert(arg != nullptr);
-        args.push_back(std::move(arg));
-    }
+    void addArgument(Own<Argument> arg);
 
-    NodeVec getChildNodesImpl() const override {
-        auto res = Argument::getChildNodesImpl();
-        for (auto& cur : args) {
-            res.push_back(cur.get());
-        }
-        return res;
-    }
+    void apply(const NodeMapper& map) override;
 
-    void apply(const NodeMapper& map) override {
-        for (auto& arg : args) {
-            arg = map(std::move(arg));
-        }
-    }
-
-protected:
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Term>(node);
-        return equal_targets(args, other.args);
-    }
-
-    /** Arguments */
-    VecOwn<Argument> args;
+    bool equal(const Node& node) const override;
 
 private:
+    NodeVec getChildNodesImpl() const override;
+
     template <typename... Operands>
     static VecOwn<Argument> asVec(Operands... ops) {
         Own<Argument> ary[] = {std::move(ops)...};
@@ -93,6 +63,10 @@ private:
         }
         return xs;
     }
+
+protected:
+    /** Arguments */
+    VecOwn<Argument> args;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Term.h
+++ b/src/ast/Term.h
@@ -60,7 +60,7 @@ public:
         args.push_back(std::move(arg));
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         auto res = Argument::getChildNodesImpl();
         for (auto& cur : args) {
             res.push_back(cur.get());

--- a/src/ast/TranslationUnit.cpp
+++ b/src/ast/TranslationUnit.cpp
@@ -1,0 +1,52 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/TranslationUnit.h"
+#include "Global.h"
+#include "ast/Program.h"
+#include "ast/analysis/PrecedenceGraph.h"
+#include "ast/analysis/SCCGraph.h"
+#include "reports/DebugReport.h"
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace souffle::ast {
+
+TranslationUnit::TranslationUnit(Own<Program> program, ErrorReport& e, DebugReport& d)
+        : program(std::move(program)), errorReport(e), debugReport(d) {
+    assert(this->program != nullptr);
+}
+
+TranslationUnit::~TranslationUnit() = default;
+
+/** get analysis: analysis is generated on the fly if not present */
+analysis::Analysis* TranslationUnit::addAnalysis(char const* name, Own<analysis::Analysis> analysis) const {
+    static const bool debug = Global::config().has("debug-report");
+    auto* anaPtr = analysis.get();
+    analyses.insert({name, std::move(analysis)});
+    anaPtr->run(*this);
+    if (debug) {
+        std::ostringstream ss;
+        std::string strName = name;
+        anaPtr->print(ss);
+        if (!isA<analysis::PrecedenceGraphAnalysis>(anaPtr) && !isA<analysis::SCCGraphAnalysis>(anaPtr)) {
+            debugReport.addSection(strName, "Ast Analysis [" + strName + "]", ss.str());
+        } else {
+            debugReport.addSection(
+                    DebugReportSection(strName, "Ast Analysis [" + strName + "]", {}, ss.str()));
+        }
+    }
+    return anaPtr;
+}
+
+void TranslationUnit::invalidateAnalyses() const {
+    analyses.clear();
+}
+
+}  // namespace souffle::ast

--- a/src/ast/TranslationUnit.h
+++ b/src/ast/TranslationUnit.h
@@ -16,22 +16,23 @@
 
 #pragma once
 
-#include "Global.h"
-#include "ast/Program.h"
-#include "ast/analysis/Analysis.h"
-#include "ast/analysis/PrecedenceGraph.h"
-#include "ast/analysis/SCCGraph.h"
-#include "ast/analysis/SumTypeBranches.h"
-#include "ast/analysis/Type.h"
-#include "reports/DebugReport.h"
-#include "reports/ErrorReport.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/Types.h"
 #include <map>
-#include <memory>
-#include <sstream>
-#include <string>
 #include <utility>
 
+namespace souffle {
+class ErrorReport;
+class DebugReport;
+}  // namespace souffle
+
 namespace souffle::ast {
+
+class Program;
+
+namespace analysis {
+class Analysis;
+}
 
 /**
  * @class TranslationUnit
@@ -44,39 +45,25 @@ namespace souffle::ast {
 
 class TranslationUnit {
 public:
-    TranslationUnit(Own<Program> program, ErrorReport& e, DebugReport& d)
-            : program(std::move(program)), errorReport(e), debugReport(d) {}
-
-    virtual ~TranslationUnit() = default;
+    TranslationUnit(Own<Program> program, ErrorReport& e, DebugReport& d);
+    virtual ~TranslationUnit();
 
     /** get analysis: analysis is generated on the fly if not present */
     template <class Analysis>
     Analysis* getAnalysis() const {
-        static const bool debug = Global::config().has("debug-report");
-        std::string name = Analysis::name;
-        auto it = analyses.find(name);
+        auto it = analyses.find(Analysis::name);
+        analysis::Analysis* ana = nullptr;
         if (it == analyses.end()) {
-            // analysis does not exist yet, create instance and run it.
-            analyses[name] = mk<Analysis>();
-            analyses[name]->run(*this);
-            if (debug) {
-                std::stringstream ss;
-                analyses[name]->print(ss);
-                if (!isA<analysis::PrecedenceGraphAnalysis>(analyses[name]) &&
-                        !isA<analysis::SCCGraphAnalysis>(analyses[name])) {
-                    debugReport.addSection(name, "Ast Analysis [" + name + "]", ss.str());
-                } else {
-                    debugReport.addSection(
-                            DebugReportSection(name, "Ast Analysis [" + name + "]", {}, ss.str()));
-                }
-            }
+            ana = addAnalysis(Analysis::name, mk<Analysis>());
+        } else {
+            ana = it->second.get();
         }
-        return as<Analysis>(analyses[name]);
+
+        return as<Analysis>(ana);
     }
 
     /** Return the program */
     Program& getProgram() const {
-        assert(program && "NULL program");
         return *program.get();
     }
 
@@ -86,14 +73,15 @@ public:
     }
 
     /** Destroy all cached analyses of translation unit */
-    void invalidateAnalyses() const {
-        analyses.clear();
-    }
+    void invalidateAnalyses() const;
 
     /** Return debug report */
     DebugReport& getDebugReport() {
         return debugReport;
     }
+
+private:
+    analysis::Analysis* addAnalysis(char const* name, Own<analysis::Analysis> analysis) const;
 
 private:
     /** Cached analyses */

--- a/src/ast/Type.cpp
+++ b/src/ast/Type.cpp
@@ -1,0 +1,20 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Type.h"
+#include <utility>
+
+namespace souffle::ast {
+
+Type::Type(QualifiedName name, SrcLocation loc) : Node(std::move(loc)), name(std::move(name)) {}
+
+void Type::setQualifiedName(QualifiedName name) {
+    this->name = std::move(name);
+}
+
+}  // namespace souffle::ast

--- a/src/ast/Type.h
+++ b/src/ast/Type.h
@@ -19,8 +19,6 @@
 #include "ast/Node.h"
 #include "ast/QualifiedName.h"
 #include "parser/SrcLocation.h"
-#include <string>
-#include <utility>
 
 namespace souffle::ast {
 
@@ -30,7 +28,7 @@ namespace souffle::ast {
  */
 class Type : public Node {
 public:
-    Type(QualifiedName name = {}, SrcLocation loc = {}) : Node(std::move(loc)), name(std::move(name)) {}
+    Type(QualifiedName name = {}, SrcLocation loc = {});
 
     /** Return type name */
     const QualifiedName& getQualifiedName() const {
@@ -38,9 +36,7 @@ public:
     }
 
     /** Set type name */
-    void setQualifiedName(QualifiedName name) {
-        this->name = std::move(name);
-    }
+    void setQualifiedName(QualifiedName name);
 
 private:
     /** type name */

--- a/src/ast/TypeCast.cpp
+++ b/src/ast/TypeCast.cpp
@@ -1,0 +1,50 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/TypeCast.h"
+#include "ast/utility/NodeMapper.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/tinyformat.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+TypeCast::TypeCast(Own<Argument> value, QualifiedName type, SrcLocation loc)
+        : Argument(std::move(loc)), value(std::move(value)), type(std::move(type)) {
+    assert(this->value != nullptr);
+}
+
+void TypeCast::setType(QualifiedName type) {
+    this->type = std::move(type);
+}
+
+Node::NodeVec TypeCast::getChildNodesImpl() const {
+    auto res = Argument::getChildNodesImpl();
+    res.push_back(value.get());
+    return res;
+}
+
+void TypeCast::apply(const NodeMapper& map) {
+    value = map(std::move(value));
+}
+
+void TypeCast::print(std::ostream& os) const {
+    os << tfm::format("as(%s, %s)", *value, type);
+}
+
+bool TypeCast::equal(const Node& node) const {
+    const auto& other = asAssert<TypeCast>(node);
+    return type == other.type && equal_ptr(value, other.value);
+}
+
+TypeCast* TypeCast::cloneImpl() const {
+    return new TypeCast(souffle::clone(value), type, getSrcLoc());
+}
+}  // namespace souffle::ast

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -19,14 +19,7 @@
 #include "ast/Argument.h"
 #include "ast/QualifiedName.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/tinyformat.h"
-#include <memory>
-#include <ostream>
-#include <string>
-#include <utility>
-#include <vector>
+#include <iosfwd>
 
 namespace souffle::ast {
 

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -17,9 +17,7 @@
 #pragma once
 
 #include "ast/Argument.h"
-#include "ast/Node.h"
 #include "ast/QualifiedName.h"
-#include "ast/utility/NodeMapper.h"
 #include "parser/SrcLocation.h"
 #include "souffle/utility/ContainerUtil.h"
 #include "souffle/utility/MiscUtil.h"
@@ -39,10 +37,7 @@ namespace souffle::ast {
 
 class TypeCast : public Argument {
 public:
-    TypeCast(Own<Argument> value, QualifiedName type, SrcLocation loc = {})
-            : Argument(std::move(loc)), value(std::move(value)), type(std::move(type)) {
-        assert(this->value != nullptr);
-    }
+    TypeCast(Own<Argument> value, QualifiedName type, SrcLocation loc = {});
 
     /** Return value */
     Argument* getValue() const {
@@ -55,34 +50,19 @@ public:
     }
 
     /** Set cast type */
-    void setType(const QualifiedName& type) {
-        this->type = type;
-    }
+    void setType(QualifiedName type);
 
-    NodeVec getChildNodesImpl() const override {
-        auto res = Argument::getChildNodesImpl();
-        res.push_back(value.get());
-        return res;
-    }
-
-    void apply(const NodeMapper& map) override {
-        value = map(std::move(value));
-    }
+    void apply(const NodeMapper& map) override;
 
 protected:
-    void print(std::ostream& os) const override {
-        os << tfm::format("as(%s, %s)", *value, type);
-    }
+    void print(std::ostream& os) const override;
 
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<TypeCast>(node);
-        return type == other.type && equal_ptr(value, other.value);
-    }
+    NodeVec getChildNodesImpl() const override;
 
 private:
-    TypeCast* cloneImpl() const override {
-        return new TypeCast(souffle::clone(value), type, getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    TypeCast* cloneImpl() const override;
 
 private:
     /** Casted value */

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -59,7 +59,7 @@ public:
         this->type = type;
     }
 
-    std::vector<const Node*> getChildNodesImpl() const override {
+    NodeVec getChildNodesImpl() const override {
         auto res = Argument::getChildNodesImpl();
         res.push_back(value.get());
         return res;

--- a/src/ast/UnionType.cpp
+++ b/src/ast/UnionType.cpp
@@ -1,0 +1,40 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/UnionType.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+UnionType::UnionType(QualifiedName name, std::vector<QualifiedName> types, SrcLocation loc)
+        : Type(std::move(name), std::move(loc)), types(std::move(types)) {}
+
+void UnionType::add(QualifiedName type) {
+    types.push_back(std::move(type));
+}
+
+void UnionType::setType(std::size_t idx, QualifiedName type) {
+    types.at(idx) = std::move(type);
+}
+
+void UnionType::print(std::ostream& os) const {
+    os << ".type " << getQualifiedName() << " = " << join(types, " | ");
+}
+
+bool UnionType::equal(const Node& node) const {
+    const auto& other = asAssert<UnionType>(node);
+    return getQualifiedName() == other.getQualifiedName() && types == other.types;
+}
+
+UnionType* UnionType::cloneImpl() const {
+    return new UnionType(getQualifiedName(), types, getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/UnionType.h
+++ b/src/ast/UnionType.h
@@ -16,17 +16,11 @@
 
 #pragma once
 
-#include "ast/Node.h"
 #include "ast/QualifiedName.h"
 #include "ast/Type.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <algorithm>
 #include <cstddef>
-#include <iostream>
-#include <string>
-#include <utility>
+#include <iosfwd>
 #include <vector>
 
 namespace souffle::ast {
@@ -44,8 +38,7 @@ namespace souffle::ast {
  */
 class UnionType : public Type {
 public:
-    UnionType(QualifiedName name, std::vector<QualifiedName> types, SrcLocation loc = {})
-            : Type(std::move(name), std::move(loc)), types(std::move(types)) {}
+    UnionType(QualifiedName name, std::vector<QualifiedName> types, SrcLocation loc = {});
 
     /** Return list of unioned types */
     const std::vector<QualifiedName>& getTypes() const {
@@ -57,29 +50,18 @@ public:
     }
 
     /** Add another unioned type */
-    void add(QualifiedName type) {
-        types.push_back(std::move(type));
-    }
+    void add(QualifiedName type);
 
     /** Set type */
-    void setType(size_t idx, QualifiedName type) {
-        types.at(idx) = std::move(type);
-    }
+    void setType(std::size_t idx, QualifiedName type);
 
 protected:
-    void print(std::ostream& os) const override {
-        os << ".type " << getQualifiedName() << " = " << join(types, " | ");
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<UnionType>(node);
-        return getQualifiedName() == other.getQualifiedName() && types == other.types;
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    UnionType* cloneImpl() const override {
-        return new UnionType(getQualifiedName(), types, getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    UnionType* cloneImpl() const override;
 
 private:
     /** List of unioned types */

--- a/src/ast/UnnamedVariable.cpp
+++ b/src/ast/UnnamedVariable.cpp
@@ -1,0 +1,22 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/UnnamedVariable.h"
+#include <ostream>
+
+namespace souffle::ast {
+
+void UnnamedVariable::print(std::ostream& os) const {
+    os << "_";
+}
+
+UnnamedVariable* UnnamedVariable::cloneImpl() const {
+    return new UnnamedVariable(getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/UnnamedVariable.h
+++ b/src/ast/UnnamedVariable.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "ast/Argument.h"
-#include <ostream>
+#include <iosfwd>
 
 namespace souffle::ast {
 
@@ -30,14 +30,10 @@ public:
     using Argument::Argument;
 
 protected:
-    void print(std::ostream& os) const override {
-        os << "_";
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    UnnamedVariable* cloneImpl() const override {
-        return new UnnamedVariable(getSrcLoc());
-    }
+    UnnamedVariable* cloneImpl() const override;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/UserDefinedFunctor.cpp
+++ b/src/ast/UserDefinedFunctor.cpp
@@ -1,0 +1,37 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/UserDefinedFunctor.h"
+#include "souffle/utility/ContainerUtil.h"
+#include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/StreamUtil.h"
+#include <cassert>
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+
+UserDefinedFunctor::UserDefinedFunctor(std::string name) : Functor({}, {}), name(std::move(name)){};
+
+UserDefinedFunctor::UserDefinedFunctor(std::string name, VecOwn<Argument> args, SrcLocation loc)
+        : Functor(std::move(args), std::move(loc)), name(std::move(name)) {}
+
+void UserDefinedFunctor::print(std::ostream& os) const {
+    os << '@' << name << "(" << join(args) << ")";
+}
+
+bool UserDefinedFunctor::equal(const Node& node) const {
+    const auto& other = asAssert<UserDefinedFunctor>(node);
+    return name == other.name && Functor::equal(node);
+}
+
+UserDefinedFunctor* UserDefinedFunctor::cloneImpl() const {
+    return new UserDefinedFunctor(name, souffle::clone(args), getSrcLoc());
+}
+
+}  // namespace souffle::ast

--- a/src/ast/UserDefinedFunctor.h
+++ b/src/ast/UserDefinedFunctor.h
@@ -18,19 +18,10 @@
 
 #include "ast/Argument.h"
 #include "ast/Functor.h"
-#include "ast/Node.h"
 #include "parser/SrcLocation.h"
 #include "souffle/TypeAttribute.h"
-#include "souffle/utility/ContainerUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include <cassert>
-#include <cstddef>
-#include <optional>
-#include <ostream>
+#include <iosfwd>
 #include <string>
-#include <utility>
-#include <vector>
 
 namespace souffle::ast {
 
@@ -40,10 +31,9 @@ namespace souffle::ast {
  */
 class UserDefinedFunctor : public Functor {
 public:
-    explicit UserDefinedFunctor(std::string name) : Functor({}, {}), name(std::move(name)){};
+    explicit UserDefinedFunctor(std::string name);
 
-    UserDefinedFunctor(std::string name, VecOwn<Argument> args, SrcLocation loc = {})
-            : Functor(std::move(args), std::move(loc)), name(std::move(name)) {}
+    UserDefinedFunctor(std::string name, VecOwn<Argument> args, SrcLocation loc = {});
 
     /** return the name */
     const std::string& getName() const {
@@ -51,22 +41,16 @@ public:
     }
 
 protected:
-    void print(std::ostream& os) const override {
-        os << '@' << name << "(" << join(args) << ")";
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<UserDefinedFunctor>(node);
-        return name == other.name && Functor::equal(node);
-    }
-
-    /** Name */
-    const std::string name;
+    void print(std::ostream& os) const override;
 
 private:
-    UserDefinedFunctor* cloneImpl() const override {
-        return new UserDefinedFunctor(name, souffle::clone(args), getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    UserDefinedFunctor* cloneImpl() const override;
+
+private:
+    /** Name */
+    const std::string name;
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Variable.cpp
+++ b/src/ast/Variable.cpp
@@ -1,0 +1,33 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+#include "ast/Variable.h"
+#include "souffle/utility/MiscUtil.h"
+#include <ostream>
+#include <utility>
+
+namespace souffle::ast {
+Variable::Variable(std::string name, SrcLocation loc) : Argument(std::move(loc)), name(std::move(name)) {}
+
+void Variable::setName(std::string name) {
+    this->name = std::move(name);
+}
+
+void Variable::print(std::ostream& os) const {
+    os << name;
+}
+
+bool Variable::equal(const Node& node) const {
+    const auto& other = asAssert<Variable>(node);
+    return name == other.name;
+}
+
+Variable* Variable::cloneImpl() const {
+    return new Variable(name, getSrcLoc());
+}
+}  // namespace souffle::ast

--- a/src/ast/Variable.h
+++ b/src/ast/Variable.h
@@ -17,12 +17,9 @@
 #pragma once
 
 #include "ast/Argument.h"
-#include "ast/Node.h"
 #include "parser/SrcLocation.h"
-#include "souffle/utility/MiscUtil.h"
-#include <ostream>
+#include <iosfwd>
 #include <string>
-#include <utility>
 
 namespace souffle::ast {
 
@@ -32,12 +29,10 @@ namespace souffle::ast {
  */
 class Variable : public Argument {
 public:
-    Variable(std::string name, SrcLocation loc = {}) : Argument(std::move(loc)), name(std::move(name)) {}
+    Variable(std::string name, SrcLocation loc = {});
 
     /** Set variable name */
-    void setName(std::string name) {
-        this->name = std::move(name);
-    }
+    void setName(std::string name);
 
     /** Return variable name */
     const std::string& getName() const {
@@ -45,19 +40,12 @@ public:
     }
 
 protected:
-    void print(std::ostream& os) const override {
-        os << name;
-    }
-
-    bool equal(const Node& node) const override {
-        const auto& other = asAssert<Variable>(node);
-        return name == other.name;
-    }
+    void print(std::ostream& os) const override;
 
 private:
-    Variable* cloneImpl() const override {
-        return new Variable(name, getSrcLoc());
-    }
+    bool equal(const Node& node) const override;
+
+    Variable* cloneImpl() const override;
 
 private:
     /** Name */

--- a/src/ast/analysis/Functor.cpp
+++ b/src/ast/analysis/Functor.cpp
@@ -19,6 +19,7 @@
 #include "ast/FunctorDeclaration.h"
 #include "ast/IntrinsicFunctor.h"
 #include "ast/TranslationUnit.h"
+#include "ast/analysis/Type.h"
 #include "ast/utility/Utils.h"
 
 namespace souffle::ast::analysis {

--- a/src/ast/analysis/PolymorphicObjects.cpp
+++ b/src/ast/analysis/PolymorphicObjects.cpp
@@ -18,6 +18,7 @@
 #include "ast/IntrinsicFunctor.h"
 #include "ast/NumericConstant.h"
 #include "ast/TranslationUnit.h"
+#include "ast/analysis/Type.h"
 #include "ast/utility/Visitor.h"
 #include "souffle/utility/ContainerUtil.h"
 

--- a/src/ast/analysis/TypeConstraints.cpp
+++ b/src/ast/analysis/TypeConstraints.cpp
@@ -13,6 +13,7 @@
  ***********************************************************************/
 
 #include "ast/analysis/TypeConstraints.h"
+#include "ast/analysis/Type.h"
 
 namespace souffle::ast::analysis {
 

--- a/src/ast/analysis/TypeConstraints.h
+++ b/src/ast/analysis/TypeConstraints.h
@@ -16,6 +16,7 @@
 
 #include "ast/analysis/Constraint.h"
 #include "ast/analysis/ConstraintSystem.h"
+#include "ast/analysis/SumTypeBranches.h"
 #include "ast/analysis/TypeEnvironment.h"
 #include "ast/analysis/TypeSystem.h"
 #include "ast/utility/Utils.h"

--- a/src/ast/transform/GroundWitnesses.cpp
+++ b/src/ast/transform/GroundWitnesses.cpp
@@ -16,8 +16,8 @@
 #include "ast/Aggregator.h"
 #include "ast/Clause.h"
 #include "ast/analysis/Aggregate.h"
-#include "ast/utility/NodeMapper.h"
 #include "ast/analysis/Ground.h"
+#include "ast/utility/NodeMapper.h"
 #include "ast/utility/Visitor.h"
 #include "souffle/utility/StringUtil.h"
 

--- a/src/ast/transform/GroundWitnesses.cpp
+++ b/src/ast/transform/GroundWitnesses.cpp
@@ -16,6 +16,7 @@
 #include "ast/Aggregator.h"
 #include "ast/Clause.h"
 #include "ast/analysis/Aggregate.h"
+#include "ast/utility/NodeMapper.h"
 #include "ast/analysis/Ground.h"
 #include "ast/utility/Visitor.h"
 #include "souffle/utility/StringUtil.h"

--- a/src/ast/transform/MaterializeAggregationQueries.h
+++ b/src/ast/transform/MaterializeAggregationQueries.h
@@ -20,7 +20,12 @@
 #include "ast/Aggregator.h"
 #include "ast/TranslationUnit.h"
 #include "ast/transform/Transformer.h"
+#include <set>
 #include <string>
+
+namespace souffle::ast {
+class Clause;
+}
 
 namespace souffle::ast::transform {
 /**

--- a/src/ast/transform/MaterializeSingletonAggregation.cpp
+++ b/src/ast/transform/MaterializeSingletonAggregation.cpp
@@ -27,6 +27,7 @@
 #include "ast/TranslationUnit.h"
 #include "ast/Variable.h"
 #include "ast/analysis/Aggregate.h"
+#include "ast/analysis/Type.h"
 #include "ast/utility/NodeMapper.h"
 #include "ast/utility/Utils.h"
 #include "ast/utility/Visitor.h"

--- a/src/ast/transform/MinimiseProgram.h
+++ b/src/ast/transform/MinimiseProgram.h
@@ -22,6 +22,10 @@
 #include <string>
 #include <vector>
 
+namespace souffle::ast {
+class Relation;
+}
+
 namespace souffle::ast::transform {
 
 /**

--- a/src/ast/transform/NormaliseGenerators.cpp
+++ b/src/ast/transform/NormaliseGenerators.cpp
@@ -16,13 +16,13 @@
  ***********************************************************************/
 
 #include "ast/transform/NormaliseGenerators.h"
-#include "ast/analysis/Functor.h"
 #include "ast/BinaryConstraint.h"
 #include "ast/IntrinsicFunctor.h"
 #include "ast/Program.h"
 #include "ast/TranslationUnit.h"
-#include "ast/utility/NodeMapper.h"
 #include "ast/Variable.h"
+#include "ast/analysis/Functor.h"
+#include "ast/utility/NodeMapper.h"
 #include "souffle/utility/ContainerUtil.h"
 
 namespace souffle::ast::transform {

--- a/src/ast/transform/NormaliseGenerators.cpp
+++ b/src/ast/transform/NormaliseGenerators.cpp
@@ -16,12 +16,13 @@
  ***********************************************************************/
 
 #include "ast/transform/NormaliseGenerators.h"
+#include "ast/analysis/Functor.h"
 #include "ast/BinaryConstraint.h"
 #include "ast/IntrinsicFunctor.h"
 #include "ast/Program.h"
 #include "ast/TranslationUnit.h"
+#include "ast/utility/NodeMapper.h"
 #include "ast/Variable.h"
-#include "ast/analysis/Functor.h"
 #include "souffle/utility/ContainerUtil.h"
 
 namespace souffle::ast::transform {

--- a/src/ast/transform/SemanticChecker.cpp
+++ b/src/ast/transform/SemanticChecker.cpp
@@ -951,17 +951,17 @@ void SemanticCheckerImpl::checkInlining() {
     // Returns the pair (isValid, lastSrcLoc) where:
     //  - isValid is true if and only if the node contains an invalid underscore, and
     //  - lastSrcLoc is the source location of the last visited node
-    std::function<std::pair<bool, SrcLocation>(const Node*)> checkInvalidUnderscore = [&](const Node* node) {
+    std::function<std::pair<bool, SrcLocation>(const Node&)> checkInvalidUnderscore = [&](const Node& node) {
         if (isA<UnnamedVariable>(node)) {
             // Found an invalid underscore
-            return std::make_pair(true, node->getSrcLoc());
+            return std::make_pair(true, node.getSrcLoc());
         } else if (isA<Aggregator>(node)) {
             // Don't care about underscores within aggregators
-            return std::make_pair(false, node->getSrcLoc());
+            return std::make_pair(false, node.getSrcLoc());
         }
 
         // Check if any children nodes use invalid underscores
-        for (const Node* child : node->getChildNodes()) {
+        for (const Node& child : node.getChildNodes()) {
             std::pair<bool, SrcLocation> childStatus = checkInvalidUnderscore(child);
             if (childStatus.first) {
                 // Found an invalid underscore
@@ -969,7 +969,7 @@ void SemanticCheckerImpl::checkInlining() {
             }
         }
 
-        return std::make_pair(false, node->getSrcLoc());
+        return std::make_pair(false, node.getSrcLoc());
     };
 
     // Perform the check
@@ -977,7 +977,7 @@ void SemanticCheckerImpl::checkInlining() {
         const Atom* associatedAtom = negation.getAtom();
         const Relation* associatedRelation = getRelation(program, associatedAtom->getQualifiedName());
         if (associatedRelation != nullptr && isInline(associatedRelation)) {
-            std::pair<bool, SrcLocation> atomStatus = checkInvalidUnderscore(associatedAtom);
+            std::pair<bool, SrcLocation> atomStatus = checkInvalidUnderscore(*associatedAtom);
             if (atomStatus.first) {
                 report.addError(
                         "Cannot inline negated atom containing an unnamed variable unless the variable is "

--- a/src/ast/transform/SimplifyAggregateTargetExpression.h
+++ b/src/ast/transform/SimplifyAggregateTargetExpression.h
@@ -18,6 +18,10 @@
 #include "ast/transform/Transformer.h"
 #include <string>
 
+namespace souffle::ast {
+class Clause;
+}
+
 namespace souffle::ast::transform {
 /**
  * Transformation pass to rename aggregation variables to make them unique.

--- a/src/ast/transform/TypeChecker.cpp
+++ b/src/ast/transform/TypeChecker.cpp
@@ -15,6 +15,7 @@
  ***********************************************************************/
 
 #include "ast/transform/TypeChecker.h"
+#include "Global.h"
 #include "ast/Aggregator.h"
 #include "ast/AlgebraicDataType.h"
 #include "ast/Argument.h"
@@ -36,6 +37,7 @@
 #include "ast/analysis/TypeSystem.h"
 #include "ast/utility/Utils.h"
 #include "ast/utility/Visitor.h"
+#include "reports/ErrorReport.h"
 #include "souffle/utility/StringUtil.h"
 #include <map>
 #include <sstream>

--- a/src/ast/utility/NodeMapper.h
+++ b/src/ast/utility/NodeMapper.h
@@ -19,7 +19,7 @@
 #include "souffle/utility/ContainerUtil.h"
 #include "souffle/utility/MiscUtil.h"
 #include <cassert>
-#include <memory>
+#include <utility>
 
 namespace souffle::ast {
 class Node;
@@ -50,5 +50,12 @@ public:
         return Own<T>(as<T>(resPtr.release()));
     }
 };
+
+template <typename R>
+void mapAll(R& range, NodeMapper const& mapper) {
+    for (auto& cur : range) {
+        cur = mapper(std::move(cur));
+    }
+}
 
 }  // namespace souffle::ast

--- a/src/ast2ram/utility/Utils.cpp
+++ b/src/ast2ram/utility/Utils.cpp
@@ -21,6 +21,7 @@
 #include "ast/Relation.h"
 #include "ast/UnnamedVariable.h"
 #include "ast/Variable.h"
+#include "ast/utility/NodeMapper.h"
 #include "ast/utility/Utils.h"
 #include "ast2ram/utility/Location.h"
 #include "ram/Clear.h"

--- a/src/include/souffle/utility/Iteration.h
+++ b/src/include/souffle/utility/Iteration.h
@@ -311,4 +311,58 @@ auto makeDerefRange(Iter&& begin, Iter&& end) {
     return make_range(derefIter(std::forward<Iter>(begin)), derefIter(std::forward<Iter>(end)));
 }
 
+/**
+ * This wraps the Range container, and const_casts in place.
+ */
+template <typename Range, typename F>
+class OwningTransformRange {
+private:
+    // using const_reference = decltype(*std::cbegin(std::declval<Range&>()));
+    // using reference = decltype(*std::begin(std::declval<Range&>()));
+    // using value_type = std::remove_const_t<std::remove_reference_t<reference>>;
+
+public:
+    OwningTransformRange(Range&& range, F f) : range(std::move(range)), f(std::move(f)) {}
+
+    auto begin() {
+        return transformIter(std::begin(range), f);
+    }
+
+    auto begin() const {
+        return transformIter(std::begin(range), f);
+    }
+
+    auto cbegin() const {
+        return transformIter(std::cbegin(range), f);
+    }
+
+    auto end() {
+        return transformIter(std::end(range), f);
+    }
+
+    auto end() const {
+        return transformIter(std::begin(range), f);
+    }
+
+    auto cend() const {
+        return transformIter(std::cend(range), f);
+    }
+
+    auto size() const {
+        return range.size();
+    }
+
+    auto& operator[](std::size_t ii) {
+        return begin()[ii];
+    }
+
+    auto& operator[](std::size_t ii) const {
+        return cbegin()[ii];
+    }
+
+private:
+    Range range;
+    F f;
+};
+
 }  // namespace souffle

--- a/src/include/souffle/utility/Iteration.h
+++ b/src/include/souffle/utility/Iteration.h
@@ -365,4 +365,13 @@ private:
     F f;
 };
 
+/**
+ * Convert a range of any ptr-like to a range
+ * of pointers
+ */
+template <typename R>
+auto toPtrRange(R const& range) {
+    return makeTransformRange(range, [](auto const& ptrLike) { return &*ptrLike; });
+}
+
 }  // namespace souffle

--- a/src/include/souffle/utility/Iteration.h
+++ b/src/include/souffle/utility/Iteration.h
@@ -1,6 +1,6 @@
 /*
  * Souffle - A Datalog Compiler
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
  * Licensed under the Universal Permissive License v 1.0 as shown at:
  * - https://opensource.org/licenses/UPL
  * - <souffle root>/licenses/SOUFFLE-UPL.txt
@@ -370,7 +370,7 @@ private:
  * of pointers
  */
 template <typename R>
-auto toPtrRange(R const& range) {
+auto makePtrRange(R const& range) {
     return makeTransformRange(range, [](auto const& ptrLike) { return &*ptrLike; });
 }
 

--- a/src/include/souffle/utility/Types.h
+++ b/src/include/souffle/utility/Types.h
@@ -1,6 +1,6 @@
 /*
  * Souffle - A Datalog Compiler
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved
+ * Copyright (c) 2020, The Souffle Developers. All rights reserved
  * Licensed under the Universal Permissive License v 1.0 as shown at:
  * - https://opensource.org/licenses/UPL
  * - <souffle root>/licenses/SOUFFLE-UPL.txt


### PR DESCRIPTION
Merge after #1823.

After strengthening the `ast::Node` invariants and refactoring the Visitors, I am now converting `ast::Node::getChildren` to return references rather than pointers, meaning `nullptr` checking will be unnecessary.

The other changes are mostly QOI:
1) Move implementations of `ast::Node`-derived classes out-of-line into .cpp files
2) This minimizes the number of header dependencies, speeding up recompilations after changes
3) Small QOI changes (e.g. `ast::Node::operator==`)
4) Added helper functions to simplify repetitive code (see e.g. `ast::Component::apply` and `ast::Component::getChildNodesImpl`)
