### PR TITLE
tidy up relationHandler

### DIFF
--- a/src/interpreter/Engine.cpp
+++ b/src/interpreter/Engine.cpp
@@ -792,7 +792,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define EMPTINESS_CHECK(Structure, Arity, ...)                         \
     CASE(EmptinessCheck, Structure, Arity)                             \
-        const auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         return rel.empty();                                            \
     ESAC(EmptinessCheck)
 
@@ -801,7 +801,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define RELATION_SIZE(Structure, Arity, ...)                           \
     CASE(RelationSize, Structure, Arity)                               \
-        const auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         return rel.size();                                             \
     ESAC(RelationSize)
 
@@ -916,7 +916,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define SCAN(Structure, Arity, ...)                                    \
     CASE(Scan, Structure, Arity)                                       \
-        const auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         return evalScan(rel, cur, shadow, ctxt);                       \
     ESAC(Scan)
 
@@ -925,7 +925,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define PARALLEL_SCAN(Structure, Arity, ...)                           \
     CASE(ParallelScan, Structure, Arity)                               \
-        const auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         return evalParallelScan(rel, cur, shadow, ctxt);               \
     ESAC(ParallelScan)
         FOR_EACH(PARALLEL_SCAN)
@@ -941,7 +941,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define PARALLEL_INDEX_SCAN(Structure, Arity, ...)                     \
     CASE(ParallelIndexScan, Structure, Arity)                          \
-        const auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         return evalParallelIndexScan(rel, cur, shadow, ctxt);          \
     ESAC(ParallelIndexScan)
 
@@ -950,7 +950,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define CHOICE(Structure, Arity, ...)                                  \
     CASE(Choice, Structure, Arity)                                     \
-        const auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         return evalChoice(rel, cur, shadow, ctxt);                     \
     ESAC(Choice)
 
@@ -959,7 +959,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define PARALLEL_CHOICE(Structure, Arity, ...)                         \
     CASE(ParallelChoice, Structure, Arity)                             \
-        const auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         return evalParallelChoice(rel, cur, shadow, ctxt);             \
     ESAC(ParallelChoice)
 
@@ -976,7 +976,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define PARALLEL_INDEX_CHOICE(Structure, Arity, ...)                   \
     CASE(ParallelIndexChoice, Structure, Arity)                        \
-        const auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         return evalParallelIndexChoice(rel, cur, shadow, ctxt);        \
     ESAC(ParallelIndexChoice)
 
@@ -1004,7 +1004,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define PARALLEL_AGGREGATE(Structure, Arity, ...)                      \
     CASE(ParallelAggregate, Structure, Arity)                          \
-        const auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         return evalParallelAggregate(rel, cur, shadow, ctxt);          \
     ESAC(ParallelAggregate)
 
@@ -1013,7 +1013,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define AGGREGATE(Structure, Arity, ...)                                                                  \
     CASE(Aggregate, Structure, Arity)                                                                     \
-        const auto& rel = *static_cast<RelType*>(node->getRelation());                                    \
+        const auto& rel = *static_cast<RelType*>(shadow.getRelation());                                    \
         return evalAggregate(cur, *shadow.getCondition(), shadow.getExpr(), *shadow.getNestedOperation(), \
                 rel.scan(), ctxt);                                                                        \
     ESAC(Aggregate)
@@ -1065,7 +1065,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define GUARDED_PROJECT(Structure, Arity, ...)                   \
     CASE(GuardedProject, Structure, Arity)                       \
-        auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         return evalGuardedProject(rel, shadow, ctxt);            \
     ESAC(GuardedProject)
 
@@ -1074,7 +1074,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define PROJECT(Structure, Arity, ...)                           \
     CASE(Project, Structure, Arity)                              \
-        auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         return evalProject(rel, shadow, ctxt);                   \
     ESAC(Project)
 
@@ -1125,7 +1125,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
         CASE(LogRelationTimer)
             Logger logger(cur.getMessage(), getIterationNumber(),
-                    std::bind(&RelationWrapper::size, node->getRelation()));
+                    std::bind(&RelationWrapper::size, shadow.getRelation()));
             return execute(shadow.getChild(), ctxt);
         ESAC(LogRelationTimer)
 
@@ -1141,7 +1141,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define CLEAR(Structure, Arity, ...)                             \
     CASE(Clear, Structure, Arity)                                \
-        auto& rel = *static_cast<RelType*>(node->getRelation()); \
+        auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
         rel.__purge();                                           \
         return true;                                             \
     ESAC(Clear)
@@ -1155,7 +1155,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
         ESAC(Call)
 
         CASE(LogSize)
-            const auto& rel = *node->getRelation();
+            const auto& rel = *shadow.getRelation();
             ProfileEventSingleton::instance().makeQuantityEvent(
                     cur.getMessage(), rel.size(), getIterationNumber());
             return true;
@@ -1164,7 +1164,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
         CASE(IO)
             const auto& directive = cur.getDirectives();
             const std::string& op = cur.get("operation");
-            auto& rel = *node->getRelation();
+            auto& rel = *shadow.getRelation();
 
             if (op == "input") {
                 try {

--- a/src/interpreter/Engine.cpp
+++ b/src/interpreter/Engine.cpp
@@ -790,19 +790,19 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
             return !execute(shadow.getChild(), ctxt);
         ESAC(Negation)
 
-#define EMPTINESS_CHECK(Structure, Arity, ...)                         \
-    CASE(EmptinessCheck, Structure, Arity)                             \
+#define EMPTINESS_CHECK(Structure, Arity, ...)                          \
+    CASE(EmptinessCheck, Structure, Arity)                              \
         const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        return rel.empty();                                            \
+        return rel.empty();                                             \
     ESAC(EmptinessCheck)
 
         FOR_EACH(EMPTINESS_CHECK)
 #undef EMPTINESS_CHECK
 
-#define RELATION_SIZE(Structure, Arity, ...)                           \
-    CASE(RelationSize, Structure, Arity)                               \
+#define RELATION_SIZE(Structure, Arity, ...)                            \
+    CASE(RelationSize, Structure, Arity)                                \
         const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        return rel.size();                                             \
+        return rel.size();                                              \
     ESAC(RelationSize)
 
         FOR_EACH(RELATION_SIZE)
@@ -914,19 +914,19 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
             return result;
         ESAC(TupleOperation)
 
-#define SCAN(Structure, Arity, ...)                                    \
-    CASE(Scan, Structure, Arity)                                       \
+#define SCAN(Structure, Arity, ...)                                     \
+    CASE(Scan, Structure, Arity)                                        \
         const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        return evalScan(rel, cur, shadow, ctxt);                       \
+        return evalScan(rel, cur, shadow, ctxt);                        \
     ESAC(Scan)
 
         FOR_EACH(SCAN)
 #undef SCAN
 
-#define PARALLEL_SCAN(Structure, Arity, ...)                           \
-    CASE(ParallelScan, Structure, Arity)                               \
+#define PARALLEL_SCAN(Structure, Arity, ...)                            \
+    CASE(ParallelScan, Structure, Arity)                                \
         const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        return evalParallelScan(rel, cur, shadow, ctxt);               \
+        return evalParallelScan(rel, cur, shadow, ctxt);                \
     ESAC(ParallelScan)
         FOR_EACH(PARALLEL_SCAN)
 #undef PARALLEL_SCAN
@@ -939,28 +939,28 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
         FOR_EACH(INDEX_SCAN)
 #undef INDEX_SCAN
 
-#define PARALLEL_INDEX_SCAN(Structure, Arity, ...)                     \
-    CASE(ParallelIndexScan, Structure, Arity)                          \
+#define PARALLEL_INDEX_SCAN(Structure, Arity, ...)                      \
+    CASE(ParallelIndexScan, Structure, Arity)                           \
         const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        return evalParallelIndexScan(rel, cur, shadow, ctxt);          \
+        return evalParallelIndexScan(rel, cur, shadow, ctxt);           \
     ESAC(ParallelIndexScan)
 
         FOR_EACH(PARALLEL_INDEX_SCAN)
 #undef PARALLEL_INDEX_SCAN
 
-#define CHOICE(Structure, Arity, ...)                                  \
-    CASE(Choice, Structure, Arity)                                     \
+#define CHOICE(Structure, Arity, ...)                                   \
+    CASE(Choice, Structure, Arity)                                      \
         const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        return evalChoice(rel, cur, shadow, ctxt);                     \
+        return evalChoice(rel, cur, shadow, ctxt);                      \
     ESAC(Choice)
 
         FOR_EACH(CHOICE)
 #undef CHOICE
 
-#define PARALLEL_CHOICE(Structure, Arity, ...)                         \
-    CASE(ParallelChoice, Structure, Arity)                             \
+#define PARALLEL_CHOICE(Structure, Arity, ...)                          \
+    CASE(ParallelChoice, Structure, Arity)                              \
         const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        return evalParallelChoice(rel, cur, shadow, ctxt);             \
+        return evalParallelChoice(rel, cur, shadow, ctxt);              \
     ESAC(ParallelChoice)
 
         FOR_EACH(PARALLEL_CHOICE)
@@ -974,10 +974,10 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
         FOR_EACH(INDEX_CHOICE)
 #undef INDEX_CHOICE
 
-#define PARALLEL_INDEX_CHOICE(Structure, Arity, ...)                   \
-    CASE(ParallelIndexChoice, Structure, Arity)                        \
+#define PARALLEL_INDEX_CHOICE(Structure, Arity, ...)                    \
+    CASE(ParallelIndexChoice, Structure, Arity)                         \
         const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        return evalParallelIndexChoice(rel, cur, shadow, ctxt);        \
+        return evalParallelIndexChoice(rel, cur, shadow, ctxt);         \
     ESAC(ParallelIndexChoice)
 
         FOR_EACH(PARALLEL_INDEX_CHOICE)
@@ -1002,10 +1002,10 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
             return execute(shadow.getNestedOperation(), ctxt);
         ESAC(UnpackRecord)
 
-#define PARALLEL_AGGREGATE(Structure, Arity, ...)                      \
-    CASE(ParallelAggregate, Structure, Arity)                          \
+#define PARALLEL_AGGREGATE(Structure, Arity, ...)                       \
+    CASE(ParallelAggregate, Structure, Arity)                           \
         const auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        return evalParallelAggregate(rel, cur, shadow, ctxt);          \
+        return evalParallelAggregate(rel, cur, shadow, ctxt);           \
     ESAC(ParallelAggregate)
 
         FOR_EACH(PARALLEL_AGGREGATE)
@@ -1013,7 +1013,7 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
 
 #define AGGREGATE(Structure, Arity, ...)                                                                  \
     CASE(Aggregate, Structure, Arity)                                                                     \
-        const auto& rel = *static_cast<RelType*>(shadow.getRelation());                                    \
+        const auto& rel = *static_cast<RelType*>(shadow.getRelation());                                   \
         return evalAggregate(cur, *shadow.getCondition(), shadow.getExpr(), *shadow.getNestedOperation(), \
                 rel.scan(), ctxt);                                                                        \
     ESAC(Aggregate)
@@ -1063,19 +1063,19 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
             return result;
         ESAC(Filter)
 
-#define GUARDED_PROJECT(Structure, Arity, ...)                   \
-    CASE(GuardedProject, Structure, Arity)                       \
+#define GUARDED_PROJECT(Structure, Arity, ...)                    \
+    CASE(GuardedProject, Structure, Arity)                        \
         auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        return evalGuardedProject(rel, shadow, ctxt);            \
+        return evalGuardedProject(rel, shadow, ctxt);             \
     ESAC(GuardedProject)
 
         FOR_EACH(GUARDED_PROJECT)
 #undef GUARDED_PROJECT
 
-#define PROJECT(Structure, Arity, ...)                           \
-    CASE(Project, Structure, Arity)                              \
+#define PROJECT(Structure, Arity, ...)                            \
+    CASE(Project, Structure, Arity)                               \
         auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        return evalProject(rel, shadow, ctxt);                   \
+        return evalProject(rel, shadow, ctxt);                    \
     ESAC(Project)
 
         FOR_EACH(PROJECT)
@@ -1139,11 +1139,11 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
             return execute(shadow.getChild(), ctxt);
         ESAC(DebugInfo)
 
-#define CLEAR(Structure, Arity, ...)                             \
-    CASE(Clear, Structure, Arity)                                \
+#define CLEAR(Structure, Arity, ...)                              \
+    CASE(Clear, Structure, Arity)                                 \
         auto& rel = *static_cast<RelType*>(shadow.getRelation()); \
-        rel.__purge();                                           \
-        return true;                                             \
+        rel.__purge();                                            \
+        return true;                                              \
     ESAC(Clear)
 
         FOR_EACH(CLEAR)


### PR DESCRIPTION
Tidy up the `interpreter::Node`, so that only operation that actually involves with a runtime relation will have the `RelationHandle` attribute. 
