### PR TITLE
Fix Issue #1858 

### DIFF
--- a/src/synthesiser/Relation.cpp
+++ b/src/synthesiser/Relation.cpp
@@ -772,10 +772,10 @@ void IndirectRelation::generateTypeStruct(std::ostream& out) {
         if (eqSize == arity) {
             // if lower == upper we can just do a find
             out << "if (cmp == 0) {\n";
-            out << "    auto pos = find(lower, h);\n";
-            out << "    auto fin = end();\n";
+            out << "    auto pos = ind_" << indNum << ".find(&lower, h.hints_" << indNum << "_lower);\n";
+            out << "    auto fin = ind_" << indNum << ".end();\n";
             out << "    if (pos != fin) {fin = pos; ++fin;}\n";
-            out << "    return make_range(pos, fin);\n";
+            out << "    return range<iterator_" << indNum << ">(pos, fin);\n";
             out << "}\n";
         }
         // if lower > upper then we have an empty range

--- a/tests/evaluation/indexed_inequalities/indexed_inequalities.dl
+++ b/tests/evaluation/indexed_inequalities/indexed_inequalities.dl
@@ -34,3 +34,11 @@ rel_4(x) :- rel_3(x), x >= 0.04, x <= 0.2.
 rel_5(0, "apple", 3.0, 0).
 rel_5(x-1, "strawberry", z+0.125, a-2) :- rel_5(x, _, z, a), x >= -5, z <= 5.0, a > -12.
 rel_5(x, "mango", z, a) :- rel_5(x, _, z, a), x >= -3, z <= 4.0, a > -10.
+
+.decl rel_6(s1: number, s2: number, s3: number, s4: number, s5: number, s6: number, s7: number)
+rel_6(1,2,3,4,5,6,7).
+
+.decl rel_7(x:number)
+.output rel_7
+
+rel_7(x) :- rel_6(1,_,3,4,5,_,_), rel_6(1,2,y,4,5,6,7), rel_6(_,2,3,4,5,6,_), rel_6(_,2,_,4,_,6,_), rel_6(1,_,_,4,_,_,_), rel_6(_,_,x,_,_,_,_), x > 3, y > 3.


### PR DESCRIPTION
A simple fix for Issue #1858.

The code generation for the indirect B-Tree struct was calling find() and end() functions on the collection of indexes (i.e. the struct) rather than the indexes themselves. The result was that find() called ind_0.find() and end() called ind_1.end() returning iterators that were templated on different comparator functions.

The fix was just to call the appropriate methods on the respective indexes directly rather than deferring to methods on the struct.