### PR TITLE
Fix performance bug

### DIFF
--- a/src/ram/transform/MakeIndex.cpp
+++ b/src/ram/transform/MakeIndex.cpp
@@ -400,7 +400,7 @@ Own<Condition> MakeIndexTransformer::constructPattern(const std::vector<std::str
 }
 
 Own<Operation> MakeIndexTransformer::rewriteAggregate(const Aggregate* agg) {
-    if (isA<True>(agg->getCondition())) {
+    if (!isA<True>(agg->getCondition())) {
         const Relation& rel = relAnalysis->lookup(agg->getRelation());
         int identifier = agg->getTupleId();
         RamPattern queryPattern;


### PR DESCRIPTION
Fix a minor error introduced in #1816 in [MakeIndex.cpp](https://github.com/souffle-lang/souffle/pull/1816/files#diff-6a3d4d6a88c8b4cd84fc34e8cc7d05aec9e03f81a170f19f8797c5bc5b9952b8L403-R403), caused the index transformer failed to index aggregates and slow down the gcc benchmark in DDISASM by about 450%.

