### PR TITLE
Remove travis dependencies in shell scripts

### DIFF
--- a/sh/Dockerfile
+++ b/sh/Dockerfile
@@ -34,4 +34,4 @@ RUN ./bootstrap
 RUN ./configure ${SOUFFLE_CONFIGURE_OPTIONS}
 RUN make -j${SOUFFLE_MAKE_JOBS}
 
-ENTRYPOINT ["./.travis/run_docker.sh", "souffle"]
+ENTRYPOINT ["./sh/run_docker.sh", "souffle"]

--- a/sh/after_failure.sh
+++ b/sh/after_failure.sh
@@ -12,7 +12,7 @@
 # Author: Nic H.                                                          #
 # Date: 2016-Oct-10                                                       #
 #                                                                         #
-# Cats the contents of the first failed test case to travis's output,     #
+# Cats the contents of the first failed test case to the output,          #
 # allowing us to debug the problem.                                       #
 #=========================================================================#
 
@@ -88,7 +88,7 @@ else
     pretty_print "No test logs found"
 fi
 
-if [ "$TRAVIS_OS_NAME" == "osx" ]
+if [ `uname -a|awk {print $1}` == "Darwin" ]
 then
     pretty_print "OSX Diagnostic Reports"
     for f in ~/Library/Logs/DiagnosticReports/*; do

--- a/sh/init-windows-test.sh
+++ b/sh/init-windows-test.sh
@@ -2,6 +2,6 @@
 
 choco install wsl-ubuntu-1804 --ignorechecksums
 choco install visualstudio2019community -y --version 16.7.2.0 --params="--installPath 'C:\\VS' --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest --add Microsoft.VisualStudio.Component.Windows10SDK --add Microsoft.VisualStudio.Component.Windows10SDK.18362 --includeRecommended --passive --wait"
-./.travis/install-get-opt-msvc.bat
+./sh/install-get-opt-msvc.bat
 wsl bash -c "apt-get update -y"
 wsl bash -c "apt-get install -y autoconf bison build-essential dos2unix flex libffi-dev libncurses5-dev libtool lsb-release mcpp swig zlib1g-dev libsqlite3-dev"

--- a/sh/linux/install_centos_deps.sh
+++ b/sh/linux/install_centos_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-travis_retry() {
+retry() {
   local result=0
   local count=1
   while [ $count -le 3 ]; do
@@ -22,14 +22,14 @@ travis_retry() {
 }
 
 # Build dependencies
-travis_retry yum install -y -q autoconf automake bison clang flex gcc gcc-c++ git kernel-devel libffi-devel libtool make mcpp ncurses-devel python3 sqlite sqlite-devel sudo swig zlib-devel
+retry yum install -y -q autoconf automake bison clang flex gcc gcc-c++ git kernel-devel libffi-devel libtool make mcpp ncurses-devel python3 sqlite sqlite-devel sudo swig zlib-devel
 
 # Set up a more recent gcc that supports C++11
-travis_retry yum install -y centos-release-scl
+retry yum install -y centos-release-scl
 
 # Set up the package builder
-travis_retry yum install -y -q rpm-build ruby-devel
-travis_retry gem install --no-ri --no-rdoc rake
-travis_retry gem install --no-ri --no-rdoc fpm
+retry yum install -y -q rpm-build ruby-devel
+retry gem install --no-ri --no-rdoc rake
+retry gem install --no-ri --no-rdoc fpm
 
 fpm --version

--- a/sh/linux/install_fedora_deps.sh
+++ b/sh/linux/install_fedora_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-travis_retry() {
+retry() {
   local result=0
   local count=1
   while [ $count -le 3 ]; do
@@ -22,11 +22,11 @@ travis_retry() {
 }
 
 # Build dependencies
-travis_retry yum install -y -q autoconf automake bison clang doxygen flex gcc gcc-c++ git kernel-devel libffi-devel libtool make mcpp ncurses-devel python sqlite sqlite-devel sudo swig zlib-devel
+retry yum install -y -q autoconf automake bison clang doxygen flex gcc gcc-c++ git kernel-devel libffi-devel libtool make mcpp ncurses-devel python sqlite sqlite-devel sudo swig zlib-devel
 
 # Set up the package builder
-travis_retry yum install -y -q rpm-build ruby-devel
-travis_retry gem install --no-ri --no-rdoc rake
-travis_retry gem install --no-ri --no-rdoc fpm
+retry yum install -y -q rpm-build ruby-devel
+retry gem install --no-ri --no-rdoc rake
+retry gem install --no-ri --no-rdoc fpm
 
 fpm --version

--- a/sh/osx/brew.sh
+++ b/sh/osx/brew.sh
@@ -20,7 +20,7 @@ chmod 600 ~/.ssh/id_ed25519
 ssh-keyscan github.com > ~/.ssh/known_hosts
 
 # set up git user
-git config --global user.name "travis-deployer"
+git config --global user.name "bot-deployer"
 git config --global user.email "souffle-lang@gmail.com"
 git config --global push.default simple
 

--- a/sh/osx/install.sh
+++ b/sh/osx/install.sh
@@ -13,7 +13,5 @@ brew link libffi --force || echo "brew link libffi failed"
 export PATH="/usr/local/opt/bison/bin:$PATH"
 export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig/"
 
-rm /Users/travis/Library/Logs/DiagnosticReports/* || true
-
 set +e
 set +x

--- a/sh/osx/install_withgcc.sh
+++ b/sh/osx/install_withgcc.sh
@@ -6,7 +6,7 @@ set -e
 set -x
 
 # Install requirements of MAC OS X
-. .travis/osx/install.sh
+. sh/osx/install.sh
 
 rm /usr/local/include/c++ || true
 

--- a/sh/run_docker.sh
+++ b/sh/run_docker.sh
@@ -7,7 +7,7 @@ then
     SOUFFLE_DOCKER_TAG="$(echo ${SOUFFLE_DOCKER_BASE_IMAGE} | sed 's/-base/-test/g')"
     docker build \
         --tag ${SOUFFLE_DOCKER_TAG} \
-        --file .travis/Dockerfile \
+        --file sh/Dockerfile \
         --build-arg CC="${CC}" \
         --build-arg CXX="${CXX}" \
         --build-arg SOUFFLE_CATEGORY="${SOUFFLE_CATEGORY}" \
@@ -28,5 +28,5 @@ else
         cd tests
     fi
     TESTSUITEFLAGS="-j${SOUFFLE_MAKE_JOBS}" make check -j${SOUFFLE_MAKE_JOBS} \
-        || (cd $BASEDIR && .travis/after_failure.sh && false)
+        || (cd $BASEDIR && sh/after_failure.sh && false)
 fi


### PR DESCRIPTION
This is an attempt to make the shell scripts Travis independent; the shell script could be useful for later build jobs in continuous testing environments. 

This PR is related to issue #1754.