### PR TITLE
CompileScript: Added error flag and added swig directory to search path

### DIFF
--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -10,6 +10,8 @@
 # script that compiles a generated C++ program and executes it
 #
 
+set -e 
+
 # Show usage
 usage() {
   printf "Name:
@@ -55,7 +57,8 @@ WARNINGS=""
 SWIGLANG=""
 
 # find header files of souffle
-HEADER_DIRS=" -I$(dirname $0)/../include -I$(dirname $0)/include "
+HEADER_DIRS=" -I$(dirname $0)/../include -I$(dirname $0)/include -I$(dirname $0)/../include/souffle/swig -I$(dirname
+$0)/include/souffle/swig"
 
 # Options processing via getopts builtin, it is very limiting but on OSX the
 # default getopt is an old BSD getopt, so need this for portability

--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -57,8 +57,8 @@ WARNINGS=""
 SWIGLANG=""
 
 # find header files of souffle
-HEADER_DIRS=" -I$(dirname $0)/../include -I$(dirname $0)/include -I$(dirname $0)/../include/souffle/swig -I$(dirname
-$0)/include/souffle/swig"
+P="$(dirname $0)"
+HEADER_DIRS=" -I$P/../include -I$P/include -I$P/../include/souffle/swig -I$P/include/souffle/swig "
 
 # Options processing via getopts builtin, it is very limiting but on OSX the
 # default getopt is an old BSD getopt, so need this for portability


### PR DESCRIPTION
An earlier directory-structure refactoring destroyed the search path for SWIG. This PR adds the SWIG directory to the include directories. It also sets the error flag in the compile script. 