### PR TITLE
Fixed former travis script

### DIFF
--- a/sh/after_failure.sh
+++ b/sh/after_failure.sh
@@ -88,7 +88,7 @@ else
     pretty_print "No test logs found"
 fi
 
-if [ `uname -a|awk {print $1}` == "Darwin" ]
+if [[ "$OSTYPE" == "darwin"* ]]
 then
     pretty_print "OSX Diagnostic Reports"
     for f in ~/Library/Logs/DiagnosticReports/*; do


### PR DESCRIPTION
The OSTYPE was not correctly checked in sh/after_failure.sh.

This is related to issue #1754.