### PR TITLE
Add override keyword

### DIFF
--- a/src/ast/transform/ResolveAliases.h
+++ b/src/ast/transform/ResolveAliases.h
@@ -37,7 +37,7 @@ public:
     /**
      * ResolveAliasesTransformer cannot be disabled.
      */
-    bool isSwitchable() {
+    bool isSwitchable() override {
         return false;
     }
 


### PR DESCRIPTION
The override keyword for the method isSwitchable() is missing. This is related to issue #1882.
