### PR TITLE
Fix error message

### DIFF
--- a/src/include/souffle/profile/Reader.h
+++ b/src/include/souffle/profile/Reader.h
@@ -303,6 +303,7 @@ public:
             if (startTimeEntry != nullptr) {
                 run->setStarttime(startTimeEntry->getTime());
                 run->setEndtime(std::chrono::duration_cast<microseconds>(now().time_since_epoch()));
+                loaded = true;
             }
         } else {
             run->setStarttime(programDuration->getStart());
@@ -312,7 +313,8 @@ public:
 
         auto relations = as<DirectoryEntry>(db.lookupEntry({"program", "relation"}));
         if (relations == nullptr) {
-            // Souffle hasn't generated any profiling information yet.
+            // Souffle hasn't generated any profiling information yet
+            // or program is empty.
             return;
         }
         for (const auto& cur : relations->getKeys()) {

--- a/src/include/souffle/profile/Tui.h
+++ b/src/include/souffle/profile/Tui.h
@@ -215,7 +215,7 @@ public:
 
     void runProf() {
         if (!loaded && !f_name.empty()) {
-            std::cout << "Error: File cannot be floaded\n";
+            std::cout << "Error: File cannot be loaded\n";
             return;
         }
         if (loaded) {


### PR DESCRIPTION
Fixes a typo in a profiling error message and profiles of programs without rules can be still loaded without a missing file error. 

This is an issue related to #1759.