### PR TITLE
Fix issue #1916

### DIFF
--- a/src/interpreter/Engine.cpp
+++ b/src/interpreter/Engine.cpp
@@ -148,6 +148,9 @@ Engine::Engine(ram::TranslationUnit& tUnit)
 #ifdef _OPENMP
     if (numOfThreads > 0) {
         omp_set_num_threads(numOfThreads);
+    } else {
+        // Update threads to the system default
+        numOfThreads = omp_get_num_threads();
     }
 #endif
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -313,6 +313,7 @@ int main(int argc, char** argv) {
             if (!Global::config().has("jobs", "auto")) {
                 throw std::runtime_error("-j/--jobs may only be set to 'auto' or an integer greater than 0.");
             }
+            // set jobs to zero to indicate the synthesiser and interpreter to use the system default.
             Global::config().set("jobs", "0");
         }
 #else


### PR DESCRIPTION
Let the interpreter choose the correct number of threads if  `-jauto` is used.