### PR TITLE
Simple change to allow for multiple library options

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -230,7 +230,7 @@ int main(int argc, char** argv) {
                 {"swig", 's', "LANG", "", false,
                         "Generate SWIG interface for given language. The values <LANG> accepts is java and "
                         "python. "},
-                {"library-dir", 'L', "DIR", "", false, "Specify directory for library files."},
+                {"library-dir", 'L', "DIR", "", true, "Specify directory for library files."},
                 {"libraries", 'l', "FILE", "", true, "Specify libraries."},
                 {"no-warn", 'w', "", "", false, "Disable warnings."},
                 {"magic-transform", 'm', "RELATIONS", "", false,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,7 +231,7 @@ int main(int argc, char** argv) {
                         "Generate SWIG interface for given language. The values <LANG> accepts is java and "
                         "python. "},
                 {"library-dir", 'L', "DIR", "", false, "Specify directory for library files."},
-                {"libraries", 'l', "FILE", "", false, "Specify libraries."},
+                {"libraries", 'l', "FILE", "", true, "Specify libraries."},
                 {"no-warn", 'w', "", "", false, "Disable warnings."},
                 {"magic-transform", 'm', "RELATIONS", "", false,
                         "Enable magic set transformation changes on the given relations, use '*' "


### PR DESCRIPTION
This very minor change allows for multiple library options when calling souffle.

I have successfully tested it locally with the following calls:

```
souffle --libraries='Rmath m' rmath.dl # old
souffle -c --libraries='Rmath m' rmath.dl # old
souffle -lRmath -lm rmath.dl # new
souffle -c -lRmath -lm rmath.dl # new
souffle `pkg-config --libs libRmath` rmath.dl # new
souffle -c `pkg-config --libs libRmath` rmath.dl # new
```

so this seems to maintain the old behaviour and now allows for multiple `-l` options. Ideally, we should add some tests for this.

-- Mark