### PR TITLE
Improve RAM representation

### DIFF
--- a/src/ram/AbstractExistenceCheck.h
+++ b/src/ram/AbstractExistenceCheck.h
@@ -77,7 +77,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "(" << join(values, ",") << ") ∈ " << relation;
+        os << "(" << join(values, ",") << ") IN " << relation;
     }
 
     bool equal(const Node& node) const override {

--- a/src/ram/Aggregate.h
+++ b/src/ram/Aggregate.h
@@ -74,9 +74,9 @@ public:
 protected:
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
-        os << "t" << getTupleId() << ".0=";
+        os << "t" << getTupleId() << ".0 = ";
         AbstractAggregate::print(os, tabpos);
-        os << "FOR ALL t" << getTupleId() << " ∈ " << getRelation();
+        os << "FOR ALL t" << getTupleId() << " IN " << getRelation();
         if (!isTrue(condition.get())) {
             os << " WHERE " << getCondition();
         }

--- a/src/ram/AutoIncrement.h
+++ b/src/ram/AutoIncrement.h
@@ -35,7 +35,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "autoinc()";
+        os << "AUTOINC()";
     }
 };
 

--- a/src/ram/DebugInfo.h
+++ b/src/ram/DebugInfo.h
@@ -58,9 +58,9 @@ public:
 
 protected:
     void print(std::ostream& os, int tabpos) const override {
-        os << times(" ", tabpos) << "BEGIN_DEBUG \"" << stringify(message) << "\"" << std::endl;
+        os << times(" ", tabpos) << "DEBUG \"" << stringify(message) << "\"" << std::endl;
         Statement::print(statement.get(), os, tabpos + 1);
-        os << times(" ", tabpos) << "END_DEBUG" << std::endl;
+        os << times(" ", tabpos) << "END DEBUG" << std::endl;
     }
 };
 

--- a/src/ram/EmptinessCheck.h
+++ b/src/ram/EmptinessCheck.h
@@ -58,7 +58,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "(" << relation << " = ∅)";
+        os << "ISEMPTY(" << relation << ")";
     }
 
     bool equal(const Node& node) const override {

--- a/src/ram/False.h
+++ b/src/ram/False.h
@@ -36,7 +36,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "false";
+        os << "FALSE";
     }
 };
 

--- a/src/ram/FloatConstant.h
+++ b/src/ram/FloatConstant.h
@@ -47,7 +47,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "float(" << getValue() << ")";
+        os << "FLOAT(" << getValue() << ")";
     }
 };
 

--- a/src/ram/IfExists.h
+++ b/src/ram/IfExists.h
@@ -74,7 +74,7 @@ public:
 protected:
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
-        os << "IF ∃t" << getTupleId();
+        os << "IF EXISTS t" << getTupleId();
         os << " IN " << relation;
         os << " WHERE " << getCondition();
         os << std::endl;

--- a/src/ram/IndexAggregate.h
+++ b/src/ram/IndexAggregate.h
@@ -79,9 +79,9 @@ public:
 protected:
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
-        os << "t" << getTupleId() << ".0=";
+        os << "t" << getTupleId() << ".0 = ";
         AbstractAggregate::print(os, tabpos);
-        os << "SEARCH t" << getTupleId() << " ∈ " << relation;
+        os << "SEARCH t" << getTupleId() << " IN " << relation;
         printIndex(os);
         if (!isTrue(condition.get())) {
             os << " WHERE " << getCondition();

--- a/src/ram/IndexIfExists.h
+++ b/src/ram/IndexIfExists.h
@@ -94,7 +94,7 @@ public:
 protected:
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
-        os << "IF ∃t" << getTupleId() << " IN " << relation;
+        os << "IF EXISTS t" << getTupleId() << " IN " << relation;
         printIndex(os);
         os << " WHERE " << getCondition();
         os << std::endl;

--- a/src/ram/LogRelationTimer.h
+++ b/src/ram/LogRelationTimer.h
@@ -70,10 +70,10 @@ public:
 
 protected:
     void print(std::ostream& os, int tabpos) const override {
-        os << times(" ", tabpos) << "START_TIMER ON " << relation << " \"" << stringify(message) << "\""
+        os << times(" ", tabpos) << "TIMER ON " << relation << " \"" << stringify(message) << "\""
            << std::endl;
         Statement::print(statement.get(), os, tabpos + 1);
-        os << times(" ", tabpos) << "END_TIMER" << std::endl;
+        os << times(" ", tabpos) << "END TIMER" << std::endl;
     }
 };
 

--- a/src/ram/LogSize.h
+++ b/src/ram/LogSize.h
@@ -46,7 +46,7 @@ public:
 
 protected:
     void print(std::ostream& os, int tabpos) const override {
-        os << times(" ", tabpos) << "LOGSIZE " << relation;
+        os << times(" ", tabpos) << "LOG SIZE " << relation;
         os << " TEXT "
            << "\"" << stringify(message) << "\"";
         os << std::endl;

--- a/src/ram/LogTimer.h
+++ b/src/ram/LogTimer.h
@@ -66,9 +66,9 @@ public:
 
 protected:
     void print(std::ostream& os, int tabpos) const override {
-        os << times(" ", tabpos) << "START_TIMER \"" << stringify(message) << "\"" << std::endl;
+        os << times(" ", tabpos) << "TIMER \"" << stringify(message) << "\"" << std::endl;
         Statement::print(statement.get(), os, tabpos + 1);
-        os << times(" ", tabpos) << "END_TIMER" << std::endl;
+        os << times(" ", tabpos) << "END TIMER" << std::endl;
     }
 };
 

--- a/src/ram/PackRecord.h
+++ b/src/ram/PackRecord.h
@@ -71,8 +71,8 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "PACK(" << join(arguments, ",", [](std::ostream& out, const Own<Expression>& arg) { out << *arg; })
-           << ")";
+        os << "PACK("
+           << join(arguments, ",", [](std::ostream& out, const Own<Expression>& arg) { out << *arg; }) << ")";
     }
 
     bool equal(const Node& node) const override {

--- a/src/ram/PackRecord.h
+++ b/src/ram/PackRecord.h
@@ -71,8 +71,8 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "[" << join(arguments, ",", [](std::ostream& out, const Own<Expression>& arg) { out << *arg; })
-           << "]";
+        os << "PACK(" << join(arguments, ",", [](std::ostream& out, const Own<Expression>& arg) { out << *arg; })
+           << ")";
     }
 
     bool equal(const Node& node) const override {

--- a/src/ram/ParallelAggregate.h
+++ b/src/ram/ParallelAggregate.h
@@ -60,9 +60,9 @@ public:
 protected:
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
-        os << "PARALLEL t" << getTupleId() << ".0=";
+        os << "PARALLEL t" << getTupleId() << ".0 = ";
         AbstractAggregate::print(os, tabpos);
-        os << "FOR ALL t" << getTupleId() << " ∈ " << relation;
+        os << "FOR ALL t" << getTupleId() << " IN " << relation;
         if (!isTrue(condition.get())) {
             os << " WHERE " << getCondition();
         }

--- a/src/ram/ParallelIfExists.h
+++ b/src/ram/ParallelIfExists.h
@@ -58,7 +58,7 @@ public:
 protected:
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
-        os << "PARALLEL IF ∃t" << getTupleId();
+        os << "PARALLEL IF EXISTS t" << getTupleId();
         os << " IN " << relation;
         os << " WHERE " << getCondition();
         os << std::endl;

--- a/src/ram/ParallelIndexAggregate.h
+++ b/src/ram/ParallelIndexAggregate.h
@@ -67,9 +67,9 @@ public:
 protected:
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
-        os << "PARALLEL t" << getTupleId() << ".0=";
+        os << "PARALLEL t" << getTupleId() << ".0 = ";
         AbstractAggregate::print(os, tabpos);
-        os << "SEARCH t" << getTupleId() << " ∈ " << relation;
+        os << "SEARCH t" << getTupleId() << " IN " << relation;
         printIndex(os);
         if (!isTrue(condition.get())) {
             os << " WHERE " << getCondition();

--- a/src/ram/ParallelIndexIfExists.h
+++ b/src/ram/ParallelIndexIfExists.h
@@ -75,7 +75,7 @@ public:
 protected:
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
-        os << "PARALLEL IF ∃t" << getTupleId() << " IN " << relation;
+        os << "PARALLEL IF EXISTS t" << getTupleId() << " IN " << relation;
         printIndex(os);
         os << " WHERE " << getCondition();
         os << std::endl;

--- a/src/ram/ProvenanceExistenceCheck.h
+++ b/src/ram/ProvenanceExistenceCheck.h
@@ -47,7 +47,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "prov";
+        os << "PROV ";
         AbstractExistenceCheck::print(os);
     }
 };

--- a/src/ram/Query.h
+++ b/src/ram/Query.h
@@ -41,6 +41,7 @@ namespace souffle::ram {
  *   FOR t0 in A
  *     FOR t1 in B
  *       ...
+ * END QUERY
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
 class Query : public Statement {
@@ -70,6 +71,7 @@ protected:
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos) << "QUERY" << std::endl;
         operation->print(os, tabpos + 1);
+        os << times(" ", tabpos) << "END QUERY" << std::endl;
     }
 
     bool equal(const Node& node) const override {

--- a/src/ram/RelationSize.h
+++ b/src/ram/RelationSize.h
@@ -55,7 +55,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "size(" << relation << ")";
+        os << "SIZE(" << relation << ")";
     }
 
     bool equal(const Node& node) const override {

--- a/src/ram/SignedConstant.h
+++ b/src/ram/SignedConstant.h
@@ -47,7 +47,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "number(" << constant << ")";
+        os << "NUMBER(" << constant << ")";
     }
 };
 

--- a/src/ram/SubroutineArgument.h
+++ b/src/ram/SubroutineArgument.h
@@ -47,7 +47,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "argument(" << number << ")";
+        os << "ARGUMENT(" << number << ")";
     }
 
     bool equal(const Node& node) const override {

--- a/src/ram/True.h
+++ b/src/ram/True.h
@@ -36,7 +36,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "true";
+        os << "TRUE";
     }
 };
 

--- a/src/ram/UndefValue.h
+++ b/src/ram/UndefValue.h
@@ -35,7 +35,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "⊥";
+        os << "UNDEF";
     }
 };
 

--- a/src/ram/UnsignedConstant.h
+++ b/src/ram/UnsignedConstant.h
@@ -47,7 +47,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "unsigned(" << getValue() << ")";
+        os << "UNSIGNED(" << getValue() << ")";
     }
 };
 


### PR DESCRIPTION
The output of RAM was not uniform. This PR attempts to uniform the output language, avoid Unicode characters in the output and make the output more verbose. 