### PR TITLE
Add "max-bound-delta" SIPS strategy

### DIFF
--- a/src/ast/utility/SipsMetric.h
+++ b/src/ast/utility/SipsMetric.h
@@ -100,6 +100,17 @@ protected:
             const std::vector<Atom*> atoms, const BindingStore& bindingStore) const override;
 };
 
+/** Goal: prioritise (1) all-bound, then (2) max number of bound vars, then (3) left-most, but use deltas as a
+ * tiebreaker between these. */
+class MaxBoundDeltaSips : public SipsMetric {
+public:
+    MaxBoundDeltaSips() = default;
+
+protected:
+    std::vector<double> evaluateCosts(
+            const std::vector<Atom*> atoms, const BindingStore& bindingStore) const override;
+};
+
 /** Goal: prioritise max ratio of bound args */
 class MaxRatioSips : public SipsMetric {
 public:


### PR DESCRIPTION
Like 'max-bound', but prefers delta relations when other conditions are tied.

This seems to be very slightly faster for my own program, but I won't be offended if this doesn't seem useful to others :smile: I mostly wanted to share because I didn't see other SIPS strategies with a "tiebreaker" and thought it might be a helpful idea.