### PR TITLE
Refactor RAM Node

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ set(SOUFFLE_SOURCES
     parser/ParserDriver.cpp
     parser/ParserUtils.cpp
     parser/SrcLocation.cpp
+    ram/Node.cpp
     ram/analysis/Complexity.cpp
     ram/analysis/Index.cpp
     ram/analysis/Level.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -331,6 +331,7 @@ souffle_sources = \
         ram/NestedIntrinsicOperator.h                      \
         ram/NestedOperation.h                              \
         ram/Node.h                                         \
+        ram/Node.cpp                                       \
         ram/NumericConstant.h                              \
         ram/Operation.h                                    \
         ram/PackRecord.h                                   \

--- a/src/interpreter/Generator.cpp
+++ b/src/interpreter/Generator.cpp
@@ -150,7 +150,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::ExistenceCheck>, const ram::Exi
             isTotal = false;
         }
     }
-    auto ramRelation = lookup(exists.getRelation());
+    const auto& ramRelation = lookup(exists.getRelation());
     NodeType type = constructNodeType("ExistenceCheck", ramRelation);
     return mk<ExistenceCheck>(type, &exists, isTotal, encodeView(&exists), std::move(superOp),
             ramRelation.isTemp(), ramRelation.getName());
@@ -540,7 +540,7 @@ const ram::Relation& NodeGenerator::lookup(const std::string& relName) {
 }
 
 std::size_t NodeGenerator::getArity(const std::string& relName) {
-    auto rel = lookup(relName);
+    const auto& rel = lookup(relName);
     return rel.getArity();
 }
 

--- a/src/ram/Node.cpp
+++ b/src/ram/Node.cpp
@@ -1,5 +1,6 @@
 /*
  * Souffle - A Datalog Compiler
+ * Copyright (c) 2021, The Souffle Developers. All rights reserved
  * Licensed under the Universal Permissive License v 1.0 as shown at:
  * - https://opensource.org/licenses/UPL
  * - <souffle root>/licenses/SOUFFLE-UPL.txt

--- a/src/ram/Node.cpp
+++ b/src/ram/Node.cpp
@@ -1,0 +1,42 @@
+/*
+ * Souffle - A Datalog Compiler
+ * Licensed under the Universal Permissive License v 1.0 as shown at:
+ * - https://opensource.org/licenses/UPL
+ * - <souffle root>/licenses/SOUFFLE-UPL.txt
+ */
+
+/************************************************************************
+ *
+ * @file Node.cpp
+ *
+ * Implementation of RAM node
+ *
+ ***********************************************************************/
+
+#pragma once
+
+#include "ram/Node.h"
+#include <cassert>
+#include <functional>
+#include <memory>
+#include <typeinfo>
+#include <utility>
+#include <vector>
+
+namespace souffle::ram {
+
+void Node::rewrite(const Node* oldNode, Own<Node> newNode) {
+    assert(oldNode != nullptr && "old node is a null-pointer");
+    assert(newNode != nullptr && "new node is a null-pointer");
+    std::function<Own<Node>(Own<Node>)> rewriter = [&](Own<Node> node) -> Own<Node> {
+        if (oldNode == node.get()) {
+            return std::move(newNode);
+        } else {
+            node->apply(makeLambdaRamMapper(rewriter));
+            return node;
+        }
+    };
+    apply(makeLambdaRamMapper(rewriter));
+}
+
+}  // namespace souffle::ram

--- a/src/ram/Node.cpp
+++ b/src/ram/Node.cpp
@@ -14,8 +14,6 @@
  *
  ***********************************************************************/
 
-#pragma once
-
 #include "ram/Node.h"
 #include <cassert>
 #include <functional>

--- a/src/ram/Node.h
+++ b/src/ram/Node.h
@@ -10,7 +10,7 @@
  *
  * @file Node.h
  *
- * Declaration of RAM node and mappers for RAM nodes
+ * Declaration of RAM node
  *
  ***********************************************************************/
 
@@ -36,10 +36,10 @@ class NodeMapper;
  */
 class Node {
 public:
-    /*
-     * @brief A virtual destructor for RAM nodes
-     */
+    Node() = default;
+    Node(Node const&) = delete;
     virtual ~Node() = default;
+    Node& operator=(Node const&) = delete;
 
     /**
      * @brief Equivalence check for two RAM nodes
@@ -68,19 +68,7 @@ public:
     /**
      * @brief Rewrite a child node
      */
-    virtual void rewrite(const Node* oldNode, Own<Node> newNode) {
-        assert(oldNode != nullptr && "old node is a null-pointer");
-        assert(newNode != nullptr && "new node is a null-pointer");
-        std::function<Own<Node>(Own<Node>)> rewriter = [&](Own<Node> node) -> Own<Node> {
-            if (oldNode == node.get()) {
-                return std::move(newNode);
-            } else {
-                node->apply(makeLambdaRamMapper(rewriter));
-                return node;
-            }
-        };
-        apply(makeLambdaRamMapper(rewriter));
-    };
+    virtual void rewrite(const Node* oldNode, Own<Node> newNode);
 
     /**
      * @brief Obtain list of all embedded child nodes


### PR DESCRIPTION
- By deleting the copy constructor and copy operator in class Node, shallow copies are prohibited in the source code. 
- The more complex method rewrite() code was pushed into Node.cpp 
- Fixed the use of shallow copies in the interpreter (use references instead) 
