### PR TITLE
Fix record_table_test #1958

### DIFF
--- a/src/tests/record_table_test.cpp
+++ b/src/tests/record_table_test.cpp
@@ -138,18 +138,18 @@ TEMPLATE_TEST(PackUnpack, Vector, std::size_t VectorSize, VectorSize) {
 
 // special version of the test for vector of size 0
 SPECIALIZE_TEMPLATE_TEST(PackUnpack, Vector, 0) {
-  RecordTable recordTable;
+    RecordTable recordTable;
 
-  std::vector<RamDomain> toPack(0);
+    std::vector<RamDomain> toPack(0);
 
-  RamDomain tupleRef = recordTable.pack(toPack.data(), 0);
+    RamDomain tupleRef = recordTable.pack(toPack.data(), 0);
 
-  // empty record has reference 0
-  EXPECT_EQ(tupleRef, 1);
-  const RamDomain* unpacked{recordTable.unpack(tupleRef, 0)};
+    // empty record has reference 0
+    EXPECT_EQ(tupleRef, 1);
+    const RamDomain* unpacked{recordTable.unpack(tupleRef, 0)};
 
-  // unpacking empty record returns nullptr
-  EXPECT_EQ(unpacked, nullptr);
+    // unpacking empty record returns nullptr
+    EXPECT_EQ(unpacked, nullptr);
 }
 
 INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 0);

--- a/src/tests/record_table_test.cpp
+++ b/src/tests/record_table_test.cpp
@@ -164,5 +164,4 @@ INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 11);
 INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 23);
 INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 59);
 
-
 }  // namespace souffle::test

--- a/src/tests/record_table_test.cpp
+++ b/src/tests/record_table_test.cpp
@@ -19,7 +19,6 @@
 #include "souffle/RamTypes.h"
 #include "souffle/RecordTable.h"
 #include <algorithm>
-#include <execution>
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -71,7 +70,7 @@ TEMPLATE_TEST(PackUnpack, Tuple, std::size_t TupleSize, TupleSize) {
 
     // Generate and pack the tuples
     for (std::size_t i = 0; i < NUMBER_OF_TESTS; ++i) {
-        std::generate(std::execution::seq, toPack[i].begin(), toPack[i].end(), rnd);
+        std::generate(toPack[i].begin(), toPack[i].end(), rnd);
         tupleRef[i] = pack(recordTable, toPack[i]);
         EXPECT_LT(0, tupleRef[i]);
     }
@@ -122,7 +121,7 @@ TEMPLATE_TEST(PackUnpack, Vector, std::size_t VectorSize, VectorSize) {
     // Generate and pack the tuples
     for (std::size_t i = 0; i < NUMBER_OF_TESTS; ++i) {
         toPack[i].resize(vectorSize);
-        std::generate(std::execution::seq, toPack[i].begin(), toPack[i].end(), rnd);
+        std::generate(toPack[i].begin(), toPack[i].end(), rnd);
         tupleRef[i] = recordTable.pack(toPack[i].data(), vectorSize);
         EXPECT_LT(0, tupleRef[i]);
     }

--- a/src/tests/record_table_test.cpp
+++ b/src/tests/record_table_test.cpp
@@ -18,6 +18,8 @@
 
 #include "souffle/RamTypes.h"
 #include "souffle/RecordTable.h"
+#include <algorithm>
+#include <execution>
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -47,9 +49,9 @@ TEST(Pack, Tuple) {
 // Generate random tuples
 // pack them all
 // unpack and test for equality
-TEST(PackUnpack, Tuple) {
-    constexpr std::size_t tupleSize = 3;
-    using tupleType = Tuple<RamDomain, tupleSize>;
+TEMPLATE_TEST(PackUnpack, Tuple, std::size_t TupleSize, TupleSize) {
+    using tupleType = Tuple<RamDomain, TupleSize>;
+    constexpr std::size_t tupleSize = TupleSize;
 
     RecordTable recordTable;
 
@@ -59,6 +61,7 @@ TEST(PackUnpack, Tuple) {
             std::numeric_limits<RamDomain>::lowest(), std::numeric_limits<RamDomain>::max());
 
     auto random = std::bind(distribution, randomGenerator);
+    auto rnd = [&]() { return random(); };
 
     // Tuples that will be packed
     std::vector<tupleType> toPack(NUMBER_OF_TESTS);
@@ -68,23 +71,45 @@ TEST(PackUnpack, Tuple) {
 
     // Generate and pack the tuples
     for (std::size_t i = 0; i < NUMBER_OF_TESTS; ++i) {
-        toPack[i] = {{random(), random(), random()}};
+        std::generate(std::execution::seq, toPack[i].begin(), toPack[i].end(), rnd);
         tupleRef[i] = pack(recordTable, toPack[i]);
+        EXPECT_LT(0, tupleRef[i]);
     }
 
     // unpack and test
     for (std::size_t i = 0; i < NUMBER_OF_TESTS; ++i) {
-        auto unpacked = recordTable.unpack(tupleRef[i], tupleSize);
-        tupleType cmp = {unpacked[0], unpacked[1], unpacked[2]};
+        const RamDomain* unpacked = recordTable.unpack(tupleRef[i], tupleSize);
+        tupleType cmp;
+        std::copy_n(unpacked, TupleSize, cmp.begin());
         EXPECT_EQ(toPack[i], cmp);
     }
 }
 
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Tuple, 0);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Tuple, 1);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Tuple, 2);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Tuple, 3);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Tuple, 4);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Tuple, 5);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Tuple, 6);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Tuple, 7);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Tuple, 11);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Tuple, 23);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Tuple, 59);
+
 // Generate random vectors
 // pack them all
 // unpack and test for equality
-TEST(PackUnpack, Vector) {
-    constexpr std::size_t vectorSize = 10;
+TEMPLATE_TEST(PackUnpack, Vector, std::size_t VectorSize, VectorSize) {
+    constexpr std::size_t vectorSize = VectorSize;
+
+    // Setup random number generation
+    std::default_random_engine randomGenerator(3);
+    std::uniform_int_distribution<RamDomain> distribution(
+            std::numeric_limits<RamDomain>::lowest(), std::numeric_limits<RamDomain>::max());
+
+    auto random = std::bind(distribution, randomGenerator);
+    auto rnd = [&]() { return random(); };
 
     RecordTable recordTable;
 
@@ -96,9 +121,10 @@ TEST(PackUnpack, Vector) {
 
     // Generate and pack the tuples
     for (std::size_t i = 0; i < NUMBER_OF_TESTS; ++i) {
-        toPack[i] = testutil::generateRandomVector<RamDomain>(10);
+        toPack[i].resize(vectorSize);
+        std::generate(std::execution::seq, toPack[i].begin(), toPack[i].end(), rnd);
         tupleRef[i] = recordTable.pack(toPack[i].data(), vectorSize);
-        std::cerr << "Ref: " << tupleRef[i] << std::endl;
+        EXPECT_LT(0, tupleRef[i]);
     }
 
     // unpack and test
@@ -109,5 +135,34 @@ TEST(PackUnpack, Vector) {
         }
     }
 }
+
+// special version of the test for vector of size 0
+SPECIALIZE_TEMPLATE_TEST(PackUnpack, Vector, 0) {
+  RecordTable recordTable;
+
+  std::vector<RamDomain> toPack(0);
+
+  RamDomain tupleRef = recordTable.pack(toPack.data(), 0);
+
+  // empty record has reference 0
+  EXPECT_EQ(tupleRef, 1);
+  const RamDomain* unpacked{recordTable.unpack(tupleRef, 0)};
+
+  // unpacking empty record returns nullptr
+  EXPECT_EQ(unpacked, nullptr);
+}
+
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 0);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 1);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 2);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 3);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 4);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 5);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 6);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 7);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 11);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 23);
+INSTANTIATE_TEMPLATE_TEST(PackUnpack, Vector, 59);
+
 
 }  // namespace souffle::test

--- a/src/tests/test.h
+++ b/src/tests/test.h
@@ -168,6 +168,9 @@ public:
     }
 };
 
+#define PASTE(x, y) x ## y
+#define PASTE2(x, y) PASTE(x, y)
+
 #define TEST(a, b)                                                       \
     class test_##a##_##b : public TestCase {                             \
     public:                                                              \
@@ -175,6 +178,23 @@ public:
         void run();                                                      \
     } Test_##a##_##b(#a, #b);                                            \
     void test_##a##_##b::run()
+
+#define TEMPLATE_TEST(a, b, Param, P)                                                       \
+    template <Param>                                                                        \
+    class test_##a##_##b : public TestCase {                                                \
+    public:                                                                                 \
+        test_##a##_##b(std::string g, std::string t, std::string k) : TestCase(g, t + k) {} \
+        void run();                                                                         \
+    };                                                                                      \
+    template <Param>                                                                        \
+    void test_##a##_##b<P>::run()
+
+#define SPECIALIZE_TEMPLATE_TEST(a, b, P) \
+    template <>                           \
+    void test_##a##_##b<P>::run()
+
+#define INSTANTIATE_TEMPLATE_TEST(a, b, V) \
+    test_##a##_##b<V> PASTE2(Test_##a##_##b##_, __LINE__)(#a, #b, #V)
 
 #define S(x) #x
 #define S_(x) S(x)

--- a/src/tests/test.h
+++ b/src/tests/test.h
@@ -168,7 +168,7 @@ public:
     }
 };
 
-#define PASTE(x, y) x ## y
+#define PASTE(x, y) x##y
 #define PASTE2(x, y) PASTE(x, y)
 
 #define TEST(a, b)                                                       \
@@ -193,8 +193,7 @@ public:
     template <>                           \
     void test_##a##_##b<P>::run()
 
-#define INSTANTIATE_TEMPLATE_TEST(a, b, V) \
-    test_##a##_##b<V> PASTE2(Test_##a##_##b##_, __LINE__)(#a, #b, #V)
+#define INSTANTIATE_TEMPLATE_TEST(a, b, V) test_##a##_##b<V> PASTE2(Test_##a##_##b##_, __LINE__)(#a, #b, #V)
 
 #define S(x) #x
 #define S_(x) S(x)


### PR DESCRIPTION
Fix the `record_table_test` test.

Introduce new test macros in `test.h`:
- `TEMPLATE_TEST` to define a test that have template parameters.
- `SPECIALIZE_TEMPLATE_TEST` to specialize a template test for the specified parameters.
- `INSTANTIATE_TEMPLATE_TEST` to instantiate a template test for the specified parameters.

Output of the `record_table_test` is:
```
Pack
        OK (3/3)        Tuple
PackUnpack
        OK (6000/6000)  Vector59
        OK (2400/2400)  Vector23
        OK (1200/1200)  Vector11
        OK (800/800)    Vector7
        OK (700/700)    Vector6
        OK (600/600)    Vector5
        OK (500/500)    Vector4
        OK (400/400)    Vector3
        OK (300/300)    Vector2
        OK (200/200)    Vector1
        OK (2/2)        Vector0
        OK (200/200)    Tuple59
        OK (200/200)    Tuple23
        OK (200/200)    Tuple11
        OK (200/200)    Tuple7
        OK (200/200)    Tuple6
        OK (200/200)    Tuple5
        OK (200/200)    Tuple4
        OK (200/200)    Tuple3
        OK (200/200)    Tuple2
        OK (200/200)    Tuple1
        OK (200/200)    Tuple0
```