### PR TITLE
trivial - fix `SOUFFLE_SANITISE_THREAD` having no effect on cmake build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ doc
 .DS_Store
 
 .vscode
+# cmake generated file used by various tools
+/compile_commands.json
 
 stamp-h1
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,7 @@ endif()
 # --------------------------------------------------
 # Thread Sanitiser
 # --------------------------------------------------
-if (SOUFFLE_SANITISE_MEMORY)
+if (SOUFFLE_SANITISE_THREAD)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=thread")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
 endif()
@@ -296,4 +296,3 @@ add_subdirectory(src)
 if (SOUFFLE_ENABLE_TESTING)
     add_subdirectory(tests)
 endif()
-


### PR DESCRIPTION
Fixes a likely copy-pasta typo in `CMakeList.txt`.