### PR TITLE
Added timeout for CI actions

### DIFF
--- a/.github/workflows/CI-Tests.yml
+++ b/.github/workflows/CI-Tests.yml
@@ -20,6 +20,7 @@ jobs:
       
   Ubuntu:
     needs: Code-Style
+    timeout-minutes: 150
 
     strategy: 
       fail-fast: false
@@ -52,6 +53,7 @@ jobs:
 
   Ubuntu-CMake:
     needs: Code-Style
+    timeout-minutes: 150
 
     strategy: 
       fail-fast: false
@@ -84,6 +86,7 @@ jobs:
 
   OSX:
     needs: Code-Style
+    timeout-minutes: 150
 
     runs-on: macos-latest
 
@@ -105,6 +108,7 @@ jobs:
 
   Memory-Check:
     needs: Code-Style
+    timeout-minutes: 150
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Added a 2.5 hrs timeout for CI actions. Based on the log, CI action can usually be finished within 1.5 hrs.