### PR TITLE
Fix parser

### DIFF
--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -270,8 +270,8 @@
 %type <Mov<std::vector<ast::QualifiedName>>>   type_params
 %type <Mov<std::vector<ast::QualifiedName>>>   type_param_list
 %type <Mov<std::vector<ast::QualifiedName>>>   union_type_list
-%type <Mov<VecOwn<ast::BranchDeclaration>>>    sum_branch_list
-%type <Mov<Own<ast::BranchDeclaration>>>       sum_branch
+%type <Mov<VecOwn<ast::BranchDeclaration>>>    adt_branch_list
+%type <Mov<Own<ast::BranchDeclaration>>>       adt_branch
 
 /* -- Operator precedence -- */
 %left L_OR
@@ -333,7 +333,7 @@ type
   : TYPE IDENT SUBTYPE qualified_name    { $$ = mk<ast::SubsetType>($2, $4, @$); }
   | TYPE IDENT EQUALS  union_type_list   { $$ = mk<ast::UnionType>($2, $4, @$); }
   | TYPE IDENT EQUALS  record_type_list  { $$ = mk<ast::RecordType>($2, $4, @$); }
-  | TYPE IDENT EQUALS  sum_branch_list   { $$ = mk<ast::AlgebraicDataType>($2, $4, @$); }
+  | TYPE IDENT EQUALS  adt_branch_list   { $$ = mk<ast::AlgebraicDataType>($2, $4, @$); }
     /* deprecated subset type forms */
   | NUMBER_TYPE IDENT { $$ = driver.mkDeprecatedSubType($IDENT, "number", @$); }
   | SYMBOL_TYPE IDENT { $$ = driver.mkDeprecatedSubType($IDENT, "symbol", @$); }
@@ -346,12 +346,12 @@ union_type_list
   | union_type_list PIPE  qualified_name { $$ = $1; $$.push_back($qualified_name); }
   ;
 
-sum_branch_list
-  : sum_branch                      { $$.push_back($sum_branch); }
-  | sum_branch_list PIPE sum_branch { $$ = $1; $$.push_back($sum_branch); }
+adt_branch_list
+  : adt_branch                      { $$.push_back($adt_branch); }
+  | adt_branch_list PIPE adt_branch { $$ = $1; $$.push_back($adt_branch); }
   ;
 
-sum_branch
+adt_branch
   : IDENT[name] LBRACE RBRACE
     { $$ = mk<ast::BranchDeclaration>($name, VecOwn<ast::Attribute>{}, @$); }
   | IDENT[name] LBRACE non_empty_attributes[attributes] RBRACE

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -22,6 +22,7 @@
 %define api.value.type variant
 %define parse.assert
 %define api.location.type {SrcLocation}
+
 // Defined in version 3.2. This would solve a lot of the verbose `std::move`s.
 // NOTE:  Turns out becaue of another unspeakable hack (see below),
 //        we dont need as many of these `std::move`s anymore.
@@ -224,9 +225,9 @@
 %type <Mov<Own<ast::Atom>>>                    atom
 %type <Mov<VecOwn<ast::Attribute>>>            attributes_list
 %type <Mov<RuleBody>>                          body
-%type <Mov<Own<ast::ComponentType>>>           comp_type
-%type <Mov<Own<ast::ComponentInit>>>           comp_init
-%type <Mov<Own<ast::Component>>>               component
+%type <Mov<Own<ast::ComponentType>>>           component_type
+%type <Mov<Own<ast::ComponentInit>>>           component_init
+%type <Mov<Own<ast::Component>>>               component_decl
 %type <Mov<Own<ast::Component>>>               component_body
 %type <Mov<Own<ast::Component>>>               component_head
 %type <Mov<RuleBody>>                          conjunction
@@ -235,9 +236,9 @@
 %type <Mov<VecOwn<ast::FunctionalConstraint>>> dependency_list
 %type <Mov<VecOwn<ast::FunctionalConstraint>>> dependency_list_aux
 %type <Mov<RuleBody>>                          disjunction
-%type <Mov<Own<ast::ExecutionOrder>>>          exec_order
-%type <Mov<Own<ast::ExecutionPlan>>>           exec_plan
-%type <Mov<Own<ast::ExecutionPlan>>>           exec_plan_list
+%type <Mov<Own<ast::ExecutionOrder>>>          plan_order
+%type <Mov<Own<ast::ExecutionPlan>>>           query_plan
+%type <Mov<Own<ast::ExecutionPlan>>>           query_plan_list
 %type <Mov<Own<ast::Clause>>>                  fact
 %type <Mov<VecOwn<ast::Attribute>>>            functor_arg_type_list
 %type <Mov<std::string>>                       functor_built_in
@@ -252,13 +253,13 @@
 %type <Mov<VecOwn<ast::Argument>>>             non_empty_arg_list
 %type <Mov<Own<ast::Attribute>>>               attribute
 %type <Mov<VecOwn<ast::Attribute>>>            non_empty_attributes
-%type <Mov<std::vector<std::string>>>          non_empty_variables
-%type <Mov<ast::ExecutionOrder::ExecOrder>>    non_empty_exec_order_list
+%type <Mov<std::vector<std::string>>>          non_empty_attribute_names
+%type <Mov<ast::ExecutionOrder::ExecOrder>>    non_empty_plan_order_list
 %type <Mov<VecOwn<ast::Attribute>>>            non_empty_functor_arg_type_list
 %type <Mov<Own<ast::Attribute>>>               functor_attribute;
 %type <Mov<std::vector<std::pair
             <std::string, std::string>>>>      non_empty_key_value_pairs
-%type <Mov<VecOwn<ast::Relation>>>             non_empty_relation_list
+%type <Mov<VecOwn<ast::Relation>>>             relation_names
 %type <Mov<Own<ast::Pragma>>>                  pragma
 %type <Mov<VecOwn<ast::Attribute>>>            record_type_list
 %type <Mov<VecOwn<ast::Relation>>>             relation_decl
@@ -267,8 +268,8 @@
 %type <Mov<VecOwn<ast::Clause>>>               rule_def
 %type <Mov<RuleBody>>                          term
 %type <Mov<Own<ast::Type>>>                    type
-%type <Mov<std::vector<ast::QualifiedName>>>   type_params
-%type <Mov<std::vector<ast::QualifiedName>>>   type_param_list
+%type <Mov<std::vector<ast::QualifiedName>>>   component_type_params
+%type <Mov<std::vector<ast::QualifiedName>>>   component_param_list
 %type <Mov<std::vector<ast::QualifiedName>>>   union_type_list
 %type <Mov<VecOwn<ast::BranchDeclaration>>>    adt_branch_list
 %type <Mov<Own<ast::BranchDeclaration>>>       adt_branch
@@ -291,588 +292,1176 @@
 
 %start program;
 
-/* Program */
+/**
+ * Program
+ */
 program
   : unit
   ;
 
-/* Top-level statement */
+/**
+ * Top-level Program Elements 
+ */
 unit
-  : %empty              { }
-  | unit directive_head { for (auto&& cur : $directive_head) driver.addDirective(std::move(cur)); }
-  | unit rule           { for (auto&& cur : $rule   ) driver.addClause(std::move(cur)); }
-  | unit fact           { driver.addClause            ($fact); }
-  | unit component      { driver.addComponent         ($component); }
-  | unit comp_init      { driver.addInstantiation     ($comp_init); }
-  | unit pragma         { driver.addPragma            ($pragma); }
-  | unit type           { driver.addType              ($type); }
-  | unit functor_decl   { driver.addFunctorDeclaration($functor_decl); }
-  | unit relation_decl  {
-        for (auto&& rel : $relation_decl) {
-            driver.addIoFromDeprecatedTag(*rel);
-            driver.addRelation(std::move(rel));
-        }
+  : %empty
+    { }
+  | unit directive_head
+    {
+      for (auto&& cur : $directive_head)
+        driver.addDirective(std::move(cur));
+    }
+  | unit rule
+    {
+      for (auto&& cur : $rule   )
+        driver.addClause(std::move(cur));
+    }
+  | unit fact
+    {
+      driver.addClause($fact);
+    }
+  | unit component_decl
+    {
+      driver.addComponent($component_decl);
+    }
+  | unit component_init
+    {
+      driver.addInstantiation($component_init);
+    }
+  | unit pragma
+    {
+      driver.addPragma($pragma);
+    }
+  | unit type
+    {
+      driver.addType($type);
+    }
+  | unit functor_decl
+    {
+      driver.addFunctorDeclaration($functor_decl);
+    }
+  | unit relation_decl
+    {
+      for (auto&& rel : $relation_decl) {
+        driver.addIoFromDeprecatedTag(*rel);
+        driver.addRelation(std::move(rel));
+      }
     }
   ;
 
 /**
- * Qualified Names 
+ * A Qualified Name
  */
 
 qualified_name
-  : IDENT                     { $$ = $IDENT; }
-  | qualified_name DOT  IDENT { $$ = $1; $$->append($IDENT); }
+  : IDENT
+    {
+      $$ = $IDENT;
+    }
+  | qualified_name DOT  IDENT
+    {
+      $$ = $1; $$->append($IDENT);
+    }
   ;
 
 /**
  * Types
  */
 
-/* Type declarations */
+/**
+ * Type Declarations
+ */
 type
-  : TYPE IDENT SUBTYPE qualified_name    { $$ = mk<ast::SubsetType>($2, $4, @$); }
-  | TYPE IDENT EQUALS  union_type_list   { $$ = mk<ast::UnionType>($2, $4, @$); }
-  | TYPE IDENT EQUALS  record_type_list  { $$ = mk<ast::RecordType>($2, $4, @$); }
-  | TYPE IDENT EQUALS  adt_branch_list   { $$ = mk<ast::AlgebraicDataType>($2, $4, @$); }
-    /* deprecated subset type forms */
-  | NUMBER_TYPE IDENT { $$ = driver.mkDeprecatedSubType($IDENT, "number", @$); }
-  | SYMBOL_TYPE IDENT { $$ = driver.mkDeprecatedSubType($IDENT, "symbol", @$); }
-  | TYPE        IDENT { $$ = driver.mkDeprecatedSubType($IDENT, "symbol", @$); }
+  : TYPE IDENT SUBTYPE qualified_name
+    {
+      $$ = mk<ast::SubsetType>($2, $4, @$);
+    }
+  | TYPE IDENT EQUALS union_type_list
+    {
+      $$ = mk<ast::UnionType>($2, $4, @$);
+    }
+  | TYPE IDENT EQUALS record_type_list
+    {
+      $$ = mk<ast::RecordType>($2, $4, @$);
+    }
+  | TYPE IDENT EQUALS adt_branch_list
+    {
+      $$ = mk<ast::AlgebraicDataType>($2, $4, @$);
+    }
+    /* Deprecated Types */
+  | NUMBER_TYPE IDENT
+    {
+      $$ = driver.mkDeprecatedSubType($IDENT, "number", @$);
+    }
+  | SYMBOL_TYPE IDENT
+    {
+      $$ = driver.mkDeprecatedSubType($IDENT, "symbol", @$);
+    }
+  | TYPE IDENT
+    {
+      $$ = driver.mkDeprecatedSubType($IDENT, "symbol", @$);
+    }
+  ;
+
+/* Attribute definition of a relation */
+/* specific wrapper to ensure the err msg says "expected ',' or ')'" */
+record_type_list
+  : LBRACKET RBRACKET
+    { }
+  | LBRACKET non_empty_attributes RBRACKET
+    {
+      $$ = $2;
+    }
   ;
 
 /* Union type argument declarations */
 union_type_list
-  : qualified_name                       { $$.push_back($qualified_name); }
-  | union_type_list PIPE  qualified_name { $$ = $1; $$.push_back($qualified_name); }
+  : qualified_name
+    {
+      $$.push_back($qualified_name);
+    }
+  | union_type_list PIPE qualified_name
+    {
+      $$ = $1;
+      $$.push_back($qualified_name);
+    }
   ;
 
 adt_branch_list
-  : adt_branch                      { $$.push_back($adt_branch); }
-  | adt_branch_list PIPE adt_branch { $$ = $1; $$.push_back($adt_branch); }
+  : adt_branch
+    {
+      $$.push_back($adt_branch);
+    }
+  | adt_branch_list PIPE adt_branch
+    {
+      $$ = $1;
+      $$.push_back($adt_branch);
+    }
   ;
 
 adt_branch
   : IDENT[name] LBRACE RBRACE
-    { $$ = mk<ast::BranchDeclaration>($name, VecOwn<ast::Attribute>{}, @$); }
+    {
+      $$ = mk<ast::BranchDeclaration>($name, VecOwn<ast::Attribute>{}, @$);
+    }
   | IDENT[name] LBRACE non_empty_attributes[attributes] RBRACE
-    { $$ = mk<ast::BranchDeclaration>($name, $attributes, @$); }
+    {
+      $$ = mk<ast::BranchDeclaration>($name, $attributes, @$);
+    }
   ;
 
 /**
  * Relations
  */
 
-/* Relation declaration */
+/**
+ * Relation Declaration
+ */
 relation_decl
-  : DECL non_empty_relation_list attributes_list relation_tags dependency_list {
-        auto tags             = $relation_tags;
-        auto attributes_list  = $attributes_list;
-
-        $$ = $non_empty_relation_list;
-        for (auto&& rel : $$) {
-            for (auto tag : tags) {
-                if (isRelationQualifierTag(tag)) {
-                    rel->addQualifier(getRelationQualifierFromTag(tag));
-                } else if (isRelationRepresentationTag(tag)) {
-                    rel->setRepresentation(getRelationRepresentationFromTag(tag));
-                } else {
-                    assert(false && "unhandled tag");
-                }
-            }
-
-            for (auto&& fd : $dependency_list) {
-                rel->addDependency(souffle::clone(fd));
-            }
-
-            rel->setAttributes(clone(attributes_list));
+  : DECL relation_names attributes_list relation_tags dependency_list
+    {
+      auto tags = $relation_tags;
+      auto attributes_list = $attributes_list;
+      $$ = $relation_names;
+      for (auto&& rel : $$) {
+        for (auto tag : tags) {
+          if (isRelationQualifierTag(tag)) {
+            rel->addQualifier(getRelationQualifierFromTag(tag));
+          } else if (isRelationRepresentationTag(tag)) {
+            rel->setRepresentation(getRelationRepresentationFromTag(tag));
+          } else {
+            assert(false && "unhandled tag");
+          }
         }
+        for (auto&& fd : $dependency_list) {
+          rel->addDependency(souffle::clone(fd));
+        }
+        rel->setAttributes(clone(attributes_list));
+      }
     }
   ;
+
+/**
+ * Relation Names
+ */
+relation_names
+  : IDENT
+    {
+      $$.push_back(mk<ast::Relation>($1, @1));
+    }
+  | relation_names COMMA IDENT
+    {
+      $$ = $1;
+      $$.push_back(mk<ast::Relation>($3, @3));
+    }
   ;
 
-/* List of relation names to declare */
-non_empty_relation_list
-  : IDENT                               {          $$.push_back(mk<ast::Relation>($1, @1)); }
-  | non_empty_relation_list COMMA IDENT { $$ = $1; $$.push_back(mk<ast::Relation>($3, @3)); }
-  ;
-
-/* Attribute definition of a relation */
-/* specific wrapper to ensure the err msg says "expected ',' or ')'" */
-record_type_list
-  : LBRACKET RBRACKET                       { }
-  | LBRACKET non_empty_attributes RBRACKET  { $$ = $2; }
-  ;
-
+/**
+ * Attributes
+ */
 attributes_list
-  : LPAREN RPAREN                       { }
-  | LPAREN non_empty_attributes RPAREN  { $$ = $2; }
+  : LPAREN RPAREN
+    { }
+  | LPAREN non_empty_attributes RPAREN
+    {
+      $$ = $2;
+    }
   ;
 
 non_empty_attributes
-  : attribute                            {           $$.push_back($attribute); }
-  | non_empty_attributes COMMA attribute { $$ = $1;  $$.push_back($attribute); }
+  : attribute
+    {
+      $$.push_back($attribute);
+    }
+  | non_empty_attributes COMMA attribute
+    {
+      $$ = $1;
+      $$.push_back($attribute);
+    }
   ;
 
 attribute
-  : IDENT[name] COLON qualified_name[type] { $$ = mk<ast::Attribute>($name, $type, @type); }
-  ;
-
-/* Relation tags */
-relation_tags
-  : %empty { }
-  | relation_tags      OUTPUT_QUALIFIER
-    { $$ = driver.addDeprecatedTag(RelationTag::OUTPUT, @2, $1); }
-  | relation_tags       INPUT_QUALIFIER
-    { $$ = driver.addDeprecatedTag(RelationTag::INPUT, @2, $1); }
-  | relation_tags   PRINTSIZE_QUALIFIER
-    { $$ = driver.addDeprecatedTag(RelationTag::PRINTSIZE, @2, $1); }
-  | relation_tags OVERRIDABLE_QUALIFIER { $$ = driver.addTag(RelationTag::OVERRIDABLE , @2, $1); }
-  | relation_tags      INLINE_QUALIFIER { $$ = driver.addTag(RelationTag::INLINE      , @2, $1); }
-  | relation_tags       MAGIC_QUALIFIER { $$ = driver.addTag(RelationTag::MAGIC       , @2, $1); }
-  | relation_tags        BRIE_QUALIFIER { $$ = driver.addReprTag(RelationTag::BRIE    , @2, $1); }
-  | relation_tags       BTREE_QUALIFIER { $$ = driver.addReprTag(RelationTag::BTREE   , @2, $1); }
-  | relation_tags       EQREL_QUALIFIER { $$ = driver.addReprTag(RelationTag::EQREL   , @2, $1); }
-  ;
-
-  /* List of variables */
-non_empty_variables
-  : IDENT {
-        $$.push_back($IDENT);
-  }
-
-  | non_empty_variables[curr_var_list] COMMA IDENT {
-        $$ = $curr_var_list;
-        $$.push_back($IDENT);
+  : IDENT[name] COLON qualified_name[type]
+    {
+      $$ = mk<ast::Attribute>($name, $type, @type);
     }
   ;
 
-/*  a functional dependency on relation */
+/**
+ * Relation Tags
+ */
+relation_tags
+  : %empty
+    { }
+  | relation_tags OVERRIDABLE_QUALIFIER
+    {
+      $$ = driver.addTag(RelationTag::OVERRIDABLE, @2, $1);
+    }
+  | relation_tags INLINE_QUALIFIER
+    {
+      $$ = driver.addTag(RelationTag::INLINE, @2, $1);
+    }
+  | relation_tags MAGIC_QUALIFIER
+    {
+      $$ = driver.addTag(RelationTag::MAGIC, @2, $1);
+    }
+  | relation_tags BRIE_QUALIFIER
+    {
+      $$ = driver.addReprTag(RelationTag::BRIE, @2, $1);
+    }
+  | relation_tags BTREE_QUALIFIER
+    {
+      $$ = driver.addReprTag(RelationTag::BTREE, @2, $1);
+    }
+  | relation_tags EQREL_QUALIFIER
+    {
+      $$ = driver.addReprTag(RelationTag::EQREL, @2, $1);
+    }
+  /* Deprecated Qualifiers */
+  | relation_tags OUTPUT_QUALIFIER
+    {
+      $$ = driver.addDeprecatedTag(RelationTag::OUTPUT, @2, $1);
+    }
+  | relation_tags INPUT_QUALIFIER
+    {
+      $$ = driver.addDeprecatedTag(RelationTag::INPUT, @2, $1);
+    }
+  | relation_tags PRINTSIZE_QUALIFIER
+    {
+      $$ = driver.addDeprecatedTag(RelationTag::PRINTSIZE, @2, $1);
+    }
+  ;
+
+/**
+ * Attribute Name List
+ */
+non_empty_attribute_names
+  : IDENT
+    {
+      $$.push_back($IDENT);
+    }
+
+  | non_empty_attribute_names[curr_var_list] COMMA IDENT
+    {
+      $$ = $curr_var_list;
+      $$.push_back($IDENT);
+    }
+  ;
+
+/**
+ * Functional Dependency Constraint
+ */
 dependency
-  : IDENT[key] {
+  : IDENT[key]
+    {
         $$ = mk<ast::FunctionalConstraint>(mk<ast::Variable>($key, @$), @$);
     }
-
-  | LPAREN non_empty_variables RPAREN {
-        VecOwn<ast::Variable> keys;
-        for (std::string s : $non_empty_variables) {
-          keys.push_back(mk<ast::Variable>(s, @$));
-        }
-        $$ = mk<ast::FunctionalConstraint>(std::move(keys), @$);
-  }
+  | LPAREN non_empty_attribute_names RPAREN
+    {
+      VecOwn<ast::Variable> keys;
+      for (std::string s : $non_empty_attribute_names) {
+        keys.push_back(mk<ast::Variable>(s, @$));
+      }
+      $$ = mk<ast::FunctionalConstraint>(std::move(keys), @$);
+    }
   ;
 
 dependency_list_aux
-  : dependency { $$.push_back($dependency); }
-
-  | dependency_list_aux[list] COMMA dependency[next] {
-    $$ = std::move($list);
-    $$.push_back(std::move($next));
-  }
+  : dependency
+    {
+      $$.push_back($dependency);
+    }
+  | dependency_list_aux[list] COMMA dependency[next]
+    {
+      $$ = std::move($list);
+      $$.push_back(std::move($next));
+    }
   ;
 
-/*  List of functional dependencies on relation */
 dependency_list
-  : %empty { }
-
-  | CHOICEDOMAIN dependency_list_aux[list] {
-    $$ = std::move($list);
-  }
+  : %empty
+    { }
+  | CHOICEDOMAIN dependency_list_aux[list]
+    {
+      $$ = std::move($list);
+    }
   ;
 
 /**
  * Datalog Rule Structure
  */
 
-/* Fact */
-fact : atom DOT { $$ = mk<ast::Clause>($atom, Mov<VecOwn<ast::Literal>> {}, nullptr, @$); };
+/**
+ * Fact
+ */
+fact
+  : atom DOT
+    {
+      $$ = mk<ast::Clause>($atom, Mov<VecOwn<ast::Literal>> {}, nullptr, @$);
+    }
+  ;
 
-/* Rule */
+/**
+ * Rule
+ */
 rule
-  : rule_def {
-        $$ = $rule_def;
+  : rule_def
+    {
+      $$ = $rule_def;
     }
-  | rule_def exec_plan {
-        $$ = $rule_def;
-        auto exec_plan = $exec_plan;
-        for (auto&& rule : $$) {
-            rule->setExecutionPlan(clone(exec_plan));
-        }
+  | rule_def query_plan
+    {
+      $$ = $rule_def;
+      auto query_plan = $query_plan;
+      for (auto&& rule : $$) {
+        rule->setExecutionPlan(clone(query_plan));
+      }
     }
   ;
 
-/* Rule definition */
+/**
+ * Rule Definition
+ */
 rule_def
-  : head[heads] IF body DOT {
-        auto bodies = $body->toClauseBodies();
-
-        for (auto&& head : $heads) {
-            for (auto&& body : bodies) {
-                auto cur = clone(body);
-                cur->setHead(clone(head));
-                cur->setSrcLoc(@$);
-                $$.push_back(std::move(cur));
-            }
+  : head[heads] IF body DOT
+    {
+      auto bodies = $body->toClauseBodies();
+      for (auto&& head : $heads) {
+        for (auto&& body : bodies) {
+          auto cur = clone(body);
+          cur->setHead(clone(head));
+          cur->setSrcLoc(@$);
+          $$.push_back(std::move(cur));
         }
+      }
     }
   ;
 
-/* Rule head */
+/**
+ * Rule Head
+ */
 head
-  :            atom {          $$.push_back($atom); }
-  | head COMMA atom { $$ = $1; $$.push_back($atom); }
+  : atom
+    {
+      $$.push_back($atom);
+    }
+  | head COMMA atom
+    {
+      $$ = $1; $$.push_back($atom);
+    }
   ;
 
-/* Rule body */
-body : disjunction { $$ = $disjunction; };
+/**
+ * Rule Body
+ */
+body
+  : disjunction
+    {
+      $$ = $disjunction;
+    }
+  ;
 
 disjunction
-  :                       conjunction { $$ = $conjunction; }
-  | disjunction SEMICOLON conjunction { $$ = $1; $$->disjunct($conjunction); }
+  : conjunction
+    {
+      $$ = $conjunction;
+    }
+  | disjunction SEMICOLON conjunction
+    {
+      $$ = $1;
+      $$->disjunct($conjunction);
+    }
   ;
 
 conjunction
-  :                   term { $$ = $term; }
-  | conjunction COMMA term { $$ = $1; $$->conjunct($term); }
-  ;
-
-/* Rule execution plan */
-exec_plan : PLAN exec_plan_list { $$ = $exec_plan_list; };
-
-/* Rule execution plan list */
-exec_plan_list
-  : NUMBER COLON exec_order {
-        $$ = mk<ast::ExecutionPlan>();
-        $$->setOrderFor(RamSignedFromString($NUMBER), Own<ast::ExecutionOrder>($exec_order));
+  : term
+    {
+      $$ = $term;
     }
-  | exec_plan_list[curr_list] COMMA NUMBER COLON exec_order {
-        $$ = $curr_list;
-        $$->setOrderFor(RamSignedFromString($NUMBER), $exec_order);
+  | conjunction COMMA term
+    {
+      $$ = $1;
+      $$->conjunct($term);
     }
-  ;
-
-/* Rule execution order */
-exec_order
-  : LPAREN RPAREN                           { $$ = mk<ast::ExecutionOrder>(ast::ExecutionOrder::ExecOrder(), @$); }
-  | LPAREN non_empty_exec_order_list RPAREN { $$ = mk<ast::ExecutionOrder>($2, @$); }
-  ;
-non_empty_exec_order_list
-  :                                 NUMBER {          $$.push_back(RamUnsignedFromString($NUMBER)); }
-  | non_empty_exec_order_list COMMA NUMBER { $$ = $1; $$.push_back(RamUnsignedFromString($NUMBER)); }
   ;
 
 /**
  * Terms in Rule Bodies
  */
-
-/* Rule body term */
 term
-  : atom                      { $$ = RuleBody::atom($atom); }
-  | constraint                { $$ = RuleBody::constraint($constraint); }
-  | LPAREN disjunction RPAREN { $$ = $disjunction; }
-  | EXCLAMATION term          { $$ = $2->negated(); }
+  : atom
+    {
+      $$ = RuleBody::atom($atom);
+    }
+  | constraint
+    {
+      $$ = RuleBody::constraint($constraint);
+    }
+  | LPAREN disjunction RPAREN
+    {
+      $$ = $disjunction;
+    }
+  | EXCLAMATION term
+    {
+      $$ = $2->negated();
+    }
   ;
 
-/* Rule body atom */
-atom : qualified_name LPAREN arg_list RPAREN { $$ = mk<ast::Atom>($qualified_name, $arg_list, @$); };
+/**
+ * Rule body atom
+ */
+atom
+  : qualified_name LPAREN arg_list RPAREN
+    {
+      $$ = mk<ast::Atom>($qualified_name, $arg_list, @$);
+    }
+  ;
 
-/* Rule literal constraints */
+/**
+ * Literal Constraints
+ */
 constraint
     /* binary infix constraints */
-  : arg LT      arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::LT, $1, $3, @$); }
-  | arg GT      arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::GT, $1, $3, @$); }
-  | arg LE      arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::LE, $1, $3, @$); }
-  | arg GE      arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::GE, $1, $3, @$); }
-  | arg EQUALS  arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::EQ, $1, $3, @$); }
-  | arg NE      arg { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::NE, $1, $3, @$); }
+  : arg LT arg
+    {
+      $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::LT, $1, $3, @$);
+    }
+  | arg GT arg
+    {
+      $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::GT, $1, $3, @$);
+    }
+  | arg LE arg
+    {
+      $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::LE, $1, $3, @$);
+    }
+  | arg GE arg
+    {
+      $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::GE, $1, $3, @$);
+    }
+  | arg EQUALS arg
+    {
+      $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::EQ, $1, $3, @$);
+    }
+  | arg NE arg
+    {
+      $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::NE, $1, $3, @$);
+    }
 
     /* binary prefix constraints */
-  | TMATCH    LPAREN arg[a0] COMMA arg[a1] RPAREN
-    { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::MATCH   , $a0, $a1, @$); }
+  | TMATCH LPAREN arg[a0] COMMA arg[a1] RPAREN
+    {
+      $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::MATCH, $a0, $a1, @$);
+    }
   | TCONTAINS LPAREN arg[a0] COMMA arg[a1] RPAREN
-    { $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::CONTAINS, $a0, $a1, @$); }
+    {
+       $$ = mk<ast::BinaryConstraint>(BinaryConstraintOp::CONTAINS, $a0, $a1, @$);
+    }
 
     /* zero-arity constraints */
-  | TRUE  { $$ = mk<ast::BooleanConstraint>(true , @$); }
-  | FALSE { $$ = mk<ast::BooleanConstraint>(false, @$); }
+  | TRUE
+    {
+      $$ = mk<ast::BooleanConstraint>(true , @$);
+    }
+  | FALSE
+    {
+      $$ = mk<ast::BooleanConstraint>(false, @$);
+    }
   ;
 
-/* Argument list */
-arg_list : %empty { } | non_empty_arg_list { $$ = $1; } ;
+/**
+ * Argument List
+ */
+arg_list
+  : %empty
+    { }
+  | non_empty_arg_list
+    {
+      $$ = $1;
+    } ;
+
 non_empty_arg_list
-  :                           arg {          $$.push_back($arg); }
-  | non_empty_arg_list COMMA  arg { $$ = $1; $$.push_back($arg); }
+  : arg
+    {
+      $$.push_back($arg);
+    }
+  | non_empty_arg_list COMMA arg
+    {
+      $$ = $1; $$.push_back($arg);
+    }
   ;
 
-/* Atom argument */
+/**
+ * Atom argument
+ */
 arg
-  : STRING      { $$ = mk<ast::StringConstant >($STRING, @$); }
-  | FLOAT       { $$ = mk<ast::NumericConstant>($FLOAT, ast::NumericConstant::Type::Float, @$); }
-  | UNSIGNED    {
+  : STRING
+    {
+      $$ = mk<ast::StringConstant>($STRING, @$);
+    }
+  | FLOAT
+    {
+      $$ = mk<ast::NumericConstant>($FLOAT, ast::NumericConstant::Type::Float, @$);
+    }
+  | UNSIGNED
+    {
       auto&& n = $UNSIGNED; // drop the last character (`u`)
       $$ = mk<ast::NumericConstant>(n.substr(0, n.size() - 1), ast::NumericConstant::Type::Uint, @$);
     }
-  | NUMBER      { $$ = mk<ast::NumericConstant>($NUMBER, @$); }
-  | UNDERSCORE  { $$ = mk<ast::UnnamedVariable>(@$); }
-  | DOLLAR      { $$ = mk<ast::Counter        >(@$); }
-  | IDENT       { $$ = mk<ast::Variable       >($IDENT, @$); }
-  | NIL         { $$ = mk<ast::NilConstant    >(@$); }
-  | LBRACKET arg_list RBRACKET                  { $$ = mk<ast::RecordInit>($arg_list, @$); }
-  | DOLLAR IDENT[branch] LPAREN arg_list RPAREN { $$ = mk<ast::BranchInit>($branch, $arg_list, @$); }
-  | DOLLAR IDENT[branch]                        { $$ = mk<ast::BranchInit>($branch, VecOwn<ast::Argument>{}, @$); }
-  | LPAREN arg RPAREN                           { $$ = $2; }
-  | AS LPAREN arg COMMA qualified_name RPAREN   { $$ = mk<ast::TypeCast>($3, $qualified_name, @$); }
-  | AT IDENT         LPAREN arg_list RPAREN { $$ = mk<ast::UserDefinedFunctor>($IDENT, *$arg_list, @$); }
-  | functor_built_in LPAREN arg_list RPAREN { $$ = mk<ast::IntrinsicFunctor>($functor_built_in, *$arg_list, @$); }
+  | NUMBER
+    {
+      $$ = mk<ast::NumericConstant>($NUMBER, @$);
+    }
+  | UNDERSCORE
+    {
+      $$ = mk<ast::UnnamedVariable>(@$);
+    }
+  | DOLLAR
+    {
+      $$ = mk<ast::Counter>(@$);
+    }
+  | IDENT
+    {
+      $$ = mk<ast::Variable>($IDENT, @$);
+    }
+  | NIL
+    {
+      $$ = mk<ast::NilConstant>(@$);
+    }
+  | LBRACKET arg_list RBRACKET
+    {
+      $$ = mk<ast::RecordInit>($arg_list, @$);
+    }
+  | DOLLAR IDENT[branch] LPAREN arg_list RPAREN
+    {
+      $$ = mk<ast::BranchInit>($branch, $arg_list, @$);
+    }
+  | DOLLAR IDENT[branch]
+    {
+      $$ = mk<ast::BranchInit>($branch, VecOwn<ast::Argument>{}, @$);
+    }
+  | LPAREN arg RPAREN
+    {
+      $$ = $2;
+    }
+  | AS LPAREN arg COMMA qualified_name RPAREN
+    {
+      $$ = mk<ast::TypeCast>($3, $qualified_name, @$);
+    }
+  | AT IDENT LPAREN arg_list RPAREN
+    {
+      $$ = mk<ast::UserDefinedFunctor>($IDENT, *$arg_list, @$);
+    }
+  | functor_built_in LPAREN arg_list RPAREN
+    {
+      $$ = mk<ast::IntrinsicFunctor>($functor_built_in, *$arg_list, @$);
+    }
 
     /* some aggregates have the same name as functors */
-  | aggregate_func LPAREN arg[first] COMMA non_empty_arg_list[rest] RPAREN {
-        VecOwn<ast::Argument> arg_list = $rest;
-        arg_list.insert(arg_list.begin(), $first);
-
-        auto agg_2_func = [](AggregateOp op) -> char const* {
-          switch (op) {
-            case AggregateOp::COUNT : return {};
-            case AggregateOp::MAX   : return "max";
-            case AggregateOp::MEAN  : return {};
-            case AggregateOp::MIN   : return "min";
-            case AggregateOp::SUM   : return {};
-            default                 :
-              fatal("missing base op handler, or got an overload op?");
-          }
-        };
-
-        if (auto* func_op = agg_2_func($aggregate_func)) {
-          $$ = mk<ast::IntrinsicFunctor>(func_op, std::move(arg_list), @$);
-        } else {
-          driver.error(@$, "aggregate operation has no functor equivalent");
-          $$ = mk<ast::UnnamedVariable>(@$);
+  | aggregate_func LPAREN arg[first] COMMA non_empty_arg_list[rest] RPAREN
+    {
+      VecOwn<ast::Argument> arg_list = $rest;
+      arg_list.insert(arg_list.begin(), $first);
+      auto agg_2_func = [](AggregateOp op) -> char const* {
+        switch (op) {
+          case AggregateOp::COUNT : return {};
+          case AggregateOp::MAX   : return "max";
+          case AggregateOp::MEAN  : return {};
+          case AggregateOp::MIN   : return "min";
+          case AggregateOp::SUM   : return {};
+          default                 :
+            fatal("missing base op handler, or got an overload op?");
         }
+      };
+      if (auto* func_op = agg_2_func($aggregate_func)) {
+        $$ = mk<ast::IntrinsicFunctor>(func_op, std::move(arg_list), @$);
+      } else {
+        driver.error(@$, "aggregate operation has no functor equivalent");
+        $$ = mk<ast::UnnamedVariable>(@$);
+      }
     }
 
     /* -- intrinsic functor -- */
     /* unary functors */
-  | MINUS arg[nested_arg] %prec NEG {
-        // If we have a constant that is not already negated we just negate the constant value.
-        auto nested_arg = *$nested_arg;
-        const auto* asNumeric = as<ast::NumericConstant>(*nested_arg);
-        if (asNumeric && !isPrefix("-", asNumeric->getConstant())) {
-            $$ = mk<ast::NumericConstant>("-" + asNumeric->getConstant(), asNumeric->getFixedType(), @nested_arg);
-        } else { // Otherwise, create a functor.
-            $$ = mk<ast::IntrinsicFunctor>(@$, FUNCTOR_INTRINSIC_PREFIX_NEGATE_NAME, std::move(nested_arg));
-        }
+  | MINUS arg[nested_arg] %prec NEG
+    {
+      // If we have a constant that is not already negated we just negate the constant value.
+      auto nested_arg = *$nested_arg;
+      const auto* asNumeric = as<ast::NumericConstant>(*nested_arg);
+      if (asNumeric && !isPrefix("-", asNumeric->getConstant())) {
+        $$ = mk<ast::NumericConstant>("-" + asNumeric->getConstant(), asNumeric->getFixedType(), @nested_arg);
+      } else { // Otherwise, create a functor.
+        $$ = mk<ast::IntrinsicFunctor>(@$, FUNCTOR_INTRINSIC_PREFIX_NEGATE_NAME, std::move(nested_arg));
+      }
     }
-  | BW_NOT  arg { $$ = mk<ast::IntrinsicFunctor>(@$, "~", $2); }
-  | L_NOT   arg { $$ = mk<ast::IntrinsicFunctor>(@$, "!", $2); }
+  | BW_NOT  arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "~", $2);
+    }
+  | L_NOT arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "!", $2);
+    }
 
     /* binary infix functors */
-  | arg PLUS                arg { $$ = mk<ast::IntrinsicFunctor>(@$, "+"  , $1, $3); }
-  | arg MINUS               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "-"  , $1, $3); }
-  | arg STAR                arg { $$ = mk<ast::IntrinsicFunctor>(@$, "*"  , $1, $3); }
-  | arg SLASH               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "/"  , $1, $3); }
-  | arg PERCENT             arg { $$ = mk<ast::IntrinsicFunctor>(@$, "%"  , $1, $3); }
-  | arg CARET               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "**" , $1, $3); }
-  | arg L_AND               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "&&" , $1, $3); }
-  | arg L_OR                arg { $$ = mk<ast::IntrinsicFunctor>(@$, "||" , $1, $3); }
-  | arg L_XOR               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "^^" , $1, $3); }
-  | arg BW_AND              arg { $$ = mk<ast::IntrinsicFunctor>(@$, "&"  , $1, $3); }
-  | arg BW_OR               arg { $$ = mk<ast::IntrinsicFunctor>(@$, "|"  , $1, $3); }
-  | arg BW_XOR              arg { $$ = mk<ast::IntrinsicFunctor>(@$, "^"  , $1, $3); }
-  | arg BW_SHIFT_L          arg { $$ = mk<ast::IntrinsicFunctor>(@$, "<<" , $1, $3); }
-  | arg BW_SHIFT_R          arg { $$ = mk<ast::IntrinsicFunctor>(@$, ">>" , $1, $3); }
-  | arg BW_SHIFT_R_UNSIGNED arg { $$ = mk<ast::IntrinsicFunctor>(@$, ">>>", $1, $3); }
+  | arg PLUS arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "+"  , $1, $3);
+    }
+  | arg MINUS arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "-"  , $1, $3);
+    }
+  | arg STAR arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "*"  , $1, $3);
+    }
+  | arg SLASH arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "/"  , $1, $3);
+    }
+  | arg PERCENT arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "%"  , $1, $3);
+    }
+  | arg CARET arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "**" , $1, $3);
+    }
+  | arg L_AND arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "&&" , $1, $3);
+    }
+  | arg L_OR arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "||" , $1, $3);
+    }
+  | arg L_XOR arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "^^" , $1, $3);
+    }
+  | arg BW_AND arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "&"  , $1, $3);
+    }
+  | arg BW_OR arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "|"  , $1, $3);
+    }
+  | arg BW_XOR arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "^"  , $1, $3);
+    }
+  | arg BW_SHIFT_L arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, "<<" , $1, $3);
+    }
+  | arg BW_SHIFT_R arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, ">>" , $1, $3);
+    }
+  | arg BW_SHIFT_R_UNSIGNED arg
+    {
+      $$ = mk<ast::IntrinsicFunctor>(@$, ">>>", $1, $3);
+    }
 
     /* -- aggregators -- */
-  | aggregate_func arg_list COLON aggregate_body {
-        auto bodies = $aggregate_body->toClauseBodies();
-        if (bodies.size() != 1) {
-            driver.error("ERROR: disjunctions in aggregation clauses are currently not supported");
-        }
-
-        // TODO: move this to a semantic check when aggs are extended to multiple exprs
-        auto given    = $arg_list.size();
-        auto required = aggregateArity($aggregate_func);
-        if (given < required.first || required.second < given) {
-            driver.error("ERROR: incorrect expression arity for given aggregate mode");
-        }
-
-        auto expr = $arg_list.empty() ? nullptr : std::move($arg_list[0]);
-        auto body = (bodies.size() == 1) ? clone(bodies[0]->getBodyLiterals()) : VecOwn<ast::Literal> {};
-        $$ = mk<ast::Aggregator>($aggregate_func, std::move(expr), std::move(body), @$);
+  | aggregate_func arg_list COLON aggregate_body
+    {
+      auto bodies = $aggregate_body->toClauseBodies();
+      if (bodies.size() != 1) {
+        driver.error("ERROR: disjunctions in aggregation clauses are currently not supported");
+      }
+      // TODO: move this to a semantic check when aggs are extended to multiple exprs
+      auto given    = $arg_list.size();
+      auto required = aggregateArity($aggregate_func);
+      if (given < required.first || required.second < given) {
+        driver.error("ERROR: incorrect expression arity for given aggregate mode");
+      }
+      auto expr = $arg_list.empty() ? nullptr : std::move($arg_list[0]);
+      auto body = (bodies.size() == 1) ? clone(bodies[0]->getBodyLiterals()) : VecOwn<ast::Literal> {};
+      $$ = mk<ast::Aggregator>($aggregate_func, std::move(expr), std::move(body), @$);
     }
   ;
 
 functor_built_in
-  : CAT         { $$ = "cat";         }
-  | ORD         { $$ = "ord";         }
-  | RANGE       { $$ = "range";       }
-  | STRLEN      { $$ = "strlen";      }
-  | SUBSTR      { $$ = "substr";      }
-  | TOFLOAT     { $$ = "to_float";    }
-  | TONUMBER    { $$ = "to_number";   }
-  | TOSTRING    { $$ = "to_string";   }
-  | TOUNSIGNED  { $$ = "to_unsigned"; }
+  : CAT
+    {
+      $$ = "cat";
+    }
+  | ORD
+    {
+      $$ = "ord";
+    }
+  | RANGE
+    {
+      $$ = "range";
+    }
+  | STRLEN
+    {
+      $$ = "strlen";
+    }
+  | SUBSTR
+    {
+      $$ = "substr";
+    }
+  | TOFLOAT
+    {
+      $$ = "to_float";
+    }
+  | TONUMBER
+    {
+      $$ = "to_number";
+    }
+  | TOSTRING
+    {
+      $$ = "to_string";
+    }
+  | TOUNSIGNED
+    {
+      $$ = "to_unsigned";
+    }
   ;
 
 aggregate_func
-  : COUNT { $$ = AggregateOp::COUNT;  }
-  | MAX   { $$ = AggregateOp::MAX;    }
-  | MEAN  { $$ = AggregateOp::MEAN;   }
-  | MIN   { $$ = AggregateOp::MIN;    }
-  | SUM   { $$ = AggregateOp::SUM;    }
+  : COUNT
+    {
+      $$ = AggregateOp::COUNT;
+    }
+  | MAX
+    {
+      $$ = AggregateOp::MAX;
+    }
+  | MEAN
+    {
+      $$ = AggregateOp::MEAN;
+    }
+  | MIN
+    {
+      $$ = AggregateOp::MIN;
+    }
+  | SUM
+    {
+      $$ = AggregateOp::SUM;
+    }
   ;
 
 aggregate_body
-  : LBRACE body RBRACE  { $$ = $body; }
-  | atom                { $$ = RuleBody::atom($atom); }
+  : LBRACE body RBRACE
+    {
+      $$ = $body;
+    }
+  | atom
+    {
+      $$ = RuleBody::atom($atom);
+    }
+  ;
+
+/**
+ * Query Plan
+ */
+query_plan
+  : PLAN query_plan_list
+    {
+      $$ = $query_plan_list;
+    };
+
+query_plan_list
+  : NUMBER COLON plan_order
+    {
+      $$ = mk<ast::ExecutionPlan>();
+      $$->setOrderFor(RamSignedFromString($NUMBER), Own<ast::ExecutionOrder>($plan_order));
+    }
+  | query_plan_list[curr_list] COMMA NUMBER COLON plan_order
+    {
+      $$ = $curr_list;
+      $$->setOrderFor(RamSignedFromString($NUMBER), $plan_order);
+    }
+  ;
+
+plan_order
+  : LPAREN RPAREN
+    {
+      $$ = mk<ast::ExecutionOrder>(ast::ExecutionOrder::ExecOrder(), @$);
+    }
+  | LPAREN non_empty_plan_order_list RPAREN
+    {
+      $$ = mk<ast::ExecutionOrder>($2, @$);
+    }
+  ;
+
+non_empty_plan_order_list
+  : NUMBER
+    {
+      $$.push_back(RamUnsignedFromString($NUMBER));
+    }
+  | non_empty_plan_order_list COMMA NUMBER
+    {
+      $$ = $1; $$.push_back(RamUnsignedFromString($NUMBER));
+    }
   ;
 
 /**
  * Components
  */
 
-/* Component */
-component
-  : component_head LBRACE component_body RBRACE {
-        auto head = $component_head;
-        $$ = $component_body;
-        $$->setComponentType(clone(head->getComponentType()));
-        $$->copyBaseComponents(**head);
-        $$->setSrcLoc(@$);
+/**
+ * Component Declaration
+ */
+component_decl
+  : component_head LBRACE component_body RBRACE
+    {
+      auto head = $component_head;
+      $$ = $component_body;
+      $$->setComponentType(clone(head->getComponentType()));
+      $$->copyBaseComponents(**head);
+      $$->setSrcLoc(@$);
     }
   ;
 
-/* Component head */
+/**
+ * Component Head
+ */
 component_head
-  : COMPONENT             comp_type { $$ = mk<ast::Component>();  $$->setComponentType($comp_type); }
-  | component_head COLON  comp_type { $$ = $1;                  $$->addBaseComponent($comp_type); }
-  | component_head COMMA  comp_type { $$ = $1;                  $$->addBaseComponent($comp_type); }
-  ;
-
-/* Component type */
-comp_type : IDENT type_params { $$ = mk<ast::ComponentType>($IDENT, $type_params, @$); };
-
-/* Component type parameters */
-type_params
-  : %empty                { }
-  | LT type_param_list GT { $$ = $type_param_list; }
-  ;
-
-/* Component type parameter list */
-type_param_list
-  :                       IDENT {          $$.push_back($IDENT); }
-  | type_param_list COMMA IDENT { $$ = $1; $$.push_back($IDENT); }
-  ;
-
-/* Component body */
-component_body
-  : %empty                        { $$ = mk<ast::Component>(); }
-  | component_body directive_head { $$ = $1; for (auto&& x : $2) $$->addDirective(std::move(x)); }
-  | component_body rule           { $$ = $1; for (auto&& x : $2) $$->addClause(std::move(x)); }
-  | component_body fact           { $$ = $1; $$->addClause       ($2); }
-  | component_body OVERRIDE IDENT { $$ = $1; $$->addOverride     ($3); }
-  | component_body comp_init      { $$ = $1; $$->addInstantiation($2); }
-  | component_body component      { $$ = $1; $$->addComponent    ($2); }
-  | component_body type           { $$ = $1; $$->addType         ($2); }
-  | component_body relation_decl  {
-        $$ = $1;
-        for (auto&& rel : $relation_decl) {
-            driver.addIoFromDeprecatedTag(*rel);
-            $$->addRelation(std::move(rel));
-        }
+  : COMPONENT component_type
+    {
+      $$ = mk<ast::Component>();
+      $$->setComponentType($component_type);
+    }
+  | component_head COLON component_type
+    {
+      $$ = $1;
+      $$->addBaseComponent($component_type);
+    }
+  | component_head COMMA component_type
+    {
+      $$ = $1;
+      $$->addBaseComponent($component_type);
     }
   ;
 
-/* Component initialisation */
-comp_init : INSTANTIATE IDENT EQUALS comp_type { $$ = mk<ast::ComponentInit>($IDENT, $comp_type, @$); };
+/**
+ * Component Type
+ */
+component_type
+  : IDENT component_type_params
+    {
+      $$ = mk<ast::ComponentType>($IDENT, $component_type_params, @$);
+    };
+
+/**
+ * Component Parameters
+ */
+component_type_params
+  : %empty
+    { }
+  | LT component_param_list GT
+    {
+      $$ = $component_param_list;
+    }
+  ;
+
+/**
+ * Component Parameter List
+ */
+component_param_list
+  : IDENT
+    {
+      $$.push_back($IDENT);
+    }
+  | component_param_list COMMA IDENT
+    {
+      $$ = $1;
+      $$.push_back($IDENT);
+    }
+  ;
+
+/**
+ * Component body 
+ */
+component_body
+  : %empty
+    {
+      $$ = mk<ast::Component>();
+    }
+  | component_body directive_head
+    {
+      $$ = $1;
+      for (auto&& x : $2) {
+        $$->addDirective(std::move(x));
+      }
+    }
+  | component_body rule
+    {
+      $$ = $1;
+      for (auto&& x : $2) {
+        $$->addClause(std::move(x));
+      }
+    }
+  | component_body fact
+    {
+      $$ = $1;
+      $$->addClause($2);
+    }
+  | component_body OVERRIDE IDENT
+    {
+      $$ = $1;
+      $$->addOverride($3);
+    }
+  | component_body component_init
+    {
+      $$ = $1;
+      $$->addInstantiation($2);
+    }
+  | component_body component_decl
+    {
+      $$ = $1;
+      $$->addComponent($2);
+    }
+  | component_body type
+    {
+      $$ = $1;
+      $$->addType($2);
+    }
+  | component_body relation_decl
+    {
+      $$ = $1;
+      for (auto&& rel : $relation_decl) {
+        driver.addIoFromDeprecatedTag(*rel);
+        $$->addRelation(std::move(rel));
+      }
+    }
+  ;
+
+/**
+ * Component Initialisation
+ */
+component_init
+  : INSTANTIATE IDENT EQUALS component_type
+    {
+      $$ = mk<ast::ComponentInit>($IDENT, $component_type, @$);
+    }
+  ;
 
 /**
  * User-Defined Functors
  */
 
-/* Functor declaration */
+/**
+ * Functor declaration
+ */
 functor_decl
   : FUNCTOR IDENT LPAREN functor_arg_type_list[args] RPAREN COLON qualified_name
-    { $$ = mk<ast::FunctorDeclaration>($IDENT, $args, mk<ast::Attribute>("return_type", $qualified_name, @qualified_name), false, @$); }
+    {
+      $$ = mk<ast::FunctorDeclaration>($IDENT, $args, mk<ast::Attribute>("return_type", $qualified_name, @qualified_name), false, @$);
+    }
   | FUNCTOR IDENT LPAREN functor_arg_type_list[args] RPAREN COLON qualified_name STATEFUL
-    { $$ = mk<ast::FunctorDeclaration>($IDENT, $args, mk<ast::Attribute>("return_type", $qualified_name, @qualified_name), true, @$); }
+    {
+      $$ = mk<ast::FunctorDeclaration>($IDENT, $args, mk<ast::Attribute>("return_type", $qualified_name, @qualified_name), true, @$);
+    }
   ;
 
-/* Functor argument list type */
-functor_arg_type_list : %empty { } | non_empty_functor_arg_type_list { $$ = $1; };
+/**
+ * Functor argument list type
+ */
+functor_arg_type_list
+  : %empty { }
+  | non_empty_functor_arg_type_list
+    {
+      $$ = $1;
+    }
+  ;
+
 non_empty_functor_arg_type_list
-  :                                        functor_attribute {          $$.push_back($functor_attribute); }
-  | non_empty_functor_arg_type_list COMMA  functor_attribute { $$ = $1; $$.push_back($functor_attribute); }
+  : functor_attribute
+    {
+      $$.push_back($functor_attribute);
+    }
+  | non_empty_functor_arg_type_list COMMA functor_attribute
+    {
+      $$ = $1; $$.push_back($functor_attribute);
+    }
   ;
 
 functor_attribute
-  : qualified_name[type] { $$ = mk<ast::Attribute>("", $type, @type); }
-  | IDENT[name] COLON qualified_name[type] { $$ = mk<ast::Attribute>($name, $type, @type); }
+  : qualified_name[type]
+    {
+      $$ = mk<ast::Attribute>("", $type, @type);
+    }
+  | IDENT[name] COLON qualified_name[type]
+    {
+      $$ = mk<ast::Attribute>($name, $type, @type);
+    }
   ;
 
 /**
  * Other Directives
  */
 
-/* Pragma directives */
+/**
+ * Pragma Directives
+ */
 pragma
-  : PRAGMA STRING[key   ] STRING[value] { $$ = mk<ast::Pragma>($key   , $value, @$); }
-  | PRAGMA STRING[option]               { $$ = mk<ast::Pragma>($option, ""    , @$); }
+  : PRAGMA STRING[key] STRING[value]
+    {
+      $$ = mk<ast::Pragma>($key, $value, @$);
+    }
+  | PRAGMA STRING[option]
+    {
+      $$ = mk<ast::Pragma>($option, "", @$);
+    }
   ;
 
-/* io directives */
+/**
+ * Directives
+ */
 directive_head
-  : directive_head_decl directive_list {
-        auto directive_head_decl = $directive_head_decl;
-        for (auto&& io : $directive_list) {
-            io->setType(directive_head_decl);
-            $$.push_back(std::move(io));
-        }
+  : directive_head_decl directive_list
+    {
+      auto directive_head_decl = $directive_head_decl;
+      for (auto&& io : $directive_list) {
+        io->setType(directive_head_decl);
+        $$.push_back(std::move(io));
+      }
     }
   ;
 
 directive_head_decl
-  : INPUT_DECL      { $$ = ast::DirectiveType::input;      }
-  | OUTPUT_DECL     { $$ = ast::DirectiveType::output;     }
-  | PRINTSIZE_DECL  { $$ = ast::DirectiveType::printsize;  }
-  | LIMITSIZE_DECL  { $$ = ast::DirectiveType::limitsize;  }
-  ;
-
-/* IO directive list */
-directive_list
-  : relation_directive_list                { $$ = $relation_directive_list; }
-  | relation_directive_list LPAREN RPAREN  { $$ = $relation_directive_list; }
-  | relation_directive_list LPAREN non_empty_key_value_pairs RPAREN {
-        $$ = $relation_directive_list;
-        for (auto&& kvp : $non_empty_key_value_pairs) {
-            for (auto&& io : $$) {
-                io->addParameter(kvp.first, kvp.second);
-            }
-        }
+  : INPUT_DECL
+    {
+      $$ = ast::DirectiveType::input;
+    }
+  | OUTPUT_DECL
+    {
+      $$ = ast::DirectiveType::output;
+    }
+  | PRINTSIZE_DECL
+    {
+      $$ = ast::DirectiveType::printsize;
+    }
+  | LIMITSIZE_DECL
+    {
+      $$ = ast::DirectiveType::limitsize;
     }
   ;
 
-/* IO relation list */
-/* use a dummy `ast::DirectiveType` for now. `directive_head` will replace it */
-relation_directive_list
-  :                         qualified_name {          $$.push_back(mk<ast::Directive>(ast::DirectiveType::input, $1, @1)); }
-  | relation_directive_list COMMA  qualified_name { $$ = $1; $$.push_back(mk<ast::Directive>(ast::DirectiveType::input, $3, @3)); }
+/**
+ * Directive List
+ */
+directive_list
+  : relation_directive_list
+    {
+      $$ = $relation_directive_list;
+    }
+  | relation_directive_list LPAREN RPAREN
+    {
+      $$ = $relation_directive_list;
+    }
+  | relation_directive_list LPAREN non_empty_key_value_pairs RPAREN
+    {
+      $$ = $relation_directive_list;
+      for (auto&& kvp : $non_empty_key_value_pairs) {
+        for (auto&& io : $$) {
+          io->addParameter(kvp.first, kvp.second);
+        }
+      }
+    }
   ;
 
-/* Key-value pairs */
-non_empty_key_value_pairs
-  :                                 IDENT EQUALS kvp_value {          $$.push_back({ $1, $3 }); }
-  | non_empty_key_value_pairs COMMA IDENT EQUALS kvp_value { $$ = $1; $$.push_back({ $3, $5 }); }
+/**
+ * Directive List
+ */
+relation_directive_list
+  : qualified_name
+    {
+      $$.push_back(mk<ast::Directive>(ast::DirectiveType::input, $1, @1));
+    }
+  | relation_directive_list COMMA qualified_name
+    {
+      $$ = $1;
+      $$.push_back(mk<ast::Directive>(ast::DirectiveType::input, $3, @3));
+    }
   ;
+
+/**
+ * Key-value Pairs
+ */
+non_empty_key_value_pairs
+  : IDENT EQUALS kvp_value
+    {
+      $$.push_back({$1, $3});
+    }
+  | non_empty_key_value_pairs COMMA IDENT EQUALS kvp_value
+    {
+      $$ = $1;
+      $$.push_back({$3, $5});
+    }
+  ;
+
 kvp_value
-  : STRING  { $$ = $STRING; }
-  | IDENT   { $$ = $IDENT; }
-  | NUMBER  { $$ = $NUMBER; }
-  | TRUE    { $$ = "true"; }
-  | FALSE   { $$ = "false"; }
+  : STRING
+    {
+      $$ = $STRING;
+    }
+  | IDENT
+    {
+      $$ = $IDENT;
+    }
+  | NUMBER
+    {
+      $$ = $NUMBER;
+    }
+  | TRUE
+    {
+      $$ = "true";
+    }
+  | FALSE
+    {
+      $$ = "false";
+    }
   ;
 
 %%
 
-void yy::parser::error(const location_type &l, const std::string &m) {
-    driver.error(l, m);
+void yy::parser::error(const location_type &l, const std::string &m)
+{
+  driver.error(l, m);
 }


### PR DESCRIPTION
The subtype grammar rule did except only an identifier instead of a qualified name (discovered by reading railroad grammar  (#1970).
I also renamed non-terminals, removed some outdated TODOs and reformatted the parser slightly. 

