### PR TITLE
[cmake] Fix: test Souffle with -j8 when openmp is detected. Add run src/tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,7 @@ endif()
 add_subdirectory(src)
 
 if (SOUFFLE_ENABLE_TESTING)
+    add_subdirectory(src/tests)
     add_subdirectory(tests)
 endif()
 

--- a/cmake/SouffleTests.cmake
+++ b/cmake/SouffleTests.cmake
@@ -187,17 +187,19 @@ function(SOUFFLE_RUN_TEST_HELPER)
                                        FIXTURE_NAME ${FIXTURE_NAME}
                                        TEST_LABELS ${TEST_LABELS})
 
+    if (OPENMP_FOUND)
+        set(SOUFFLE_PARAMS "${EXTRA_FLAGS} -j8 -D . -F '${FACTS_DIR}'")
+    else()
+        set(SOUFFLE_PARAMS "${EXTRA_FLAGS} -D . -F '${FACTS_DIR}'")
+    endif()
+
     souffle_run_integration_test(TEST_NAME ${PARAM_TEST_NAME}
                                  QUALIFIED_TEST_NAME ${QUALIFIED_TEST_NAME}
                                  INPUT_DIR ${INPUT_DIR}
                                  OUTPUT_DIR ${OUTPUT_DIR}
                                  FIXTURE_NAME ${FIXTURE_NAME}
                                  NEGATIVE ${PARAM_NEGATIVE}
-                                 if (OPENMP_FOUND)
-                                    SOUFFLE_PARAMS "${EXTRA_FLAGS} -j8 -D . -F '${FACTS_DIR}'"
-                                 else()
-                                    SOUFFLE_PARAMS "${EXTRA_FLAGS} -D . -F '${FACTS_DIR}'"
-                                 endif()
+                                 SOUFFLE_PARAMS ${SOUFFLE_PARAMS}
                                  TEST_LABELS ${TEST_LABELS})
 
     souffle_compare_std_outputs(TEST_NAME ${PARAM_TEST_NAME}

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Souffle - A Datalog Compiler
+# Copyright (c) 2021 The Souffle Developers. All rights reserved
+# Licensed under the Universal Permissive License v 1.0 as shown at:
+# - https://opensource.org/licenses/UPL
+# - <souffle root>/licenses/SOUFFLE-UPL.txt
+
+include(SouffleTests)
+
+souffle_add_binary_test(binary_relation_test src)
+souffle_add_binary_test(brie_test src)
+souffle_add_binary_test(btree_multiset_test src)
+souffle_add_binary_test(btree_set_test src)
+souffle_add_binary_test(compiled_tuple_test src)
+souffle_add_binary_test(eqrel_datastructure_test src)
+souffle_add_binary_test(graph_utils_test src)
+souffle_add_binary_test(parallel_utils_test src)
+souffle_add_binary_test(profile_util_test src)
+souffle_add_binary_test(record_table_test src)
+souffle_add_binary_test(symbol_table_test src)
+souffle_add_binary_test(table_test src)
+souffle_add_binary_test(util_test src)
+


### PR DESCRIPTION
Add missing tests from `src/tests` in CMake files.

Pass `-j8` to Souffle when testing and `OPENMP_FOUND` is set. It seems that the existing piece of code did not work as expected. 
You can observe the issue by running `ctest -VV -R adt_access` and you will see that the generated souffle command does not contain `-j8` even when openmp is detected by cmake.