### PR TITLE
Fix/packaging bash completion

### DIFF
--- a/.github/actions/create-package/entrypoint.sh
+++ b/.github/actions/create-package/entrypoint.sh
@@ -2,6 +2,8 @@
 
 PACKAGE_CLOUD_API_KEY="$1"
 
+PACKAGECLOUD_TOKEN="$PACKAGE_CLOUD_API_KEY" package_cloud yank souffle-lang/souffle-test/ubuntu/hirsute souffle_3734596_amd64.deb
+
 # Run the build command
 case "$DOMAIN_SIZE" in
   	"64bit")

--- a/.github/actions/create-package/fedora/34/64bit/Dockerfile
+++ b/.github/actions/create-package/fedora/34/64bit/Dockerfile
@@ -9,13 +9,10 @@ RUN yum -y install autoconf automake bison clang doxygen flex g++ git libffi lib
 # For CMakeLists.txt to figure out the specific version of Ubuntu. Also installing rpmbuild so that we can package our app into an rpm file
 RUN yum -y install redhat-lsb rpm-build
 
-# Install dependencies for packagecloud CLI
+# Install dependencies for packagecloud CLI as well as package_cloud CLI
 RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB && \
 	curl -sSL https://get.rvm.io | bash -s stable
 RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && rvm install 2.7.4 && gem install package_cloud"
-
-# Install package_cloud
-RUN sudo gem install package_cloud
 
 # Copy everything into souffle directory
 COPY . .

--- a/.github/actions/create-package/fedora/34/64bit/Dockerfile
+++ b/.github/actions/create-package/fedora/34/64bit/Dockerfile
@@ -14,6 +14,9 @@ RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A170311380
 	curl -sSL https://get.rvm.io | bash -s stable
 RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && rvm install 2.7.4 && gem install package_cloud"
 
+# Install package_cloud
+RUN sudo gem install package_cloud
+
 # Copy everything into souffle directory
 COPY . .
 

--- a/.github/actions/create-package/fedora/34/64bit/Dockerfile
+++ b/.github/actions/create-package/fedora/34/64bit/Dockerfile
@@ -4,7 +4,7 @@ FROM fedora:34
 WORKDIR /souffle
 
 # Install souffle build dependencies
-RUN yum -y install autoconf automake bison clang doxygen flex g++ git libffi libffi-devel ncurses-devel libtool libsqlite3x make mcpp python sqlite sqlite-devel zlib-devel cmake
+RUN yum -y install bash-completion autoconf automake bison clang doxygen flex g++ git libffi libffi-devel ncurses-devel libtool libsqlite3x make mcpp python sqlite sqlite-devel zlib-devel cmake
 
 # For CMakeLists.txt to figure out the specific version of Ubuntu. Also installing rpmbuild so that we can package our app into an rpm file
 RUN yum -y install redhat-lsb rpm-build

--- a/.github/actions/create-package/ubuntu/18.04/32bit/Dockerfile
+++ b/.github/actions/create-package/ubuntu/18.04/32bit/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
 
 # Install souffle build dependencies
 RUN apt-get update && \
-	apt-get -y install autoconf automake bison build-essential clang doxygen flex g++ git libffi-dev libncurses5-dev libtool libsqlite3-dev make mcpp python sqlite zlib1g-dev cmake
+	apt-get -y install bash-completion autoconf automake bison build-essential clang doxygen flex g++ git libffi-dev libncurses5-dev libtool libsqlite3-dev make mcpp python sqlite zlib1g-dev cmake
 
 # For CMakeLists.txt to figure out the specific version of Ubuntu
 RUN apt-get -y install lsb-release

--- a/.github/actions/create-package/ubuntu/18.04/64bit/Dockerfile
+++ b/.github/actions/create-package/ubuntu/18.04/64bit/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
 
 # Install souffle build dependencies
 RUN apt-get update && \
-	apt-get -y install autoconf automake bison build-essential clang doxygen flex g++ git libffi-dev libncurses5-dev libtool libsqlite3-dev make mcpp python sqlite zlib1g-dev cmake
+	apt-get -y install bash-completion autoconf automake bison build-essential clang doxygen flex g++ git libffi-dev libncurses5-dev libtool libsqlite3-dev make mcpp python sqlite zlib1g-dev cmake
 
 # Ubuntu 18.04 ships with g++ version 7, which is problematic
 RUN apt-get -y install software-properties-common && \

--- a/.github/actions/create-package/ubuntu/20.04/64bit/Dockerfile
+++ b/.github/actions/create-package/ubuntu/20.04/64bit/Dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /souffle
 
 # Install souffle build dependencies
-RUN apt update && apt -y install sudo autoconf automake bison build-essential clang doxygen flex g++ git libffi-dev libncurses5-dev libtool libsqlite3-dev make mcpp python sqlite zlib1g-dev cmake
+RUN apt update && apt -y install bash-completion sudo autoconf automake bison build-essential clang doxygen flex g++ git libffi-dev libncurses5-dev libtool libsqlite3-dev make mcpp python sqlite zlib1g-dev cmake
 
 # For CMakeLists.txt to figure out the specific version of Ubuntu
 RUN apt -y install lsb-release

--- a/.github/actions/create-package/ubuntu/21.04/64bit/Dockerfile
+++ b/.github/actions/create-package/ubuntu/21.04/64bit/Dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /souffle
 
 # Install souffle build dependencies
-RUN apt update && apt -y install sudo autoconf automake bison build-essential clang doxygen flex g++ git libffi-dev libncurses5-dev libtool libsqlite3-dev make mcpp python sqlite zlib1g-dev cmake
+RUN apt update && apt -y install bash-completion sudo autoconf automake bison build-essential clang doxygen flex g++ git libffi-dev libncurses5-dev libtool libsqlite3-dev make mcpp python sqlite zlib1g-dev cmake
 
 # For CMakeLists.txt to figure out the specific version of Ubuntu
 RUN apt -y install lsb-release

--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -51,7 +51,7 @@ jobs:
         # Private action is stored in the following directory
         uses: ./.github/actions/create-package/fedora/34/64bit/
         with:
-         package_cloud_api_key: ${{ secrets.PACKAGECLOUD_TOKEN }}
+          package_cloud_api_key: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
 #   Package-Ubuntu-1804-64bit:
 #     strategy:

--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -36,22 +36,22 @@ jobs:
         with:
           package_cloud_api_key: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
-#  Package-Fedora-34-64bit:
-#    strategy:
-#      fail-fast: false
-#
-#    runs-on: ubuntu-latest
-#    steps:
-#      # To use this repository's private action, check out the repository
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#        with:
-#          fetch-depth: 0
-#      - name: Package souffle
-#        # Private action is stored in the following directory
-#        uses: ./.github/actions/create-package/fedora/34/64bit/
-#        with:
-#          package_cloud_api_key: ${{ secrets.PACKAGECLOUD_TOKEN }}
+  Package-Fedora-34-64bit:
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+    steps:
+      # To use this repository's private action, check out the repository
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Package souffle
+        # Private action is stored in the following directory
+        uses: ./.github/actions/create-package/fedora/34/64bit/
+        with:
+         package_cloud_api_key: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
 #   Package-Ubuntu-1804-64bit:
 #     strategy:

--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -1,5 +1,5 @@
 name: Create Packages
-on: [release]
+on: [push]
 
 jobs:
   Package-Ubuntu-2104-64bit:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,9 @@ SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A Datalog Compiler")
 # Use all available threads (primarily for compression of files)
 SET(CPACK_THREADS 0)
 
+# Make sure changelog, bash-completion and other important files in debian directory is also packaged
+SET(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/debian/changelog.in" "${CMAKE_SOURCE_DIR}/debian/souffle.bash-completion" "${CMAKE_SOURCE_DIR}/debian/rules" "${CMAKE_SOURCE_DIR}/debian/copyright")
+
 # --------------------------------------------------
 # CPack configuration for Linux
 # --------------------------------------------------


### PR DESCRIPTION
I've added the following line to `CMakeLists.txt` that ensures that the changelog file and bash-completion scripts (along with other related/relevant files) are copied into the final package.

`SET(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/debian/changelog.in" "${CMAKE_SOURCE_DIR}/debian/souffle.bash-completion" "${CMAKE_SOURCE_DIR}/debian/rules" "${CMAKE_SOURCE_DIR}/debian/copyright")`

I've also double-checked that they are indeed copied into the packages. However, additional work needs to be done in order for bash-completions to be installed out of box when user runs `sudo apt install` on our `souffle` package.