### PR TITLE
Fix/packaging bash completion

### DIFF
--- a/.github/actions/create-package/entrypoint.sh
+++ b/.github/actions/create-package/entrypoint.sh
@@ -2,8 +2,6 @@
 
 PACKAGE_CLOUD_API_KEY="$1"
 
-PACKAGECLOUD_TOKEN="$PACKAGE_CLOUD_API_KEY" package_cloud yank souffle-lang/souffle-test/ubuntu/hirsute souffle_3734596_amd64.deb
-
 # Run the build command
 case "$DOMAIN_SIZE" in
   	"64bit")

--- a/.github/actions/create-package/fedora/34/64bit/Dockerfile
+++ b/.github/actions/create-package/fedora/34/64bit/Dockerfile
@@ -4,7 +4,28 @@ FROM fedora:34
 WORKDIR /souffle
 
 # Install souffle build dependencies
-RUN yum -y install bash-completion autoconf automake bison clang doxygen flex g++ git libffi libffi-devel ncurses-devel libtool libsqlite3x make mcpp python sqlite sqlite-devel zlib-devel cmake
+RUN yum -y install \
+    bash-completion \
+    autoconf \
+    automake \
+    bison \
+    clang \
+    doxygen \
+    flex \
+    g++ \
+    git \
+    libffi \
+    libffi-devel \
+    ncurses-devel \
+    libtool \
+    libsqlite3x \
+    make \
+    mcpp \
+    python \
+    sqlite \
+    sqlite-devel \
+    zlib-devel \
+    cmake
 
 # For CMakeLists.txt to figure out the specific version of Ubuntu. Also installing rpmbuild so that we can package our app into an rpm file
 RUN yum -y install redhat-lsb rpm-build
@@ -16,9 +37,6 @@ RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && rvm install 2.7.4 && gem install
 
 # Copy everything into souffle directory
 COPY . .
-
-# Install dependencies to build souffle
-# RUN sudo sh/setup/install_ubuntu_deps.sh
 
 ENV DOMAIN_SIZE "64bit"
 ENV PKG_EXTENSION ".rpm"

--- a/.github/actions/create-package/ubuntu/20.10/64bit/Dockerfile
+++ b/.github/actions/create-package/ubuntu/20.10/64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -42,6 +42,6 @@ COPY . .
 
 ENV DOMAIN_SIZE "64bit"
 ENV PKG_EXTENSION ".deb"
-ENV PKG_CLOUD_OS_NAME "ubuntu/focal"
+ENV PKG_CLOUD_OS_NAME "ubuntu/groovy"
 
 ENTRYPOINT [".github/actions/create-package/entrypoint.sh"]

--- a/.github/actions/create-package/ubuntu/20.10/64bit/action.yml
+++ b/.github/actions/create-package/ubuntu/20.10/64bit/action.yml
@@ -1,0 +1,12 @@
+name: Package for Ubuntu 20.10 64bit
+description: Package for Ubuntu 20.10 64bit
+inputs:
+  package_cloud_api_key:
+    description: 'Package Cloud API Key'
+    required: true
+    default: ''
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.package_cloud_api_key }}

--- a/.github/actions/create-package/ubuntu/21.04/64bit/Dockerfile
+++ b/.github/actions/create-package/ubuntu/21.04/64bit/Dockerfile
@@ -6,20 +6,39 @@ ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /souffle
 
 # Install souffle build dependencies
-RUN apt update && apt -y install bash-completion sudo autoconf automake bison build-essential clang doxygen flex g++ git libffi-dev libncurses5-dev libtool libsqlite3-dev make mcpp python sqlite zlib1g-dev cmake
+RUN apt-get update && \
+	apt-get -y install \
+	bash-completion \
+	sudo \
+	autoconf \
+	automake \
+	bison \
+	build-essential \
+	clang \
+	doxygen \
+	flex \
+	g++ \
+	git \
+	libffi-dev \
+	libncurses5-dev \
+	libtool \
+	libsqlite3-dev \
+	make \
+	mcpp \
+	python \
+	sqlite \
+	zlib1g-dev \
+	cmake
 
 # For CMakeLists.txt to figure out the specific version of Ubuntu
-RUN apt -y install lsb-release
+RUN apt-get -y install lsb-release
 
 # Install dependencies for packagecloud CLI
-RUN apt -y install ruby-full
+RUN apt-get -y install ruby-full
 RUN sudo gem install package_cloud
 
 # Copy everything into souffle directory
 COPY . .
-
-# Install dependencies to build souffle
-# RUN sudo sh/setup/install_ubuntu_deps.sh
 
 ENV DOMAIN_SIZE "64bit"
 ENV PKG_EXTENSION ".deb"

--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -1,5 +1,5 @@
 name: Create Packages
-on: [push]
+on: [release]
 
 jobs:
   Package-Ubuntu-2104-64bit:

--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           package_cloud_api_key: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
-  Package-Fedora-34-64bit:
+  Package-Ubuntu-2010-64bit:
     strategy:
       fail-fast: false
 
@@ -49,9 +49,27 @@ jobs:
           fetch-depth: 0
       - name: Package souffle
         # Private action is stored in the following directory
-        uses: ./.github/actions/create-package/fedora/34/64bit/
+        uses: ./.github/actions/create-package/ubuntu/20.10/64bit/
         with:
           package_cloud_api_key: ${{ secrets.PACKAGECLOUD_TOKEN }}
+
+
+#  Package-Fedora-34-64bit:
+#    strategy:
+#      fail-fast: false
+#
+#    runs-on: ubuntu-latest
+#    steps:
+#      # To use this repository's private action, check out the repository
+#      - name: Checkout
+#        uses: actions/checkout@v2
+#        with:
+#          fetch-depth: 0
+#      - name: Package souffle
+#        # Private action is stored in the following directory
+#        uses: ./.github/actions/create-package/fedora/34/64bit/
+#        with:
+#          package_cloud_api_key: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
 #   Package-Ubuntu-1804-64bit:
 #     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,23 @@ if (SOUFFLE_ENABLE_TESTING)
 endif()
 
 # --------------------------------------------------
+# Installing bash completion file
+# --------------------------------------------------
+find_package (bash-completion)
+if (BASH_COMPLETION_FOUND)
+    message(STATUS "Using bash completion dir ${BASH_COMPLETION_COMPLETIONSDIR}")
+else()
+    set (BASH_COMPLETION_COMPLETIONSDIR "/etc/bash_completion.d")
+    message (STATUS "Using fallback bash completion dir ${BASH_COMPLETION_COMPLETIONSDIR}")
+endif()
+
+install(
+    FILES "${CMAKE_SOURCE_DIR}/debian/souffle.bash-completion"
+    DESTINATION ${BASH_COMPLETION_COMPLETIONSDIR}
+    RENAME "souffle"
+)
+
+# --------------------------------------------------
 # Utility function to help us distinguish between Linux distros when packaging
 # --------------------------------------------------
 
@@ -328,7 +345,7 @@ SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A Datalog Compiler")
 SET(CPACK_THREADS 0)
 
 # Make sure changelog, bash-completion and other important files in debian directory is also packaged
-SET(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/debian/changelog.in" "${CMAKE_SOURCE_DIR}/debian/souffle.bash-completion" "${CMAKE_SOURCE_DIR}/debian/rules" "${CMAKE_SOURCE_DIR}/debian/copyright")
+SET(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/debian/changelog.in")
 
 # --------------------------------------------------
 # CPack configuration for Linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,8 +344,8 @@ SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A Datalog Compiler")
 # Use all available threads (primarily for compression of files)
 SET(CPACK_THREADS 0)
 
-# Make sure changelog, bash-completion and other important files in debian directory is also packaged
-SET(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/debian/changelog.in")
+# Make sure changelog, bash-completion and other important files in debian directory also packaged
+SET(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/debian/changelog.in" "${CMAKE_SOURCE_DIR}/debian/souffle.bash-completion" "${CMAKE_SOURCE_DIR}/debian/copyright")
 
 # --------------------------------------------------
 # CPack configuration for Linux


### PR DESCRIPTION
- Edited CMakeLists.txt so that `souffle.bash-completion` is copied to the user's `completions` directory where it will be used by `bash-completion`.
- Created relevant Dockerfile for Ubuntu 20.10 64bit so that we can created packages for it.
- Refactored Dockerfiles so dependencies are clearer and easier to understand. Also converted uses of `apt` to `apt-get` for terminal-friendly output.
