### PR TITLE
Suppress file errors when -w is set

### DIFF
--- a/licenses/SOUFFLE-UPL.txt
+++ b/licenses/SOUFFLE-UPL.txt
@@ -1,4 +1,5 @@
-Copyright (c) 2016 Oracle and/or its affiliates. All Rights reserved
+Copyright (c) 2016-21 The Souffle Developers. All Rights reserved
+Copyright (c) 2013-16 Oracle and/or its affiliates. All Rights reserved
 
 The Universal Permissive License (UPL), Version 1.0
 

--- a/src/ast2ram/seminaive/UnitTranslator.cpp
+++ b/src/ast2ram/seminaive/UnitTranslator.cpp
@@ -383,6 +383,9 @@ Own<ram::Statement> UnitTranslator::generateLoadRelation(const ast::Relation* re
         for (const auto& [key, value] : load->getParameters()) {
             directives.insert(std::make_pair(key, unescape(value)));
         }
+        if (Global::config().has("no-warn")) {
+            directives.insert(std::make_pair("no-warn", "true"));
+        }
         addAuxiliaryArity(relation, directives);
 
         // Create the resultant load statement, with profile information
@@ -393,7 +396,6 @@ Own<ram::Statement> UnitTranslator::generateLoadRelation(const ast::Relation* re
                     LogStatement::tRelationLoadTime(ramRelationName, relation->getSrcLoc());
             loadStmt = mk<ram::LogRelationTimer>(std::move(loadStmt), logTimerStatement, ramRelationName);
         }
-
         appendStmt(loadStmts, std::move(loadStmt));
     }
     return mk<ram::Sequence>(std::move(loadStmts));
@@ -417,7 +419,6 @@ Own<ram::Statement> UnitTranslator::generateStoreRelation(const ast::Relation* r
                     LogStatement::tRelationSaveTime(ramRelationName, relation->getSrcLoc());
             storeStmt = mk<ram::LogRelationTimer>(std::move(storeStmt), logTimerStatement, ramRelationName);
         }
-
         appendStmt(storeStmts, std::move(storeStmt));
     }
     return mk<ram::Sequence>(std::move(storeStmts));

--- a/src/include/souffle/io/ReadStreamCSV.h
+++ b/src/include/souffle/io/ReadStreamCSV.h
@@ -306,7 +306,10 @@ public:
               baseName(souffle::baseName(getFileName(rwOperation))),
               fileHandle(getFileName(rwOperation), std::ios::in | std::ios::binary) {
         if (!fileHandle.is_open()) {
-            throw std::invalid_argument("Cannot open fact file " + baseName + "\n");
+            // suppress error message in case file cannot be open when flag -w is set
+            if (getOr(rwOperation, "no-warn", "false") != "true") {
+                throw std::invalid_argument("Cannot open fact file " + baseName + "\n");
+            }
         }
         // Strip headers if we're using them
         if (getOr(rwOperation, "headers", "false") == "true") {


### PR DESCRIPTION
This has been requested by the Gigahorse folks to suppress file error warnings when flag `-w` is set. 
