### PR TITLE
move execution plan semantic checks to ExecutionPlanChecker

### DIFF
--- a/src/ast/transform/ExecutionPlanChecker.cpp
+++ b/src/ast/transform/ExecutionPlanChecker.cpp
@@ -25,6 +25,7 @@
 #include "ast/analysis/RelationSchedule.h"
 #include "ast/utility/Utils.h"
 #include "reports/ErrorReport.h"
+#include "souffle/utility/ContainerUtil.h"
 #include <algorithm>
 #include <map>
 #include <set>
@@ -69,6 +70,18 @@ bool ExecutionPlanChecker::transform(TranslationUnit& translationUnit) {
                                             cur.second->getSrcLoc()),
                                     {DiagnosticMessage("only versions 0.." + std::to_string(version - 1) +
                                                        " permitted")}));
+                        }
+                        bool isComplete = true;
+                        auto order = cur.second->getOrder();
+                        for (unsigned i = 1; i <= order.size(); i++) {
+                            if (!contains(order, i)) {
+                                isComplete = false;
+                                break;
+                            }
+                        }
+                        auto numAtoms = getBodyLiterals<Atom>(*clause).size();
+                        if (order.size() != numAtoms || !isComplete) {
+                            report.addError("Invalid execution order in plan", cur.second->getSrcLoc());
                         }
                     }
                 }

--- a/src/ast/transform/ExecutionPlanChecker.cpp
+++ b/src/ast/transform/ExecutionPlanChecker.cpp
@@ -59,6 +59,19 @@ bool ExecutionPlanChecker::transform(TranslationUnit& translationUnit) {
                 int maxVersion = -1;
                 for (auto const& cur : clause->getExecutionPlan()->getOrders()) {
                     maxVersion = std::max(cur.first, maxVersion);
+
+                    bool isComplete = true;
+                    auto order = cur.second->getOrder();
+                    for (unsigned i = 1; i <= order.size(); i++) {
+                        if (!contains(order, i)) {
+                            isComplete = false;
+                            break;
+                        }
+                    }
+                    auto numAtoms = getBodyLiterals<Atom>(*clause).size();
+                    if (order.size() != numAtoms || !isComplete) {
+                        report.addError("Invalid execution order in plan", cur.second->getSrcLoc());
+                    }
                 }
 
                 if (version <= maxVersion) {
@@ -70,18 +83,6 @@ bool ExecutionPlanChecker::transform(TranslationUnit& translationUnit) {
                                             cur.second->getSrcLoc()),
                                     {DiagnosticMessage("only versions 0.." + std::to_string(version - 1) +
                                                        " permitted")}));
-                        }
-                        bool isComplete = true;
-                        auto order = cur.second->getOrder();
-                        for (unsigned i = 1; i <= order.size(); i++) {
-                            if (!contains(order, i)) {
-                                isComplete = false;
-                                break;
-                            }
-                        }
-                        auto numAtoms = getBodyLiterals<Atom>(*clause).size();
-                        if (order.size() != numAtoms || !isComplete) {
-                            report.addError("Invalid execution order in plan", cur.second->getSrcLoc());
                         }
                     }
                 }

--- a/src/ast/transform/SemanticChecker.cpp
+++ b/src/ast/transform/SemanticChecker.cpp
@@ -492,24 +492,6 @@ void SemanticCheckerImpl::checkClause(const Clause& clause) {
         }
     }
 
-    // check execution plan
-    if (clause.getExecutionPlan() != nullptr) {
-        auto numAtoms = getBodyLiterals<Atom>(clause).size();
-        for (const auto& cur : clause.getExecutionPlan()->getOrders()) {
-            bool isComplete = true;
-            auto order = cur.second->getOrder();
-            for (unsigned i = 1; i <= order.size(); i++) {
-                if (!contains(order, i)) {
-                    isComplete = false;
-                    break;
-                }
-            }
-            if (order.size() != numAtoms || !isComplete) {
-                report.addError("Invalid execution order in plan", cur.second->getSrcLoc());
-            }
-        }
-    }
-
     // check auto-increment
     if (recursiveClauses.recursive(&clause)) {
         visit(clause, [&](const Counter& ctr) {

--- a/tests/semantic/execution_plan/execution_plan.dl
+++ b/tests/semantic/execution_plan/execution_plan.dl
@@ -1,14 +1,25 @@
 .type S <: symbol
 
 
-.decl r(x:S,y:S)
+.decl r1(x:S,y:S)
+.decl r2(x:S,y:S)
+.decl r3(x:S,y:S)
+.decl r4(x:S,y:S)
+.output r1
+.output r2
+.output r3
+.output r4
 
-r(a,d) :- r(a,b),r(b,c),r(c,d).
+r1(a,d) :- r1(a,b),r1(b,c),r1(c,d).
 
 // this one is ok
-r(a,d) :- r(a,b),r(b,c),r(c,d).
+r2(a,d) :- r2(a,b),r2(b,c),r2(c,d).
+        .plan 0: (1,2,3), 1: (3,2,1), 2: (2,3,1)
+
+// this one is not
+r3(a,d) :- r3(a,b),r3(b,c),r3(c,d).
         .plan 1: (1,2,3), 2: (3,2,1), 3: (2,3,1)
 
 // this one is not
-r(a,d) :- r(a,b),r(b,c),r(c,d).
-        .plan 1: (1,2,2), 2: (3,2), 3: (2,3,1,3)
+r4(a,d) :- r4(a,b),r4(b,c),r4(c,d).
+        .plan 0: (1,2,2), 1: (3,2), 2: (2,3,1,3)

--- a/tests/semantic/execution_plan/execution_plan.err
+++ b/tests/semantic/execution_plan/execution_plan.err
@@ -1,10 +1,14 @@
-Error: Invalid execution order in plan in file execution_plan.dl at line 14
-        .plan 1: (1,2,2), 2: (3,2), 3: (2,3,1,3)
+Error: execution plan for version 3 in file execution_plan.dl at line 21
+        .plan 1: (1,2,3), 2: (3,2,1), 3: (2,3,1)
+-----------------------------------------^-------
+only versions 0..2 permitted
+Error: Invalid execution order in plan in file execution_plan.dl at line 25
+        .plan 0: (1,2,2), 1: (3,2), 2: (2,3,1,3)
 -----------------^-------------------------------
-Error: Invalid execution order in plan in file execution_plan.dl at line 14
-        .plan 1: (1,2,2), 2: (3,2), 3: (2,3,1,3)
+Error: Invalid execution order in plan in file execution_plan.dl at line 25
+        .plan 0: (1,2,2), 1: (3,2), 2: (2,3,1,3)
 -----------------------------^-------------------
-Error: Invalid execution order in plan in file execution_plan.dl at line 14
-        .plan 1: (1,2,2), 2: (3,2), 3: (2,3,1,3)
+Error: Invalid execution order in plan in file execution_plan.dl at line 25
+        .plan 0: (1,2,2), 1: (3,2), 2: (2,3,1,3)
 ---------------------------------------^---------
-3 errors generated, evaluation aborted
+4 errors generated, evaluation aborted


### PR DESCRIPTION
The SemanticChecker contains code that checks whether the size of an execution plan matches the number of atoms in the rule. 
In rules containing inlined relations, the number of atoms may differ before and after the relation inlining.
Because the SemanticChecker runs before the inlining pass, an execution plan may fail due to an incorrect size even though the size is correct after inlining.
I propose to move this check to the ExecutionPlanChecker, which makes more sense since this is where other checks on the execution plans occur.