### PR TITLE
fix profiler when multiple rules with same source location

### DIFF
--- a/src/include/souffle/profile/Iteration.h
+++ b/src/include/souffle/profile/Iteration.h
@@ -36,8 +36,8 @@ private:
 public:
     Iteration() : rules() {}
 
-    void addRule(const std::string& ruleKey, std::shared_ptr<Rule>& rule) {
-        rules[ruleKey] = rule;
+    void addRule(std::shared_ptr<Rule>& rule) {
+        rules[rule->getId()] = rule;
     }
 
     const std::unordered_map<std::string, std::shared_ptr<Rule>>& getRules() const {

--- a/src/include/souffle/profile/Reader.h
+++ b/src/include/souffle/profile/Reader.h
@@ -118,9 +118,7 @@ public:
             for (const auto& versionKey : versions.getKeys()) {
                 versions.readEntry(versionKey)->accept(visitor);
             }
-            // To match map keys defined in Iteration::addRule()
-            std::string ruleKey = key + rule->getLocator() + key;
-            iteration.addRule(ruleKey, rule);
+            iteration.addRule(rule);
         }
     }
 

--- a/src/include/souffle/profile/Relation.h
+++ b/src/include/souffle/profile/Relation.h
@@ -185,7 +185,7 @@ public:
     }
 
     /**
-     * Return a map of Rules, indexed by srcLocator.
+     * Return a map of Rules, indexed by their unique Ids.
      *
      * @return the ruleMap
      */
@@ -194,7 +194,7 @@ public:
     }
 
     void addRule(std::shared_ptr<Rule> rule) {
-        ruleMap[rule->getLocator()] = rule;
+        ruleMap[rule->getId()] = rule;
     }
 
     std::vector<std::shared_ptr<Rule>> getRuleRecList() const {

--- a/src/include/souffle/profile/Tui.h
+++ b/src/include/souffle/profile/Tui.h
@@ -756,12 +756,12 @@ public:
             std::cout << "Relation ceased to exist. Odd." << std::endl;
             return;
         }
-        if (rel->getRuleMap().count(srcLocator) == 0) {
+        if (rel->getRuleMap().count(id) == 0) {
             std::cout << "Rule ceased to exist. Odd." << std::endl;
             return;
         }
 
-        auto& rul = rel->getRuleMap().at(srcLocator);
+        auto& rul = rel->getRuleMap().at(id);
         usage(rul->getEndtime(), rul->getStarttime());
     }
 


### PR DESCRIPTION
When rules have disjunctions, they are translated into multiple rules that will all have the same source location.
The profiler code use the source location as key to store rules in a map, which has the effect of overriding previous rules whenever two rules have the same source loc.
This pull requests fixes that by using the unique Id generated for each rule as the key instead of the source location.