### PR TITLE
perf improvement to SQLite output

### DIFF
--- a/src/include/souffle/io/WriteStreamSQLite.h
+++ b/src/include/souffle/io/WriteStreamSQLite.h
@@ -41,10 +41,11 @@ public:
         openDB();
         createTables();
         prepareStatements();
-        //        executeSQL("BEGIN TRANSACTION", db);
+        executeSQL("BEGIN TRANSACTION", db);
     }
 
     ~WriteStreamSQLite() override {
+        executeSQL("COMMIT", db);
         sqlite3_finalize(insertStatement);
         sqlite3_finalize(symbolInsertStatement);
         sqlite3_finalize(symbolSelectStatement);


### PR DESCRIPTION
The SQLite io is very slow on large relations. Encapsulating all the insertions in a transaction is much faster.