### PR TITLE
improved conditions reordering

### DIFF
--- a/src/ram/analysis/Complexity.cpp
+++ b/src/ram/analysis/Complexity.cpp
@@ -57,6 +57,14 @@ int ComplexityAnalysis::getComplexity(const Node* node) const {
             return 2;
         }
 
+        int visit_(type_identity<Constraint>, const Constraint& c) override {
+            return dispatch(c.getLHS()) + dispatch(c.getRHS());
+        }
+
+        int visit_(type_identity<UserDefinedOperator>, const UserDefinedOperator&) override {
+            return 10;
+        }
+
         // emptiness check
         int visit_(type_identity<EmptinessCheck>, const EmptinessCheck& emptiness) override {
             // emptiness check for nullary relations is for free; others have weight one


### PR DESCRIPTION
The condition reordering to first execute the cheapest conditions first was only active for Filter nodes. There are many other kinds of nodes with conditions that could benefit from this reordering as well.

At the same time, I assume that the cost for execution a user-defined functor is expensive.