### PR TITLE
Misc tiny fixes to `TransformIterator`, `OwningTransformRange`, and `ReorderConditionsTransformer`

### DIFF
--- a/src/ast/transform/IOAttributes.h
+++ b/src/ast/transform/IOAttributes.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include "Global.h"
 #include "ast/AlgebraicDataType.h"
 #include "ast/Attribute.h"
 #include "ast/Directive.h"

--- a/src/include/souffle/utility/Iteration.h
+++ b/src/include/souffle/utility/Iteration.h
@@ -120,7 +120,7 @@ public:
     }
 
     /* Support for the pointer operator. */
-    auto operator->() const {
+    auto operator-> () const {
         return &**this;
     }
 

--- a/src/include/souffle/utility/Iteration.h
+++ b/src/include/souffle/utility/Iteration.h
@@ -338,7 +338,7 @@ public:
     }
 
     auto end() const {
-        return transformIter(std::begin(range), f);
+        return transformIter(std::end(range), f);
     }
 
     auto cend() const {

--- a/src/include/souffle/utility/Iteration.h
+++ b/src/include/souffle/utility/Iteration.h
@@ -64,9 +64,8 @@ public:
     static_assert(std::is_empty_v<F>, "Function object must be stateless");
 
     // some constructors
-    template <typename It>
-    TransformIterator(It iter, std::enable_if_t<std::is_empty_v<F>, void*> = nullptr)
-            : iter(std::move(iter)), fun(detail::makeFun<F>()) {}
+    template <typename = std::enable_if_t<std::is_empty_v<F>>>
+    TransformIterator(Iter iter) : TransformIterator(std::move(iter), detail::makeFun<F>()) {}
     TransformIterator(Iter iter, F f) : iter(std::move(iter)), fun(std::move(f)) {}
 
     /* The equality operator as required by the iterator concept. */

--- a/src/include/souffle/utility/Iteration.h
+++ b/src/include/souffle/utility/Iteration.h
@@ -29,7 +29,8 @@ namespace detail {
 
 // This is a helper in the cases when the lambda is stateless
 template <typename F>
-F const& makeFun() {
+F makeFun() {
+    static_assert(std::is_empty_v<F>);
     // Even thought the lambda is stateless, it has no default ctor
     // Is this gross?  Yes, yes it is.
     // FIXME: Remove after C++20

--- a/src/ram/transform/ReorderConditions.cpp
+++ b/src/ram/transform/ReorderConditions.cpp
@@ -29,9 +29,11 @@
 
 namespace souffle::ram::transform {
 
-bool ReorderConditionsTransformer::reorderConditions(Program& program) {
+bool ReorderConditionsTransformer::transform(TranslationUnit& tu) {
+    auto* rca = tu.getAnalysis<analysis::ComplexityAnalysis>();
+
     bool changed = false;
-    visit(program, [&](const Query& query) {
+    visit(tu.getProgram(), [&](const Query& query) {
         std::function<Own<Node>(Own<Node>)> filterRewriter = [&](Own<Node> node) -> Own<Node> {
             if (const Condition* condition = as<Condition>(node)) {
                 VecOwn<Condition> sortedConds;

--- a/src/ram/transform/ReorderConditions.h
+++ b/src/ram/transform/ReorderConditions.h
@@ -63,15 +63,7 @@ public:
      * @return Flag showing whether the program has been changed
      *         by the transformation
      */
-    bool reorderConditions(Program& program);
-
-protected:
-    analysis::ComplexityAnalysis* rca{nullptr};
-
-    bool transform(TranslationUnit& translationUnit) override {
-        rca = translationUnit.getAnalysis<analysis::ComplexityAnalysis>();
-        return reorderConditions(translationUnit.getProgram());
-    }
+    bool transform(TranslationUnit&) override;
 };
 
 }  // namespace souffle::ram::transform


### PR DESCRIPTION
Cut from #2009.

Fix:
* `OwningTransformRange::end() const`  returned a begin iterator instead of an end iterator
* `TransformIterator` was missing public type members for `difference_type`, `value_type`, `pointer`, and `reference`
* `TransformIterator` would fail to copy/move its lambda during copy/move assignments
* UB caused by ref to dead storage in `TransformIterator` helper (likely still dodgy due to type punning, but best I can think of pre C++20)
* `ReorderConditionsTransformer::reorderConditions` would crash if directly invoked instead of via protected `transform`