### PR TITLE
clang - enable ubsan, link with lld, link to libc++ by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,8 +210,13 @@ endif()
 # Memory Sanitiser
 # --------------------------------------------------
 if (SOUFFLE_SANITISE_MEMORY)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address,leak")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,leak")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address,leak,undefined")
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,leak,undefined")
+    else()
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address,leak")
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,leak")
+    endif()
 endif()
 
 # --------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@
 
 cmake_minimum_required(VERSION 3.15)
 
+include(CMakeDependentOption)
+
 find_package(Git REQUIRED)
 
 # PACKAGE_VERSION is the full tag with git hash
@@ -110,8 +112,18 @@ option(SOUFFLE_ENABLE_TESTING "Enable/Disable testing" ${SOUFFLE_ENABLE_TESTING_
 option(SOUFFLE_GENERATE_DOXYGEN "Generate Doxygen files (html;htmlhelp;man;rtf;xml;latex)" "")
 option(SOUFFLE_CODE_COVERAGE "Enable coverage reporting" OFF)
 
+cmake_dependent_option(SOUFFLE_USE_LIBCPP "Link to libc++ instead of libstdc++" ON
+    "CMAKE_CXX_COMPILER_ID STREQUAL Clang" OFF)
+
 # Add aditional modules to CMake
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
+if (SOUFFLE_USE_LIBCPP)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lc++abi")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -lc++abi")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lc++abi")
+endif()
 
 # --------------------------------------------------
 # curses libraries for Provenance information

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,13 @@ option(SOUFFLE_CODE_COVERAGE "Enable coverage reporting" OFF)
 cmake_dependent_option(SOUFFLE_USE_LIBCPP "Link to libc++ instead of libstdc++" ON
     "CMAKE_CXX_COMPILER_ID STREQUAL Clang" OFF)
 
+# Using Clang? Likely want to use `lld` too.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
+endif()
+
 # Add aditional modules to CMake
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 


### PR DESCRIPTION
The following only apply when clang is being used.

Changes:
* cmake option `SOUFFLE_USE_LIBCPP`  (default true) - link to libc++ instead of libstdc++ (better integration with llvm tooling)
* `SOUFFLE_SANITISE_MEMORY` now enables ubsan
* use `lld` (slightly faster linking, better diagnostics)