### PR TITLE
fix print of FunctorDeclaration

### DIFF
--- a/src/ast/FunctorDeclaration.cpp
+++ b/src/ast/FunctorDeclaration.cpp
@@ -27,9 +27,9 @@ FunctorDeclaration::FunctorDeclaration(
 }
 
 void FunctorDeclaration::print(std::ostream& out) const {
-    auto convert = [&](Own<Attribute> const& attr) { return attr->getName() + ": " + attr->getTypeName(); };
+    auto convert = [&](Own<Attribute> const& attr) { return attr->getName() + ": " + attr->getTypeName().toString(); };
 
-    tfm::format(out, ".declfun %s(%s): %s", name, join(map(params, convert), ","), returnType->getTypeName());
+    tfm::format(out, ".functor %s(%s): %s", name, join(map(params, convert), ","), returnType->getTypeName());
     if (stateful) {
         out << " stateful";
     }

--- a/src/ast/FunctorDeclaration.h
+++ b/src/ast/FunctorDeclaration.h
@@ -31,7 +31,7 @@ namespace souffle::ast {
  * @brief User-defined functor declaration
  *
  * Example:
- *    .declfun foo(x:number, y:number):number
+ *    .functor foo(x:number, y:number):number
  */
 
 class FunctorDeclaration : public Node {


### PR DESCRIPTION
The `print` of `FunctorDeclaration` was producing wrong output.

Because `attr->getTypeName()` returns a `QualifiedName`, and there is this operator `QualifiedName operator+(const std::string& name, const QualifiedName& id)` that prepend a `string` to a `QualifiedName`, this code would construct a strange `QualifiedName`: `return attr->getName() + ": " + attr->getTypeName();` instead of concatenating three strings as expected.

I think the `operator+` can easily produce unexpected results here and there while a concatenation of strings is expected.