### PR TITLE
make `Program::print` public

### DIFF
--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -98,9 +98,9 @@ public:
 
     void apply(const NodeMapper& map) override;
 
-protected:
     void print(std::ostream& os) const override;
 
+protected:
     NodeVec getChildNodesImpl() const override;
 
     friend class souffle::ParserDriver;


### PR DESCRIPTION
Hi, this small change makes `Program::print` public so that it is possible to call it from any code linked with libSouffle. Most other classes of `src/ast` already have a public `print`.