### PR TITLE
allow conjunction on empty RuleBody

### DIFF
--- a/src/parser/ParserUtils.cpp
+++ b/src/parser/ParserUtils.cpp
@@ -50,7 +50,6 @@ RuleBody RuleBody::negated() const {
 }
 
 void RuleBody::conjunct(RuleBody other) {
-
     if (dnf.size() == 0) {
         dnf = std::move(other.dnf);
 


### PR DESCRIPTION
Hi, this change allow to `conjunct` on an empty `RuleBody`. 
The rationale for this change is to be able to construct an initially empty `RuleBody` object and then progressively conjuct clauses on it. This eases the construction of an AST in a non-bottom-up way outside of the parser.