### PR TITLE
EQREL: Extend delta relations, rather than new relations

### DIFF
--- a/src/ram/Extend.h
+++ b/src/ram/Extend.h
@@ -33,6 +33,9 @@ namespace souffle::ram {
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * EXTEND B WITH A
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * The source relation represents new knowledge, whereas the target relation is
+ * old knowledge.
  */
 class Extend : public BinRelationStatement {
 public:


### PR DESCRIPTION
Previously, a RAM EXTEND operation was emitted to extend the new
relation before inserting into the main relation. This is inefficient,
since it adds information/tuples from the main relation to the new
relation, and then just goes back and adds them from the new relation to
the main relation. Instead, we can avoid this duplication by extending
the *delta* relation by the main relation after its been swapped with
the new relation (which is actually what's described in "Fast Parallel
Equivalence Relations in a Datalog Compiler", anyway).

Fixes #2052. WIP because I haven't tested it yet.