### PR TITLE
Improves synthesized program compilation time

### DIFF
--- a/src/include/souffle/CompiledSouffle.h
+++ b/src/include/souffle/CompiledSouffle.h
@@ -26,34 +26,10 @@
 #include "souffle/datastructure/Table.h"
 #include "souffle/io/IOSystem.h"
 #include "souffle/io/WriteStream.h"
-#include "souffle/utility/CacheUtil.h"
-#include "souffle/utility/ContainerUtil.h"
 #include "souffle/utility/EvaluatorUtil.h"
-#include "souffle/utility/FileUtil.h"
-#include "souffle/utility/FunctionalUtil.h"
-#include "souffle/utility/MiscUtil.h"
-#include "souffle/utility/ParallelUtil.h"
-#include "souffle/utility/StreamUtil.h"
-#include "souffle/utility/StringUtil.h"
 #ifndef __EMBEDDED_SOUFFLE__
 #include "souffle/CompiledOptions.h"
-#include "souffle/profile/Logger.h"
-#include "souffle/profile/ProfileEvent.h"
 #endif
-#include <array>
-#include <atomic>
-#include <cassert>
-#include <cmath>
-#include <cstdint>
-#include <cstdlib>
-#include <exception>
-#include <iostream>
-#include <iterator>
-#include <memory>
-#include <regex>
-#include <string>
-#include <utility>
-#include <vector>
 
 #if defined(_OPENMP)
 #include <omp.h>

--- a/src/include/souffle/RecordTable.h
+++ b/src/include/souffle/RecordTable.h
@@ -482,9 +482,9 @@ public:
 };
 
 /** The interface of any Record Table. */
-class RecordTableInterface {
+class RecordTable {
 public:
-    virtual ~RecordTableInterface() {}
+    virtual ~RecordTable() {}
 
     virtual void setNumLanes(const std::size_t NumLanes) = 0;
 
@@ -495,7 +495,7 @@ public:
 
 /** A concurrent Record Table with some specialized record maps. */
 template <std::size_t... SpecializedArities>
-class SpecializedRecordTable : public RecordTableInterface {
+class SpecializedRecordTable : public RecordTable {
 private:
     // The current size of the Maps vector.
     std::size_t Size;
@@ -540,7 +540,9 @@ public:
     virtual void setNumLanes(const std::size_t NumLanes) override {
         Lanes.setNumLanes(NumLanes);
         for (auto& Map : Maps) {
-            Map->setNumLanes(NumLanes);
+            if (Map) {
+                Map->setNumLanes(NumLanes);
+            }
         }
     }
 
@@ -599,9 +601,6 @@ private:
         Lanes.unlockAllBut();
     }
 };
-
-/** Default record table uses specialized record maps for arities 0 to 12. */
-using RecordTable = SpecializedRecordTable<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12>;
 
 /** @brief helper to convert tuple to record reference for the synthesiser */
 template <class RecordTableT, std::size_t Arity>

--- a/src/include/souffle/io/SerialisationStream.h
+++ b/src/include/souffle/io/SerialisationStream.h
@@ -29,7 +29,7 @@
 
 namespace souffle {
 
-class RecordTableInterface;
+class RecordTable;
 class SymbolTable;
 
 using json11::Json;
@@ -43,18 +43,18 @@ protected:
     template <typename A>
     using RO = std::conditional_t<readOnlyTables, const A, A>;
 
-    SerialisationStream(RO<SymbolTable>& symTab, RO<RecordTableInterface>& recTab, Json types,
+    SerialisationStream(RO<SymbolTable>& symTab, RO<RecordTable>& recTab, Json types,
             std::vector<std::string> relTypes, std::size_t auxArity = 0)
             : symbolTable(symTab), recordTable(recTab), types(std::move(types)),
               typeAttributes(std::move(relTypes)), arity(typeAttributes.size() - auxArity),
               auxiliaryArity(auxArity) {}
 
-    SerialisationStream(RO<SymbolTable>& symTab, RO<RecordTableInterface>& recTab, Json types)
+    SerialisationStream(RO<SymbolTable>& symTab, RO<RecordTable>& recTab, Json types)
             : symbolTable(symTab), recordTable(recTab), types(std::move(types)) {
         setupFromJson();
     }
 
-    SerialisationStream(RO<SymbolTable>& symTab, RO<RecordTableInterface>& recTab,
+    SerialisationStream(RO<SymbolTable>& symTab, RO<RecordTable>& recTab,
             const std::map<std::string, std::string>& rwOperation)
             : symbolTable(symTab), recordTable(recTab) {
         std::string parseErrors;
@@ -67,7 +67,7 @@ protected:
     }
 
     RO<SymbolTable>& symbolTable;
-    RO<RecordTableInterface>& recordTable;
+    RO<RecordTable>& recordTable;
     Json types;
     std::vector<std::string> typeAttributes;
 

--- a/src/interpreter/Engine.h
+++ b/src/interpreter/Engine.h
@@ -178,8 +178,8 @@ private:
     ram::TranslationUnit& tUnit;
     /** IndexAnalysis */
     ram::analysis::IndexAnalysis* isa;
-    /** Record Table*/
-    RecordTable recordTable;
+    /** Record Table Implementation*/
+    SpecializedRecordTable<0, 1, 2, 3, 4, 5, 6, 7, 8, 9> recordTable;
     /** Symbol table for relations */
     VecOwn<RelationHandle> relations;
     /** Symbol table */

--- a/src/synthesiser/Synthesiser.h
+++ b/src/synthesiser/Synthesiser.h
@@ -39,7 +39,6 @@ namespace souffle::synthesiser {
 class Synthesiser {
 private:
     /** Record Table */
-    // RecordTable recordTable;
 
     /** RAM translation unit */
     ram::TranslationUnit& translationUnit;
@@ -65,10 +64,13 @@ private:
     /** Symbol map */
     mutable std::vector<std::string> symbolIndex;
 
-protected:
-    /** Get record table */
-    // const RecordTable& getRecordTable();
+    /** Is set to true if there is a need to include std::regex */
+    bool UsingStdRegex = false;
 
+    /** Set of packed and unpacked records arities */
+    std::set<std::size_t> arities;
+
+protected:
     /** Convert RAM identifier */
     const std::string convertRamIdent(const std::string& name);
 


### PR DESCRIPTION
Save precious hundreds of milliseconds based on compilation time
observed with clang `-ftime-trace` (https://github.com/aras-p/llvm-project-20170507/pull/2)

The timings for the CI in my branch: https://github.com/quentin/souffle/actions/runs/1203147528
 - OSX completed in 1h28.
 - Memcheck completed in 1h35.

Changes:
 - Each specialized record map takes about 100ms to compile (clang), so
   synthesize specialized record maps only for the arities of the
   program's records.
 - Do not include regular expressions facilities unless necessary.
 - Do not include profiling or logging facilities unless necessary.

As suggested by @b-scholz:
 - hides implementation of record tables behind the abstract
   `RecordTable` interface.

**Please review**:
 - not sure I gather record arities in the cleanest way.
 - added a little output stream help class to simplify conditional outputs, I'm not sure this class belongs to its current location and I don't know if that's an output pattern we want to have. 

`TODO:` The inclusion of `IOSystem.h` consumes a non-negligible amount of
compilation time. It would be nice to avoid including all the providers
when it is possible.