### PR TITLE
sqlite view columns named as relation parameters

### DIFF
--- a/src/include/souffle/io/SerialisationStream.h
+++ b/src/include/souffle/io/SerialisationStream.h
@@ -60,6 +60,12 @@ protected:
         std::string parseErrors;
         types = Json::parse(rwOperation.at("types"), parseErrors);
         assert(parseErrors.size() == 0 && "Internal JSON parsing failed.");
+        if (rwOperation.count("params") > 0) {
+            params = Json::parse(rwOperation.at("params"), parseErrors);
+            assert(parseErrors.size() == 0 && "Internal JSON parsing failed.");
+        } else {
+            params = Json::object();
+        }
 
         auxiliaryArity = RamSignedFromString(getOr(rwOperation, "auxArity", "0"));
 
@@ -69,6 +75,7 @@ protected:
     RO<SymbolTable>& symbolTable;
     RO<RecordTableInterface>& recordTable;
     Json types;
+    Json params;
     std::vector<std::string> typeAttributes;
 
     std::size_t arity = 0;


### PR DESCRIPTION
Name the view columns using the relation parameters identifier in the sqlite output database. Fallback to numbering in case parameters names are not available.