### PR TITLE
EQREL: Call EXTEND after inserting delta into main relation

### DIFF
--- a/src/ast2ram/seminaive/UnitTranslator.cpp
+++ b/src/ast2ram/seminaive/UnitTranslator.cpp
@@ -201,7 +201,7 @@ Own<ram::Statement> UnitTranslator::generateMergeRelations(
     auto insertion = mk<ram::Insert>(destRelation, std::move(values));
     auto stmt = mk<ram::Query>(mk<ram::Scan>(srcRelation, 0, std::move(insertion)));
     if (rel->getRepresentation() == RelationRepresentation::EQREL) {
-        return mk<ram::Sequence>(mk<ram::Extend>(destRelation, srcRelation), std::move(stmt));
+        return mk<ram::Sequence>(std::move(stmt), mk<ram::Extend>(destRelation, srcRelation));
     }
     return stmt;
 }


### PR DESCRIPTION
In the worst case, EXTEND can insert every tuple from the main relation into the delta, which is then immediately scanned to insert every tuple in the delta back into the main relation, costing O(n^2) time (see #2054). Calling EXTEND after insertion is more performant.

For a concrete example, we can see what this does to this program:
```
.decl e(x: number, y: number) eqrel
e(0, 0).
e(x, x + 1) :-
  x < 1000,
  e(x, x).
.printsize e
```
It turns this RAM (gathered with Souffle HEAD):
```
   EXTEND e WITH @new_e
   QUERY
    FOR t0 IN @new_e
     INSERT (t0.0, t0.1) INTO e
   END QUERY
```
into this:
```
   QUERY
    FOR t0 IN @new_e
     INSERT (t0.0, t0.1) INTO e
   END QUERY
   EXTEND e WITH @new_e
```
Note that this doesn't solve the fundamental issue of EXTEND being able to blow up the delta relation - it just alleviates it by reducing the number of iterations over that large delta.