### PR TITLE
Make functor analysis responsible for user-defined functors

### DIFF
--- a/src/ast/analysis/Functor.cpp
+++ b/src/ast/analysis/Functor.cpp
@@ -10,7 +10,7 @@
  *
  * @file Functor.cpp
  *
- * Analysis that provides type information for functors
+ * Analysis that provides information about functors
  *
  ***********************************************************************/
 
@@ -32,17 +32,9 @@ TypeAttribute FunctorAnalysis::getReturnTypeAttribute(const Functor& functor) co
     return typeAnalysis->getFunctorReturnTypeAttribute(functor);
 }
 
-Type const& FunctorAnalysis::getReturnType(const UserDefinedFunctor& functor) const {
-    return typeAnalysis->getFunctorReturnType(functor);
-}
-
 /** Return parameter type of functor */
 TypeAttribute FunctorAnalysis::getParamTypeAttribute(const Functor& functor, const std::size_t idx) const {
     return typeAnalysis->getFunctorParamTypeAttribute(functor, idx);
-}
-
-Type const& FunctorAnalysis::getParamType(const UserDefinedFunctor& functor, const std::size_t idx) const {
-    return typeAnalysis->getFunctorParamType(functor, idx);
 }
 
 std::vector<TypeAttribute> FunctorAnalysis::getParamTypeAttributes(const UserDefinedFunctor& functor) const {

--- a/src/ast/analysis/Functor.h
+++ b/src/ast/analysis/Functor.h
@@ -16,9 +16,11 @@
 
 #pragma once
 
+#include "ast/FunctorDeclaration.h"
 #include "ast/TranslationUnit.h"
 #include "souffle/TypeAttribute.h"
 #include <iosfwd>
+#include <unordered_map>
 #include <vector>
 
 namespace souffle::ast {
@@ -43,21 +45,18 @@ public:
 
     void print(std::ostream& /* os */) const override {}
 
-    /** Return return type of functor */
-    TypeAttribute getReturnTypeAttribute(const Functor& functor) const;
-
-    /** Return parameter type of functor */
-    TypeAttribute getParamTypeAttribute(const Functor& functor, const std::size_t idx) const;
-
     static bool isMultiResult(const Functor& functor);
 
-    std::vector<TypeAttribute> getParamTypeAttributes(const UserDefinedFunctor& functor) const;
+    std::size_t getFunctorArity(UserDefinedFunctor const& functor) const;
+    QualifiedName const& getFunctorReturnType(const UserDefinedFunctor& functor) const;
+    bool isStatefulFunctor(const UserDefinedFunctor& functor) const;
+    const FunctorDeclaration& getFunctorDeclaration(const UserDefinedFunctor& functor) const;
 
     /** Return whether a UDF is stateful */
     bool isStateful(const UserDefinedFunctor& udf) const;
 
 private:
-    const TypeAnalysis* typeAnalysis = nullptr;
+    std::unordered_map<std::string, const FunctorDeclaration*> functorNameToDeclaration;
 };
 
 }  // namespace souffle::ast::analysis

--- a/src/ast/analysis/Functor.h
+++ b/src/ast/analysis/Functor.h
@@ -45,11 +45,9 @@ public:
 
     /** Return return type of functor */
     TypeAttribute getReturnTypeAttribute(const Functor& functor) const;
-    Type const& getReturnType(const UserDefinedFunctor& functor) const;
 
-    /** Return paramument type of functor */
+    /** Return parameter type of functor */
     TypeAttribute getParamTypeAttribute(const Functor& functor, const std::size_t idx) const;
-    Type const& getParamType(const UserDefinedFunctor& functor, const std::size_t idx) const;
 
     static bool isMultiResult(const Functor& functor);
 

--- a/src/ast/analysis/Type.h
+++ b/src/ast/analysis/Type.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "AggregateOp.h"
+#include "Functor.h"
 #include "FunctorOps.h"
 #include "ast/Clause.h"
 #include "ast/NumericConstant.h"
@@ -86,10 +87,6 @@ public:
     TypeAttribute getFunctorParamTypeAttribute(const Functor& functor, std::size_t idx) const;
     std::vector<TypeAttribute> getFunctorParamTypeAttributes(const UserDefinedFunctor& functor) const;
 
-    std::size_t getFunctorArity(UserDefinedFunctor const& functor) const;
-    bool isStatefulFunctor(const UserDefinedFunctor& udf) const;
-    static bool isMultiResultFunctor(const Functor& functor);
-
     /** -- Polymorphism-related methods -- */
     NumericConstant::Type getPolymorphicNumericConstantType(const NumericConstant& nc) const;
     const std::map<const NumericConstant*, NumericConstant::Type>& getNumericConstantTypes() const;
@@ -100,6 +97,7 @@ public:
 private:
     // General type analysis
     TypeEnvironment const* typeEnv = nullptr;
+    FunctorAnalysis const* functorAnalysis = nullptr;
     std::map<const Argument*, TypeSet> argumentTypes;
     VecOwn<Clause> annotatedClauses;
     std::stringstream analysisLogs;
@@ -110,7 +108,6 @@ private:
 
     // Polymorphic objects analysis
     std::map<const IntrinsicFunctor*, const IntrinsicFunctorInfo*> functorInfo;
-    std::map<std::string, const FunctorDeclaration*> udfDeclaration;
     std::map<const NumericConstant*, NumericConstant::Type> numericConstantType;
     std::map<const Aggregator*, AggregateOp> aggregatorType;
     std::map<const BinaryConstraint*, BinaryConstraintOp> constraintType;

--- a/src/ast/analysis/TypeConstraints.cpp
+++ b/src/ast/analysis/TypeConstraints.cpp
@@ -540,7 +540,7 @@ void TypeConstraintsAnalysis::visit_(type_identity<UserDefinedFunctor>, const Us
     // order of the passes/transformers.  So, for now, here's a comment for the next
     // person going doing this rabbit hole.
     auto const& arguments = fun.getArguments();
-    if (!typeAnalysis.hasValidTypeInfo(fun) || typeAnalysis.getFunctorArity(fun) != arguments.size()) {
+    if (!typeAnalysis.hasValidTypeInfo(fun) || functorAnalysis.getFunctorArity(fun) != arguments.size()) {
         return;
     }
 

--- a/src/ast/analysis/TypeConstraints.h
+++ b/src/ast/analysis/TypeConstraints.h
@@ -91,6 +91,7 @@ private:
     const Program& program = tu.getProgram();
     const SumTypeBranchesAnalysis& sumTypesBranches = tu.getAnalysis<SumTypeBranchesAnalysis>();
     const TypeAnalysis& typeAnalysis = tu.getAnalysis<TypeAnalysis>();
+    const FunctorAnalysis& functorAnalysis = tu.getAnalysis<FunctorAnalysis>();
 
     // Sinks = {head} ∪ {negated atoms}
     std::set<const Atom*> sinks;

--- a/src/ast/transform/TypeChecker.cpp
+++ b/src/ast/transform/TypeChecker.cpp
@@ -76,7 +76,6 @@ public:
 
     /** Analyse types, clause by clause */
     void run() {
-        const Program& program = tu.getProgram();
         for (auto const* clause : program.getClauses()) {
             visit(*clause, *this);
         }
@@ -112,7 +111,6 @@ private:
     ErrorReport& report = tu.getErrorReport();
     const TypeAnalysis& typeAnalysis = tu.getAnalysis<TypeAnalysis>();
     const TypeEnvironment& typeEnv = tu.getAnalysis<TypeEnvironmentAnalysis>().getTypeEnvironment();
-    const FunctorAnalysis& functorAnalysis = tu.getAnalysis<FunctorAnalysis>();
     const PolymorphicObjectsAnalysis& polyAnalysis = tu.getAnalysis<PolymorphicObjectsAnalysis>();
     const SumTypeBranchesAnalysis& sumTypesBranches = tu.getAnalysis<SumTypeBranchesAnalysis>();
 
@@ -561,7 +559,7 @@ void TypeCheckerImpl::visit_(type_identity<UserDefinedFunctor>, const UserDefine
         return;
     }
 
-    Type const& returnType = functorAnalysis.getReturnType(fun);
+    Type const& returnType = typeAnalysis.getFunctorReturnType(fun);
 
     if (resultTypes.isAll() || resultTypes.size() != 1) {
         std::ostringstream out;
@@ -600,7 +598,7 @@ void TypeCheckerImpl::visit_(type_identity<UserDefinedFunctor>, const UserDefine
 
     for (std::size_t ii = 0; ii < toCheck; ++ii) {
         auto const& arg = args[ii];
-        Type const& paramType = functorAnalysis.getParamType(fun, ii);
+        Type const& paramType = typeAnalysis.getFunctorParamType(fun, ii);
         TypeSet const& argTypes = typeAnalysis.getTypes(arg);
 
         if (argTypes.isAll() || argTypes.size() != 1) {

--- a/src/ast2ram/utility/TranslatorContext.cpp
+++ b/src/ast2ram/utility/TranslatorContext.cpp
@@ -27,6 +27,7 @@
 #include "ast/analysis/RelationSchedule.h"
 #include "ast/analysis/SCCGraph.h"
 #include "ast/analysis/SumTypeBranches.h"
+#include "ast/analysis/Type.h"
 #include "ast/analysis/TypeEnvironment.h"
 #include "ast/analysis/TypeSystem.h"
 #include "ast/utility/SipsMetric.h"
@@ -55,6 +56,7 @@ TranslatorContext::TranslatorContext(const ast::TranslationUnit& tu) {
     relationSchedule = &tu.getAnalysis<ast::analysis::RelationScheduleAnalysis>();
     relationDetail = &tu.getAnalysis<ast::analysis::RelationDetailCacheAnalysis>();
     ioType = &tu.getAnalysis<ast::analysis::IOTypeAnalysis>();
+    typeAnalysis = &tu.getAnalysis<ast::analysis::TypeAnalysis>();
     typeEnv = &tu.getAnalysis<ast::analysis::TypeEnvironmentAnalysis>().getTypeEnvironment();
     sumTypeBranches = &tu.getAnalysis<ast::analysis::SumTypeBranchesAnalysis>();
     polyAnalysis = &tu.getAnalysis<ast::analysis::PolymorphicObjectsAnalysis>();
@@ -158,21 +160,21 @@ ast::Relation* TranslatorContext::getRelation(const ast::QualifiedName& name) co
 }
 
 TypeAttribute TranslatorContext::getFunctorReturnTypeAttribute(const ast::Functor& functor) const {
-    return functorAnalysis->getReturnTypeAttribute(functor);
+    return typeAnalysis->getFunctorReturnTypeAttribute(functor);
 }
 
 TypeAttribute TranslatorContext::getFunctorParamTypeAtribute(
         const ast::Functor& functor, std::size_t idx) const {
-    return functorAnalysis->getParamTypeAttribute(functor, idx);
+    return typeAnalysis->getFunctorParamTypeAttribute(functor, idx);
 }
 
 std::vector<TypeAttribute> TranslatorContext::getFunctorParamTypeAtributes(
         const ast::UserDefinedFunctor& udf) const {
-    return functorAnalysis->getParamTypeAttributes(udf);
+    return typeAnalysis->getFunctorParamTypeAttributes(udf);
 }
 
 bool TranslatorContext::isStatefulFunctor(const ast::UserDefinedFunctor& udf) const {
-    return functorAnalysis->isStateful(udf);
+    return functorAnalysis->isStatefulFunctor(udf);
 }
 
 ast::NumericConstant::Type TranslatorContext::getInferredNumericConstantType(

--- a/src/ast2ram/utility/TranslatorContext.h
+++ b/src/ast2ram/utility/TranslatorContext.h
@@ -17,6 +17,7 @@
 #include "AggregateOp.h"
 #include "FunctorOps.h"
 #include "ast/NumericConstant.h"
+#include "ast/analysis/Type.h"
 #include "souffle/BinaryConstraintOps.h"
 #include "souffle/TypeAttribute.h"
 #include "souffle/utility/ContainerUtil.h"
@@ -135,6 +136,7 @@ private:
     const ast::analysis::RelationDetailCacheAnalysis* relationDetail;
     const ast::analysis::FunctorAnalysis* functorAnalysis;
     const ast::analysis::IOTypeAnalysis* ioType;
+    const ast::analysis::TypeAnalysis* typeAnalysis;
     const ast::analysis::TypeEnvironment* typeEnv;
     const ast::analysis::SumTypeBranchesAnalysis* sumTypeBranches;
     const ast::analysis::PolymorphicObjectsAnalysis* polyAnalysis;


### PR DESCRIPTION
Follow up to #2074.

Before the change functor analysis served as a proxy to some of the
type analysis operations.

With this change it becomes responsible for retrieving information
about user-defined functors from their declarations (which was handled
by type analysis).