### PR TITLE
Fix windows compilation

### DIFF
--- a/src/include/souffle/SignalHandler.h
+++ b/src/include/souffle/SignalHandler.h
@@ -25,7 +25,13 @@
 #include <iostream>
 #include <mutex>
 #include <string>
+
+#ifdef _WIN32
+#include <io.h>
+#define STDERR_FILENO 2 /* Standard error output.  */
+#else
 #include <unistd.h>
+#endif  //_WIN32
 
 namespace souffle {
 

--- a/src/include/souffle/io/ReadStream.h
+++ b/src/include/souffle/io/ReadStream.h
@@ -176,8 +176,7 @@ protected:
                 return branchIdx;
             }
 
-            const RamDomain empty[] = {};
-            RamDomain emptyArgs = recordTable.pack(empty, 0);
+            RamDomain emptyArgs = recordTable.pack(toVector<RamDomain>().data(), 0);
             const RamDomain record[] = {branchIdx, emptyArgs};
             return recordTable.pack(record, 2);
         }


### PR DESCRIPTION
- Remove unistd.h dependency for SignalHandler.h
- Remove static array of size zero (which is not allowed by MSVC https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2466?view=msvc-160 and it is not ansi C++). I recovered the previous implementation instead.