### PR TITLE
Fix build issues on CentOS 8

### DIFF
--- a/.github/actions/create-package/centos/8/64bit/Dockerfile
+++ b/.github/actions/create-package/centos/8/64bit/Dockerfile
@@ -1,0 +1,42 @@
+FROM centos:8
+
+# Create a souffle directory
+WORKDIR /souffle
+
+# Install souffle build dependencies
+RUN dnf -y install \
+    autoconf \
+    automake \
+    bash-completion \
+    bison \
+    clang \
+    cmake \
+    doxygen \
+    flex \
+    gcc-c++ \
+    git \
+    libffi-devel \
+    libtool \
+    make \
+    mcpp \
+    ncurses-devel \
+    pkg-config \
+    python39 \
+    redhat-lsb-core \
+    rpm-build \
+    sqlite-devel \
+    zlib-devel
+
+# Install dependencies for packagecloud CLI as well as package_cloud CLI
+RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB && \
+	curl -sSL https://get.rvm.io | bash -s stable
+RUN /bin/bash -l -c ". /etc/profile.d/rvm.sh && rvm install 2.7.4 && gem install package_cloud"
+
+# Copy everything into souffle directory
+COPY . .
+
+ENV DOMAIN_SIZE "64bit"
+ENV PKG_EXTENSION ".rpm"
+ENV PKG_CLOUD_OS_NAME "centos/8"
+
+ENTRYPOINT ["/bin/bash", "-l", "-c", ".github/actions/create-package/entrypoint.sh"]

--- a/.github/actions/create-package/centos/8/64bit/action.yml
+++ b/.github/actions/create-package/centos/8/64bit/action.yml
@@ -1,0 +1,12 @@
+name: Package for CentOS 8 64bit
+description: Package for CentOS 8 64bit
+inputs:
+  package_cloud_api_key:
+    description: 'Package Cloud API Key'
+    required: true
+    default: ''
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.package_cloud_api_key }}

--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -56,6 +56,23 @@ jobs:
           package_cloud_api_key: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
 
+#  Package-CentOS-8-64bit:
+#    strategy:
+#      fail-fast: false
+#
+#    runs-on: ubuntu-latest
+#    steps:
+#      # To use this repository's private action, check out the repository
+#      - name: Checkout
+#        uses: actions/checkout@v2
+#        with:
+#          fetch-depth: 0
+#      - name: Package souffle
+#        # Private action is stored in the following directory
+#        uses: ./.github/actions/create-package/centos/8/64bit/
+#        with:
+#          package_cloud_api_key: ${{ secrets.PACKAGECLOUD_TOKEN }}
+
 #  Package-Fedora-34-64bit:
 #    strategy:
 #      fail-fast: false

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -17,7 +17,6 @@
 %require "3.0.2"
 
 %defines
-%define api.parser.class {parser}
 %define api.token.constructor
 %define api.value.type variant
 %define parse.assert

--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -1388,7 +1388,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                 default: fatal("Unhandled aggregate operation");
             }
 
-            char const* type;
+            char const* type = NULL;
             switch (getTypeAttributeAggregate(aggregate.getFunction())) {
                 case TypeAttribute::Signed: type = "RamSigned"; break;
                 case TypeAttribute::Unsigned: type = "RamUnsigned"; break;


### PR DESCRIPTION
I was running into two issues when building Souffle on CentOS 8.

After applying those changes all tests passed:

```
$ ctest --output-on-failure --progress -j$(nproc)
Test project /home/cmuellner/src/souffle/builddir
3082/3082 Test #2946: provenance/explain_float_unsigned_c_compare_csv
100% tests passed, 0 tests failed out of 3082

Label Time Summary:
ast            =   0.19 sec*proc (6 tests)
compiled       = 5002.81 sec*proc (1476 tests)
evaluation     = 2520.26 sec*proc (1112 tests)
integration    = 5358.70 sec*proc (2996 tests)
interface      =  52.31 sec*proc (16 tests)
interpreted    = 345.52 sec*proc (1480 tests)
interpreter    =   0.14 sec*proc (3 tests)
negative       = 108.53 sec*proc (552 tests)
positive       = 5355.35 sec*proc (2500 tests)
provenance     = 433.84 sec*proc (128 tests)
ram            =   0.19 sec*proc (7 tests)
semantic       = 1931.03 sec*proc (1364 tests)
src            =  24.92 sec*proc (14 tests)
syntactic      = 410.88 sec*proc (336 tests)
unit_test      =  25.43 sec*proc (30 tests)

Total Test time (real) =  51.12 sec
```