### PR TITLE
Fixed compilation warning where variable `type` may be uninitialized

### DIFF
--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -1388,7 +1388,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                 default: fatal("Unhandled aggregate operation");
             }
 
-            char const* type;
+            char const* type = "";
             switch (getTypeAttributeAggregate(aggregate.getFunction())) {
                 case TypeAttribute::Signed: type = "RamSigned"; break;
                 case TypeAttribute::Unsigned: type = "RamUnsigned"; break;
@@ -2645,7 +2645,7 @@ void runFunction(std::string  inputDirectoryArg,
     this->inputDirectory  = std::move(inputDirectoryArg);
     this->outputDirectory = std::move(outputDirectoryArg);
     this->performIO       = performIOArg;
-    this->pruneImdtRels   = pruneImdtRelsArg; 
+    this->pruneImdtRels   = pruneImdtRelsArg;
 
     // set default threads (in embedded mode)
     // if this is not set, and omp is used, the default omp setting of number of cores is used.


### PR DESCRIPTION
This PR tries to fix a compilation warning that is caused by the following line:

https://github.com/souffle-lang/souffle/blob/e4184ab103bf4878d8fd85cb5373d690691bfe32/src/synthesiser/Synthesiser.cpp#L1391

The compilation warning says:

```
souffle/src/synthesiser/Synthesiser.cpp: In member function ‘virtual void souffle::synthesiser::Synthesiser::emitCode(std::ostream&, const souffle::ram::Statement&)::CodeEmitter::visit_(souffle::type_identity<souffle::ram::ParallelAggregate>, const souffle::ram::ParallelAggregate&, std::ostream&)’:
souffle/src/synthesiser/Synthesiser.cpp:1438:75: error: ‘type’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
                     out << "res0 = std::max(res0, ramBitCast<" << type << ">(";
                                                                           ^~~~
cc1plus: all warnings being treated as errors
src/CMakeFiles/libsouffle.dir/build.make:2088: recipe for target 'src/CMakeFiles/libsouffle.dir/synthesiser/Synthesiser.cpp.o' failed
```

This PR tries to resolve this warning by introducing an empty string initial value.