### PR TITLE
Fix dependency

### DIFF
--- a/.github/images/arch-linux/PKGBUILD.in
+++ b/.github/images/arch-linux/PKGBUILD.in
@@ -5,7 +5,7 @@
 #
 # This PKGBUILD is automatically generated and always points to the 
 # latest release from the souffle official repository.
-# Source: .github/images/arch-linx/PKGBUILD.in
+# Source: .github/images/arch-linux/PKGBUILD.in
 #
 
 pkgname=souffle
@@ -16,7 +16,7 @@ arch=('any')
 url="https://github.com/souffle-lang/souffle"
 license=('UPL')
 groups=()
-depends=('mcpp' 'gcc>=7' 'openmp' 'sqlite')
+depends=('mcpp' 'gcc>=8' 'openmp' 'sqlite')
 makedepends=('git' 'cmake>=3.15' 'bison>=3.0.4' 'flex' 'libffi' 'ncurses' 'zlib' 'lsb-release')
 optdepends=('bash-completion')
 provides=('souffle')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,7 +382,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
 		# --------------------------------------------------
 
 		# Specifying runtime dependencies
-		set(CPACK_DEBIAN_PACKAGE_DEPENDS "g++ (>= 7), libffi-dev, libncurses5-dev, libsqlite3-dev, mcpp, zlib1g-dev")
+		set(CPACK_DEBIAN_PACKAGE_DEPENDS "g++ (>= 8), libffi-dev, libncurses5-dev, libsqlite3-dev, mcpp, zlib1g-dev")
 
 		# Auto-generate any runtime dependencies that are required
 		SET(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
@@ -404,7 +404,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
 		# --------------------------------------------------
 
 		# Specifying runtime dependencies
-		set(CPACK_RPM_PACKAGE_REQUIRES "gcc-c++ >= 7, libffi, libffi-devel, ncurses-devel, sqlite-devel, mcpp, zlib-devel")
+		set(CPACK_RPM_PACKAGE_REQUIRES "gcc-c++ >= 8, libffi, libffi-devel, ncurses-devel, sqlite-devel, mcpp, zlib-devel")
 
         # Note: By default automatic dependency detection is enabled by rpm generator.
         # SET(CPACK_RPM_PACKAGE_AUTOREQPROV "no")


### PR DESCRIPTION
#2089

gcc-7 can still work but requires some tweaking on the warning flags.
People who want to use gcc-7 should modify the makefile and compile from the source.

Most of the warnings we got are unused variables from structured bindings. The behaviour of the warning has been improved with gcc-8.
See https://stackoverflow.com/questions/41404001/structured-binding-with-maybe-unused
https://stackoverflow.com/questions/47005032/structured-bindings-and-range-based-for-supress-unused-warning-in-gcc