### PR TITLE
Add option to output graph dot text files

### DIFF
--- a/src/ast/analysis/PrecedenceGraph.cpp
+++ b/src/ast/analysis/PrecedenceGraph.cpp
@@ -52,9 +52,8 @@ void PrecedenceGraphAnalysis::run(const TranslationUnit& translationUnit) {
     }
 }
 
-void PrecedenceGraphAnalysis::print(std::ostream& os) const {
+void PrecedenceGraphAnalysis::printRaw(std::stringstream& ss) const {
     /* Print dependency graph */
-    std::stringstream ss;
     ss << "digraph {\n";
     /* Print node of dependence graph */
     for (const Relation* rel : backingGraph.vertices()) {
@@ -74,6 +73,17 @@ void PrecedenceGraphAnalysis::print(std::ostream& os) const {
         }
     }
     ss << "}\n";
+}
+
+void PrecedenceGraphAnalysis::print(std::ostream& os) const {
+    std::stringstream ss;
+    printRaw(ss);
+    os << ss.str();
+}
+
+void PrecedenceGraphAnalysis::printHTML(std::ostream& os) const {
+    std::stringstream ss;
+    printRaw(ss);
     printHTMLGraph(os, ss.str(), getName());
 }
 

--- a/src/ast/analysis/PrecedenceGraph.h
+++ b/src/ast/analysis/PrecedenceGraph.h
@@ -40,8 +40,11 @@ public:
 
     void run(const TranslationUnit& translationUnit) override;
 
-    /** Output precedence graph in graphviz format to a given stream */
+    /** Output precedence graph in text format to a given stream */
     void print(std::ostream& os) const override;
+
+    /** Output precedence graph in graphviz format to a given stream */
+    void printHTML(std::ostream& os) const;
 
     const Graph<const Relation*, NameComparison>& graph() const {
         return backingGraph;
@@ -50,6 +53,9 @@ public:
 private:
     /** Adjacency list of precedence graph (determined by the dependencies of the relations) */
     Graph<const Relation*, NameComparison> backingGraph;
+
+    /** Output precedence graph in text format to a given stringstream */
+    void printRaw(std::stringstream& ss) const;
 };
 
 }  // namespace analysis

--- a/src/ast/analysis/SCCGraph.cpp
+++ b/src/ast/analysis/SCCGraph.cpp
@@ -114,9 +114,8 @@ void SCCGraphAnalysis::scR(const Relation* w, std::map<const Relation*, std::siz
     numSCCs++;
 }
 
-void SCCGraphAnalysis::print(std::ostream& os) const {
+void SCCGraphAnalysis::printRaw(std::stringstream& ss) const {
     const std::string& name = Global::config().get("name");
-    std::stringstream ss;
     /* Print SCC graph */
     ss << "digraph {" << std::endl;
     /* Print nodes of SCC graph */
@@ -132,6 +131,17 @@ void SCCGraphAnalysis::print(std::ostream& os) const {
         }
     }
     ss << "}";
+}
+
+void SCCGraphAnalysis::print(std::ostream& os) const {
+    std::stringstream ss;
+    printRaw(ss);
+    os << ss.str();
+}
+
+void SCCGraphAnalysis::printHTML(std::ostream& os) const {
+    std::stringstream ss;
+    printRaw(ss);
     printHTMLGraph(os, ss.str(), getName());
 }
 

--- a/src/ast/analysis/SCCGraph.h
+++ b/src/ast/analysis/SCCGraph.h
@@ -202,8 +202,11 @@ public:
         return true;
     }
 
-    /** Print the SCC graph. */
+    /** Print the SCC graph in text format. */
     void print(std::ostream& os) const override;
+
+    /** Print the SCC graph in HTML format. */
+    void printHTML(std::ostream& os) const;
 
 private:
     PrecedenceGraphAnalysis* precedenceGraph = nullptr;
@@ -225,6 +228,9 @@ private:
             std::stack<const Relation*>& S, std::stack<const Relation*>& P, std::size_t& numSCCs);
 
     IOTypeAnalysis* ioType = nullptr;
+
+    /** Print the SCC graph to a string. */
+    void printRaw(std::stringstream& ss) const;
 };
 
 }  // namespace analysis

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -257,7 +257,9 @@ int main(int argc, char** argv) {
                         "\tinitial-ram\n"
                         "\tparse-errors\n"
                         "\tprecedence-graph\n"
+                        "\tprecedence-graph-text\n"
                         "\tscc-graph\n"
+                        "\tscc-graph-text\n"
                         "\ttransformed-ast\n"
                         "\ttransformed-ram\n"
                         "\ttype-analysis"},
@@ -570,12 +572,24 @@ int main(int argc, char** argv) {
 
     // Output the precedence graph in graphviz dot format
     if (hasShowOpt("precedence-graph")) {
+        astTranslationUnit->getAnalysis<ast::analysis::PrecedenceGraphAnalysis>().printHTML(std::cout);
+        std::cout << std::endl;
+    }
+
+    // Output the precedence graph in text format
+    if (hasShowOpt("precedence-graph-text")) {
         astTranslationUnit->getAnalysis<ast::analysis::PrecedenceGraphAnalysis>().print(std::cout);
         std::cout << std::endl;
     }
 
     // Output the scc graph in graphviz dot format
     if (hasShowOpt("scc-graph")) {
+        astTranslationUnit->getAnalysis<ast::analysis::SCCGraphAnalysis>().printHTML(std::cout);
+        std::cout << std::endl;
+    }
+
+    // Output the scc graph in text format
+    if (hasShowOpt("scc-graph-text")) {
         astTranslationUnit->getAnalysis<ast::analysis::SCCGraphAnalysis>().print(std::cout);
         std::cout << std::endl;
     }


### PR DESCRIPTION
This PR adds the capability of producing the precedence and SCC graphs in text format (in addition to the svg format).
This format is more amenable for downstream analyses and processing.