### PR TITLE
Correctly deserialise floats from SQLite

### DIFF
--- a/src/include/souffle/io/ReadStreamSQLite.h
+++ b/src/include/souffle/io/ReadStreamSQLite.h
@@ -74,9 +74,9 @@ protected:
                 auto&& ty = typeAttributes.at(column);
                 switch (ty[0]) {
                     case 's': tuple[column] = symbolTable.encode(element); break;
+                    case 'f': tuple[column] = ramBitCast(RamFloatFromString(element)); break;
                     case 'i':
                     case 'u':
-                    case 'f':
                     case 'r': tuple[column] = RamSignedFromString(element); break;
                     default: fatal("invalid type attribute: `%c`", ty[0]);
                 }


### PR DESCRIPTION
This patch addes a extra cases in `ReadStreamSQLite::readNextTuple` to correctly deserialise floats.

Closes #2093