### PR TITLE
fix range-loop-construct error (gcc 11)

### DIFF
--- a/src/tests/flyweight_test.cpp
+++ b/src/tests/flyweight_test.cpp
@@ -169,7 +169,7 @@ TEST(Flyweight, IteratorEmptyBeginEnd) {
     EXPECT_EQ(flyweight.begin(), flyweight.begin());
     EXPECT_EQ(flyweight.end(), flyweight.end());
     EXPECT_EQ(flyweight.begin()++, flyweight.end());
-    for (const auto val : flyweight) {
+    for (const auto& val : flyweight) {
         testutil::ignore(val);
         EXPECT_TRUE(false);
     }


### PR DESCRIPTION
Compilation with GCC 11 errors out on `range-loop-construct` because the loop should use a reference type to prevent copying.