### PR TITLE
translate subsumptive rules after regular ones

### DIFF
--- a/src/ast2ram/seminaive/UnitTranslator.cpp
+++ b/src/ast2ram/seminaive/UnitTranslator.cpp
@@ -487,24 +487,34 @@ Own<ram::Statement> UnitTranslator::generateStratumTableUpdates(
 
 Own<ram::Statement> UnitTranslator::generateStratumLoopBody(const std::set<const ast::Relation*>& scc) const {
     VecOwn<ram::Statement> loopBody;
-    for (const ast::Relation* rel : scc) {
-        auto relClauses = translateRecursiveClauses(scc, rel);
 
-        auto delClauses = translateSubsumptiveRecursiveClauses(scc, rel);
-
-        relClauses = mk<ram::Sequence>(std::move(relClauses), std::move(delClauses));
-
-        // add profiling information
+    auto addProfiling = [](const ast::Relation* rel, Own<ram::Statement> stmt) -> Own<ram::Statement> {
         if (Global::config().has("profile")) {
             const std::string& relationName = toString(rel->getQualifiedName());
             const auto& srcLocation = rel->getSrcLoc();
             const std::string logTimerStatement = LogStatement::tRecursiveRelation(relationName, srcLocation);
-            relClauses = mk<ram::LogRelationTimer>(mk<ram::Sequence>(std::move(relClauses)),
+            return mk<ram::LogRelationTimer>(mk<ram::Sequence>(std::move(stmt)),
                     logTimerStatement, getNewRelationName(rel->getQualifiedName()));
         }
+        return stmt;
+    };
 
+    // first translate regular recursive clauses
+    for (const ast::Relation* rel : scc) {
+        auto relClauses = translateRecursiveClauses(scc, rel);
+        // add profiling information
+        relClauses = addProfiling(rel, std::move(relClauses));
         appendStmt(loopBody, mk<ram::Sequence>(std::move(relClauses)));
     }
+
+    // translating subsumptive clauses
+    for (const ast::Relation* rel : scc) {
+        auto relClauses = translateSubsumptiveRecursiveClauses(scc, rel);
+        // add profiling information
+        relClauses = addProfiling(rel, std::move(relClauses));
+        appendStmt(loopBody, mk<ram::Sequence>(std::move(relClauses)));
+    }
+
     return mk<ram::Sequence>(std::move(loopBody));
 }
 

--- a/src/ast2ram/seminaive/UnitTranslator.cpp
+++ b/src/ast2ram/seminaive/UnitTranslator.cpp
@@ -493,8 +493,8 @@ Own<ram::Statement> UnitTranslator::generateStratumLoopBody(const std::set<const
             const std::string& relationName = toString(rel->getQualifiedName());
             const auto& srcLocation = rel->getSrcLoc();
             const std::string logTimerStatement = LogStatement::tRecursiveRelation(relationName, srcLocation);
-            return mk<ram::LogRelationTimer>(mk<ram::Sequence>(std::move(stmt)),
-                    logTimerStatement, getNewRelationName(rel->getQualifiedName()));
+            return mk<ram::LogRelationTimer>(mk<ram::Sequence>(std::move(stmt)), logTimerStatement,
+                    getNewRelationName(rel->getQualifiedName()));
         }
         return stmt;
     };


### PR DESCRIPTION
We have a problem with the translation of relations with subsumptive clauses.
Because the RAM for subsumptive clauses updates the @delta_ relation, we must make sure that all the non-subsumptive recursive clauses have been executed first, otherwise they would be using a @delta_ relation that's already the one for the next iteration.

More generally, I think there would still be an ordering problem if subsumptive clauses for R2 have in their body a @delta_R1 with R1 also having subsumptive clauses : the @delta_R1 occuring in the subsumptive clauses of R2 will use the "new" @delta_R1 that was intended to be used at the next iteration.