### PR TITLE
ClauseTranslator: Allocate ValueIndex eagerly to avoid NULL-ptr derefs

### DIFF
--- a/src/ast2ram/seminaive/ClauseTranslator.cpp
+++ b/src/ast2ram/seminaive/ClauseTranslator.cpp
@@ -65,7 +65,7 @@
 namespace souffle::ast2ram::seminaive {
 
 ClauseTranslator::ClauseTranslator(const TranslatorContext& context, TranslationMode mode)
-        : ast2ram::ClauseTranslator(context, mode) {}
+        : ast2ram::ClauseTranslator(context, mode), valueIndex(mk<ValueIndex>()) {}
 
 ClauseTranslator::~ClauseTranslator() = default;
 
@@ -196,7 +196,6 @@ Own<ram::Statement> ClauseTranslator::createRamRuleQuery(const ast::Clause& clau
     assert(isRule(clause) && "clause should be rule");
 
     // Index all variables and generators in the clause
-    valueIndex = mk<ValueIndex>();
     indexClause(clause);
 
     // Set up the RAM statement bottom-up


### PR DESCRIPTION
libstdc++ offers the preprocessor macro `_GLIBCXX_ASSERTIONS` to enable additional run-time checks (assertions).
One of these checks validates the pointer value of std::unique_ptr objects.

This assertion is triggered by the lazy allocation of `valueIndex` in class ClauseTranslator.
The allocation only happens when `createRamRuleQuery()` is called. However, other members
(e.g. `createInsertion()`) dereference `valueIndex` and thus trigger the assertion.

Changing the allocation strategy to eagerly (i.e. as part of the constructor) omits this issue.

This PR fixes all failing test cases reported in #2038 (assertions triggered by `_GLIBCXX_ASSERTIONS`).
No new regressions were observed.