### PR TITLE
Don't disable compiler warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -297,14 +297,14 @@ function(AUTOMAKE_COMPATIBLE_SUBST F_IN F_OUT)
 
     # Compile flags
     string(TOUPPER ${CMAKE_BUILD_TYPE} BT_UPPER)
-    # Remove -Wall/-Wextra/-Werror from the default flag set for compilation using `souffle-compile`.
-    # *) `-d` option in `souffle-compile` adds these flags back
+    # Remove -Werror from the default flag set for compilation using `souffle-compile`.
+    # *) `-d` option in `souffle-compile` adds this flag back
     # *) The compiler used by `souffle-compile` isn't neccesarily the same as the one used by `cmake`.
     #    Code that's free of warnings w/ the cmake compiler might not be w/ `souffle-compile`'s compiler.
     #    e.g. we might use clang-10, user might use gcc or some newer version of clang.
     # *) Synth'd code isn't warning free for now anyways.
     #    TODO: Require/verify that test case synthesised code is warning free as part of test suite.
-    string(REGEX REPLACE "-Wall|-Wextra|-Werror" ""  SOUFFLE_CXXFLAGS "${CMAKE_CXX_FLAGS}")
+    string(REGEX REPLACE "-Werror" ""  SOUFFLE_CXXFLAGS "${CMAKE_CXX_FLAGS}")
     set(SOUFFLE_CXXFLAGS "${SOUFFLE_CXXFLAGS} ${CMAKE_CXX_FLAGS_${BT_UPPER}} ${SUBST_DEFS}")
     if (OPENMP_FOUND)
        set(SOUFFLE_CXXFLAGS "${SOUFFLE_CXXFLAGS} -fopenmp")


### PR DESCRIPTION
Filtering `-Wall` and `-Wextra` can have undesired side-effects
(e.g. causing compiler errors if compiling with `-Wformat-security`).

Let's resolve this by accepting the fact that the generated C++ code
triggers warnings. Maybe the visibility of the warnings will motivate
a fellow hacker to improve the code generation.

See #2122