### PR TITLE
Add a virtual destructor for BTreeDelete node to fix new-delete-type-mismatch #2127

### DIFF
--- a/src/include/souffle/datastructure/BTreeDelete.h
+++ b/src/include/souffle/datastructure/BTreeDelete.h
@@ -655,6 +655,8 @@ protected:
         }
 
     public:
+        virtual ~node() = default;
+
         /**
          * Prints a textual representation of this tree to the given output stream.
          * This feature is mainly intended for debugging and tuning purposes.


### PR DESCRIPTION
Fixes #2127. This is only a partial fix since there is now a `heap-use-after-free` error, I will create a new issue for this.

Root cause: The `delete` on [this line](https://github.com/souffle-lang/souffle/blob/master/src/include/souffle/datastructure/BTreeDelete.h#L1913) is for a parent `node` pointer, however `node` is polymorphic and could be an `inner_node` (which has its own [destructor](https://github.com/souffle-lang/souffle/blob/master/src/include/souffle/datastructure/BTreeDelete.h#L879)).