### PR TITLE
fix crashes in type printer when using --debug-report

### DIFF
--- a/src/ast/analysis/typesystem/Type.cpp
+++ b/src/ast/analysis/typesystem/Type.cpp
@@ -733,10 +733,12 @@ void TypeAnnotationPrinter::print_(type_identity<Aggregator>, const Aggregator& 
     auto bodyLiterals = agg.getBodyLiterals();
     os << baseOperator << " ";
     auto targetExpr = agg.getTargetExpression();
-    auto tySet = argumentTypes.find(targetExpr)->second;
-    assert(tySet.size() == 1);
-    auto ty = tySet.begin();
-    branchOnArgument(targetExpr, *ty);
+    if (targetExpr /* the target expression can be null */) {
+        auto tySet = argumentTypes.find(targetExpr)->second;
+        assert(tySet.size() == 1);
+        auto ty = tySet.begin();
+        branchOnArgument(targetExpr, *ty);
+    }
     os << " : { ";
     printBodyLiterals(bodyLiterals, "        ");
     os << " }";

--- a/src/ast/analysis/typesystem/TypeSystem.h
+++ b/src/ast/analysis/typesystem/TypeSystem.h
@@ -513,10 +513,10 @@ public:
             case TypeAttribute::Unsigned: return getType("__unsignedConstant");
             case TypeAttribute::Float: return getType("__floatConstant");
             case TypeAttribute::Symbol: return getType("__symbolConstant");
-            case TypeAttribute::Record: break;
-            case TypeAttribute::ADT: break;
+            case TypeAttribute::Record: return getType("__numberConstant");
+            case TypeAttribute::ADT: return getType("__numberConstant");
         }
-        fatal("There is no constant record type");
+        fatal("Unhandled type");
     }
 
     bool isPrimitiveType(const QualifiedName& identifier) const {


### PR DESCRIPTION
Hi,
I found two issues related to type printing while using `--debug-report`, both leading Souffle to crash.

First, the target expression of an aggregate can be `null`, thus it should be printed conditionally.

Second, there is a special case of the intrinsics `ord` that takes a record or an ADT as a parameter and that case must be supported in `getConstantType()`.