### PR TITLE
fix a race-condition in ConcurrentFlyweight when the number of lanes is less than the number of threads

### DIFF
--- a/src/tests/flyweight_test.cpp
+++ b/src/tests/flyweight_test.cpp
@@ -29,153 +29,238 @@
 #define RANDOM_TESTS 32
 #define RANDOM_TEST_SIZE 64
 
-// For some reason, just using `assert` doesn't work, even if cassert is
-// included.
-void local_assert(bool cond, std::string msg) {
-    if (!cond) {
-        std::cerr << "Tests failed.\n";
-        std::cerr << msg << "\n";
-        exit(99);
-    }
-}
-
-// The ASSERT_* macros make use of scoping in such a way that they can't be used
-// outside a TEST macro block.
-#define LOCAL_ASSERT_LE(x, y) local_assert(x <= y, #x " <= " #y)
-#define LOCAL_ASSERT_LT(x, y) local_assert(x < y, #x " < " #y)
-#define LOCAL_ASSERT_EQ(x, y) local_assert(x == y, #x " == " #y)
-#define LOCAL_ASSERT_TRUE(x) local_assert(x, #x)
-
 namespace souffle::test {
 
-static char random_char() {
-    static constexpr char charset[] =
-            "0123456789"
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-            "abcdefghijklmnopqrstuvwxyz";
-    static constexpr size_t max_index = sizeof(charset) - 2;
-    std::random_device rd;
-    std::mt19937 mt(rd());
-    std::uniform_int_distribution<std::size_t> dist(0, max_index);
-    return charset[dist(mt)];
-}
+// Base class for Find-Or-Insert-Copy tests.
+class FindOrInsertCopyBase {
+    TestCaseInterface& TestInterface;
 
-static std::string random_string_with_length(std::size_t length) {
-    std::string str(length, 0);
-    std::generate_n(str.begin(), length, random_char);
-    return str;
-}
+    // isolated random generator for a thread
+    struct RandomGenerator {
+        static constexpr char charset[] =
+                "0123456789"
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                "abcdefghijklmnopqrstuvwxyz";
+        static constexpr std::size_t max_index = sizeof(charset) - 2;
 
-static std::string random_string() {
-    // The number 16 was chosen so that the strings are relatively short - both
-    // to be light on CPU/memory, and to make collisions possible.
-    static constexpr std::size_t max_size = 16;
-    std::random_device rd;
-    std::mt19937 mt(rd());
-    std::uniform_int_distribution<std::size_t> dist(0, max_size);
-    return random_string_with_length(dist(mt));
-}
+        // The number 6 was chosen so that the strings are relatively short - both
+        // to be light on CPU/memory, and to make collisions possible.
+        static constexpr std::size_t max_string_len = 6;
 
-static void check_iter_contains(FlyweightImpl<std::string>& flyweight) {
-    for (const auto& it : flyweight) {
-        LOCAL_ASSERT_TRUE(flyweight.weakContains(it.first));
-    }
-}
+        std::mt19937 rand_engine;
+        std::uniform_int_distribution<std::size_t> charset_dist;
+        std::uniform_int_distribution<std::size_t> string_len_dist;
 
-static void check_iter_find(FlyweightImpl<std::string>& flyweight) {
-    for (const auto& it : flyweight) {
-        bool was_new;
-        std::tie(std::ignore, was_new) = flyweight.findOrInsert(it.first);
-        LOCAL_ASSERT_TRUE(!was_new);
-    }
-}
+        RandomGenerator() : charset_dist(0, max_index), string_len_dist(1, max_string_len) {
+            std::random_device rd;
+            rand_engine.seed(rd());
+        }
 
-// Check invariants
-static void check(FlyweightImpl<std::string>& flyweight) {
-    check_iter_contains(flyweight);
-    check_iter_find(flyweight);
-}
+        // return a random alphanum character
+        std::string random_alphanum_string() {
+            const std::size_t len = string_len_dist(rand_engine);
+            std::string str(len, 0);
+            for (std::size_t i = 0; i < len; ++i) {
+                str[i] = charset[charset_dist(rand_engine)];
+            }
 
-// Construct a random flyweight by performing random API operations
-static std::vector<std::pair<FlyweightImpl<std::string>::index_type, std::string>> random_flyweight(
-        FlyweightImpl<std::string>& flyweight, std::size_t min_size, std::size_t max_size) {
-    assert(min_size < max_size);
-    std::vector<std::pair<FlyweightImpl<std::string>::index_type, std::string>> values;
-    std::mutex mu;
-    const auto add_new = [&] {
-        FlyweightImpl<std::string>::index_type key;
-        std::string s = random_string();
-        std::tie(key, std::ignore) = flyweight.findOrInsert(s);
-        LOCAL_ASSERT_TRUE(flyweight.weakContains(s));
-        const std::lock_guard<std::mutex> lock(mu);
-        values.emplace_back(key, s);
+            return str;
+        }
     };
+
+    // random generators for up to 256 threads
+    RandomGenerator rand_generators[256];
+
+public:
+    explicit FindOrInsertCopyBase(TestCaseInterface& Itf) : TestInterface(Itf) {}
+
+    TestCaseInterface& testInterface() {
+        return TestInterface;
+    }
+
+    void parametrizedFindOrInsertCopy(
+            const std::size_t LaneCount, const std::size_t InitialCapacity, std::size_t MaxThreadCount) {
+#ifdef _OPENMP
+        omp_set_num_threads(std::min(MaxThreadCount, (std::size_t)omp_get_max_threads()));
+#else
+        testutil::ignore(MaxThreadCount);
+#endif
+        for (int i = 0; i < RANDOM_TESTS; ++i) {
+            FlyweightImpl<std::string> flyweight{LaneCount, InitialCapacity};
+
+            random_flyweight(flyweight, 0, RANDOM_TEST_SIZE);
+
 #ifdef _OPENMP
 #pragma omp parallel
-    {
-        srand(omp_get_thread_num());
+            {
+                srand(omp_get_thread_num());
 #pragma omp for
 #endif
-        for (std::size_t i = 0; i < max_size; ++i) {
-            if (rand() % 2) {
-                add_new();
-            } else {
-                if (rand() % 2 && values.size() > 0) {
-                    FlyweightImpl<std::string>::index_type key;
-                    std::string val;
-                    {
-                        const std::lock_guard<std::mutex> lock(mu);
-                        std::tie(key, val) = values[rand() % values.size()];
-                    }
-                    LOCAL_ASSERT_EQ(val, flyweight.fetch(key));
-                } else if (values.size() > 0) {
-                    std::string val;
-                    {
-                        const std::lock_guard<std::mutex> lock(mu);
-                        val = values[rand() % values.size()].second;
-                    }
-                    LOCAL_ASSERT_TRUE(flyweight.weakContains(val));
+                for (int j = 0; j < RANDOM_TEST_SIZE; ++j) {
+                    // Guarantee uniqueness by appending something not in the character set
+                    // and then the index.
+                    std::string s = random_alphanum_string() + "~" + std::to_string(j);
+                    FlyweightImpl<std::string>::index_type data1, data2;
+                    bool was_new1, was_new2;
+                    std::tie(data1, was_new1) = flyweight.findOrInsert(s);
+                    std::tie(data2, was_new2) = flyweight.findOrInsert(s);
+                    EXPECT_EQ(data1, data2);
+                    EXPECT_TRUE(was_new1);
+                    EXPECT_FALSE(was_new2);
                 }
-            }
-        }
 #ifdef _OPENMP
-    }
+            }
 #endif
-
-    while (values.size() < min_size) {
-        add_new();
+        }
     }
-    check(flyweight);
-    return values;
-}
 
-TEST(Flyweight, FindOrInsertCopy) {
-    for (int i = 0; i < RANDOM_TESTS; ++i) {
-        FlyweightImpl<std::string> flyweight{8};
-        random_flyweight(flyweight, 0, RANDOM_TEST_SIZE);
+    // Construct a random flyweight by performing random API operations
+    std::vector<std::pair<FlyweightImpl<std::string>::index_type, std::string>> random_flyweight(
+            FlyweightImpl<std::string>& flyweight, std::size_t min_size, std::size_t max_size) {
+        assert(min_size < max_size);
+        std::vector<std::pair<FlyweightImpl<std::string>::index_type, std::string>> values;
+        values.reserve(max_size);
+
+        std::mutex mu;
+        const auto add_new = [&] {
+            FlyweightImpl<std::string>::index_type key;
+            const std::string s = random_alphanum_string();
+            bool inserted;
+            std::tie(key, inserted) = flyweight.findOrInsert(s);
+            EXPECT_TRUE(flyweight.weakContains(s));
+            if (inserted) {
+                const std::lock_guard<std::mutex> lock(mu);
+                values.emplace_back(key, s);
+            }
+        };
 #ifdef _OPENMP
 #pragma omp parallel
         {
             srand(omp_get_thread_num());
 #pragma omp for
 #endif
-            for (int j = 0; j < RANDOM_TEST_SIZE; ++j) {
-                // Guarantee uniqueness by appending something not in the character set
-                // and then the index.
-                std::string s = random_string() + "~" + std::to_string(j);
-                FlyweightImpl<std::string>::index_type data1, data2;
-                bool was_new1, was_new2;
-                std::tie(data1, was_new1) = flyweight.findOrInsert(s);
-                std::tie(data2, was_new2) = flyweight.findOrInsert(std::string(s));
-                EXPECT_EQ(data1, data2);
-                EXPECT_TRUE(was_new1);
-                EXPECT_FALSE(was_new2);
+            for (std::size_t i = 0; i < max_size; ++i) {
+                const auto sel = rand() % 3;
+                if (sel == 0) {
+                    add_new();
+                } else if (sel == 1) {
+                    std::size_t size;
+                    FlyweightImpl<std::string>::index_type expected_idx;
+                    const std::string* expected_val;
+                    {
+                        const std::lock_guard<std::mutex> lock(mu);
+                        size = values.size();
+                        if (size > 0) {
+                            const auto r = rand();
+                            const auto& couple = values[r % size];
+                            expected_idx = couple.first;
+                            expected_val = &couple.second;
+                        }
+                    }
+
+                    if (size > 0) {
+                        const std::string& fetched = flyweight.fetch(expected_idx);
+                        EXPECT_EQ(*expected_val, fetched);
+                    } else {
+                        add_new();
+                    }
+                } else {
+                    const std::string* expected_val;
+                    std::size_t size;
+                    {
+                        const std::lock_guard<std::mutex> lock(mu);
+                        size = values.size();
+                        if (size > 0) {
+                            const auto r = rand();
+                            expected_val = &values[r % size].second;
+                        }
+                    }
+
+                    if (size > 0) {
+                        const bool found = flyweight.weakContains(*expected_val);
+                        EXPECT_TRUE(found);
+                    } else {
+                        add_new();
+                    }
+                }
             }
 #ifdef _OPENMP
         }
 #endif
+
+        while (values.size() < min_size) {
+            add_new();
+        }
+        check(flyweight);
+        return values;
     }
+
+    void check_iter_contains(FlyweightImpl<std::string>& flyweight) {
+        for (const auto& it : flyweight) {
+            EXPECT_TRUE(flyweight.weakContains(it.first));
+        }
+    }
+
+    void check_iter_find(FlyweightImpl<std::string>& flyweight) {
+        for (const auto& it : flyweight) {
+            bool was_new;
+            std::tie(std::ignore, was_new) = flyweight.findOrInsert(it.first);
+            EXPECT_TRUE(!was_new);
+        }
+    }
+
+    // Check invariants
+    void check(FlyweightImpl<std::string>& flyweight) {
+        check_iter_contains(flyweight);
+        check_iter_find(flyweight);
+    }
+
+    std::string random_alphanum_string() {
+        const std::size_t Tid =
+#ifdef _OPENMP
+                static_cast<std::size_t>(omp_get_thread_num());
+#else
+                0;
+#endif
+        return rand_generators[Tid].random_alphanum_string();
+    }
+};
+
+// Test with a single access lane and a single thread
+DERIVED_TEST(Flyweight, FindOrInsertCopy_OneLane_OneThread, FindOrInsertCopyBase) {
+    parametrizedFindOrInsertCopy(1, 1, 1);
 }
+
+// Test with two access lanes and one thread
+DERIVED_TEST(Flyweight, FindOrInsertCopy_TwoLanes_OneThread, FindOrInsertCopyBase) {
+    parametrizedFindOrInsertCopy(2, 1, 1);
+}
+
+#ifdef _OPENMP
+// Test with a single access lane and as many threads
+DERIVED_TEST(Flyweight, FindOrInsertCopy_OneLane_ManyThreads, FindOrInsertCopyBase) {
+    const std::size_t threadCount = static_cast<std::size_t>(omp_get_max_threads());
+    parametrizedFindOrInsertCopy(1, 1, threadCount);
+}
+
+// Test with two access lanes and many threads
+DERIVED_TEST(Flyweight, FindOrInsertCopy_TwoLanes_ManyThreads, FindOrInsertCopyBase) {
+    const std::size_t threadCount = static_cast<std::size_t>(omp_get_max_threads());
+    parametrizedFindOrInsertCopy(2, 1, threadCount);
+}
+
+// Test with one access lane per thread
+DERIVED_TEST(Flyweight, FindOrInsertCopy_OneLanePerThread_ManyThreads, FindOrInsertCopyBase) {
+    const std::size_t threadCount = static_cast<std::size_t>(omp_get_max_threads());
+    parametrizedFindOrInsertCopy(threadCount, 1, threadCount);
+}
+
+// Test with one access lane per thread, high initial capacity that amortizes growing
+DERIVED_TEST(Flyweight, FindOrInsertCopy_OneLanePerThread_ManyThreads_HighCapacity, FindOrInsertCopyBase) {
+    const std::size_t threadCount = static_cast<std::size_t>(omp_get_max_threads());
+    parametrizedFindOrInsertCopy(threadCount, 1UL << 16, threadCount);
+}
+#endif
 
 TEST(Flyweight, IteratorEmptyBeginEnd) {
     FlyweightImpl<std::string> flyweight{1};


### PR DESCRIPTION
Hi,
I found a race condition in the concurrent data-structure used for symbols and records tables. Being the original author of that piece of code, I make my amends.

### When does it happen ?
The race-condition may only happen when the number of threads is greater than the number of configured lanes. **Souffle's engines are safe** because we always configure the number of lanes to be equal to the number of threads. But the `flyweight` test used a fixed 8-lanes configuration, hence the issue can only be exercised when this test runs with >8 threads.

### What is this change ?
This change is the fix. I added some comments. I also re-factored the `flyweight` test with several thread-count/lanes-count configurations to exercise the racing on any multi-threaded run (1 lane / 2+N threads).

### What is the fix ?
**The fix forces a thread to reload the lane's state after it attempted to grow the data-structure**. This is not strictly required if we know that the number of lanes is greater than the number of threads and that each thread is allocated a different lane. That is the case in Souffle engines, that's why this issue is not visible during Souffle's operation.

**I believe the overhead of performing this reload is negligible, because it only happens when the data-structure grows.**

### Details
When a thread in a lane wants to find-or-insert an element in the data-structure, it must get an available *slot* in case the element is absent and insertion is required. If there is no available slot for the lane, the thread must reserve a fresh slot and optionally grow the data-structure accordingly. The fresh slot will either be consumed immediately if insertion is required, or will remain in the lane's state for a future insertion.

The data-race may happen when a thread just reserved a fresh slot index but the data-structure must grow first. The growing operation involves an optional back-off phase where the current thread may have to release the lane to guarantee global progress and avoid mutual interlock. After that back-off, the lane is made available for any thread.

The current thread (T1) may not re-acquire the lane immediately because another thread (T2) is waiting to use the same lane and is scheduled first to acquire it. If that take-over happens, T2 might consume the slot reserved by T1, reset the lane's state and leave. When T1 eventually re-acquires the lane, the slot that it reserved previously cannot be used any more because it was consumed by T2. **The issue was that T1 did not update its view of the lane's state at this point and re-used the already consumed slot**. The correct behavior after T1 tried to grow the data-structure is that T1 must reload the lane's state and repeat the slot reservation process accordingly if needed.


