### PR TITLE
Qualify Path to check_os.sh Script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,7 +339,7 @@ endif()
 # --------------------------------------------------
 # CPack configuration
 # --------------------------------------------------
-execute_process(COMMAND bash "sh/check_os.sh"
+execute_process(COMMAND bash "${CMAKE_SOURCE_DIR}/sh/check_os.sh"
                 RESULT_VARIABLE CHECK_OS_RESULT
                 OUTPUT_VARIABLE CHECK_OS_OUTPUT)
 


### PR DESCRIPTION
Make path to check_os.sh script relative to CMAKE_SOURCE_DIR so it can
be found when cmake is run outside of CMAKE_SOURCE_DIR.