### PR TITLE
Allow user to specify bash-completion install dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,12 +320,16 @@ endif()
 # Installing bash completion file
 # --------------------------------------------------
 IF (SOUFFLE_BASH_COMPLETION) 
-    find_package (bash-completion)
-    if (BASH_COMPLETION_FOUND)
-        message(STATUS "Using bash completion dir ${BASH_COMPLETION_COMPLETIONSDIR}")
+    if(NOT DEFINED BASH_COMPLETION_COMPLETIONSDIR)
+        find_package (bash-completion)
+        if (BASH_COMPLETION_FOUND)
+            message(STATUS "Using bash completion dir ${BASH_COMPLETION_COMPLETIONSDIR}")
+        else()
+            set (BASH_COMPLETION_COMPLETIONSDIR "/etc/bash_completion.d")
+            message (STATUS "Using fallback bash completion dir ${BASH_COMPLETION_COMPLETIONSDIR}")
+        endif()
     else()
-        set (BASH_COMPLETION_COMPLETIONSDIR "/etc/bash_completion.d")
-        message (STATUS "Using fallback bash completion dir ${BASH_COMPLETION_COMPLETIONSDIR}")
+        message(STATUS "Using user-provided bash completion dir ${BASH_COMPLETION_COMPLETIONSDIR}")
     endif()
 
     install(


### PR DESCRIPTION
Before this change, non-root installation with alternative install
prefix would still try to copy bash completion files into root owned
locations such as `/etc/bash_completion.d` (if bash-completion is not
installed) or `/usr/share/bash-completion/completions` (if bash-completion
is installed, could be different depending on distro), which would fail
due to lack of write permission.

The change allows an additional option such as
  `-DBASH_COMPLETION_COMPLETIONSDIR=$HOME/.bash_completion.d`
so that completions can be installed to user-specific completion dir.