### PR TITLE
Fix profiler name

### DIFF
--- a/src/include/souffle/profile/Cli.h
+++ b/src/include/souffle/profile/Cli.h
@@ -54,7 +54,7 @@ public:
 
     void parse() {
         if (args.size() == 0) {
-            std::cout << "No arguments provided.\nTry souffle-profile -h for help.\n";
+            std::cout << "No arguments provided.\nTry souffleprof -h for help.\n";
             exit(EXIT_FAILURE);
         }
 


### PR DESCRIPTION
This is related to issue 
https://github.com/souffle-lang/souffle-lang.github.io/issues/102

The profiler verbose message prints the old name, i.e., `souffle-profiler` instead of `souffleprof`.
