### PR TITLE
Remove Delta SIPs from AST

### DIFF
--- a/src/ast/utility/Utils.cpp
+++ b/src/ast/utility/Utils.cpp
@@ -149,14 +149,6 @@ bool isProposition(const Atom* atom) {
     return atom->getArguments().empty();
 }
 
-bool isDeltaRelation(const QualifiedName& name) {
-    const auto& qualifiers = name.getQualifiers();
-    if (qualifiers.empty()) {
-        return false;
-    }
-    return isPrefix("@delta_", qualifiers[0]);
-}
-
 std::vector<Atom*> reorderAtoms(const std::vector<Atom*>& atoms, const std::vector<unsigned int>& newOrder) {
     // Validate given order
     assert(newOrder.size() == atoms.size());

--- a/src/ast/utility/Utils.h
+++ b/src/ast/utility/Utils.h
@@ -137,12 +137,6 @@ bool isRule(const Clause& clause);
 bool isProposition(const Atom* atom);
 
 /**
- * Returns whether the given atom is a delta relation
- * @return true iff the atom is a delta relation
- */
-bool isDeltaRelation(const QualifiedName& name);
-
-/**
  * Reorders the atoms of a clause to be in the given order.
  * Remaining body literals remain in the same order.
  *


### PR DESCRIPTION
AST still contained utilities for checking delta relation. With the new ast-to-ram translator, delta relations are no further present in AST and hence Delta-SIPS and Delta utilities in AST need to be removed. 

Following SIPS are defunct:
 - max-bound-delta 
 - delta
 - delta-input 

In future, scheduling should be done in RAM (not in AST). 
