### PR TITLE
Renaming  method setBody to setBodyLiterals for Aggregates

### DIFF
--- a/src/ast/Aggregator.cpp
+++ b/src/ast/Aggregator.cpp
@@ -28,7 +28,7 @@ std::vector<Literal*> Aggregator::getBodyLiterals() const {
     return toPtrVector(body);
 }
 
-void Aggregator::setBody(VecOwn<Literal> bodyLiterals) {
+void Aggregator::setBodyLiterals(VecOwn<Literal> bodyLiterals) {
     assert(allValidPtrs(body));
     body = std::move(bodyLiterals);
 }

--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -58,8 +58,8 @@ public:
     /** Return body literals */
     std::vector<Literal*> getBodyLiterals() const;
 
-    /** Set body */
-    void setBody(VecOwn<Literal> bodyLiterals);
+    /** Set body literals */
+    void setBodyLiterals(VecOwn<Literal> bodyLiterals);
 
     void apply(const NodeMapper& map) override;
 

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -52,7 +52,7 @@ public:
     /** Set the head of clause to @p h */
     void setHead(Own<Atom> h);
 
-    /** Set the bodyLiterals of clause to @p body */
+    /** Set the body literals of clause to @p body */
     void setBodyLiterals(VecOwn<Literal> body);
 
     /** Return the atom that represents the head of the clause */

--- a/src/ast/tests/ast_print_test.cpp
+++ b/src/ast/tests/ast_print_test.cpp
@@ -128,7 +128,7 @@ TEST(AstPrint, AggregatorMin) {
     VecOwn<Literal> body;
     body.push_back(mk<Atom>("B"));
 
-    min->setBody(std::move(body));
+    min->setBodyLiterals(std::move(body));
 
     auto tu1 = makeATU();
     auto& prog1 = tu1->getProgram();
@@ -144,7 +144,7 @@ TEST(AstPrint, AggregatorMax) {
 
     VecOwn<Literal> body;
     body.push_back(std::move(atom));
-    max->setBody(std::move(body));
+    max->setBodyLiterals(std::move(body));
 
     auto tu1 = makeATU();
     auto& prog1 = tu1->getProgram();
@@ -160,7 +160,7 @@ TEST(AstPrint, AggregatorCount) {
 
     VecOwn<Literal> body;
     body.push_back(std::move(atom));
-    count->setBody(std::move(body));
+    count->setBodyLiterals(std::move(body));
 
     auto tu1 = makeATU();
     auto& prog1 = tu1->getProgram();
@@ -176,7 +176,7 @@ TEST(AstPrint, AggregatorSum) {
 
     VecOwn<Literal> body;
     body.push_back(std::move(atom));
-    sum->setBody(std::move(body));
+    sum->setBodyLiterals(std::move(body));
 
     auto tu1 = makeATU();
     auto& prog1 = tu1->getProgram();

--- a/src/ast/tests/ast_program_test.cpp
+++ b/src/ast/tests/ast_program_test.cpp
@@ -202,7 +202,7 @@ TEST(Program, RemoveClauseByEquality) {
     auto sum = mk<Aggregator>(AggregateOp::SUM, mk<Variable>("x"));
     VecOwn<Literal> body;
     body.push_back(std::move(atom));
-    sum->setBody(std::move(body));
+    sum->setBodyLiterals(std::move(body));
 
     auto tu1 = makeATU(".decl A,B(x:number) \n A(sum x : B(x)).");
     auto clauses_pre = tu1->getProgram().getClauses();

--- a/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
+++ b/src/ast/transform/AddNullariesToAtomlessAggregates.cpp
@@ -63,7 +63,7 @@ bool AddNullariesToAtomlessAggregatesTransformer::transform(TranslationUnit& tra
             newBody.push_back(clone(lit));
         }
         newBody.push_back(mk<Atom>(relName));
-        agg.setBody(std::move(newBody));
+        agg.setBodyLiterals(std::move(newBody));
     });
     return changed;
 }

--- a/src/ast/transform/InlineRelations.cpp
+++ b/src/ast/transform/InlineRelations.cpp
@@ -567,7 +567,7 @@ NullableVector<Argument*> getInlinedArgument(Program& program, const Argument* a
                     for (Literal* lit : aggr->getBodyLiterals()) {
                         newBody.push_back(clone(lit));
                     }
-                    newAggr->setBody(std::move(newBody));
+                    newAggr->setBodyLiterals(std::move(newBody));
                     versions.push_back(newAggr);
                 }
             }
@@ -610,7 +610,7 @@ NullableVector<Argument*> getInlinedArgument(Program& program, const Argument* a
                             newBody.push_back(Own<Literal>(addedLit));
                         }
 
-                        newAggr->setBody(std::move(newBody));
+                        newAggr->setBodyLiterals(std::move(newBody));
                         aggrVersions.push_back(newAggr);
                     }
 

--- a/src/ast/transform/MaterializeAggregationQueries.cpp
+++ b/src/ast/transform/MaterializeAggregationQueries.cpp
@@ -128,7 +128,7 @@ void MaterializeAggregationQueriesTransformer::groundInjectedParameters(
                         newBody.push_back(mk<Negation>(clone(atom)));
                     }
                 }
-                aggregate->setBody(std::move(newBody));
+                aggregate->setBodyLiterals(std::move(newBody));
             }
             node->apply(*this);
             return node;
@@ -341,7 +341,7 @@ bool MaterializeAggregationQueriesTransformer::materializeAggregationQueries(
 
             VecOwn<Literal> newBody;
             newBody.push_back(std::move(aggAtom));
-            agg.setBody(std::move(newBody));
+            agg.setBodyLiterals(std::move(newBody));
             // Now we can just add these new things (relation and its single clause) to the program
             program.addClause(std::move(aggClause));
             program.addRelation(std::move(aggRel));

--- a/src/ast/transform/RemoveBooleanConstraints.cpp
+++ b/src/ast/transform/RemoveBooleanConstraints.cpp
@@ -96,7 +96,7 @@ bool RemoveBooleanConstraintsTransformer::transform(TranslationUnit& translation
                                 BinaryConstraintOp::EQ, mk<NumericConstant>(0), mk<NumericConstant>(1)));
                     }
 
-                    replacementAggregator->setBody(std::move(newBody));
+                    replacementAggregator->setBodyLiterals(std::move(newBody));
                     return replacementAggregator;
                 }
             }

--- a/src/ast/transform/RemoveRedundantSums.cpp
+++ b/src/ast/transform/RemoveRedundantSums.cpp
@@ -48,7 +48,7 @@ bool RemoveRedundantSumsTransformer::transform(TranslationUnit& translationUnit)
                         for (const auto& lit : agg->getBodyLiterals()) {
                             newBody.push_back(clone(lit));
                         }
-                        count->setBody(std::move(newBody));
+                        count->setBodyLiterals(std::move(newBody));
                         auto number = clone(constant);
                         // Now it's constant * count : { ... }
                         auto result = mk<IntrinsicFunctor>("*", std::move(number), std::move(count));


### PR DESCRIPTION
This refactoring is to make naming consistent (i.e. setBodyLiterals in Clause). 