### PR TITLE
Fix double to int32_t/uint32_t undefined overflow behaviour

### DIFF
--- a/src/interpreter/Engine.cpp
+++ b/src/interpreter/Engine.cpp
@@ -128,10 +128,14 @@ namespace souffle::interpreter {
 #define FFI_RamSigned ffi_type_sint64
 #define FFI_RamUnsigned ffi_type_uint64
 #define FFI_RamFloat ffi_type_double
+#define EXP_RamUnsigned RamUnsigned
+#define EXP_RamSigned RamSigned
 #else
 #define FFI_RamSigned ffi_type_sint32
 #define FFI_RamUnsigned ffi_type_uint32
 #define FFI_RamFloat ffi_type_float
+#define EXP_RamUnsigned int64_t
+#define EXP_RamSigned int64_t
 #endif
 
 #define FFI_Symbol ffi_type_pointer
@@ -551,14 +555,16 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
                     // clang-format on
 
                 case FunctorOp::EXP: {
-                    return std::pow(execute(shadow.getChild(0), ctxt), execute(shadow.getChild(1), ctxt));
+                    return ramBitCast(static_cast<RamSigned>(static_cast<EXP_RamSigned>(
+                            std::pow(execute(shadow.getChild(0), ctxt), execute(shadow.getChild(1), ctxt)))));
                 }
 
                 case FunctorOp::UEXP: {
                     auto first = ramBitCast<RamUnsigned>(execute(shadow.getChild(0), ctxt));
                     auto second = ramBitCast<RamUnsigned>(execute(shadow.getChild(1), ctxt));
                     // Extra casting required: pow returns a floating point.
-                    return ramBitCast(static_cast<RamUnsigned>(std::pow(first, second)));
+                    return ramBitCast(
+                            static_cast<RamUnsigned>(static_cast<EXP_RamUnsigned>(std::pow(first, second))));
                 }
 
                 case FunctorOp::FEXP: {

--- a/src/interpreter/tests/ram_arithmetic_test.cpp
+++ b/src/interpreter/tests/ram_arithmetic_test.cpp
@@ -393,7 +393,7 @@ TEST(Binary, SignedExp) {
         auto arg1 = vecArg1[i];
         auto arg2 = vecArg2[i];
         RamDomain result = evalBinary(functor, arg1, arg2);
-        EXPECT_EQ(result, static_cast<RamDomain>(std::pow(arg1, arg2)));
+        EXPECT_EQ(result, static_cast<RamDomain>(static_cast<int64_t>(std::pow(arg1, arg2))));
     }
 }
 


### PR DESCRIPTION
If Soufflé is in 32-bit mode (which is the default [[1]](https://github.com/souffle-lang/souffle/blob/babc4192ecca04080bf5c01433f982b77065ce19/CMakeLists.txt#L80) [[2]](https://github.com/souffle-lang/souffle/blob/babc4192ecca04080bf5c01433f982b77065ce19/src/include/souffle/RamTypes.h#L40)) then there may be undefined behaviour on exponentials in the interpreter.

The problem is shown by compiling with `clang++` the following minimal example:
```
#include <cmath>
#include <iostream>

int main() {
    uint32_t x = std::pow(2, 32);
    std::cout << x << '\n';
    return 0;
}
```
Where on x86_64 architecture I see the result:
```
0
```
And on aarch64 I see:
```
4294967295
```
There is an overflow when casting the `double` returned by `std::pow` to a `uint32_t`. Actually "6.3.1.4 Real floating and integer" of the C spec defines the above example as having undefined behaviour.

Proposed solution is to match the synthesiser which is mapping to an `int64_t` as an intermediate type ([[3]](https://github.com/souffle-lang/souffle/blob/babc4192ecca04080bf5c01433f982b77065ce19/src/synthesiser/Synthesiser.cpp#L2123) [[4]](https://github.com/souffle-lang/souffle/blob/babc4192ecca04080bf5c01433f982b77065ce19/src/synthesiser/Synthesiser.cpp#L2024)).