### PR TITLE
Parallelise tests into chunks among workers

### DIFF
--- a/.github/actions/cmake-test/action.yml
+++ b/.github/actions/cmake-test/action.yml
@@ -1,0 +1,42 @@
+name: 'cmake-test'
+description: 'CMake and CTest reusable component'
+inputs:
+  cmake-flags:
+    description: 'CMake flags to add to build options'
+    required: true
+  n-chunks:
+    chunk: 'Total number of test chunks'
+    required: true
+  chunk:
+    chunk: 'Chunk index to test'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: setup-env
+      run: |
+        JOBS=$(nproc || sysctl -n hw.ncpu || echo 2)
+        echo "JOBS=${JOBS}" >> $GITHUB_ENV
+        echo "[Debug] Test runner will use ${JOBS} jobs."
+      shell: bash
+
+    - name: setup-domain
+      run: cmake -S . -B build ${{ inputs.cmake-flags }}
+      shell: bash
+
+    - name: make
+      run: cmake --build build -j${JOBS}
+      shell: bash
+
+    - name: ctest
+      run: |
+        TESTS_TO_RUN=$(
+        echo "$(ctest --test-dir build --show-only=json-v1 | jq '.tests | length') ${{ inputs.n-chunks }} ${{ inputs.chunk }}" |
+        sh/chunkify.py
+        )
+        echo "[Debug] Running tests in range ${TESTS_TO_RUN}."
+        ctest --test-dir build -I "${TESTS_TO_RUN}" --output-on-failure --progress -j${JOBS}
+      shell: bash

--- a/.github/actions/set-test-ids/action.yml
+++ b/.github/actions/set-test-ids/action.yml
@@ -1,0 +1,17 @@
+name: 'set-test-ids'
+inputs:
+  n-chunks:
+    description: 'Total number of test chunks'
+    required: true
+outputs:
+  chunks:
+    description: "Test IDs"
+    value: ${{ steps.set-test-ids.outputs.chunks }}
+runs:
+  using: "composite"
+  steps:
+    - id: set-test-ids
+      run: |
+        CHUNKS=$(python3 -c "print(list(range(${{ inputs.n-chunks }})))")
+        echo "::set-output name=chunks::${CHUNKS}"
+      shell: bash

--- a/.github/workflows/CI-Tests.yml
+++ b/.github/workflows/CI-Tests.yml
@@ -17,14 +17,35 @@ jobs:
     - name: clang-format
       run: sh/run_test_format.sh
 
+  Test-Setup:
+    name: Test-Setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        n-chunks: [5]
+    outputs:
+      n-chunks: ${{ matrix.n-chunks }}
+      chunks: ${{ steps.set-test-ids.outputs.chunks }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - id: set-test-ids
+        uses: ./.github/actions/set-test-ids
+        with:
+          n-chunks: ${{ matrix.n-chunks }}
+
   Ubuntu-CMake:
+    needs: Test-Setup
     timeout-minutes: 150
+
+    name: Ubuntu-CMake-${{ matrix.domain }} (chunk ${{ matrix.chunk }})
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         domain: [32bit, 64bit, 64bit-noomp]
+        chunk: ${{ fromJSON(needs.Test-Setup.outputs.chunks) }}
 
     runs-on: ${{ matrix.os }}
 
@@ -32,38 +53,62 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
 
-    - name: setup-env
-      run: |
-        JOBS=$(nproc || sysctl -n hw.ncpu || echo 2)
-        echo "JOBS=${JOBS}" >> $GITHUB_ENV
-        echo "Test runner will use ${JOBS} jobs."
+    - name: install-lcov
+      if: ${{ matrix.domain == '32bit' }}
+      run: sudo apt-get update && sudo apt-get install lcov
 
     - name: install-deps
       run: sudo sh/setup/install_ubuntu_deps.sh
 
-    - name: setup-32bit-domain
+    - name: cmake-test-32bit
       if: ${{ matrix.domain == '32bit' }}
-      run: cmake -S . -B build
+      uses: ./.github/actions/cmake-test
+      with:
+        cmake-flags: -DSOUFFLE_CODE_COVERAGE=ON
+        n-chunks: ${{ needs.Test-Setup.outputs.n-chunks }}
+        chunk: ${{ matrix.chunk }}
 
-    - name: setup-64bit-domain
+    - name: cmake-test-64bit
       if: ${{ matrix.domain == '64bit' }}
-      run: cmake -S . -B build -DSOUFFLE_DOMAIN_64BIT=ON
+      uses: ./.github/actions/cmake-test
+      with:
+        cmake-flags: -DSOUFFLE_DOMAIN_64BIT=ON
+        n-chunks: ${{ needs.Test-Setup.outputs.n-chunks }}
+        chunk: ${{ matrix.chunk }}
 
-    - name: setup-64bit-domain-noomp
+    - name: cmake-test-64bit-noomp
       if: ${{ matrix.domain == '64bit-noomp' }}
-      run: cmake -S . -B build -DSOUFFLE_DOMAIN_64BIT=ON -DSOUFFLE_USE_OPENMP=OFF
+      uses: ./.github/actions/cmake-test
+      with:
+        cmake-flags: -DSOUFFLE_DOMAIN_64BIT=ON -DSOUFFLE_USE_OPENMP=OFF
+        n-chunks: ${{ needs.Test-Setup.outputs.n-chunks }}
+        chunk: ${{ matrix.chunk }}
 
-    - name: make
-      run: cmake --build build -j${JOBS}
+    - name: create-coverage-report
+      if: ${{ matrix.domain == '32bit' }}
+      run: lcov --capture --directory build --output-file coverage.info
 
-    - name: check-interpreter
-      run: cd build && ctest -L "interpreted" --output-on-failure --progress -j${JOBS}
-      
-    - name: check-others
-      run: cd build && ctest -LE "interpreted" --output-on-failure --progress -j${JOBS}
+    - name: remove-system-files-from-coverage-report
+      if: ${{ matrix.domain == '32bit' }}
+      run: lcov --remove coverage.info '/usr/*' --output-file coverage.info
+
+    - name: upload-coverage-artifact
+      if: ${{ matrix.domain == '32bit' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-${{ matrix.domain }}-${{ matrix.chunk }}
+        path: coverage.info
 
   OSX-CMake:
+    needs: Test-Setup
     timeout-minutes: 150
+
+    name: OSX-CMake (chunk ${{ matrix.chunk }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: ${{ fromJSON(needs.Test-Setup.outputs.chunks) }}
 
     runs-on: macos-latest
 
@@ -71,29 +116,26 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
 
-    - name: setup-env
-      run: |
-        JOBS=$(nproc || sysctl -n hw.ncpu || echo 2)
-        echo "JOBS=${JOBS}" >> $GITHUB_ENV
-        echo "Test runner will use ${JOBS} jobs."
-
     - name: install-deps
       run: sh/setup/install_macos_deps.sh
 
-    - name: setup-32bit-domain
-      run: cmake -S . -B build
+    - name: cmake-test-32bit
+      uses: ./.github/actions/cmake-test
+      with:
+        cmake-flags: ''
+        n-chunks: ${{ needs.Test-Setup.outputs.n-chunks }}
+        chunk: ${{ matrix.chunk }}
 
-    - name: make
-      run: cmake --build build -j${JOBS}
-
-    - name: check-interpreter
-      run: cd build && ctest -L "interpreted" --output-on-failure --progress -j${JOBS}
-
-    - name: check-others
-      run: cd build && ctest -LE "interpreted" --output-on-failure --progress -j${JOBS}
-          
   Memory-Check:
+    needs: Test-Setup
     timeout-minutes: 150
+
+    name: Memory-Check (chunk ${{ matrix.chunk }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: ${{ fromJSON(needs.Test-Setup.outputs.chunks) }}
 
     runs-on: ubuntu-latest
 
@@ -101,25 +143,18 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
 
-    - name: setup-env
-      run: |
-        JOBS=$(nproc || sysctl -n hw.ncpu || echo 2)
-        echo "JOBS=${JOBS}" >> $GITHUB_ENV
-        echo "Test runner will use ${JOBS} jobs."
-
     - name: install-deps
       run: sudo sh/setup/install_ubuntu_deps.sh
 
-    - name: setup-with-memory-sanitizer
-      run: cmake -S . -B build -DSOUFFLE_SANITISE_MEMORY=ON -DSOUFFLE_TEST_EVALUATION=OFF
-
-    - name: make
-      run: cmake --build build -j${JOBS}
-
-    - name: check
-      run: cd build && ctest --output-on-failure --progress -j${JOBS}
+    - name: cmake-test-32bit
+      uses: ./.github/actions/cmake-test
+      with:
+        cmake-flags: -DSOUFFLE_SANITISE_MEMORY=ON -DSOUFFLE_TEST_EVALUATION=OFF
+        n-chunks: ${{ needs.Test-Setup.outputs.n-chunks }}
+        chunk: ${{ matrix.chunk }}
 
   Code-Coverage:
+    needs: Ubuntu-CMake
     timeout-minutes: 150
 
     runs-on: ubuntu-latest
@@ -130,32 +165,14 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: setup-env
-      run: |
-        JOBS=$(nproc || sysctl -n hw.ncpu || echo 2)
-        echo "JOBS=${JOBS}" >> $GITHUB_ENV
-        echo "Test runner will use ${JOBS} jobs."
-
     - name: install-lcov
       run: sudo apt-get update && sudo apt-get install lcov
 
-    - name: install-deps
-      run: sudo sh/setup/install_ubuntu_deps.sh
+    - name: download-coverage-artifacts
+      uses: actions/download-artifact@v2
 
-    - name: setup-with-code-coverage-on
-      run: cmake -DSOUFFLE_CODE_COVERAGE=ON -S . -B ./build
-
-    - name: make
-      run: cmake --build build -j${JOBS}
-
-    - name: check
-      run: cd build && ctest --output-on-failure --progress -j${JOBS}
-
-    - name: create-coverage-report
-      run: lcov --capture --directory . --output-file coverage.info
-
-    - name: remove-system-files-from-coverage-report
-      run: lcov --remove coverage.info '/usr/*' --output-file coverage.info
+    - name: merge-coverage-report
+      run: lcov $(for i in coverage-*-*/coverage.info; do echo -a $i; done) --output-file coverage.info
 
     - name: upload-coverage-report
       uses: codecov/codecov-action@v2

--- a/sh/chunkify.py
+++ b/sh/chunkify.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+"""Helper for GitHub Actions."""
+
+n_tests, n_chunks, chunk_id = map(int, input().split())
+d, m = divmod(n_tests, n_chunks)
+print(f"{chunk_id * d + min(m, chunk_id) + 1},{(chunk_id+1) * d + min(m, chunk_id+1)}")


### PR DESCRIPTION
To improve the code-test-PR cycle further after #2129, I have a proposal we can split the 3154 current tests between distributed workers up to the [free limits](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration) allowed by GitHub Actions.

In my experiments it halved the runtime of the CI tests again to <30 minutes (e.g. [1h 1m 19s](https://github.com/souffle-lang/souffle/actions/runs/1700956085) before decreased to [25m 42s](https://github.com/broffra/souffle/actions/runs/1705398971) with the PR).

This will help with development, i.e. being able to work on multiple branches at once and utilise GitHub Actions to test your PR draft with quick feedback without having to use your local or remote machine to run all tests.

The proposal uses 5 workers per build (since each worker has 2 threads, 10 tests can execute in parallel). For example each worker will get tests in its respective range:
1. worker 1 -> tests `1,631` (630 tests)
1. worker 2 -> tests `632,1262` (630 tests)
1. worker 3 -> tests `1263,1893` (630 tests)
1. worker 4 -> tests `1894,2524` (630 tests)
1. worker 5 -> tests `2525,3154` (629 tests)

Then (for the 32-bit build only) each worker will uploads its individual coverage report as an artifact. The artifacts will be combined into a final coverage report and uploaded by a separate job.

A note: The memory checker now is the bottleneck (regular test cycle is finished in <20 minutes), but we likely won't see further benefits from parallelising it further since most of the additional time is spent during the build phase, which is required for each worker.

This was inspired by the following blog post: https://imhoff.blog/posts/parallelizing-jest-with-github-actions