### PR TITLE
Do not print newline after functor declaration

### DIFF
--- a/src/ast/FunctorDeclaration.cpp
+++ b/src/ast/FunctorDeclaration.cpp
@@ -36,7 +36,6 @@ void FunctorDeclaration::print(std::ostream& out) const {
     if (stateful) {
         out << " stateful";
     }
-    out << std::endl;
 }
 
 bool FunctorDeclaration::equal(const Node& node) const {


### PR DESCRIPTION
For other declarations, e.g. relations or types, we don't print newlines, so we probably also don't want it for functors.