### PR TITLE
fix missing header in synthesized profiled program

### DIFF
--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -2424,6 +2424,7 @@ void Synthesiser::generateCode(std::ostream& sos, const std::string& id, bool& w
     }
 
     if (Global::config().has("profile") || Global::config().has("live-profile")) {
+        os << "#include \"souffle/profile/Logger.h\"";
         os << "#include \"souffle/profile/ProfileEvent.h\"";
     }
 


### PR DESCRIPTION
`Logger.h` was missing in synthesized profiled programs.

The current tests in `tests/profile` only check interpreted profiled program, hence missing this issue introduced by https://github.com/souffle-lang/souffle/commit/81b9cf2bc7564fbb56542f57dfb55fa1c181ca01

The only test that capture the issue is `tests/example/profile_default` but examples are not run as part of the continuous integration. Should they ?  