### PR TITLE
fix souffle-compile argument parsing

### DIFF
--- a/src/souffle-compile.in
+++ b/src/souffle-compile.in
@@ -116,12 +116,12 @@ done
 shift $((OPTIND - 1))
 
 # Show usage if no input is given
-test -n "$1" && error "no input file" $? 1 || true
+test -n "$1" || error "no input file" $? 1 || true
 # Check if the input file exists
-test -f "$1" && error "cannot open source file: '$1'" $? 1 || true
+test -f "$1" || error "cannot open source file: '$1'" $? 1 || true
 # Check if the input file has a valid extension
 exe=$(basename "$1" .cpp)
-test "$1" != "$exe" && error "source file is not a .cpp file: '$1'" $? 1 || true
+test "$1" != "$exe" || error "source file is not a .cpp file: '$1'" $? 1 || true
 
 # Ensure binary is compiled to same directory as cpp file
 cd "$(dirname "$1")"


### PR DESCRIPTION
It appears the `souffle-compile` executable/script behaves incorrectly on missing and/or invalid file CLI arguments.


E.g., after executing the following:
```
$ touch foo.java
$ souffle-compile foo.java
```
there is no `foo.java`, as the second line deletes the file created by the first. Similarly, not providing an argument or providing an argument with no corresponding file does not error in the expected way.

This PR I believes remedies these issues. (At least in some simple hand tests these changes cause the expected error messages to be raised describing what went wrong.)

