### PR TITLE
enable sqlite3 URI filename capabilty

### DIFF
--- a/src/include/souffle/io/ReadStreamSQLite.h
+++ b/src/include/souffle/io/ReadStreamSQLite.h
@@ -127,7 +127,7 @@ protected:
     }
 
     void openDB() {
-        sqlite3_config(SQLITE_CONFIG_URI,1);
+        sqlite3_config(SQLITE_CONFIG_URI, 1);
         if (sqlite3_open(dbFilename.c_str(), &db) != SQLITE_OK) {
             throwError("SQLite error in sqlite3_open: ");
         }

--- a/src/include/souffle/io/ReadStreamSQLite.h
+++ b/src/include/souffle/io/ReadStreamSQLite.h
@@ -127,6 +127,7 @@ protected:
     }
 
     void openDB() {
+        sqlite3_config(SQLITE_CONFIG_URI,1);
         if (sqlite3_open(dbFilename.c_str(), &db) != SQLITE_OK) {
             throwError("SQLite error in sqlite3_open: ");
         }

--- a/src/include/souffle/io/WriteStreamSQLite.h
+++ b/src/include/souffle/io/WriteStreamSQLite.h
@@ -140,7 +140,7 @@ private:
     }
 
     void openDB() {
-        sqlite3_config(SQLITE_CONFIG_URI,1);
+        sqlite3_config(SQLITE_CONFIG_URI, 1);
         if (sqlite3_open(dbFilename.c_str(), &db) != SQLITE_OK) {
             throwError("SQLite error in sqlite3_open: ");
         }

--- a/src/include/souffle/io/WriteStreamSQLite.h
+++ b/src/include/souffle/io/WriteStreamSQLite.h
@@ -140,8 +140,9 @@ private:
     }
 
     void openDB() {
+        sqlite3_config(SQLITE_CONFIG_URI,1);
         if (sqlite3_open(dbFilename.c_str(), &db) != SQLITE_OK) {
-            throwError("SQLite error in sqlite3_open");
+            throwError("SQLite error in sqlite3_open: ");
         }
         sqlite3_extended_result_codes(db, 1);
         executeSQL("PRAGMA synchronous = OFF", db);


### PR DESCRIPTION
Hello,
Test `semantic/store3` recently modified by #2177 was failing with my Linux distribution (Fedora).

The sqlite3 URI filename capability is not always enabled by default, depending on the build options of sqlite3. This change enables the capability before opening a database.

Also fix minor error message typo.