### PR TITLE
Fix -Wparentheses warning in synthesized C++ code

### DIFF
--- a/src/synthesiser/Relation.cpp
+++ b/src/synthesiser/Relation.cpp
@@ -268,10 +268,10 @@ void DirectRelation::generateTypeStruct(std::ostream& out) {
 
                 out << "(" << typecast << "(a[" << attrib << "]) < " << typecast << "(b[" << attrib << "]))";
                 if (i + 1 < bound) {
-                    out << "|| (" << typecast << "(a[" << attrib << "]) == " << typecast << "(b[" << attrib
+                    out << "|| ((" << typecast << "(a[" << attrib << "]) == " << typecast << "(b[" << attrib
                         << "])) && (";
                     genless(i + 1);
-                    out << ")";
+                    out << "))";
                 }
             };
             genless(0);
@@ -648,10 +648,10 @@ void IndirectRelation::generateTypeStruct(std::ostream& out) {
             const auto& typecast = typecasts[attrib];
             out << typecast << " ((*a)[" << attrib << "]) < " << typecast << "((*b)[" << attrib << "])";
             if (i + 1 < ind.size()) {
-                out << "|| (" << typecast << "((*a)[" << attrib << "]) == " << typecast << "((*b)[" << attrib
+                out << "|| ((" << typecast << "((*a)[" << attrib << "]) == " << typecast << "((*b)[" << attrib
                     << "]) && (";
                 genless(i + 1);
-                out << "))";
+                out << ")))";
             }
         };
         genless(0);


### PR DESCRIPTION
Resolves #2194. I compiled souffle twice, and ran `souffle -g path.{cpp,dl}` before and after on the following Datalog snippet:

```datalog
.decl edge(x: symbol, y: symbol)
.decl reachable(x: symbol, y: symbol)

.input edge
.output reachable

reachable(x, y) :-
  edge(x, y).

reachable(x, y) :-
  edge(x, z),
  reachable(z, y).
```

And then `diff` shows the following:

```bash
$ diff path.cpp.old path.cpp.new
17c17
<   return (ramBitCast<RamSigned>(a[0]) < ramBitCast<RamSigned>(b[0]))|| (ramBitCast<RamSigned>(a[0]) == ramBitCast<RamSigned>(b[0])) && ((ramBitCast<RamSigned>(a[1]) < ramBitCast<RamSigned>(b[1])));
---
>   return (ramBitCast<RamSigned>(a[0]) < ramBitCast<RamSigned>(b[0]))|| ((ramBitCast<RamSigned>(a[0]) == ramBitCast<RamSigned>(b[0])) && ((ramBitCast<RamSigned>(a[1]) < ramBitCast<RamSigned>(b[1]))));
120c120
<   return (ramBitCast<RamSigned>(a[0]) < ramBitCast<RamSigned>(b[0]))|| (ramBitCast<RamSigned>(a[0]) == ramBitCast<RamSigned>(b[0])) && ((ramBitCast<RamSigned>(a[1]) < ramBitCast<RamSigned>(b[1])));
---
>   return (ramBitCast<RamSigned>(a[0]) < ramBitCast<RamSigned>(b[0]))|| ((ramBitCast<RamSigned>(a[0]) == ramBitCast<RamSigned>(b[0])) && ((ramBitCast<RamSigned>(a[1]) < ramBitCast<RamSigned>(b[1]))));
```