### PR TITLE
emit missing '\n' in cpp includes

### DIFF
--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -2424,8 +2424,8 @@ void Synthesiser::generateCode(std::ostream& sos, const std::string& id, bool& w
     }
 
     if (Global::config().has("profile") || Global::config().has("live-profile")) {
-        os << "#include \"souffle/profile/Logger.h\"";
-        os << "#include \"souffle/profile/ProfileEvent.h\"";
+        os << "#include \"souffle/profile/Logger.h\"\n";
+        os << "#include \"souffle/profile/ProfileEvent.h\"\n";
     }
 
     os << "\n";


### PR DESCRIPTION
Without the added newlines this generates C++
which does not always compile, e.g.
```
compiler error: cannot compile source file "./soufflepxyz.cpp"
./soufflepxyz.cpp:4:36: warning: extra tokens at end of #include directive [-Wextra-tokens]
#include "souffle/profile/Logger.h"#include "souffle/profile/ProfileEvent.h"
                                   ^
```