### PR TITLE
cleanup Windows CI trigger

### DIFF
--- a/.github/workflows/VS-CI-Tests.yml
+++ b/.github/workflows/VS-CI-Tests.yml
@@ -1,10 +1,6 @@
 name: VS-CI-Tests
 
 on:
-  # TODO remove me before merge
-  push:
-    branches:
-      - '**'
   pull_request:
     types: [opened, synchronize]
   workflow_dispatch:


### PR DESCRIPTION
Removes the trigger on every push of every branches, was only necessary during dev.