### PR TITLE
Fix#2223

### DIFF
--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -2311,7 +2311,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
             auto args = op.getArguments();
             if (op.isStateful()) {
-                out << name << "(&symTable, &recordTable";
+                out << "functors::" << name << "(&symTable, &recordTable";
                 for (auto& arg : args) {
                     out << ",";
                     dispatch(*arg, out);
@@ -2323,7 +2323,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
                 if (op.getReturnType() == TypeAttribute::Symbol) {
                     out << "symTable.encode(";
                 }
-                out << name << "(";
+                out << "functors::" << name << "(";
 
                 for (std::size_t i = 0; i < args.size(); i++) {
                     if (i > 0) {
@@ -2524,7 +2524,7 @@ void Synthesiser::generateCode(std::ostream& sos, const std::string& id, bool& w
         }
         withSharedLibrary = true;
     });
-    os << "extern \"C\" {\n";
+    os << "namespace functors {\n extern \"C\" {\n";
     for (const auto& f : functors) {
         //        std::size_t arity = f.second.length() - 1;
         const std::string& name = f.first;
@@ -2558,7 +2558,7 @@ void Synthesiser::generateCode(std::ostream& sos, const std::string& id, bool& w
                     join(map(argsTypes, cppTypeDecl), ","));
         }
     }
-    os << "}\n";
+    os << "}\n}\n";
     os << "\n";
     os << "namespace souffle {\n";
     os << "static const RamDomain RAM_BIT_SHIFT_MASK = RAM_DOMAIN_SIZE - 1;\n";


### PR DESCRIPTION
The C++ generated code of a Souffle program with functors is put into the namespace souffle::functors to avoid name clashes with the Souffle system. No changes are needed in the functor libraries because the function names are defined as external "C" functions, and hence their symbols do not carry their namespace. 
https://stackoverflow.com/questions/28996944/extern-c-linkage-inside-c-namespace