### PR TITLE
Fix segfault in ~ProfileEventSingleton

### DIFF
--- a/src/include/souffle/profile/ProfileEvent.h
+++ b/src/include/souffle/profile/ProfileEvent.h
@@ -51,7 +51,7 @@ class ProfileEventSingleton {
 public:
     ~ProfileEventSingleton() {
         stopTimer();
-        ProfileEventSingleton::instance().dump();
+        dump();
     }
 
     /** get instance */


### PR DESCRIPTION
Fixes #2217. There's no need to call `::instance`, this destructor is already running on the singleton instance.