### PR TITLE
Iterate over delta first when deleting for subsumption

### DIFF
--- a/src/ast2ram/seminaive/ClauseTranslator.cpp
+++ b/src/ast2ram/seminaive/ClauseTranslator.cpp
@@ -150,8 +150,11 @@ std::string ClauseTranslator::getClauseAtomName(const ast::Clause& clause, const
         }
 
         if (dominatedHeadAtom == atom) {
-            if (mode == SubsumeDeleteCurrentDelta || mode == SubsumeDeleteCurrentCurrent) {
+            if (mode == SubsumeDeleteCurrentCurrent) {
                 return getConcreteRelationName(atom->getQualifiedName());
+            }
+            if (mode == SubsumeDeleteCurrentDelta) {
+                return getDeltaRelationName(atom->getQualifiedName());
             }
             return getNewRelationName(atom->getQualifiedName());
         }
@@ -159,8 +162,8 @@ std::string ClauseTranslator::getClauseAtomName(const ast::Clause& clause, const
         if (dominatingHeadAtom == atom) {
             switch (mode) {
                 case SubsumeRejectNewCurrent:
-                case SubsumeDeleteCurrentCurrent: return getConcreteRelationName(atom->getQualifiedName());
-                case SubsumeDeleteCurrentDelta: return getDeltaRelationName(atom->getQualifiedName());
+                case SubsumeDeleteCurrentCurrent:
+                case SubsumeDeleteCurrentDelta: return getConcreteRelationName(atom->getQualifiedName());
                 default: return getNewRelationName(atom->getQualifiedName());
             }
         }


### PR DESCRIPTION
Fixes #2232. This should be faster, assuming that the delta is usually smaller than the whole relation.

On this program:
```
.decl r(n: number, m: number)
r(0, 0).
r(n+1, n+1) :- r(n, n), n < 10.
r(m, n) <=
  r(n, p) :-
    n < p.
.output r(IO=stdout)
```
Here's the "before":
```
    QUERY
     IF ((NOT ISEMPTY(r)) AND (NOT ISEMPTY(@delta_r)))
      FOR t0 IN r
       IF EXISTS t1 IN @delta_r ON INDEX t1.0 = t0.1 AND t0.1 <= t1.1 WHERE (t0.1 != t1.1)
        INSERT (t0.0, t0.1) INTO @delete_r
    END QUERY
```
and the "after":
```
    QUERY
     IF ((NOT ISEMPTY(@delta_r)) AND (NOT ISEMPTY(r)))
      FOR t0 IN @delta_r
       IF EXISTS t1 IN r ON INDEX t1.0 = t0.1 AND t0.1 <= t1.1 WHERE (t0.1 != t1.1)
        INSERT (t0.0, t0.1) INTO @delete_r
    END QUERY
```