### PR TITLE
Not adding -g flag when compiled with NDEBUG

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,11 +174,6 @@ void compileToBinary(const std::string& command, std::string_view sourceFilename
 
     argv.push_back(command);
 
-#ifndef NDEBUG
-    // compile with debug
-    argv.push_back("-g");
-#endif
-
     if (Global::config().has("swig")) {
         argv.push_back("-s");
         argv.push_back(Global::config().get("swig"));


### PR DESCRIPTION
We have `NDEBUG = off` by default and it allows only a few asserts in the program.
Since #2098, `-g` is added automatically if `NDEBUG` is off.
If the user compiled Souffle with the default option, using `-c` flag willl always results in the target binary being compiled with `-g -O0`. 
I think this behaviour is probably counter-intuitive (unexpected performance regression) and probably not what `NDEBUG` was intended for.


This PR removes this behaviour. Users that want the debug option should compile the datalog program using `souffle-compile.py` and pass the flag explicitly. 

 