### PR TITLE
update to vcpkg 2022.03.10

### DIFF
--- a/.github/workflows/VS-CI-Tests.yml
+++ b/.github/workflows/VS-CI-Tests.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Library Dependencies (vcpkg)
       uses: lukka/run-vcpkg@v7
       with:
-        vcpkgGitCommitId: '3a28333d605f92f8659f3af1137324b2d9886101'
+        vcpkgGitCommitId: 'af2287382b1991dbdcb7e5112d236f3323b9dd7a'
         vcpkgTriplet: x64-windows
         vcpkgArguments: 'sqlite3 zlib libffi'
 


### PR DESCRIPTION
Update the version of vcpkg to see if that fixes the issue with packages not being downloaded during CI.

But I think there is currently a general issue on Github Action servers because even Ubuntu dependencies cannot be downloaded:
https://github.com/quentin/souffle/runs/5749296018?check_suite_focus=true
