### PR TITLE
Fixed auto-scheduler for recursive rules using Selinger w/ vector

### DIFF
--- a/src/ast/analysis/ProfileUse.cpp
+++ b/src/ast/analysis/ProfileUse.cpp
@@ -70,9 +70,12 @@ std::size_t ProfileUseAnalysis::getNonRecursiveUniqueKeys(
     return reader->getNonRecursiveCountUniqueKeys(rel, attributes, constants);
 }
 
-std::size_t ProfileUseAnalysis::getRecursiveUniqueKeys(
-        const std::string& rel, const std::string& attributes, const std::string& constants) const {
-    return reader->getRecursiveCountUniqueKeys(rel, attributes, constants);
+std::size_t ProfileUseAnalysis::getRecursiveUniqueKeys(const std::string& rel, const std::string& attributes,
+        const std::string& constants, const std::string& iteration) const {
+    return reader->getRecursiveCountUniqueKeys(rel, attributes, constants, iteration);
 }
 
+std::size_t ProfileUseAnalysis::getIterations(const std::string& rel) const {
+    return reader->getIterations(rel);
+}
 }  // namespace souffle::ast::analysis

--- a/src/ast/analysis/ProfileUse.h
+++ b/src/ast/analysis/ProfileUse.h
@@ -59,8 +59,10 @@ public:
     std::size_t getNonRecursiveUniqueKeys(
             const std::string& rel, const std::string& attributes, const std::string& constants) const;
 
-    std::size_t getRecursiveUniqueKeys(
-            const std::string& rel, const std::string& attributes, const std::string& constants) const;
+    std::size_t getRecursiveUniqueKeys(const std::string& rel, const std::string& attributes,
+            const std::string& constants, const std::string& iteration) const;
+
+    std::size_t getIterations(const std::string& rel) const;
 
 private:
     /** performance model of profile run */

--- a/src/ast/utility/SipsMetric.h
+++ b/src/ast/utility/SipsMetric.h
@@ -74,12 +74,9 @@ public:
 private:
     /* helper struct for Selinger */
     struct PlanTuplesCost {
-        PlanTuplesCost(const std::vector<std::size_t>& givenPlan, std::size_t givenTuples, double givenCost)
-                : plan(givenPlan), tuples(givenTuples), cost(givenCost) {}
-
         std::vector<std::size_t> plan;
-        std::size_t tuples;
-        double cost;
+        std::vector<std::size_t> tuplesPerIteration;
+        std::vector<double> costsPerIteration;
     };
 
     const PowerSet& getSubsets(std::size_t N, std::size_t K) const;

--- a/src/include/souffle/profile/Reader.h
+++ b/src/include/souffle/profile/Reader.h
@@ -428,16 +428,22 @@ public:
         return countNonRecursiveUniqueKeysMap.at(key);
     }
 
-    std::size_t getRecursiveCountUniqueKeys(
-            const std::string& rel, const std::string& attributes, const std::string& constants) {
+    std::size_t getIterations(const std::string& rel) {
+        for (auto& [key, m] : countRecursiveUniqueKeysMap) {
+            std::string token = key.substr(0, key.find(" "));
+            if (token == rel) {
+                return m.size();
+            }
+        }
+        assert(false);
+        return 0;
+    }
+
+    std::size_t getRecursiveCountUniqueKeys(const std::string& rel, const std::string& attributes,
+            const std::string& constants, const std::string& iteration) {
         auto key = rel + " " + attributes + " " + constants;
         auto& m = countRecursiveUniqueKeysMap.at(key);
-        double total = 0.0;
-        for (auto [_, count] : m) {
-            total += count;
-        }
-        double average = ceil(total / m.size());
-        return static_cast<std::size_t>(average);
+        return static_cast<std::size_t>(m.at(iteration));
     }
 
     void addRelation(const DirectoryEntry& relation) {


### PR DESCRIPTION
Before we used a heuristic of the average size of a recursive relation across iterations (say for delta relations).

Now we replace this by propagating a vector of costs/tuples throughout Selinger's algorithm.

This gets us the cost-optimal schedule for recursive rules.