### PR TITLE
Fix arch build

### DIFF
--- a/.github/images/arch-linux/entrypoint.sh
+++ b/.github/images/arch-linux/entrypoint.sh
@@ -3,6 +3,6 @@
 set -e
 set -x
 
-envsubst '${RELEASE_TAG}' < PKGBUILD.in  > PKGBUILD
+envsubst '${RELEASE_TAG},${REPO_OWNER}' < PKGBUILD.in  > PKGBUILD
 makepkg
 makepkg --printsrcinfo > .SRCINFO


### PR DESCRIPTION
See: https://aur.archlinux.org/packages/souffle
> ring0calorie commented on [2022-05-15 14:17 (UTC)](https://aur.archlinux.org/packages/souffle#comment-865129)
> Broken PKGBUILD at line 24, ${REPO_OWNER} is never set, so the path that is being contacted is: https://github.com//souffle/archive/2.3.tar.gz

I've manually fixed the issue in the package repo. This pr fixes the env script.