### PR TITLE
Add missing override keyword

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -303,7 +303,7 @@ public:
         return Stream;
     }
 
-    bool endInput() {
+    bool endInput() override {
         const int Status = pclose(Stream);
         Stream = nullptr;
         if (Status == -1) {


### PR DESCRIPTION
This fixes an error I'm seeing when building souffle-haskell for OSX.

```
       > /tmp/nix-build-souffle-2.3.drv-0/source/src/main.cpp:306:10: error: 'endInput' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
       >     bool endInput() {
       >          ^
       > /tmp/nix-build-souffle-2.3.drv-0/source/src/main.cpp:213:18: note: overridden virtual function is here
       >     virtual bool endInput() = 0;
       >                  ^
       > 1 error generated.
       > ninja: build stopped: subcommand failed.
```