### PR TITLE
fixes for the debug report

### DIFF
--- a/src/include/souffle/utility/FileUtil.h
+++ b/src/include/souffle/utility/FileUtil.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <climits>
 #include <cstdio>
 #include <cstdlib>
@@ -322,19 +323,20 @@ inline std::string tempFile() {
 }
 
 inline std::stringstream execStdOut(char const* cmd) {
-    FILE* in = popen(cmd, "r");
     std::stringstream data;
+    std::shared_ptr<FILE> command_pipe(popen(cmd, "r"), pclose);
 
-    if (in == nullptr) {
+    if (command_pipe.get() == nullptr) {
         return data;
     }
 
-    while (!feof(in)) {
-        int c = fgetc(in);
-        data << static_cast<char>(c);
+    std::array<char, 256> buffer;
+    while (!feof(command_pipe.get())) {
+        if (fgets(buffer.data(), 256, command_pipe.get()) != nullptr) {
+            data << buffer.data();
+        }
     }
 
-    pclose(in);
     return data;
 }
 

--- a/src/ram/StringConstant.h
+++ b/src/ram/StringConstant.h
@@ -44,7 +44,7 @@ public:
 
 protected:
     void print(std::ostream& os) const override {
-        os << "string(\"" << stringify(constant) << "\")";
+        os << "STRING(\"" << stringify(constant) << "\")";
     }
 
     bool equal(const Node& node) const override {


### PR DESCRIPTION
- Fix bad characters in diffs (EOF character was copied).
- Fix syntax highlighting of souffle diffs.
- Add syntax highlighting of souffle RAM diffs.

There is still the issue of graphs being printed as text instead of svg figures since #2092, because the code calls:
https://github.com/souffle-lang/souffle/blob/4a1393f0171ae91c4b9955b1876b3ed850148fa0/src/ast/analysis/PrecedenceGraph.cpp#L77
Instead of:
https://github.com/souffle-lang/souffle/blob/4a1393f0171ae91c4b9955b1876b3ed850148fa0/src/ast/analysis/PrecedenceGraph.cpp#L83