### PR TITLE
Purge intermediate relations, but not input/output

### DIFF
--- a/src/synthesiser/Synthesiser.h
+++ b/src/synthesiser/Synthesiser.h
@@ -81,6 +81,12 @@ private:
     /** signatures of the user-defined functors */
     std::map<std::string, std::pair<std::vector<std::string>, std::string>> functor_signatures;
 
+    /** Input relations */
+    std::set<std::string> loadRelations;
+
+    /** Output relations */
+    std::set<std::string> storeRelations;
+
 protected:
     /** Convert RAM identifier */
     const std::string convertRamIdent(const std::string& name);

--- a/tests/interface/insert_print/driver.cpp
+++ b/tests/interface/insert_print/driver.cpp
@@ -46,7 +46,7 @@ int main(int /* argc */, char** /* argv */) {
             }
 
             // run program
-            prog->run();
+            prog->runAll("", "", false, true);
 
             // print all relations to CSV files in current directory
             // NB: Defaul is current directory


### PR DESCRIPTION
In #2066, a new option was added to the C++ interface to allow purging intermediate relations. However, the current implementation purges input and output relations, which makes it impractical to use with `performIO` disabled (since the output relations would be purged before there is an opportunity for user code to read the output relation). By excluding input and output relations from those that are purged, the C++ interface can be used with `pruneImdtRels` enabled but `performIO` disabled.