### PR TITLE
Differentiate execution plan checker messages

### DIFF
--- a/src/ast/transform/ExecutionPlanChecker.cpp
+++ b/src/ast/transform/ExecutionPlanChecker.cpp
@@ -74,8 +74,14 @@ bool ExecutionPlanChecker::transform(TranslationUnit& translationUnit) {
                         }
                     }
                     auto numAtoms = getBodyLiterals<Atom>(*clause).size();
-                    if (order.size() != numAtoms || !isComplete) {
-                        report.addError("Invalid execution order in plan", cur.second->getSrcLoc());
+                    if (order.size() != numAtoms) {
+                        report.addError("Invalid execution order in plan (expected " +
+                                                std::to_string(numAtoms) + " atoms, not " +
+                                                std::to_string(order.size()) + ")",
+                                cur.second->getSrcLoc());
+                    } else if (!isComplete) {
+                        report.addError(
+                                "Invalid execution order in plan (incomplete)", cur.second->getSrcLoc());
                     }
                 }
 

--- a/tests/semantic/execution_plan/execution_plan.err
+++ b/tests/semantic/execution_plan/execution_plan.err
@@ -2,13 +2,13 @@ Error: execution plan for version 3 in file execution_plan.dl at line 21
         .plan 1: (1,2,3), 2: (3,2,1), 3: (2,3,1)
 -----------------------------------------^-------
 only versions 0..2 permitted
-Error: Invalid execution order in plan in file execution_plan.dl at line 25
+Error: Invalid execution order in plan (incomplete) in file execution_plan.dl at line 25
         .plan 0: (1,2,2), 1: (3,2), 2: (2,3,1,3)
 -----------------^-------------------------------
-Error: Invalid execution order in plan in file execution_plan.dl at line 25
+Error: Invalid execution order in plan (expected 3 atoms, not 2) in file execution_plan.dl at line 25
         .plan 0: (1,2,2), 1: (3,2), 2: (2,3,1,3)
 -----------------------------^-------------------
-Error: Invalid execution order in plan in file execution_plan.dl at line 25
+Error: Invalid execution order in plan (expected 3 atoms, not 4) in file execution_plan.dl at line 25
         .plan 0: (1,2,2), 1: (3,2), 2: (2,3,1,3)
 ---------------------------------------^---------
 4 errors generated, evaluation aborted

--- a/tests/semantic/plan1/plan1.err
+++ b/tests/semantic/plan1/plan1.err
@@ -1,4 +1,4 @@
-Error: Invalid execution order in plan in file plan1.dl at line 15
+Error: Invalid execution order in plan (incomplete) in file plan1.dl at line 15
 A(v1,v4) :- B(v1,v2), v1 < v2, C(v2,v3), D(v3,v4), !E(v1,v4). .plan 0:(1,2,4)
 ----------------------------------------------------------------------^-------
 1 errors generated, evaluation aborted


### PR DESCRIPTION
It can be difficult to identify the exact issue that makes an execution
plan invalid, especially with complex rules with inlined relations, for
example.

This change differentiates messages for different cases of invalid
execution plans, which makes it a bit easier for a user to identify the
issue.