### PR TITLE
Emit errors for ignored execution plan

### DIFF
--- a/src/ast/transform/ExecutionPlanChecker.cpp
+++ b/src/ast/transform/ExecutionPlanChecker.cpp
@@ -47,14 +47,17 @@ bool ExecutionPlanChecker::transform(TranslationUnit& translationUnit) {
         for (const Relation* rel : scc) {
             for (auto&& clause : program.getClauses(*rel)) {
                 if (!recursiveClauses.recursive(clause)) {
+                    if (clause->getExecutionPlan() != nullptr) {
+                        auto order = clause->getExecutionPlan()->getOrders().begin()->second;
+                        report.addError(
+                                "Ignored execution plan for non-recursive clause", order->getSrcLoc());
+                    }
                     continue;
                 }
                 if (clause->getExecutionPlan() == nullptr) {
                     continue;
                 }
-                if (isA<SubsumptiveClause>(clause)) {
-                    continue;
-                }
+
                 std::size_t version = 0;
                 for (const auto* atom : getBodyLiterals<Atom>(*clause)) {
                     if (scc.count(program.getRelation(*atom)) != 0u) {

--- a/tests/semantic/execution_plan/execution_plan.dl
+++ b/tests/semantic/execution_plan/execution_plan.dl
@@ -23,3 +23,28 @@ r3(a,d) :- r3(a,b),r3(b,c),r3(c,d).
 // this one is not
 r4(a,d) :- r4(a,b),r4(b,c),r4(c,d).
         .plan 0: (1,2,2), 1: (3,2), 2: (2,3,1,3)
+
+.decl y(a:S)
+.output y
+
+y(a) :- r1(a,_), r2(a,_), r3(a,_).
+        .plan 0:(1,2,3)
+
+.decl x1(a:number)
+.decl x2(a:number)
+.decl x3(a:number)
+.output x1
+.output x2
+.output x3
+
+// ok
+x1(a) <= x1(b) :- a < b.
+        .plan 0:(1,2)
+
+// Invalid plan: order is only 2.
+x2(a) <= x2(b) :- a < b.
+        .plan 0:(1,2,3)
+
+// Invalid plan: incomplete
+x3(a) <= x3(b) :- a < b.
+        .plan 0:(1,3)

--- a/tests/semantic/execution_plan/execution_plan.err
+++ b/tests/semantic/execution_plan/execution_plan.err
@@ -11,4 +11,13 @@ Error: Invalid execution order in plan (expected 3 atoms, not 2) in file executi
 Error: Invalid execution order in plan (expected 3 atoms, not 4) in file execution_plan.dl at line 25
         .plan 0: (1,2,2), 1: (3,2), 2: (2,3,1,3)
 ---------------------------------------^---------
-4 errors generated, evaluation aborted
+Error: Ignored execution plan for non-recursive clause in file execution_plan.dl at line 31
+        .plan 0:(1,2,3)
+----------------^-------
+Error: Invalid execution order in plan (expected 2 atoms, not 3) in file execution_plan.dl at line 46
+        .plan 0:(1,2,3)
+----------------^-------
+Error: Invalid execution order in plan (incomplete) in file execution_plan.dl at line 50
+        .plan 0:(1,3)
+----------------^-----
+7 errors generated, evaluation aborted

--- a/tests/semantic/subsumption_multiple_rules/subsumption_multiple_rules.dl
+++ b/tests/semantic/subsumption_multiple_rules/subsumption_multiple_rules.dl
@@ -111,5 +111,3 @@ mx(n) <= mx(n) :- my(n).
 .decl nx(x:number)
 nx(n) <= nx(n) :- nx(n).
 .output nx
-
-


### PR DESCRIPTION
This is intended to address https://github.com/souffle-lang/souffle/issues/2351.

It seems that user-provided execution plans are silently ignored for non-recursive and subsumptive clauses. I added an explicit error message if a user provides plans that will be ignored.

Maybe this should be a warning, instead, though, as it may break currently-working programs.