### PR TITLE
remove `Global` singleton

### DIFF
--- a/cmake/common.py
+++ b/cmake/common.py
@@ -45,6 +45,7 @@ def compare_files(expected_file, actual_file):
 
     if actual_lines != expected_lines:
         os.sys.stdout.writelines(difflib.unified_diff(open(expected_file).readlines(), open(actual_file).readlines(), fromfile=expected_file, tofile=actual_file))
+        os.sys.stdout.write("\n")
         os.sys.exit("Found output difference, expected file:'{}', actual file:'{}".format(expected_file, actual_file))
 
     return True

--- a/cmake/redirect.py
+++ b/cmake/redirect.py
@@ -41,4 +41,9 @@ if stdout:
 if stderr:
     stderr.close()
 
+if status.returncode != 0 and args.err_file:
+    with open(args.err_file, "r") as f:
+        os.sys.stderr.write(f.read())
+
+
 os.sys.exit(status.returncode)

--- a/src/Global.cpp
+++ b/src/Global.cpp
@@ -182,7 +182,7 @@ void MainConfig::processArgs(int argc, char** argv, const std::string& header, c
         while ((c = getopt_long(argc, argv, shortNames.c_str(), longNames.get(), nullptr)) != -1) {
             // case for the unknown option
             if (c == '?') {
-                std::cerr << Global::config().help();
+                std::cerr << help();
                 throw std::runtime_error("Error: Unknown command line option.");
             }
             // obtain an iterator to the option in the table referenced by the current short name
@@ -217,11 +217,11 @@ void MainConfig::processArgs(int argc, char** argv, const std::string& header, c
     }
 
     // obtain the name of the datalog file, and store it in the option with the empty key
-    if (argc > 1 && !Global::config().has("help") && !Global::config().has("version")) {
+    if (argc > 1 && !has("help") && !has("version")) {
         std::string filename = "";
         // ensure that the optind is less than the total number of arguments
         if (argc > 1 && optind >= argc) {
-            std::cerr << Global::config().help();
+            std::cerr << help();
             throw std::runtime_error("Error: Missing source file path.");
         }
 

--- a/src/Global.h
+++ b/src/Global.h
@@ -104,18 +104,21 @@ private:
  * used to isolate all globals. */
 class Global {
 public:
+    Global() = default;
     /* Deleted copy constructor. */
     Global(const Global&) = delete;
     /* Deleted assignment operator. */
     Global& operator=(const Global&) = delete;
     /* Obtain the global configuration. */
-    static MainConfig& config() {
-        static MainConfig _config;
+    MainConfig& config() {
+        return _config;
+    }
+
+    const MainConfig& config() const {
         return _config;
     }
 
 private:
-    /* Private empty constructor, there is only one global instance. */
-    Global() = default;
+    MainConfig _config;
 };
 }  // namespace souffle

--- a/src/TranslationUnitBase.h
+++ b/src/TranslationUnitBase.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "Global.h"
 #include "reports/DebugReport.h"
 #include "reports/ErrorReport.h"
 #include "souffle/utility/DynamicCasting.h"
@@ -72,8 +73,8 @@ struct TranslationUnitBase {
         virtual void run(Impl const&) = 0;
     };
 
-    TranslationUnitBase(Own<Program> prog, ErrorReport& e, DebugReport& d)
-            : program(std::move(prog)), errorReport(e), debugReport(d) {
+    TranslationUnitBase(Global& g, Own<Program> prog, ErrorReport& e, DebugReport& d)
+            : glb(g), program(std::move(prog)), errorReport(e), debugReport(d) {
         assert(program != nullptr && "program is a null-pointer");
     }
 
@@ -109,6 +110,11 @@ struct TranslationUnitBase {
         analyses.clear();
     }
 
+    /** @brief Get the global configuration */
+    Global& global() const {
+        return glb;
+    }
+
     /** @brief Get the RAM Program of the translation unit  */
     Program& getProgram() const {
         return *program;
@@ -132,6 +138,8 @@ protected:
     //       Clang is happy. GCC 9.2.0 -O1+ w/o asan is happy. Go figure.
     //       Using `std::string` appears to suppress the issue (bug?).
     mutable std::map<std::string, Own<Analysis>> analyses;
+
+    Global& glb;
 
     /* RAM program */
     Own<Program> program;

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "Global.h"
 #include "ast/Clause.h"
 #include "ast/Component.h"
 #include "ast/ComponentInit.h"

--- a/src/ast/TranslationUnit.cpp
+++ b/src/ast/TranslationUnit.cpp
@@ -8,6 +8,7 @@
 
 #include "ast/TranslationUnit.h"
 #include "Global.h"
+#include "ast/Program.h"
 #include "ast/analysis/PrecedenceGraph.h"
 #include "ast/analysis/SCCGraph.h"
 #include "reports/DebugReport.h"
@@ -17,7 +18,7 @@ namespace souffle::ast {
 
 /** get analysis: analysis is generated on the fly if not present */
 void TranslationUnit::logAnalysis(Analysis& analysis) const {
-    if (!Global::config().has("debug-report")) return;
+    if (!global().config().has("debug-report")) return;
 
     std::string name = analysis.getName();
     if (as<analysis::PrecedenceGraphAnalysis>(analysis) || as<analysis::SCCGraphAnalysis>(analysis)) {

--- a/src/ast/TranslationUnit.h
+++ b/src/ast/TranslationUnit.h
@@ -16,11 +16,10 @@
 
 #pragma once
 
+#include "Program.h"
 #include "TranslationUnitBase.h"
 
 namespace souffle::ast {
-
-class Program;
 
 /**
  * @class TranslationUnit

--- a/src/ast/analysis/JoinSize.cpp
+++ b/src/ast/analysis/JoinSize.cpp
@@ -120,7 +120,8 @@ analysis::StratumJoinSizeEstimates JoinSizeAnalysis::computeRuleVersionStatement
     return statements;
 }
 
-std::vector<analysis::StratumJoinSizeEstimates> JoinSizeAnalysis::computeJoinSizeStatements() {
+std::vector<analysis::StratumJoinSizeEstimates> JoinSizeAnalysis::computeJoinSizeStatements(
+        const bool emitStatistics) {
     auto* prog = program;
     auto getSccAtoms = [prog](const ast::Clause* clause, const ast::RelationSet& scc) {
         const auto& sccAtoms = filter(ast::getBodyLiterals<ast::Atom>(*clause),
@@ -133,8 +134,7 @@ std::vector<analysis::StratumJoinSizeEstimates> JoinSizeAnalysis::computeJoinSiz
     std::vector<analysis::StratumJoinSizeEstimates> joinSizeStatements;
     joinSizeStatements.resize(sccOrdering.size());
 
-    auto& config = Global::config();
-    if (!config.has("emit-statistics")) {
+    if (!emitStatistics) {
         return joinSizeStatements;
     }
 
@@ -240,7 +240,7 @@ void JoinSizeAnalysis::run(const TranslationUnit& translationUnit) {
     topsortSCCGraphAnalysis = &translationUnit.getAnalysis<TopologicallySortedSCCGraphAnalysis>();
     recursiveClauses = &translationUnit.getAnalysis<RecursiveClausesAnalysis>();
     polyAnalysis = &translationUnit.getAnalysis<ast::analysis::PolymorphicObjectsAnalysis>();
-    joinSizeStatements = computeJoinSizeStatements();
+    joinSizeStatements = computeJoinSizeStatements(translationUnit.global().config().has("emit-statistics"));
 }
 
 void JoinSizeAnalysis::print(std::ostream& os) const {

--- a/src/ast/analysis/JoinSize.h
+++ b/src/ast/analysis/JoinSize.h
@@ -68,7 +68,7 @@ private:
     PolymorphicObjectsAnalysis* polyAnalysis = nullptr;
 
     // for each stratum compute the EstimateJoinSize nodes to emit
-    std::vector<StratumJoinSizeEstimates> computeJoinSizeStatements();
+    std::vector<StratumJoinSizeEstimates> computeJoinSizeStatements(bool emitStatistics);
     StratumJoinSizeEstimates computeRuleVersionStatements(const RelationSet& sccRelations,
             const ast::Clause& clause, std::size_t version,
             ast2ram::TranslationMode mode = ast2ram::TranslationMode::DEFAULT);

--- a/src/ast/analysis/ProfileUse.cpp
+++ b/src/ast/analysis/ProfileUse.cpp
@@ -17,6 +17,7 @@
 
 #include "ast/analysis/ProfileUse.h"
 #include "Global.h"
+#include "ast/Program.h"
 #include "ast/QualifiedName.h"
 #include "souffle/profile/ProgramRun.h"
 #include "souffle/profile/Reader.h"
@@ -29,10 +30,10 @@ namespace souffle::ast::analysis {
 /**
  * Run analysis, i.e., retrieve profile information
  */
-void ProfileUseAnalysis::run(const TranslationUnit&) {
+void ProfileUseAnalysis::run(const TranslationUnit& TU) {
     std::string filename;
-    if (Global::config().has("auto-schedule")) {
-        filename = Global::config().get("auto-schedule");
+    if (TU.global().config().has("auto-schedule")) {
+        filename = TU.global().config().get("auto-schedule");
     }
     reader = mk<profile::Reader>(filename, programRun);
     reader->processFile();

--- a/src/ast/analysis/SCCGraph.cpp
+++ b/src/ast/analysis/SCCGraph.cpp
@@ -36,6 +36,7 @@ namespace souffle::ast::analysis {
 void SCCGraphAnalysis::run(const TranslationUnit& translationUnit) {
     precedenceGraph = &translationUnit.getAnalysis<PrecedenceGraphAnalysis>();
     ioType = &translationUnit.getAnalysis<IOTypeAnalysis>();
+    programName = translationUnit.global().config().get("name");
     sccToRelation.clear();
     relationToScc.clear();
     predecessors.clear();
@@ -115,7 +116,7 @@ void SCCGraphAnalysis::scR(const Relation* w, std::map<const Relation*, std::siz
 }
 
 void SCCGraphAnalysis::printRaw(std::stringstream& ss) const {
-    const std::string& name = Global::config().get("name");
+    const std::string& name = programName;
     /* Print SCC graph */
     ss << "digraph {" << std::endl;
     /* Print nodes of SCC graph */

--- a/src/ast/analysis/SCCGraph.h
+++ b/src/ast/analysis/SCCGraph.h
@@ -228,6 +228,8 @@ private:
 
     IOTypeAnalysis* ioType = nullptr;
 
+    std::string programName;
+
     /** Print the SCC graph to a string. */
     void printRaw(std::stringstream& ss) const;
 };

--- a/src/ast/analysis/typesystem/Type.cpp
+++ b/src/ast/analysis/typesystem/Type.cpp
@@ -510,7 +510,8 @@ bool TypeAnalysis::isSymbol(const Argument* argument) const {
 void TypeAnalysis::run(const TranslationUnit& translationUnit) {
     // Check if debugging information is being generated
     std::ostream* debugStream = nullptr;
-    if (Global::config().has("debug-report") || Global::config().has("show", "type-analysis")) {
+    if (translationUnit.global().config().has("debug-report") ||
+            translationUnit.global().config().has("show", "type-analysis")) {
         debugStream = &analysisLogs;
     }
 

--- a/src/ast/tests/ast_print_test.cpp
+++ b/src/ast/tests/ast_print_test.cpp
@@ -45,9 +45,10 @@
 namespace souffle::ast::test {
 
 inline Own<TranslationUnit> makeATU(std::string program = ".decl A,B,C(x:number)") {
+    Global glb;
     ErrorReport e;
-    DebugReport d;
-    return ParserDriver::parseTranslationUnit(program, e, d);
+    DebugReport d(glb);
+    return ParserDriver::parseTranslationUnit(glb, program, e, d);
 }
 
 inline Own<TranslationUnit> makePrintedATU(Own<TranslationUnit>& tu) {
@@ -84,11 +85,12 @@ TEST(AstPrint, NumberConstant) {
 }
 
 TEST(AstPrint, StringConstant) {
+    Global glb;
     ErrorReport e;
-    DebugReport d;
+    DebugReport d(glb);
     auto testArgument = mk<StringConstant>("test string");
 
-    auto tu1 = ParserDriver::parseTranslationUnit(".decl A,B,C(x:number)", e, d);
+    auto tu1 = ParserDriver::parseTranslationUnit(glb, ".decl A,B,C(x:number)", e, d);
     tu1->getProgram().addClause(makeClauseA(std::move(testArgument)));
     auto tu2 = makePrintedATU(tu1);
     EXPECT_EQ(tu1->getProgram(), tu2->getProgram());

--- a/src/ast/tests/ast_program_test.cpp
+++ b/src/ast/tests/ast_program_test.cpp
@@ -43,9 +43,10 @@
 namespace souffle::ast::test {
 
 inline Own<TranslationUnit> makeATU(std::string program) {
+    Global glb;
     ErrorReport e;
-    DebugReport d;
-    return ParserDriver::parseTranslationUnit(program, e, d);
+    DebugReport d(glb);
+    return ParserDriver::parseTranslationUnit(glb, program, e, d);
 }
 
 inline Own<Clause> makeClause(std::string name, Own<Argument> headArgument) {
@@ -56,16 +57,17 @@ inline Own<Clause> makeClause(std::string name, Own<Argument> headArgument) {
 }
 
 TEST(Program, Parse) {
+    Global glb;
     ErrorReport e;
-    DebugReport d;
+    DebugReport d(glb);
     // check the empty program
-    Own<TranslationUnit> empty = ParserDriver::parseTranslationUnit("", e, d);
+    Own<TranslationUnit> empty = ParserDriver::parseTranslationUnit(glb, "", e, d);
 
     EXPECT_TRUE(empty->getProgram().getTypes().empty());
     EXPECT_TRUE(empty->getProgram().getRelations().empty());
 
     // check something simple
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                    .type Node <: symbol
                    .decl e ( a : Node , b : Node )
@@ -87,16 +89,17 @@ TEST(Program, Parse) {
     EXPECT_FALSE(prog.getRelation("n"));
 }
 
-#define TESTASTCLONEANDEQUAL(SUBTYPE, DL)                                       \
-    TEST(Ast, CloneAndEqual##SUBTYPE) {                                         \
-        ErrorReport e;                                                          \
-        DebugReport d;                                                          \
-        Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(DL, e, d); \
-        Program& program = tu->getProgram();                                    \
-        EXPECT_EQ(program, program);                                            \
-        Own<Program> cl(clone(program));                                        \
-        EXPECT_NE(cl.get(), &program);                                          \
-        EXPECT_EQ(*cl, program);                                                \
+#define TESTASTCLONEANDEQUAL(SUBTYPE, DL)                                            \
+    TEST(Ast, CloneAndEqual##SUBTYPE) {                                              \
+        Global glb;                                                                  \
+        ErrorReport e;                                                               \
+        DebugReport d(glb);                                                          \
+        Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb, DL, e, d); \
+        Program& program = tu->getProgram();                                         \
+        EXPECT_EQ(program, program);                                                 \
+        Own<Program> cl(clone(program));                                             \
+        EXPECT_NE(cl.get(), &program);                                               \
+        EXPECT_EQ(*cl, program);                                                     \
     }
 
 TESTASTCLONEANDEQUAL(Program,

--- a/src/ast/tests/ast_transformers_test.cpp
+++ b/src/ast/tests/ast_transformers_test.cpp
@@ -44,10 +44,11 @@ namespace souffle::ast::transform::test {
 using namespace analysis;
 
 TEST(Transformers, GroundTermPropagation) {
+    Global glb;
     ErrorReport errorReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
     // load some test program
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                 .type D <: symbol
                 .decl p(a:D,b:D)
@@ -75,10 +76,11 @@ TEST(Transformers, GroundTermPropagation) {
 }
 
 TEST(Transformers, GroundTermPropagation2) {
+    Global glb;
     ErrorReport errorReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
     // load some test program
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                .type D <: symbol
                .decl p(a:D,b:D)
@@ -103,9 +105,10 @@ TEST(Transformers, GroundTermPropagation2) {
 
 TEST(Transformers, ResolveGroundedAliases) {
     // load some test program
+    Global glb;
     ErrorReport errorReport;
-    DebugReport debugReport;
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    DebugReport debugReport(glb);
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                 .type D <: symbol
                 .decl p(a:D,b:D)
@@ -126,9 +129,10 @@ TEST(Transformers, ResolveGroundedAliases) {
 
 TEST(Transformers, ResolveAliasesWithTermsInAtoms) {
     // load some test program
+    Global glb;
     ErrorReport errorReport;
-    DebugReport debugReport;
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    DebugReport debugReport(glb);
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                 .type D <: symbol
                 .decl p(a:D,b:D)
@@ -163,10 +167,11 @@ TEST(Transformers, ResolveAliasesWithTermsInAtoms) {
  */
 
 TEST(Transformers, RemoveRelationCopies) {
+    Global glb;
     ErrorReport errorReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
     // load some test program
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                 .type D = number
                 .decl a(a:D,b:D)
@@ -208,10 +213,11 @@ TEST(Transformers, RemoveRelationCopies) {
  *
  */
 TEST(Transformers, RemoveRelationCopiesOutput) {
+    Global glb;
     ErrorReport errorReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
     // load some test program
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                 .type D = number
                 .decl a(a:D,b:D)
@@ -242,10 +248,11 @@ TEST(Transformers, RemoveRelationCopiesOutput) {
  * Test the equivalence (or lack of equivalence) of clauses using the MinimiseProgramTransfomer.
  */
 TEST(Transformers, CheckClausalEquivalence) {
+    Global glb;
     ErrorReport errorReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
 
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                 .decl A(x:number, y:number)
                 .decl B(x:number)
@@ -333,10 +340,11 @@ TEST(Transformers, CheckClausalEquivalence) {
  * Test the equivalence (or lack of equivalence) of aggregators using the MinimiseProgramTransfomer.
  */
 TEST(Transformers, CheckAggregatorEquivalence) {
+    Global glb;
     ErrorReport errorReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
 
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                 .decl A,B,C,D(X:number) input
                 // first and second are equivalent
@@ -396,10 +404,11 @@ TEST(Transformers, CheckAggregatorEquivalence) {
  *          e.g. a(x) :- a(x), x != 0. is only true if a(x) is already true
  */
 TEST(Transformers, RemoveClauseRedundancies) {
+    Global glb;
     ErrorReport errorReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
 
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                 .decl a,b,c(X:number)
                 a(0).
@@ -453,10 +462,11 @@ TEST(Transformers, RemoveClauseRedundancies) {
  *      (4) MagicSetTransformer
  */
 TEST(Transformers, MagicSetComprehensive) {
+    Global glb;
     ErrorReport e;
-    DebugReport d;
+    DebugReport d(glb);
 
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                 // Stratum 0 - Base Relations
                 .decl BaseOne(X:number) magic

--- a/src/ast/tests/ast_utils_test.cpp
+++ b/src/ast/tests/ast_utils_test.cpp
@@ -78,11 +78,12 @@ TEST(AstUtils, Grounded) {
     // check construction
     EXPECT_EQ("r(X,Y,Z) :- \n   a(X),\n   X = Y,\n   !b(Z).", toString(*clause));
 
+    Global glb;
     auto program = mk<Program>();
     program->addClause(std::move(clause));
-    DebugReport dbgReport;
+    DebugReport dbgReport(glb);
     ErrorReport errReport;
-    TranslationUnit tu{std::move(program), errReport, dbgReport};
+    TranslationUnit tu{glb, std::move(program), errReport, dbgReport};
 
     // obtain groundness
     auto isGrounded = analysis::getGroundedTerms(tu, *tu.getProgram().getClauses()[0]);
@@ -95,9 +96,10 @@ TEST(AstUtils, Grounded) {
 }
 
 TEST(AstUtils, GroundedRecords) {
+    Global glb;
     ErrorReport e;
-    DebugReport d;
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    DebugReport d(glb);
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                  .type N <: symbol
                  .type R = [ a : N, B : N ]
@@ -132,10 +134,11 @@ TEST(AstUtils, GroundedRecords) {
 }
 
 TEST(AstUtils, ReorderClauseAtoms) {
+    Global glb;
     ErrorReport e;
-    DebugReport d;
+    DebugReport d(glb);
 
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                 .decl a,b,c,d,e(x:number)
                 a(x) :- b(x), c(x), 1 != 2, d(y), !e(z), c(z), e(x).
@@ -168,10 +171,11 @@ TEST(AstUtils, ReorderClauseAtoms) {
 }
 
 TEST(AstUtils, RemoveEquivalentClauses) {
+    Global glb;
     ErrorReport e;
-    DebugReport d;
+    DebugReport d(glb);
 
-    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(
+    Own<TranslationUnit> tu = ParserDriver::parseTranslationUnit(glb,
             R"(
                 .decl a()
                 a(). a(). a(). a(). a(). a(). a(). a(). a(). a(). a(). a(). a(). a(). a().

--- a/src/ast/transform/IODefaults.h
+++ b/src/ast/transform/IODefaults.h
@@ -68,6 +68,7 @@ private:
     bool setDefaults(TranslationUnit& translationUnit) {
         bool changed = false;
         Program& program = translationUnit.getProgram();
+        const Global& glb = translationUnit.global();
         for (Directive* io : program.getDirectives()) {
             // Don't do anything for a directive which
             // is not an I/O directive
@@ -91,19 +92,19 @@ private:
                     io->addParameter("operation", "input");
                     changed = true;
                     // Configure input directory
-                    if (Global::config().has("fact-dir")) {
-                        io->addParameter("fact-dir", Global::config().get("fact-dir"));
+                    if (glb.config().has("fact-dir")) {
+                        io->addParameter("fact-dir", glb.config().get("fact-dir"));
                     }
                 } else if (io->getType() == ast::DirectiveType::output) {
                     io->addParameter("operation", "output");
                     changed = true;
                     // Configure output directory
-                    if (Global::config().has("output-dir")) {
-                        if (Global::config().has("output-dir", "-")) {
+                    if (glb.config().has("output-dir")) {
+                        if (glb.config().has("output-dir", "-")) {
                             io->addParameter("IO", "stdout");
                             io->addParameter("headers", "true");
                         } else {
-                            io->addParameter("output-dir", Global::config().get("output-dir"));
+                            io->addParameter("output-dir", glb.config().get("output-dir"));
                         }
                     }
                 } else if (io->getType() == ast::DirectiveType::printsize) {

--- a/src/ast/transform/InlineRelations.cpp
+++ b/src/ast/transform/InlineRelations.cpp
@@ -1027,10 +1027,10 @@ std::vector<Clause*> getInlinedClause(Program& program, const Clause& clause) {
     }
 }
 
-ExcludedRelations InlineRelationsTransformer::excluded() {
+ExcludedRelations InlineRelationsTransformer::excluded(Global& glb) {
     ExcludedRelations xs;
     auto addAll = [&](const std::string& name) {
-        for (auto&& r : splitString(Global::config().get(name), ','))
+        for (auto&& r : splitString(glb.config().get(name), ','))
             xs.insert(QualifiedName(r));
     };
 
@@ -1092,7 +1092,7 @@ bool InlineUnmarkExcludedTransform::transform(TranslationUnit& translationUnit) 
     bool changed = false;
     Program& program = translationUnit.getProgram();
 
-    auto&& excluded = InlineRelationsTransformer::excluded();
+    auto&& excluded = InlineRelationsTransformer::excluded(translationUnit.global());
 
     for (Relation* rel : program.getRelations()) {
         // no-magic implies no inlining

--- a/src/ast/transform/InlineRelations.h
+++ b/src/ast/transform/InlineRelations.h
@@ -30,7 +30,7 @@ namespace souffle::ast::transform {
 class InlineRelationsTransformer : public Transformer {
 public:
     using ExcludedRelations = std::set<QualifiedName>;
-    static ExcludedRelations excluded();
+    static ExcludedRelations excluded(Global& glb);
 
     std::string getName() const override {
         return "InlineRelationsTransformer";

--- a/src/ast/transform/MagicSet.cpp
+++ b/src/ast/transform/MagicSet.cpp
@@ -94,14 +94,14 @@ std::set<QualifiedName> MagicSetTransformer::getWeaklyIgnoredRelations(const Tra
     std::set<QualifiedName> weaklyIgnoredRelations;
 
     // Add magic-transform-exclude relations to the weakly ignored set
-    for (const auto& relStr : splitString(Global::config().get("magic-transform-exclude"), ',')) {
+    for (const auto& relStr : splitString(tu.global().config().get("magic-transform-exclude"), ',')) {
         std::vector<std::string> qualifiers = splitString(relStr, '.');
         weaklyIgnoredRelations.insert(QualifiedName(qualifiers));
     }
 
     // Pick up specified relations from config
     std::set<QualifiedName> specifiedRelations;
-    for (const auto& relStr : splitString(Global::config().get("magic-transform"), ',')) {
+    for (const auto& relStr : splitString(tu.global().config().get("magic-transform"), ',')) {
         std::vector<std::string> qualifiers = splitString(relStr, '.');
         specifiedRelations.insert(QualifiedName(qualifiers));
     }
@@ -274,7 +274,7 @@ std::set<QualifiedName> MagicSetTransformer::getRelationsToNotLabel(const Transl
 
 bool MagicSetTransformer::shouldRun(const TranslationUnit& tu) {
     const Program& program = tu.getProgram();
-    if (Global::config().has("magic-transform")) return true;
+    if (tu.global().config().has("magic-transform")) return true;
     for (const auto* rel : program.getRelations()) {
         if (rel->hasQualifier(RelationQualifier::MAGIC)) return true;
     }

--- a/src/ast/transform/PragmaChecker.h
+++ b/src/ast/transform/PragmaChecker.h
@@ -32,10 +32,13 @@ public:
 
     // This helper is used to implement both `--pragma` cmd ln args and `.pragma` statements.
     struct Merger {
-        Merger();
+        Merger(Global&);
         bool operator()(std::string_view key, std::string_view value);
 
         std::set<std::string, std::less<>> locked_keys;
+
+    private:
+        Global& glb;
     };
 
 private:

--- a/src/ast/transform/SemanticChecker.cpp
+++ b/src/ast/transform/SemanticChecker.cpp
@@ -138,9 +138,9 @@ bool SemanticChecker::transform(TranslationUnit& translationUnit) {
 
 SemanticCheckerImpl::SemanticCheckerImpl(TranslationUnit& tu) : tu(tu) {
     // suppress warnings for given relations
-    if (Global::config().has("suppress-warnings")) {
+    if (tu.global().config().has("suppress-warnings")) {
         std::vector<std::string> suppressedRelations =
-                splitString(Global::config().get("suppress-warnings"), ',');
+                splitString(tu.global().config().get("suppress-warnings"), ',');
 
         if (std::find(suppressedRelations.begin(), suppressedRelations.end(), "*") !=
                 suppressedRelations.end()) {

--- a/src/ast/transform/TypeChecker.cpp
+++ b/src/ast/transform/TypeChecker.cpp
@@ -367,7 +367,7 @@ void TypeCheckerImpl::visit_(type_identity<Atom>, const Atom& atom) {
                 return isA<analysis::RecordType>(type) && !isA<analysis::SubsetType>(type);
             });
 
-            if (!validAttribute && !Global::config().has("legacy")) {
+            if (!validAttribute && !tu.global().config().has("legacy")) {
                 auto primaryDiagnostic =
                         DiagnosticMessage("Atom's argument type is not a subtype of its declared type",
                                 arguments[i]->getSrcLoc());

--- a/src/ast2ram/provenance/ClauseTranslator.cpp
+++ b/src/ast2ram/provenance/ClauseTranslator.cpp
@@ -133,7 +133,7 @@ Own<ram::Operation> ClauseTranslator::addAtomScan(Own<ram::Operation> op, const 
 
     // add a scan level
     std::stringstream ss;
-    if (Global::config().has("profile")) {
+    if (context.getGlobal()->config().has("profile")) {
         ss << "@frequency-atom" << ';';
         ss << clause.getHead()->getQualifiedName() << ';';
         ss << version << ';';

--- a/src/ast2ram/provenance/UnitTranslator.cpp
+++ b/src/ast2ram/provenance/UnitTranslator.cpp
@@ -50,6 +50,8 @@
 namespace souffle::ast2ram::provenance {
 
 Own<ram::Sequence> UnitTranslator::generateProgram(const ast::TranslationUnit& translationUnit) {
+    glb = &translationUnit.global();
+
     // Do the regular translation
     auto ramProgram = seminaive::UnitTranslator::generateProgram(translationUnit);
 
@@ -287,7 +289,7 @@ Own<ram::Sequence> UnitTranslator::generateInfoClauses(const ast::Program* progr
         auto infoClause = mk<ram::Statement, ram::Query>(std::move(factInsertion));
 
         // Add logging
-        if (Global::config().has("profile")) {
+        if (glb->config().has("profile")) {
             std::stringstream clauseText;
             clauseText << "@info.clause[" << stringify(toString(*clause)) << "]";
             const std::string logTimerStatement =

--- a/src/ast2ram/provenance/UnitTranslator.h
+++ b/src/ast2ram/provenance/UnitTranslator.h
@@ -74,6 +74,8 @@ private:
             ram::Node* node, const std::map<std::size_t, std::string>& idToVar) const;
     Own<ram::Sequence> makeIfStatement(
             Own<ram::Condition> condition, Own<ram::Operation> trueOp, Own<ram::Operation> falseOp) const;
+
+    Global* glb;
 };
 
 }  // namespace souffle::ast2ram::provenance

--- a/src/ast2ram/seminaive/ClauseTranslator.cpp
+++ b/src/ast2ram/seminaive/ClauseTranslator.cpp
@@ -116,7 +116,7 @@ Own<ram::Statement> ClauseTranslator::translateRecursiveClause(
     Own<ram::Statement> rule = translateNonRecursiveClause(clause);
 
     // Add logging
-    if (Global::config().has("profile")) {
+    if (context.getGlobal()->config().has("profile")) {
         const std::string& relationName = getConcreteRelationName(clause.getHead()->getQualifiedName());
         const auto& srcLocation = clause.getSrcLoc();
         const std::string clauseText = stringify(toString(clause));
@@ -238,7 +238,7 @@ Own<ram::Operation> ClauseTranslator::addAtomScan(Own<ram::Operation> op, const 
         }
 
         std::stringstream ss;
-        if (Global::config().has("profile")) {
+        if (context.getGlobal()->config().has("profile")) {
             ss << "@frequency-atom" << ';';
             ss << clause.getHead()->getQualifiedName() << ';';
             ss << version << ';';

--- a/src/ast2ram/seminaive/UnitTranslator.h
+++ b/src/ast2ram/seminaive/UnitTranslator.h
@@ -21,6 +21,10 @@
 #include <string>
 #include <vector>
 
+namespace souffle {
+class Global;
+}
+
 namespace souffle::ast {
 class Clause;
 class Relation;
@@ -95,6 +99,8 @@ protected:
 
 private:
     std::map<std::string, Own<ram::Statement>> ramSubroutines;
+
+    Global* glb;
 };
 
 }  // namespace souffle::ast2ram::seminaive

--- a/src/ast2ram/utility/SipsMetric.cpp
+++ b/src/ast2ram/utility/SipsMetric.cpp
@@ -309,7 +309,7 @@ std::vector<std::size_t> SelingerProfileSipsMetric::getReordering(
 
 /** Create a SIPS metric based on a given heuristic. */
 std::unique_ptr<SipsMetric> SipsMetric::create(const std::string& heuristic, const TranslationUnit& tu) {
-    if (Global::config().has("auto-schedule")) {
+    if (tu.global().config().has("auto-schedule")) {
         return mk<SelingerProfileSipsMetric>(tu);
     } else if (heuristic == "strict")
         return mk<StrictSips>(tu);

--- a/src/ast2ram/utility/TranslatorContext.cpp
+++ b/src/ast2ram/utility/TranslatorContext.cpp
@@ -50,6 +50,7 @@ namespace souffle::ast2ram {
 
 TranslatorContext::TranslatorContext(const ast::TranslationUnit& tu) {
     program = &tu.getProgram();
+    global = &tu.global();
 
     // Set up analyses
     functorAnalysis = &tu.getAnalysis<ast::analysis::FunctorAnalysis>();
@@ -76,13 +77,13 @@ TranslatorContext::TranslatorContext(const ast::TranslationUnit& tu) {
 
     // Set up SIPS metric
     std::string sipsChosen = "all-bound";
-    if (Global::config().has("RamSIPS")) {
-        sipsChosen = Global::config().get("RamSIPS");
+    if (global->config().has("RamSIPS")) {
+        sipsChosen = global->config().get("RamSIPS");
     }
     sipsMetric = ast::SipsMetric::create(sipsChosen, tu);
 
     // Set up the correct strategy
-    if (Global::config().has("provenance")) {
+    if (global->config().has("provenance")) {
         translationStrategy = mk<provenance::TranslationStrategy>();
     } else {
         translationStrategy = mk<seminaive::TranslationStrategy>();

--- a/src/ast2ram/utility/TranslatorContext.h
+++ b/src/ast2ram/utility/TranslatorContext.h
@@ -30,6 +30,10 @@
 #include <set>
 #include <vector>
 
+namespace souffle {
+class Global;
+}
+
 namespace souffle::ast {
 class Aggregator;
 class Atom;
@@ -76,6 +80,10 @@ class TranslatorContext {
 public:
     TranslatorContext(const ast::TranslationUnit& tu);
     ~TranslatorContext();
+
+    const Global* getGlobal() const {
+        return global;
+    }
 
     const ast::Program* getProgram() const {
         return program;
@@ -146,6 +154,7 @@ public:
 
 private:
     const ast::Program* program;
+    const Global* global;
     const ast::analysis::RecursiveClausesAnalysis* recursiveClauses;
     const ast::analysis::RelationScheduleAnalysis* relationSchedule;
     const ast::analysis::SCCGraphAnalysis* sccGraph;

--- a/src/interpreter/Engine.h
+++ b/src/interpreter/Engine.h
@@ -57,13 +57,23 @@ class Engine {
     friend NodeGenerator;
 
 public:
-    Engine(ram::TranslationUnit& tUnit);
+    Engine(ram::TranslationUnit& tUnit, const std::size_t numThreads);
 
     /** @brief Execute the main program */
     void executeMain();
+
     /** @brief Execute the subroutine program */
     void executeSubroutine(
             const std::string& name, const std::vector<RamDomain>& args, std::vector<RamDomain>& ret);
+
+    /** @brief Return the global object this engine uses */
+    Global& getGlobal();
+
+    /** @brief Return the string symbol table */
+    SymbolTable& getSymbolTable();
+
+    /** @brief Return the record table */
+    RecordTable& getRecordTable();
 
 private:
     /** @brief Generate intermediate representation from RAM */
@@ -74,15 +84,9 @@ private:
     void swapRelation(const std::size_t ramRel1, const std::size_t ramRel2);
     /** @brief Return a reference to the relation on the given index */
     RelationHandle& getRelationHandle(const std::size_t idx);
-    /** @brief Return the string symbol table */
-    SymbolTable& getSymbolTable() {
-        return symbolTable;
-    }
-    /** @brief Return the record table */
-    RecordTable& getRecordTable();
     /** @brief Return the ram::TranslationUnit */
     ram::TranslationUnit& getTranslationUnit();
-    /** @brief Execute the program */
+    /** @brief Execute a specific node program */
     RamDomain execute(const Node*, Context&);
     /** @brief Return method handler */
     void* getMethodHandle(const std::string& method);
@@ -167,6 +171,10 @@ private:
     template <typename Rel>
     RamDomain evalErase(Rel& rel, const Erase& shadow, Context& ctxt);
 
+    /** Program */
+    ram::TranslationUnit& tUnit;
+    /** Global */
+    Global& global;
     /** If profile is enable in this program */
     const bool profileEnabled;
     const bool frequencyCounterEnabled;
@@ -186,8 +194,6 @@ private:
     std::map<std::string, std::atomic<std::size_t>> reads;
     /** DLL */
     std::vector<void*> dll;
-    /** Program */
-    ram::TranslationUnit& tUnit;
     /** IndexAnalysis */
     ram::analysis::IndexAnalysis& isa;
     /** Record Table Implementation*/

--- a/src/interpreter/Generator.cpp
+++ b/src/interpreter/Generator.cpp
@@ -23,7 +23,7 @@ using NodePtr = Own<Node>;
 using NodePtrVec = std::vector<NodePtr>;
 using RelationHandle = Own<RelationWrapper>;
 
-NodeGenerator::NodeGenerator(Engine& engine) : engine(engine) {
+NodeGenerator::NodeGenerator(Engine& engine) : engine(engine), global(engine.getGlobal()) {
     visit(engine.tUnit.getProgram(), [&](const ram::Relation& relation) {
         assert(relationMap.find(relation.getName()) == relationMap.end() && "double-naming of relations");
         relationMap[relation.getName()] = &relation;
@@ -206,14 +206,14 @@ NodePtr NodeGenerator::visit_(type_identity<ram::Negation>, const ram::Negation&
 NodePtr NodeGenerator::visit_(type_identity<ram::EmptinessCheck>, const ram::EmptinessCheck& emptiness) {
     std::size_t relId = encodeRelation(emptiness.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("EmptinessCheck", lookup(emptiness.getRelation()));
+    NodeType type = constructNodeType(global, "EmptinessCheck", lookup(emptiness.getRelation()));
     return mk<EmptinessCheck>(type, &emptiness, rel);
 }
 
 NodePtr NodeGenerator::visit_(type_identity<ram::RelationSize>, const ram::RelationSize& size) {
     std::size_t relId = encodeRelation(size.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("RelationSize", lookup(size.getRelation()));
+    NodeType type = constructNodeType(global, "RelationSize", lookup(size.getRelation()));
     return mk<RelationSize>(type, &size, rel);
 }
 
@@ -227,7 +227,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::ExistenceCheck>, const ram::Exi
         }
     }
     const auto& ramRelation = lookup(exists.getRelation());
-    NodeType type = constructNodeType("ExistenceCheck", ramRelation);
+    NodeType type = constructNodeType(global, "ExistenceCheck", ramRelation);
     return mk<ExistenceCheck>(type, &exists, isTotal, encodeView(&exists), std::move(superOp),
             ramRelation.isTemp(), ramRelation.getName());
 }
@@ -235,7 +235,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::ExistenceCheck>, const ram::Exi
 NodePtr NodeGenerator::visit_(
         type_identity<ram::ProvenanceExistenceCheck>, const ram::ProvenanceExistenceCheck& provExists) {
     SuperInstruction superOp = getExistenceSuperInstInfo(provExists);
-    NodeType type = constructNodeType("ProvenanceExistenceCheck", lookup(provExists.getRelation()));
+    NodeType type = constructNodeType(global, "ProvenanceExistenceCheck", lookup(provExists.getRelation()));
     return mk<ProvenanceExistenceCheck>(type, &provExists, dispatch(*(--provExists.getChildNodes().end())),
             encodeView(&provExists), std::move(superOp));
 }
@@ -281,7 +281,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::Scan>, const ram::Scan& scan) {
     orderingContext.addTupleWithDefaultOrder(scan.getTupleId(), scan);
     std::size_t relId = encodeRelation(scan.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("Scan", lookup(scan.getRelation()));
+    NodeType type = constructNodeType(global, "Scan", lookup(scan.getRelation()));
     return mk<Scan>(type, &scan, rel, visit_(type_identity<ram::TupleOperation>(), scan));
 }
 
@@ -289,7 +289,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::ParallelScan>, const ram::Paral
     orderingContext.addTupleWithDefaultOrder(pScan.getTupleId(), pScan);
     std::size_t relId = encodeRelation(pScan.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("ParallelScan", lookup(pScan.getRelation()));
+    NodeType type = constructNodeType(global, "ParallelScan", lookup(pScan.getRelation()));
     auto res = mk<ParallelScan>(type, &pScan, rel, visit_(type_identity<ram::TupleOperation>(), pScan));
     res->setViewContext(parentQueryViewContext);
     return res;
@@ -298,7 +298,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::ParallelScan>, const ram::Paral
 NodePtr NodeGenerator::visit_(type_identity<ram::IndexScan>, const ram::IndexScan& iScan) {
     orderingContext.addTupleWithIndexOrder(iScan.getTupleId(), iScan);
     SuperInstruction indexOperation = getIndexSuperInstInfo(iScan);
-    NodeType type = constructNodeType("IndexScan", lookup(iScan.getRelation()));
+    NodeType type = constructNodeType(global, "IndexScan", lookup(iScan.getRelation()));
     return mk<IndexScan>(type, &iScan, nullptr, visit_(type_identity<ram::TupleOperation>(), iScan),
             encodeView(&iScan), std::move(indexOperation));
 }
@@ -308,7 +308,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::ParallelIndexScan>, const ram::
     SuperInstruction indexOperation = getIndexSuperInstInfo(piscan);
     std::size_t relId = encodeRelation(piscan.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("ParallelIndexScan", lookup(piscan.getRelation()));
+    NodeType type = constructNodeType(global, "ParallelIndexScan", lookup(piscan.getRelation()));
     auto res = mk<ParallelIndexScan>(type, &piscan, rel, visit_(type_identity<ram::TupleOperation>(), piscan),
             encodeIndexPos(piscan), std::move(indexOperation));
     res->setViewContext(parentQueryViewContext);
@@ -319,7 +319,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::IfExists>, const ram::IfExists&
     orderingContext.addTupleWithDefaultOrder(ifexists.getTupleId(), ifexists);
     std::size_t relId = encodeRelation(ifexists.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("IfExists", lookup(ifexists.getRelation()));
+    NodeType type = constructNodeType(global, "IfExists", lookup(ifexists.getRelation()));
     return mk<IfExists>(type, &ifexists, rel, dispatch(ifexists.getCondition()),
             visit_(type_identity<ram::TupleOperation>(), ifexists));
 }
@@ -328,7 +328,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::ParallelIfExists>, const ram::P
     orderingContext.addTupleWithDefaultOrder(pIfExists.getTupleId(), pIfExists);
     std::size_t relId = encodeRelation(pIfExists.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("ParallelIfExists", lookup(pIfExists.getRelation()));
+    NodeType type = constructNodeType(global, "ParallelIfExists", lookup(pIfExists.getRelation()));
     auto res = mk<ParallelIfExists>(type, &pIfExists, rel, dispatch(pIfExists.getCondition()),
             visit_(type_identity<ram::TupleOperation>(), pIfExists));
     res->setViewContext(parentQueryViewContext);
@@ -338,7 +338,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::ParallelIfExists>, const ram::P
 NodePtr NodeGenerator::visit_(type_identity<ram::IndexIfExists>, const ram::IndexIfExists& iIfExists) {
     orderingContext.addTupleWithIndexOrder(iIfExists.getTupleId(), iIfExists);
     SuperInstruction indexOperation = getIndexSuperInstInfo(iIfExists);
-    NodeType type = constructNodeType("IndexIfExists", lookup(iIfExists.getRelation()));
+    NodeType type = constructNodeType(global, "IndexIfExists", lookup(iIfExists.getRelation()));
     return mk<IndexIfExists>(type, &iIfExists, nullptr, dispatch(iIfExists.getCondition()),
             visit_(type_identity<ram::TupleOperation>(), iIfExists), encodeView(&iIfExists),
             std::move(indexOperation));
@@ -350,7 +350,7 @@ NodePtr NodeGenerator::visit_(
     SuperInstruction indexOperation = getIndexSuperInstInfo(piIfExists);
     std::size_t relId = encodeRelation(piIfExists.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("ParallelIndexIfExists", lookup(piIfExists.getRelation()));
+    NodeType type = constructNodeType(global, "ParallelIndexIfExists", lookup(piIfExists.getRelation()));
     auto res = mk<ParallelIndexIfExists>(type, &piIfExists, rel, dispatch(piIfExists.getCondition()),
             dispatch(piIfExists.getOperation()), encodeIndexPos(piIfExists), std::move(indexOperation));
     res->setViewContext(parentQueryViewContext);
@@ -399,7 +399,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::Aggregate>, const ram::Aggregat
     NodePtr nested = visit_(type_identity<ram::TupleOperation>(), aggregate);
     std::size_t relId = encodeRelation(aggregate.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("Aggregate", lookup(aggregate.getRelation()));
+    NodeType type = constructNodeType(global, "Aggregate", lookup(aggregate.getRelation()));
 
     /* Resolve functor to actual function pointer now */
     void* functionPtr = resolveFunctionPointers(aggregate);
@@ -418,7 +418,7 @@ NodePtr NodeGenerator::visit_(
     NodePtr nested = visit_(type_identity<ram::TupleOperation>(), pAggregate);
     std::size_t relId = encodeRelation(pAggregate.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("ParallelAggregate", lookup(pAggregate.getRelation()));
+    NodeType type = constructNodeType(global, "ParallelAggregate", lookup(pAggregate.getRelation()));
     /* Resolve functor to actual function pointer now */
     void* functionPtr = resolveFunctionPointers(pAggregate);
     auto res = mk<ParallelAggregate>(type, &pAggregate, rel, std::move(expr), std::move(cond),
@@ -438,7 +438,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::IndexAggregate>, const ram::Ind
     NodePtr nested = visit_(type_identity<ram::TupleOperation>(), iAggregate);
     std::size_t relId = encodeRelation(iAggregate.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("IndexAggregate", lookup(iAggregate.getRelation()));
+    NodeType type = constructNodeType(global, "IndexAggregate", lookup(iAggregate.getRelation()));
     /* Resolve functor to actual function pointer now */
     void* functionPtr = resolveFunctionPointers(iAggregate);
     return mk<IndexAggregate>(type, &iAggregate, rel, std::move(expr), std::move(cond), std::move(nested),
@@ -456,7 +456,7 @@ NodePtr NodeGenerator::visit_(
     NodePtr nested = visit_(type_identity<ram::TupleOperation>(), piAggregate);
     std::size_t relId = encodeRelation(piAggregate.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("ParallelIndexAggregate", lookup(piAggregate.getRelation()));
+    NodeType type = constructNodeType(global, "ParallelIndexAggregate", lookup(piAggregate.getRelation()));
     /* Resolve functor to actual function pointer now */
     void* functionPtr = resolveFunctionPointers(piAggregate);
     auto res = mk<ParallelIndexAggregate>(type, &piAggregate, rel, std::move(expr), std::move(cond),
@@ -478,7 +478,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::GuardedInsert>, const ram::Guar
     SuperInstruction superOp = getInsertSuperInstInfo(guardedInsert);
     std::size_t relId = encodeRelation(guardedInsert.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("GuardedInsert", lookup(guardedInsert.getRelation()));
+    NodeType type = constructNodeType(global, "GuardedInsert", lookup(guardedInsert.getRelation()));
     auto condition = guardedInsert.getCondition();
     return mk<GuardedInsert>(type, &guardedInsert, rel, std::move(superOp), dispatch(*condition));
 }
@@ -487,7 +487,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::Insert>, const ram::Insert& ins
     SuperInstruction superOp = getInsertSuperInstInfo(insert);
     std::size_t relId = encodeRelation(insert.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("Insert", lookup(insert.getRelation()));
+    NodeType type = constructNodeType(global, "Insert", lookup(insert.getRelation()));
     return mk<Insert>(type, &insert, rel, std::move(superOp));
 }
 
@@ -495,7 +495,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::Erase>, const ram::Erase& erase
     SuperInstruction superOp = getEraseSuperInstInfo(erase);
     std::size_t relId = encodeRelation(erase.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("Erase", lookup(erase.getRelation()));
+    NodeType type = constructNodeType(global, "Erase", lookup(erase.getRelation()));
     return mk<Erase>(type, &erase, rel, std::move(superOp));
 }
 
@@ -558,7 +558,7 @@ NodePtr NodeGenerator::visit_(type_identity<ram::DebugInfo>, const ram::DebugInf
 NodePtr NodeGenerator::visit_(type_identity<ram::Clear>, const ram::Clear& clear) {
     std::size_t relId = encodeRelation(clear.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("Clear", lookup(clear.getRelation()));
+    NodeType type = constructNodeType(global, "Clear", lookup(clear.getRelation()));
     return mk<Clear>(type, &clear, rel);
 }
 
@@ -566,7 +566,7 @@ NodePtr NodeGenerator::visit_(
         type_identity<ram::EstimateJoinSize>, const ram::EstimateJoinSize& estimateJoinSize) {
     std::size_t relId = encodeRelation(estimateJoinSize.getRelation());
     auto rel = getRelationHandle(relId);
-    NodeType type = constructNodeType("EstimateJoinSize", lookup(estimateJoinSize.getRelation()));
+    NodeType type = constructNodeType(global, "EstimateJoinSize", lookup(estimateJoinSize.getRelation()));
     return mk<EstimateJoinSize>(type, &estimateJoinSize, rel, encodeIndexPos(estimateJoinSize));
 }
 

--- a/src/interpreter/Generator.h
+++ b/src/interpreter/Generator.h
@@ -366,5 +366,7 @@ private:
     OrderingContext orderingContext = OrderingContext(*this);
     /** Reference to the engine instance */
     Engine& engine;
+    /** Reference to global */
+    Global& global;
 };
 }  // namespace souffle::interpreter

--- a/src/interpreter/Node.h
+++ b/src/interpreter/Node.h
@@ -140,8 +140,8 @@ enum NodeType {
  *
  * Add reflective from string to NodeType.
  */
-inline NodeType constructNodeType(std::string tokBase, const ram::Relation& rel) {
-    static bool isProvenance = Global::config().has("provenance");
+inline NodeType constructNodeType(Global& glb, std::string tokBase, const ram::Relation& rel) {
+    const bool isProvenance = glb.config().has("provenance");
 
     static const std::unordered_map<std::string, NodeType> map = {
             FOR_EACH_INTERPRETER_TOKEN(SINGLE_TOKEN_ENTRY, EXPAND_TOKEN_ENTRY)

--- a/src/interpreter/tests/interpreter_relation_test.cpp
+++ b/src/interpreter/tests/interpreter_relation_test.cpp
@@ -20,7 +20,7 @@
 #include "interpreter/Relation.h"
 #include "ram/analysis/Index.h"
 #include "souffle/SouffleInterface.h"
-#include "souffle/SymbolTable.h"
+#include "souffle/datastructure/SymbolTableImpl.h"
 #include <iosfwd>
 #include <string>
 #include <utility>

--- a/src/interpreter/tests/ram_arithmetic_test.cpp
+++ b/src/interpreter/tests/ram_arithmetic_test.cpp
@@ -53,7 +53,8 @@ RamDomain evalExpression(Own<Expression> expression) {
     VecOwn<Expression> returnValues;
     returnValues.emplace_back(std::move(expression));
 
-    Global::config().set("jobs", "1");
+    Global glb;
+    glb.config().set("jobs", "1");
     Own<Statement> query = mk<ram::Query>(mk<ram::SubroutineReturn>(std::move(returnValues)));
     std::map<std::string, Own<Statement>> subs;
     subs.insert(std::make_pair("test", std::move(query)));
@@ -62,12 +63,12 @@ RamDomain evalExpression(Own<Expression> expression) {
     Own<Program> prog = mk<Program>(std::move(rels), mk<ram::Sequence>(), std::move(subs));
 
     ErrorReport errReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
 
-    TranslationUnit translationUnit(std::move(prog), errReport, debugReport);
+    TranslationUnit translationUnit(glb, std::move(prog), errReport, debugReport);
 
     // configure and execute interpreter
-    Own<Engine> interpreter = mk<Engine>(translationUnit);
+    Own<Engine> interpreter = mk<Engine>(translationUnit, 1);
 
     std::string name("test");
     std::vector<RamDomain> ret;

--- a/src/interpreter/tests/ram_relation_test.cpp
+++ b/src/interpreter/tests/ram_relation_test.cpp
@@ -56,7 +56,8 @@ using json11::Json;
 
 const std::string testInterpreterStore(
         std::vector<std::string> attribs, std::vector<std::string> attribsTypes, VecOwn<Expression> exprs) {
-    Global::config().set("jobs", "1");
+    Global glb;
+    glb.config().set("jobs", "1");
 
     const std::size_t arity = attribs.size();
 
@@ -81,12 +82,12 @@ const std::string testInterpreterStore(
     Own<ram::Program> prog = mk<Program>(std::move(rels), std::move(main), std::move(subs));
 
     ErrorReport errReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
 
-    TranslationUnit translationUnit(std::move(prog), errReport, debugReport);
+    TranslationUnit translationUnit(glb, std::move(prog), errReport, debugReport);
 
     // configure and execute interpreter
-    Own<Engine> interpreter = mk<Engine>(translationUnit);
+    Own<Engine> interpreter = mk<Engine>(translationUnit, 1);
 
     std::streambuf* oldCoutStreambuf = std::cout.rdbuf();
     std::ostringstream sout;
@@ -237,7 +238,8 @@ TEST(IO_store, SignedChangedDelimiter) {
     const std::size_t len = randomNumbers.size();
     const std::string delimiter{", "};
 
-    Global::config().set("jobs", "1");
+    Global glb;
+    glb.config().set("jobs", "1");
 
     VecOwn<ram::Relation> rels;
 
@@ -275,12 +277,12 @@ TEST(IO_store, SignedChangedDelimiter) {
     Own<Program> prog = mk<Program>(std::move(rels), std::move(main), std::move(subs));
 
     ErrorReport errReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
 
-    TranslationUnit translationUnit(std::move(prog), errReport, debugReport);
+    TranslationUnit translationUnit(glb, std::move(prog), errReport, debugReport);
 
     // configure and execute interpreter
-    Own<Engine> interpreter = mk<Engine>(translationUnit);
+    Own<Engine> interpreter = mk<Engine>(translationUnit, 1);
 
     std::streambuf* oldCoutStreambuf = std::cout.rdbuf();
     std::ostringstream sout;
@@ -310,7 +312,8 @@ TEST(IO_store, SignedChangedDelimiter) {
 }
 
 TEST(IO_store, MixedTypes) {
-    Global::config().set("jobs", "1");
+    Global glb;
+    glb.config().set("jobs", "1");
 
     VecOwn<ram::Relation> rels;
 
@@ -330,7 +333,7 @@ TEST(IO_store, MixedTypes) {
     std::map<std::string, std::string> ioDirs = std::map<std::string, std::string>(dirs);
 
     ErrorReport errReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
 
     VecOwn<Expression> exprs;
     RamFloat floatValue = 27.75;
@@ -347,10 +350,10 @@ TEST(IO_store, MixedTypes) {
     std::map<std::string, Own<Statement>> subs;
     Own<Program> prog = mk<Program>(std::move(rels), std::move(main), std::move(subs));
 
-    TranslationUnit translationUnit(std::move(prog), errReport, debugReport);
+    TranslationUnit translationUnit(glb, std::move(prog), errReport, debugReport);
 
     // configure and execute interpreter
-    Own<Engine> interpreter = mk<Engine>(translationUnit);
+    Own<Engine> interpreter = mk<Engine>(translationUnit, 1);
 
     std::streambuf* oldCoutStreambuf = std::cout.rdbuf();
     std::ostringstream sout;
@@ -382,7 +385,8 @@ TEST(IO_load, Signed) {
     std::istringstream testInput("5	3");
     std::cin.rdbuf(testInput.rdbuf());
 
-    Global::config().set("jobs", "1");
+    Global glb;
+    glb.config().set("jobs", "1");
 
     VecOwn<ram::Relation> rels;
 
@@ -411,12 +415,12 @@ TEST(IO_load, Signed) {
     Own<Program> prog = mk<Program>(std::move(rels), std::move(main), std::move(subs));
 
     ErrorReport errReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
 
-    TranslationUnit translationUnit(std::move(prog), errReport, debugReport);
+    TranslationUnit translationUnit(glb, std::move(prog), errReport, debugReport);
 
     // configure and execute interpreter
-    Own<Engine> interpreter = mk<Engine>(translationUnit);
+    Own<Engine> interpreter = mk<Engine>(translationUnit, 1);
 
     std::streambuf* oldCoutStreambuf = std::cout.rdbuf();
     std::ostringstream sout;
@@ -442,7 +446,8 @@ TEST(IO_load, Float) {
     std::istringstream testInput("0.5	0.5");
     std::cin.rdbuf(testInput.rdbuf());
 
-    Global::config().set("jobs", "1");
+    Global glb;
+    glb.config().set("jobs", "1");
 
     VecOwn<ram::Relation> rels;
 
@@ -471,12 +476,12 @@ TEST(IO_load, Float) {
     Own<Program> prog = mk<Program>(std::move(rels), std::move(main), std::move(subs));
 
     ErrorReport errReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
 
-    TranslationUnit translationUnit(std::move(prog), errReport, debugReport);
+    TranslationUnit translationUnit(glb, std::move(prog), errReport, debugReport);
 
     // configure and execute interpreter
-    Own<Engine> interpreter = mk<Engine>(translationUnit);
+    Own<Engine> interpreter = mk<Engine>(translationUnit, 1);
 
     std::streambuf* oldCoutStreambuf = std::cout.rdbuf();
     std::ostringstream sout;
@@ -502,7 +507,8 @@ TEST(IO_load, Unsigned) {
     std::istringstream testInput("6	6");
     std::cin.rdbuf(testInput.rdbuf());
 
-    Global::config().set("jobs", "1");
+    Global glb;
+    glb.config().set("jobs", "1");
 
     VecOwn<ram::Relation> rels;
 
@@ -531,12 +537,12 @@ TEST(IO_load, Unsigned) {
     Own<Program> prog = mk<Program>(std::move(rels), std::move(main), std::move(subs));
 
     ErrorReport errReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
 
-    TranslationUnit translationUnit(std::move(prog), errReport, debugReport);
+    TranslationUnit translationUnit(glb, std::move(prog), errReport, debugReport);
 
     // configure and execute interpreter
-    Own<Engine> interpreter = mk<Engine>(translationUnit);
+    Own<Engine> interpreter = mk<Engine>(translationUnit, 1);
 
     std::streambuf* oldCoutStreambuf = std::cout.rdbuf();
     std::ostringstream sout;
@@ -562,7 +568,8 @@ TEST(IO_load, MixedTypesLoad) {
     std::istringstream testInput("meow	-3	3	0.5");
     std::cin.rdbuf(testInput.rdbuf());
 
-    Global::config().set("jobs", "1");
+    Global glb;
+    glb.config().set("jobs", "1");
 
     VecOwn<ram::Relation> rels;
 
@@ -591,12 +598,12 @@ TEST(IO_load, MixedTypesLoad) {
     Own<Program> prog = mk<Program>(std::move(rels), std::move(main), std::move(subs));
 
     ErrorReport errReport;
-    DebugReport debugReport;
+    DebugReport debugReport(glb);
 
-    TranslationUnit translationUnit(std::move(prog), errReport, debugReport);
+    TranslationUnit translationUnit(glb, std::move(prog), errReport, debugReport);
 
     // configure and execute interpreter
-    Own<Engine> interpreter = mk<Engine>(translationUnit);
+    Own<Engine> interpreter = mk<Engine>(translationUnit, 1);
 
     std::streambuf* oldCoutStreambuf = std::cout.rdbuf();
     std::ostringstream sout;

--- a/src/parser/ParserDriver.h
+++ b/src/parser/ParserDriver.h
@@ -43,6 +43,7 @@ namespace souffle {
 
 class ParserDriver {
 public:
+    ParserDriver(Global& g) : glb(g) {}
     virtual ~ParserDriver() = default;
 
     void addRelation(Own<ast::Relation> r);
@@ -70,10 +71,10 @@ public:
             const std::string& filename, FILE* in, ErrorReport& errorReport, DebugReport& debugReport);
     Own<ast::TranslationUnit> parse(
             const std::string& code, ErrorReport& errorReport, DebugReport& debugReport);
+    static Own<ast::TranslationUnit> parseTranslationUnit(Global& glb, const std::string& filename, FILE* in,
+            ErrorReport& errorReport, DebugReport& debugReport);
     static Own<ast::TranslationUnit> parseTranslationUnit(
-            const std::string& filename, FILE* in, ErrorReport& errorReport, DebugReport& debugReport);
-    static Own<ast::TranslationUnit> parseTranslationUnit(
-            const std::string& code, ErrorReport& errorReport, DebugReport& debugReport);
+            Global& glb, const std::string& code, ErrorReport& errorReport, DebugReport& debugReport);
 
     void warning(const WarnType warn, const SrcLocation& loc, const std::string& msg);
     void error(const SrcLocation& loc, const std::string& msg);
@@ -93,6 +94,9 @@ public:
     std::set<std::pair<std::filesystem::path, int>> VisitedLocations;
 
     std::deque<std::pair<SrcLocation, std::string>> ScannedComments;
+
+private:
+    Global& glb;
 };
 
 }  // end of namespace souffle

--- a/src/ram/TranslationUnit.cpp
+++ b/src/ram/TranslationUnit.cpp
@@ -8,12 +8,13 @@
 
 #include "TranslationUnit.h"
 #include "Global.h"
+#include "ram/Program.h"
 #include "souffle/utility/StringUtil.h"
 
 namespace souffle::ram {
 
 void TranslationUnit::logAnalysis(Analysis& analysis) const {
-    if (!Global::config().has("debug-report")) return;
+    if (!global().config().has("debug-report")) return;
 
     auto ss = toString(analysis);
     debugReport.addSection(

--- a/src/ram/transform/MakeIndex.cpp
+++ b/src/ram/transform/MakeIndex.cpp
@@ -90,9 +90,9 @@ ExpressionPair MakeIndexTransformer::getExpressionPair(
 ExpressionPair MakeIndexTransformer::getLowerUpperExpression(Condition* c, std::size_t& element,
         const std::optional<std::size_t>& identifier, RelationRepresentation rep) {
     if (auto* binRelOp = as<Constraint>(c)) {
-        const bool interpreter = !Global::config().has("compile") && !Global::config().has("dl-program") &&
-                                 !Global::config().has("generate") &&
-                                 !Global::config().has("generate-many") && !Global::config().has("swig");
+        const bool interpreter = !glb->config().has("compile") && !glb->config().has("dl-program") &&
+                                 !glb->config().has("generate") && !glb->config().has("generate-many") &&
+                                 !glb->config().has("swig");
         bool provenance = rep == RelationRepresentation::PROVENANCE;
         bool btree = (rep == RelationRepresentation::BTREE || rep == RelationRepresentation::DEFAULT ||
                       rep == RelationRepresentation::BTREE_DELETE);
@@ -478,7 +478,8 @@ Own<Operation> MakeIndexTransformer::rewriteIndexScan(const IndexScan* iscan) {
     return nullptr;
 }
 
-bool MakeIndexTransformer::makeIndex(Program& program) {
+bool MakeIndexTransformer::makeIndex(Global& g, Program& program) {
+    glb = &g;
     bool changed = false;
     forEachQueryMap(program, [&](auto&& go, Own<Node> node) -> Own<Node> {
         if (const Scan* scan = as<Scan>(node)) {

--- a/src/ram/transform/MakeIndex.h
+++ b/src/ram/transform/MakeIndex.h
@@ -126,7 +126,7 @@ public:
      * @param RAM program that is transformed
      * @result Flag that indicates whether the input program has changed
      */
-    bool makeIndex(Program& program);
+    bool makeIndex(Global&, Program& program);
 
 protected:
     analysis::LevelAnalysis* rla{nullptr};
@@ -134,10 +134,12 @@ protected:
     bool transform(TranslationUnit& translationUnit) override {
         rla = &translationUnit.getAnalysis<analysis::LevelAnalysis>();
         relAnalysis = &translationUnit.getAnalysis<analysis::RelationAnalysis>();
-        return makeIndex(translationUnit.getProgram());
+        return makeIndex(translationUnit.global(), translationUnit.getProgram());
     }
 
     analysis::RelationAnalysis* relAnalysis{nullptr};
+
+    Global* glb;
 };
 
 }  // namespace souffle::ram::transform

--- a/src/ram/transform/Transformer.cpp
+++ b/src/ram/transform/Transformer.cpp
@@ -31,8 +31,8 @@
 namespace souffle::ram::transform {
 
 bool Transformer::apply(TranslationUnit& translationUnit) {
-    const bool debug = Global::config().has("debug-report");
-    const bool verbose = Global::config().has("verbose");
+    const bool debug = translationUnit.global().config().has("debug-report");
+    const bool verbose = translationUnit.global().config().has("verbose");
     std::string ramProgStrOld = debug ? toString(translationUnit.getProgram()) : "";
 
     // invoke the transformation

--- a/src/reports/DebugReport.h
+++ b/src/reports/DebugReport.h
@@ -15,7 +15,10 @@
  ***********************************************************************/
 #pragma once
 
+#include "Global.h"
+
 #include <cstdint>
+#include <optional>
 #include <ostream>
 #include <stack>
 #include <string>
@@ -80,14 +83,17 @@ private:
  */
 class DebugReport {
 public:
+    DebugReport();
+
+    DebugReport(Global& glb);
+
+    DebugReport(const std::string& report_path, const std::string& program_name);
+
     ~DebugReport();
 
     void flush();
 
-    void addSection(DebugReportSection section) {
-        auto& buf = currentSubsections.empty() ? sections : currentSubsections.top();
-        buf.emplace_back(std::move(section));
-    }
+    void addSection(DebugReportSection section);
 
     void addSection(std::string id, std::string title, std::string_view code);
     void addCodeSection(std::string id, std::string title, std::string_view language, std::string_view prev,
@@ -117,13 +123,15 @@ public:
     }
 
 private:
+    bool enabled;
+    std::optional<std::string> reportPath;
+    std::optional<std::string> programName;
+
     std::vector<DebugReportSection> sections;
     std::stack<std::vector<DebugReportSection>> currentSubsections;
     uint32_t nextUniqueId = 0;  // used for generating unique HTML `id` tags
 
-    bool empty() const {
-        return sections.empty();
-    }
+    bool empty() const;
 };
 
 }  // end of namespace souffle

--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -231,18 +231,19 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
 
     private:
         Synthesiser& synthesiser;
+        Global& glb;
         IndexAnalysis* const isa = &synthesiser.getTranslationUnit().getAnalysis<IndexAnalysis>();
 
 // macros to add comments to generated code for debugging
 #ifndef PRINT_BEGIN_COMMENT
-#define PRINT_BEGIN_COMMENT(os)                                                  \
-    if (Global::config().has("debug-report") || Global::config().has("verbose")) \
+#define PRINT_BEGIN_COMMENT(os)                                          \
+    if (glb.config().has("debug-report") || glb.config().has("verbose")) \
     os << "/* BEGIN " << __FUNCTION__ << " @" << __FILE__ << ":" << __LINE__ << " */\n"
 #endif
 
 #ifndef PRINT_END_COMMENT
-#define PRINT_END_COMMENT(os)                                                    \
-    if (Global::config().has("debug-report") || Global::config().has("verbose")) \
+#define PRINT_END_COMMENT(os)                                            \
+    if (glb.config().has("debug-report") || glb.config().has("verbose")) \
     os << "/* END " << __FUNCTION__ << " @" << __FILE__ << ":" << __LINE__ << " */\n"
 #endif
 
@@ -254,7 +255,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
         bool preambleIssued = false;
 
     public:
-        CodeEmitter(Synthesiser& syn) : synthesiser(syn) {
+        CodeEmitter(Synthesiser& syn) : synthesiser(syn), glb(synthesiser.glb) {
             rec = [&](auto& out, const auto* value) {
                 out << "ramBitCast(";
                 dispatch(*value, out);
@@ -603,7 +604,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             // create local scope for name resolution
             out << "{\n";
 
-            const std::string ext = fileExtension(Global::config().get("profile"));
+            const std::string ext = fileExtension(glb.config().get("profile"));
 
             const auto* rel = synthesiser.lookup(timer.getRelation());
             auto relName = synthesiser.getRelationName(rel);
@@ -623,7 +624,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             // create local scope for name resolution
             out << "{\n";
 
-            const std::string ext = fileExtension(Global::config().get("profile"));
+            const std::string ext = fileExtension(glb.config().get("profile"));
 
             // create local timer
             out << "\tLogger logger(R\"_(" << timer.getMessage() << ")_\",iter);\n";
@@ -651,7 +652,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
         void visit_(
                 type_identity<NestedOperation>, const NestedOperation& nested, std::ostream& out) override {
             dispatch(nested.getOperation(), out);
-            if (Global::config().has("profile") && Global::config().has("profile-frequency") &&
+            if (glb.config().has("profile") && glb.config().has("profile-frequency") &&
                     !nested.getProfileText().empty()) {
                 out << "freqs[" << synthesiser.lookupFreqIdx(nested.getProfileText()) << "]++;\n";
             }
@@ -1935,7 +1936,7 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             auto arity = rel->getArity();
             assert(arity > 0 && "AstToRamTranslator failed");
             std::string after;
-            if (Global::config().has("profile") && Global::config().has("profile-frequency") &&
+            if (glb.config().has("profile") && glb.config().has("profile-frequency") &&
                     !synthesiser.lookup(exists.getRelation())->isTemp()) {
                 out << R"_((reads[)_" << synthesiser.lookupReadIdx(rel->getName()) << R"_(]++,)_";
                 after = ")";
@@ -2491,22 +2492,22 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
     package_gen_version += "\"";
     db.addGlobalDefine(package_gen_version);
 
-    if (Global::config().has("verbose")) {
+    if (glb.config().has("verbose")) {
         db.addGlobalDefine("_SOUFFLE_STATS");
         db.addGlobalInclude("\"souffle/profile/ProfileEvent.h\"");
     }
 
-    if (Global::config().has("provenance")) {
+    if (glb.config().has("provenance")) {
         db.addGlobalInclude("<mutex>");
         db.addGlobalInclude("\"souffle/provenance/Explain.h\"");
     }
 
-    if (Global::config().has("live-profile")) {
+    if (glb.config().has("live-profile")) {
         db.addGlobalInclude("<thread>");
         db.addGlobalInclude("\"souffle/profile/Tui.h\"");
     }
 
-    if (Global::config().has("profile") || Global::config().has("live-profile")) {
+    if (glb.config().has("profile") || glb.config().has("live-profile")) {
         db.addGlobalInclude("\"souffle/profile/Logger.h\"");
         db.addGlobalInclude("\"souffle/profile/ProfileEvent.h\"");
     }
@@ -2762,7 +2763,7 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
     GenFunction& constructor = mainClass.addConstructor(Visibility::Public);
     constructor.setIsConstructor();
 
-    if (Global::config().has("profile")) {
+    if (glb.config().has("profile")) {
         mainClass.addField("std::string", "profiling_fname", Visibility::Public);
         constructor.setNextArg("std::string", "pf", std::make_optional("\"profile.log\""));
         constructor.setNextInitializer("profiling_fname", "std::move(pf)");
@@ -2796,7 +2797,7 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
     mainClass.addField("ConcurrentCache<std::string,std::regex>", "regexCache", Visibility::Private);
     constructor.setNextInitializer("regexCache", "");
 
-    if (Global::config().has("profile")) {
+    if (glb.config().has("profile")) {
         std::size_t numFreq = 0;
         visit(prog, [&](const Statement&) { numFreq++; });
         mainClass.addField("std::size_t", "freqs[" + std::to_string(numFreq) + "]", Visibility::Private);
@@ -2853,6 +2854,7 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
             constructor.setNextInitializer(wrapper_name.str(), init.str());
         }
     }
+
     for (auto [name, value] : subroutineInits) {
         std::string clName = convertStratumIdent("Stratum_" + name);
         std::string fName = convertStratumIdent("stratum_" + name);
@@ -2860,7 +2862,7 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
         constructor.setNextInitializer(fName, value);
     }
 
-    if (Global::config().has("profile")) {
+    if (glb.config().has("profile")) {
         constructor.body() << "ProfileEventSingleton::instance().setOutputFile(profiling_fname);\n";
     }
 
@@ -2905,13 +2907,13 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
 
     signalHandler->set();
 )_";
-    if (Global::config().has("verbose")) {
+    if (glb.config().has("verbose")) {
         runFunction.body() << "signalHandler->enableLogging();\n";
     }
 
     // add actual program body
     runFunction.body() << "// -- query evaluation --\n";
-    if (Global::config().has("profile")) {
+    if (glb.config().has("profile")) {
         runFunction.body() << "ProfileEventSingleton::instance().startTimer();\n"
                            << R"_(ProfileEventSingleton::instance().makeTimeEvent("@time;starttime");)_"
                            << '\n'
@@ -2934,7 +2936,7 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
     currentClass = &mainClass;
     emitCode(runFunction.body(), prog.getMain());
 
-    if (Global::config().has("profile")) {
+    if (glb.config().has("profile")) {
         runFunction.body() << "}\n"
                            << "ProfileEventSingleton::instance().stopTimer();\n"
                            << "dumpFreqs();\n";
@@ -2943,7 +2945,7 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
     // add code printing hint statistics
     runFunction.body() << "\n// -- relation hint statistics --\n";
 
-    if (Global::config().has("verbose")) {
+    if (glb.config().has("verbose")) {
         for (auto rel : prog.getRelations()) {
             auto name = getRelationName(*rel);
             runFunction.body() << "std::cout << \"Statistics for Relation " << name << ":\\n\";\n"
@@ -2967,11 +2969,11 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
     runAll.setNextArg("std::string", "outputDirectoryArg", std::make_optional("\"\""));
     runAll.setNextArg("bool", "performIOArg", std::make_optional("true"));
     runAll.setNextArg("bool", "pruneImdtRelsArg", std::make_optional("true"));
-    if (Global::config().has("live-profile")) {
+    if (glb.config().has("live-profile")) {
         runAll.body() << "std::thread profiler([]() { profile::Tui().runProf(); });\n";
     }
     runAll.body() << "runFunction(inputDirectoryArg, outputDirectoryArg, performIOArg, pruneImdtRelsArg);\n";
-    if (Global::config().has("live-profile")) {
+    if (glb.config().has("live-profile")) {
         runAll.body() << "if (profiler.joinable()) { profiler.join(); }\n";
     }
 
@@ -3111,10 +3113,11 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
         }
         executeSubroutine.body() << "fatal((\"unknown subroutine \" + name).c_str());\n";
     }
+
     // dumpFreqs method
     //  Frequency counts must be emitted after subroutines otherwise lookup tables
     //  are not populated.
-    if (Global::config().has("profile")) {
+    if (glb.config().has("profile")) {
         GenFunction& dumpFreqs = mainClass.addFunction("dumpFreqs", Visibility::Private);
         dumpFreqs.setRetType("void");
 
@@ -3165,23 +3168,23 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
 
     // parse arguments
     hook << "souffle::CmdOptions opt(";
-    hook << "R\"(" << Global::config().get("") << ")\",\n";
+    hook << "R\"(" << glb.config().get("") << ")\",\n";
     hook << "R\"()\",\n";
     hook << "R\"()\",\n";
-    if (Global::config().has("profile")) {
+    if (glb.config().has("profile")) {
         hook << "true,\n";
-        hook << "R\"(" << Global::config().get("profile") << ")\",\n";
+        hook << "R\"(" << glb.config().get("profile") << ")\",\n";
     } else {
         hook << "false,\n";
         hook << "R\"()\",\n";
     }
-    hook << std::stoi(Global::config().get("jobs"));
+    hook << std::stoi(glb.config().get("jobs"));
     hook << ");\n";
 
     hook << "if (!opt.parse(argc,argv)) return 1;\n";
 
     hook << "souffle::";
-    if (Global::config().has("profile")) {
+    if (glb.config().has("profile")) {
         hook << classname + " obj(opt.getProfileName());\n";
     } else {
         hook << classname + " obj;\n";
@@ -3191,7 +3194,7 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
     hook << "obj.setNumThreads(opt.getNumJobs());\n";
     hook << "\n#endif\n";
 
-    if (Global::config().has("profile")) {
+    if (glb.config().has("profile")) {
         hook << R"_(souffle::ProfileEventSingleton::instance().makeConfigRecord("", opt.getSourceFileName());)_"
              << '\n';
         hook << R"_(souffle::ProfileEventSingleton::instance().makeConfigRecord("fact-dir", opt.getInputFileDir());)_"
@@ -3201,13 +3204,13 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
         hook << R"_(souffle::ProfileEventSingleton::instance().makeConfigRecord("output-dir", opt.getOutputFileDir());)_"
              << '\n';
         hook << R"_(souffle::ProfileEventSingleton::instance().makeConfigRecord("version", ")_"
-             << Global::config().get("version") << R"_(");)_" << '\n';
+             << glb.config().get("version") << R"_(");)_" << '\n';
     }
     hook << "obj.runAll(opt.getInputFileDir(), opt.getOutputFileDir());\n";
 
-    if (Global::config().get("provenance") == "explain") {
+    if (glb.config().get("provenance") == "explain") {
         hook << "explain(obj, false);\n";
-    } else if (Global::config().get("provenance") == "explore") {
+    } else if (glb.config().get("provenance") == "explore") {
         hook << "explain(obj, true);\n";
     }
     hook << "return 0;\n";

--- a/src/synthesiser/Synthesiser.h
+++ b/src/synthesiser/Synthesiser.h
@@ -45,6 +45,9 @@ private:
     /** RAM translation unit */
     ram::TranslationUnit& translationUnit;
 
+    /** Global */
+    Global& glb;
+
     /** RAM identifier to C++ identifier map */
     std::map<const std::string, const std::string> identifiers;
 
@@ -155,8 +158,7 @@ protected:
     std::set<std::string> accessedUserDefinedFunctors(ram::Statement& stmt);
 
 public:
-    explicit Synthesiser(/*const std::size_t laneCount, */ ram::TranslationUnit& tUnit)
-            : /*recordTable(laneCount),*/ translationUnit(tUnit) {
+    explicit Synthesiser(ram::TranslationUnit& tUnit) : translationUnit(tUnit), glb(tUnit.global()) {
         visit(tUnit.getProgram(),
                 [&](const ram::Relation& relation) { relationMap[relation.getName()] = &relation; });
     }


### PR DESCRIPTION
Hi, this change removes the `Global` singleton object. This is a requirement to allow a more flexible reuse of `libsouffle`.