### PR TITLE
Sort includes when generating multiple files

### DIFF
--- a/src/synthesiser/GenDb.cpp
+++ b/src/synthesiser/GenDb.cpp
@@ -254,16 +254,16 @@ std::string GenDb::emitMultipleFilesInDir(fs::path dir, std::vector<fs::path>& t
     auto genHeader = [&](std::ofstream& hpp, std::ofstream& cpp, GenFile& gen) {
         hpp << "#pragma once\n";
         globalHeader(hpp);
-        for (const std::string& inc : gen.getDeclIncludes()) {
+        for (const std::string& inc : gen.getSortedDeclIncludes()) {
             hpp << "#include " << inc << "\n";
         }
-        for (GenFile* dep : gen.getDeclDependencies()) {
+        for (GenFile* dep : gen.getSortedDeclDependencies()) {
             hpp << "#include " << dep->getHeader() << "\n";
         }
-        for (const std::string& inc : gen.getIncludes()) {
+        for (const std::string& inc : gen.getSortedIncludes()) {
             cpp << "#include " << inc << "\n";
         }
-        for (GenFile* dep : gen.getDependencies()) {
+        for (GenFile* dep : gen.getSortedDependencies()) {
             cpp << "#include " << dep->getHeader() << "\n";
         }
         cpp << "#include " << gen.getHeader() << "\n";

--- a/src/synthesiser/GenDb.h
+++ b/src/synthesiser/GenDb.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "souffle/utility/Types.h"
+#include <algorithm>
 #include <cassert>
 #include <filesystem>
 #include <iostream>
@@ -47,7 +48,7 @@ public:
         return basename;
     };
 
-    fs::path getHeader() {
+    fs::path getHeader() const {
         fs::path header = basename;
         return header.concat(".hpp");
     }
@@ -70,14 +71,39 @@ public:
     std::set<std::string>& getDeclIncludes() {
         return decl_includes;
     }
+    std::vector<std::string> getSortedDeclIncludes() {
+        std::vector<std::string> v{decl_includes.begin(), decl_includes.end()};
+        std::sort(v.begin(), v.end());
+        return v;
+    }
+
     std::set<std::string>& getIncludes() {
         return includes;
     }
+    std::vector<std::string> getSortedIncludes() {
+        std::vector<std::string> v{includes.begin(), includes.end()};
+        std::sort(v.begin(), v.end());
+        return v;
+    }
+
     std::set<GenFile*>& getDeclDependencies() {
         return decl_dependencies;
     }
+    std::vector<GenFile*> getSortedDeclDependencies() {
+        std::vector<GenFile*> v{decl_dependencies.begin(), decl_dependencies.end()};
+        std::sort(v.begin(), v.end(),
+                [](const GenFile* a, const GenFile* b) { return a->getHeader() < b->getHeader(); });
+        return v;
+    }
+
     std::set<GenFile*>& getDependencies() {
         return dependencies;
+    }
+    std::vector<GenFile*> getSortedDependencies() {
+        std::vector<GenFile*> v{dependencies.begin(), dependencies.end()};
+        std::sort(v.begin(), v.end(),
+                [](const GenFile* a, const GenFile* b) { return a->getHeader() < b->getHeader(); });
+        return v;
     }
 
 private:


### PR DESCRIPTION
Currently, when generating multiple files, it is possible for Datalog changes to result in spurious changes to otherwise unchanged generated files due to headers being reordered. This PR ensures that headers are always emitted in alphabetical order.

In my tests this reduces the number of files that need to be recompiled after a Datalog change by 15-20%.