### PR TITLE
Missing inline keyword for function GreaterOrEqualPrime

### DIFF
--- a/src/include/souffle/datastructure/ConcurrentInsertOnlyHashMap.h
+++ b/src/include/souffle/datastructure/ConcurrentInsertOnlyHashMap.h
@@ -38,7 +38,7 @@ static constexpr uint64_t LargestPrime64 = 18446744073709551557UL;
 
 // Return a prime greater or equal to the lower bound.
 // Return 0 if the next prime would not fit in 64 bits.
-static uint64_t GreaterOrEqualPrime(const uint64_t LowerBound) {
+inline static uint64_t GreaterOrEqualPrime(const uint64_t LowerBound) {
     if (LowerBound > LargestPrime64) {
         return 0;
     }


### PR DESCRIPTION
I receive an error on an OS X machine since `Inline` is missing. 