### PR TITLE
Eliminate nondeterminism in Condition ordering

### DIFF
--- a/src/ram/transform/MakeIndex.cpp
+++ b/src/ram/transform/MakeIndex.cpp
@@ -202,12 +202,12 @@ Own<Condition> MakeIndexTransformer::constructPattern(const std::vector<std::str
     // Define a comparator which orders all of the conditions nicely
     // 1. Equalities come before inequalities
     // 2. Conditions are ordered by the index of the constraint i.e. t0.0 comes before t0.1
-    auto cmp = [&](auto& c1, auto& c2) -> bool {
+    auto cmp = [&](const auto& c1, const auto& c2) -> bool {
         auto* cond1 = as<Constraint>(c1);
         auto* cond2 = as<Constraint>(c2);
         // place non-conditions at the end
         if (!cond1 && !cond2) {
-            return c1.get() < c2.get();
+            return false;
         }
         if (cond1 && !cond2) {
             return true;
@@ -221,7 +221,7 @@ Own<Condition> MakeIndexTransformer::constructPattern(const std::vector<std::str
         bool rhsIndexable = isIndexableConstraint(cond2->getOperator());
 
         if (!lhsIndexable && !rhsIndexable) {
-            return c1.get() < c2.get();
+            return false;
         }
         if (lhsIndexable && !rhsIndexable) {
             return true;
@@ -248,7 +248,7 @@ Own<Condition> MakeIndexTransformer::constructPattern(const std::vector<std::str
         bool rhsUndefined = isUndefValue(p2.first.get()) && isUndefValue(p2.second.get());
 
         if (lhsUndefined && rhsUndefined) {
-            return c1.get() < c2.get();
+            return false;
         }
 
         if (!lhsUndefined && rhsUndefined) {
@@ -263,7 +263,7 @@ Own<Condition> MakeIndexTransformer::constructPattern(const std::vector<std::str
         return attr1 < attr2;
     };
 
-    std::sort(conditionList.begin(), conditionList.end(), cmp);
+    std::stable_sort(conditionList.begin(), conditionList.end(), cmp);
 
     // Build query pattern and remaining condition
     bool seenInequality = false;

--- a/src/ram/transform/ReorderConditions.cpp
+++ b/src/ram/transform/ReorderConditions.cpp
@@ -41,9 +41,10 @@ bool ReorderConditionsTransformer::transform(TranslationUnit& tu) {
             for (auto& cond : condList) {
                 sortedConds.emplace_back(cond->cloning());
             }
-            std::sort(sortedConds.begin(), sortedConds.end(), [&](Own<Condition>& a, Own<Condition>& b) {
-                return rca.getComplexity(a.get()) < rca.getComplexity(b.get());
-            });
+            std::stable_sort(sortedConds.begin(), sortedConds.end(),
+                    [&](const Own<Condition>& a, const Own<Condition>& b) {
+                        return rca.getComplexity(a.get()) < rca.getComplexity(b.get());
+                    });
             auto sorted_node = toCondition(sortedConds);
 
             if (sorted_node != node) {


### PR DESCRIPTION
Conditions were sorted nondeterministically in during both the `MakeIndex` and `ReorderConditions` RAM transforms. This updates both to use `std::stable_sort` and eliminates use of pointer comparison to sort Conditions.

When building incremental builds of ddisasm with `--generate-many`, these changes significantly reduce the number of object files to recompile when a trivial change is made (with the change I am making in my particular configuration, it drops from rebuilding 18 compilation units down to two).