### PR TITLE
Read preprocessed code into buffer before parsing

### DIFF
--- a/src/parser/ParserDriver.h
+++ b/src/parser/ParserDriver.h
@@ -69,16 +69,16 @@ public:
 
     Own<ast::Counter> addDeprecatedCounter(SrcLocation tagLoc);
 
-    Own<ast::TranslationUnit> parse(const std::string& filename, FILE* in,
+    Own<ast::TranslationUnit> parse(const std::string& filename, const std::string& codein,
             bool reducedConsecutiveNonLeadingWhitespaces, ErrorReport& errorReport, DebugReport& debugReport);
     Own<ast::TranslationUnit> parse(
             const std::string& code, ErrorReport& errorReport, DebugReport& debugReport);
     Own<ast::TranslationUnit> parseFromFS(
             const std::filesystem::path& path, ErrorReport& errorReport, DebugReport& debugReport);
 
-    static Own<ast::TranslationUnit> parseTranslationUnit(Global& glb, const std::string& filename, FILE* in,
-            bool reducedConsecutiveNonLeadingWhitespaces, ErrorReport& errorReport, DebugReport& debugReport,
-            std::shared_ptr<FileSystem> vfs = nullptr);
+    static Own<ast::TranslationUnit> parseTranslationUnit(Global& glb, const std::string& filename,
+            const std::string& code, bool reducedConsecutiveNonLeadingWhitespaces, ErrorReport& errorReport,
+            DebugReport& debugReport, std::shared_ptr<FileSystem> vfs = nullptr);
     static Own<ast::TranslationUnit> parseTranslationUnit(Global& glb, const std::string& code,
             ErrorReport& errorReport, DebugReport& debugReport, std::shared_ptr<FileSystem> vfs = nullptr);
     static Own<ast::TranslationUnit> parseTranslationUnitFromFS(Global& glb,


### PR DESCRIPTION
This change resolves a race condition that existed where the parser may close the preprocessor's output pipe, causing it to terminate. Souffle would then see the process terminated unsuccessfully, and and throw an exception instead of printing information about the parsing error.

Closes https://github.com/souffle-lang/souffle/issues/2386