### PR TITLE
Purge input relations if pruneImdtRels is set

### DIFF
--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -486,9 +486,8 @@ void Synthesiser::emitCode(std::ostream& out, const Statement& stmt) {
             PRINT_BEGIN_COMMENT(out);
 
             auto Relation = synthesiser.lookup(clear.getRelation());
-            bool isIntermediate = !contains(synthesiser.loadRelations, Relation->getName()) &&
-                                  !contains(synthesiser.storeRelations, Relation->getName()) &&
-                                  !Relation->isTemp();
+            bool isIntermediate =
+                    !contains(synthesiser.storeRelations, Relation->getName()) && !Relation->isTemp();
 
             if (isIntermediate) {
                 out << "if (pruneImdtRels) ";
@@ -2618,6 +2617,7 @@ void Synthesiser::generateCode(GenDb& db, const std::string& id, bool& withShare
         db.usesDatastructure(mainClass, typeName);
     }
 
+    std::set<std::string> loadRelations;
     std::set<const IO*> loadIOs;
     std::set<const IO*> storeIOs;
 

--- a/src/synthesiser/Synthesiser.h
+++ b/src/synthesiser/Synthesiser.h
@@ -91,9 +91,6 @@ private:
     /** signatures of the user-defined functors */
     std::map<std::string, std::pair<std::vector<std::string>, std::string>> functor_signatures;
 
-    /** Input relations */
-    std::set<std::string> loadRelations;
-
     /** Output relations */
     std::set<std::string> storeRelations;
 


### PR DESCRIPTION
This PR undoes part of a previous PR that I implemented, https://github.com/souffle-lang/souffle/pull/2286. With this PR, when `pruneImdtRels` is set, `.input` relations will be purged when they are no longer needed.

In the previous PR, I changed behavior to preserve both input and output relations when the `pruneImdtRels` option was enabled. However, I think that it was the wrong decision to preserve input relations.

By preserving only output relations, this maximizes the opportunity for memory savings, allowing any relation no longer needed by souffle to be purged. If a C++ program needs to access an input relation again after running the souffle program via the C++ interface, I now realize that the program should have apply both the`.input` and `.output` directives, rather than relying on an `.input` to be preserved. This is more consistent with other Souffle behavior; if an input relation is never used by a Souffle program, Souffle is more than happy to optimize that relation out of the program entirely.