### PR TITLE
Make -D- option for compiled datalog behave same as if interpreted

### DIFF
--- a/src/include/souffle/CompiledOptions.h
+++ b/src/include/souffle/CompiledOptions.h
@@ -52,6 +52,8 @@ protected:
      */
     std::string output_dir;
 
+    bool use_stdout = false;
+
     /**
      * profiling flag
      */
@@ -93,6 +95,10 @@ public:
         return output_dir;
     }
 
+    bool getUseStdout() const {
+        return use_stdout;
+    }
+
     /**
      * is profiling switched on
      */
@@ -128,6 +134,7 @@ public:
         // local options
         std::string fact_dir = input_dir;
         std::string out_dir = output_dir;
+        bool use_stdout = this->use_stdout;
 
         // long options
         option longOptions[] = {{"facts", true, nullptr, 'F'}, {"output", true, nullptr, 'D'},
@@ -151,11 +158,16 @@ public:
                     break;
                 /* Output directory for resulting .csv files */
                 case 'D':
-                    if (*optarg && !existDir(optarg)) {
-                        printf("Output directory %s does not exists!\n", optarg);
-                        ok = false;
+                    if (*optarg) {
+                        if (dirIsStdout(optarg)) {
+                            use_stdout = true;
+                        } else if (existDir(optarg)) {
+                            out_dir = optarg;
+                        } else {
+                            printf("Output directory %s does not exists!\n", optarg);
+                            ok = false;
+                        }
                     }
-                    out_dir = optarg;
                     break;
                 case 'p':
                     if (!profiling) {
@@ -189,6 +201,7 @@ public:
         // update member fields
         input_dir = fact_dir;
         output_dir = out_dir;
+        this->use_stdout = use_stdout;
 
         // return success state
         return ok;
@@ -257,6 +270,10 @@ private:
             }
         }
         return false;
+    }
+
+    bool dirIsStdout(const std::string& name) const {
+        return name == "-";
     }
 };
 

--- a/src/include/souffle/CompiledOptions.h
+++ b/src/include/souffle/CompiledOptions.h
@@ -52,6 +52,9 @@ protected:
      */
     std::string output_dir;
 
+    /**
+     * true if output is stdout
+     */
     bool use_stdout = false;
 
     /**
@@ -95,6 +98,9 @@ public:
         return output_dir;
     }
 
+    /**
+     * get use stdout switch
+     */
     bool getUseStdout() const {
         return use_stdout;
     }

--- a/src/include/souffle/SouffleInterface.h
+++ b/src/include/souffle/SouffleInterface.h
@@ -793,7 +793,7 @@ public:
      * @param pruneImdtRels Prune intermediate relations
      */
     virtual void runAll(std::string inputDirectory = "", std::string outputDirectory = "",
-            bool performIO = false, bool pruneImdtRels = true) = 0;
+            bool useStdout = false, bool performIO = false, bool pruneImdtRels = true) = 0;
 
     /**
      * Read all input relations.
@@ -809,7 +809,7 @@ public:
      * File IO types can use the given directory to find their input file.
      * @param outputDirectory If non-empty, specifies the output directory
      */
-    virtual void printAll(std::string outputDirectory = "") = 0;
+    virtual void printAll(std::string outputDirectory = "", bool useStdout = false) = 0;
 
     /**
      * Output all the input relations in stdout, without generating any files. (for debug purposes).

--- a/src/interpreter/ProgInterface.h
+++ b/src/interpreter/ProgInterface.h
@@ -258,13 +258,13 @@ public:
     void run() override {}
 
     /** Load data, run program instance, store data: not implemented */
-    void runAll(std::string, std::string, bool, bool) override {}
+    void runAll(std::string, std::string, bool, bool, bool) override {}
 
     /** Load input data: not implemented */
     void loadAll(std::string) override {}
 
     /** Print output data: not implemented */
-    void printAll(std::string) override {}
+    void printAll(std::string, bool) override {}
 
     /** Dump inputs: not implemented */
     void dumpInputs() override {}


### PR DESCRIPTION
Makes compiled datalog handle `-D-` option as interpreted datalog. Fixes #2348 
It adds a `useStdout` property that is forwarded through the entire execution, this makes it probably a bit too intrusive.

```souffle
.decl foo(a:number)
.output foo
foo(1).
```

```
$souffle test.dl -D-
---------------
foo
a
===============
1
===============
```

Before:
```
$ souffle test.dl -o test && ./test -D-
Output directory - does not exists!
```

After:
```
$souffle test.dl -o test && ./test -D-
---------------
foo
===============
1
===============
```

As you may notice, the output of the executable is slightly different from interpreted one. I'm probably missing something on the output method.

I don't know how to test that, if you have any pointer to do that I would add a test to the PR.