### PR TITLE
Fix subsumption

### DIFF
--- a/src/ast2ram/seminaive/UnitTranslator.cpp
+++ b/src/ast2ram/seminaive/UnitTranslator.cpp
@@ -308,15 +308,11 @@ Own<ram::Statement> UnitTranslator::translateSubsumptiveRecursiveClauses(
             continue;
         }
 
-        const auto& sccAtoms = getSccAtoms(clause, scc);
-        for (std::size_t version = 0; version < sccAtoms.size(); version++) {
-            // find dominated tuples in the newR by tuples in newR  and store them in rejectR
-            appendStmt(code, context->translateRecursiveClause(*clause, scc, version, SubsumeRejectNewNew));
-
-            // find dominated tuples in the newR by tuples in R and store them in rejectR
-            appendStmt(
-                    code, context->translateRecursiveClause(*clause, scc, version, SubsumeRejectNewCurrent));
-        }
+        const std::size_t version = 0;
+        // find dominated tuples in the newR by tuples in newR  and store them in rejectR
+        appendStmt(code, context->translateRecursiveClause(*clause, scc, version, SubsumeRejectNewNew));
+        // find dominated tuples in the newR by tuples in R and store them in rejectR
+        appendStmt(code, context->translateRecursiveClause(*clause, scc, version, SubsumeRejectNewCurrent));
     }
 
     // compute new delta set, i.e., deltaR = newR \ rejectR
@@ -335,7 +331,7 @@ Own<ram::Statement> UnitTranslator::translateSubsumptiveRecursiveClauses(
         std::size_t sz = sccAtoms.size();
         for (std::size_t version = 0; version < sz; version++) {
             appendStmt(code, context->translateRecursiveClause(*clause, scc, version,
-                                     (sz > 1) ? SubsumeDeleteCurrentCurrent : SubsumeDeleteCurrentDelta));
+                                     (version >= 1) ? SubsumeDeleteCurrentCurrent : SubsumeDeleteCurrentDelta));
         }
         appendStmt(code, generateEraseTuples(rel, mainRelation, deleteRelation));
         appendStmt(code, mk<ram::Clear>(deleteRelation));

--- a/src/ast2ram/seminaive/UnitTranslator.cpp
+++ b/src/ast2ram/seminaive/UnitTranslator.cpp
@@ -330,8 +330,9 @@ Own<ram::Statement> UnitTranslator::translateSubsumptiveRecursiveClauses(
         const auto& sccAtoms = getSccAtoms(clause, scc);
         std::size_t sz = sccAtoms.size();
         for (std::size_t version = 0; version < sz; version++) {
-            appendStmt(code, context->translateRecursiveClause(*clause, scc, version,
-                                     (version >= 1) ? SubsumeDeleteCurrentCurrent : SubsumeDeleteCurrentDelta));
+            appendStmt(
+                    code, context->translateRecursiveClause(*clause, scc, version,
+                                  (version >= 1) ? SubsumeDeleteCurrentCurrent : SubsumeDeleteCurrentDelta));
         }
         appendStmt(code, generateEraseTuples(rel, mainRelation, deleteRelation));
         appendStmt(code, mk<ram::Clear>(deleteRelation));

--- a/src/ast2ram/utility/Utils.cpp
+++ b/src/ast2ram/utility/Utils.cpp
@@ -72,6 +72,8 @@ std::string getAtomName(const ast::Clause& clause, const ast::Atom* atom,
                 return getDeltaRelationName(atom->getQualifiedName());
             }
         }
+
+        return getConcreteRelationName(atom->getQualifiedName());
     }
 
     if (!isRecursive) {


### PR DESCRIPTION
I noticed a number of bugs when translating recursive subsumptive rules.

- the "reject" clauses do not need to iterate on all versions of the rule, as the must always use the "concrete" relations from the body.
- the "delete" clauses were not produced properly if the body of the subsumptive rules had atoms in the same scc.