### PR TITLE
fix "variable only occurs once" checker

### DIFF
--- a/tests/semantic/fact_plus/fact_plus.err
+++ b/tests/semantic/fact_plus/fact_plus.err
@@ -1,7 +1,4 @@
 Error: Argument in fact is not constant in file fact_plus.dl at line 10
 F(1+a,"AA").
 --^----------
-Warning: Variable a only occurs once in file fact_plus.dl at line 10
-F(1+a,"AA").
-----^--------
 1 errors generated, evaluation aborted

--- a/tests/semantic/fact_variable/fact_variable.err
+++ b/tests/semantic/fact_variable/fact_variable.err
@@ -1,7 +1,4 @@
 Error: Argument in fact is not constant in file fact_variable.dl at line 7
 F(BB,"AA").
 --^---------
-Warning: Variable BB only occurs once in file fact_variable.dl at line 7
-F(BB,"AA").
---^---------
 1 errors generated, evaluation aborted

--- a/tests/semantic/rule_typecompat/rule_typecompat.err
+++ b/tests/semantic/rule_typecompat/rule_typecompat.err
@@ -54,9 +54,6 @@ The argument's declared type is R in file rule_typecompat.dl at line 12
 Error: Ungrounded variable y in file rule_typecompat.dl at line 30
 G(x,y) :- A(x).
 ----^-----------
-Warning: Variable y only occurs once in file rule_typecompat.dl at line 30
-G(x,y) :- A(x).
-----^-----------
 Error: Unable to deduce type for variable x in file rule_typecompat.dl at line 33
 A(x) :- B(x), C(x).
 --^-----------------
@@ -80,9 +77,6 @@ The argument's declared type is T in file rule_typecompat.dl at line 11
 .decl F (r:R, t:T)
 ----------------^--
 Error: Ungrounded variable y in file rule_typecompat.dl at line 41
-F(x,y) :- F(x,z), G(z,x).
-----^---------------------
-Warning: Variable y only occurs once in file rule_typecompat.dl at line 41
 F(x,y) :- F(x,z), G(z,x).
 ----^---------------------
 Error: Unable to deduce type for variable v in file rule_typecompat.dl at line 47

--- a/tests/semantic/var_single/var_single.err
+++ b/tests/semantic/var_single/var_single.err
@@ -1,9 +1,6 @@
 Error: Ungrounded variable X in file var_single.dl at line 8
 A(X) :- A(Y).
 --^-----------
-Warning: Variable X only occurs once in file var_single.dl at line 8
-A(X) :- A(Y).
---^-----------
 Warning: Variable Y only occurs once in file var_single.dl at line 8
 A(X) :- A(Y).
 ----------^---


### PR DESCRIPTION
Fix `variable only occurs once`  checker:
- deterministic source location
- handle multi-head rules properly
- do not report ungrounded variables (already reported by another check)

Still not handling properly the variables in negated conjunctions and aggregates.  