### PR TITLE
do not consider debug_delta relations as empty

### DIFF
--- a/src/ast/transform/RemoveEmptyRelations.cpp
+++ b/src/ast/transform/RemoveEmptyRelations.cpp
@@ -48,6 +48,7 @@ bool RemoveEmptyRelationsTransformer::removeEmptyRelations(TranslationUnit& tran
     for (auto rel : program.getRelations()) {
         if (ioTypes.isInput(rel)) continue;
         if (!program.getClauses(*rel).empty()) continue;
+        if (rel->getIsDeltaDebug()) continue;
 
         emptyRelations.insert(rel->getQualifiedName());
 


### PR DESCRIPTION
The RemoveEmptyRelations pass was removing debug_delta relations because they don't have rule and are not inputs.
This PR just fixes that to make sure debug_delta relations are not considered empty.