### PR TITLE
Fix auto-scheduler profile mismatch

### DIFF
--- a/src/ast2ram/utility/SipGraph.cpp
+++ b/src/ast2ram/utility/SipGraph.cpp
@@ -180,8 +180,8 @@ std::set<std::size_t> SipGraph::getBoundIndices(
                 auto& dependentVars = varToOtherVars.at(var->getName());
 
                 // and all of these variables are grounded by "from"
-                if (std::includes(groundedVars.begin(), groundedVars.end(), dependentVars.begin(),
-                            dependentVars.end())) {
+                if (!dependentVars.empty() && std::includes(groundedVars.begin(), groundedVars.end(),
+                                                      dependentVars.begin(), dependentVars.end())) {
                     boundColumns.insert(argIdx);
                 }
             }


### PR DESCRIPTION
When using the auto-scheduler on certain inputs, the auto-scheduler may throw an error stating:
"Error: profile used for auto-scheduling doesn't match the provided program."
This was reported in Issue #2346 by another user, providing a small example to test on.

Running a `git bisect` using the example reveals that the commit 43a4ce3a8 (Working refactor of SIP Graph, 2022-06-23) was the first to introduce the error.

Inspecting the profiler output for that commit and the parent commit, I noted that some new indices appear the join columns and they should probably not be there.

After deep inspection of the refactor, I've noticed the following diff potentially changes the program behaviour:

src/ast/analysis/JoinSize.cpp
in 43a4ce3a8 (Working refactor of SIP Graph, 2022-06-23)
```diff
-  auto& dependentVars = varToOtherVars.at(var->getName());
-  if (!dependentVars.empty() &&
-          std::includes(providedVars.begin(), providedVars.end(),
-                  dependentVars.begin(), dependentVars.end())) {
-      joinColumns.push_back(argIdx);
-      ++numBound;
-      continue;
```

src/ast/utility/SipGraph.cpp
in 55c35006e (Working SIPGraph for SelingerSIPS, 2022-06-23)
```diff
+  if (std::includes(groundedVars.begin(), groundedVars.end(), dependentVars.begin(),
+            dependentVars.end())) {
+    boundColumns.insert(argIdx);
+  }
```

This commit adds the empty check, and this change makes the error disappear. While I am not certain about whether this is the correct fix, the use of `std::includes` on an empty range could be a potential cause of bugs.

I tested the join column output against the parent commit of the 43a4ce3a8 (Working refactor of SIP Graph, 2022-06-23), and can confirm that the join columns in the profile output are the same.

Closes #2346