### PR TITLE
Fix for compilation warnings

### DIFF
--- a/src/ast/analysis/PrecedenceGraph.h
+++ b/src/ast/analysis/PrecedenceGraph.h
@@ -44,7 +44,7 @@ public:
     void print(std::ostream& os) const override;
 
     /** Output precedence graph in image format to a given stream */
-    void printHTML(std::ostream& os) const;
+    void printHTML(std::ostream& os) const override;
 
     const Graph<const Relation*, NameComparison>& graph() const {
         return backingGraph;

--- a/src/ast/analysis/SCCGraph.h
+++ b/src/ast/analysis/SCCGraph.h
@@ -205,7 +205,7 @@ public:
     void print(std::ostream& os) const override;
 
     /** Print the SCC graph in HTML format. */
-    void printHTML(std::ostream& os) const;
+    void printHTML(std::ostream& os) const override;
 
 private:
     PrecedenceGraphAnalysis* precedenceGraph = nullptr;

--- a/src/tests/visitor_test.cpp
+++ b/src/tests/visitor_test.cpp
@@ -44,7 +44,7 @@ namespace {
 template <typename A, typename... XS>
 auto asVec(XS&&... xs) {
     vector<A> v;
-    (v.push_back(forward<XS>(xs)), ...);
+    (v.push_back(std::forward<XS>(xs)), ...);
     return v;
 }
 
@@ -54,7 +54,7 @@ struct Node {
     VecOwn<Node> kids;
 
     template <typename... A>
-    Node(A&&... xs) : kids(asVec<Own<Node>>(forward<A>(xs)...)) {}
+    Node(A&&... xs) : kids(asVec<Own<Node>>(std::forward<A>(xs)...)) {}
 
     virtual vector<Node const*> getChildNodes() const {
         return toPtrVector<Node const>(kids);
@@ -151,7 +151,7 @@ template <typename A, typename B>
 void TEST_INSTANTIATION_MAPPER() {
     A x;
     mapPost(x, [&](Own<B> x) { return x; });
-    mapFrontier(x, [&](Own<B> x) { return pair{move(x), false}; });
+    mapFrontier(x, [&](Own<B> x) { return pair{std::move(x), false}; });
 }
 
 // Check that visitor function instantiates successfully.
@@ -209,7 +209,7 @@ TEST(NodeMapper, mapPrePost_BarToFoo) {
 
     auto go = [](Own<NBar> n) {
         auto x = mk<NFoo>();
-        x->kids = move(n->kids);
+        x->kids = std::move(n->kids);
         return x;
     };
     EXPECT_EQ(*expected, *mapPre(mkTree(), go));
@@ -229,8 +229,8 @@ TEST(NodeMapper, mapFrontier_FooToBar) {
 
     auto go = [](Own<NFoo> n) {
         auto x = mk<NBar>();
-        x->kids = move(n->kids);
-        return pair{move(x), true};
+        x->kids = std::move(n->kids);
+        return pair{std::move(x), true};
     };
     auto&& [produced, n] = mapFrontier(mkTree(), go);
 


### PR DESCRIPTION
+ `warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]` in `visitor_test.cpp`
+ `warning: unqualified call to 'std::forward' [-Wunqualified-std-cast-call]` in `visitor_test.cpp`
+ `warning: 'printHTML' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]` in `SCCGraph.h` and `PrecedenceGraph.h`