### PR TITLE
non-RTTI dynamic cast

### DIFF
--- a/src/ast/Aggregator.cpp
+++ b/src/ast/Aggregator.cpp
@@ -16,11 +16,12 @@
 #include <utility>
 
 namespace souffle::ast {
-Aggregator::Aggregator(Own<Argument> expr, VecOwn<Literal> body, SrcLocation loc)
-        : Argument(std::move(loc)), targetExpression(std::move(expr)), body(std::move(body)) {
+Aggregator::Aggregator(NodeKind kind, Own<Argument> expr, VecOwn<Literal> body, SrcLocation loc)
+        : Argument(kind, std::move(loc)), targetExpression(std::move(expr)), body(std::move(body)) {
     // NOTE: targetExpression can be nullptr - it's used e.g. when aggregator
     // has no parameters, such as count: { body }
     assert(allValidPtrs(this->body));
+    assert(kind >= NK_Aggregator && kind < NK_LastAggregator);
 }
 
 std::vector<Literal*> Aggregator::getBodyLiterals() const {
@@ -40,6 +41,11 @@ void Aggregator::apply(const NodeMapper& map) {
     }
 
     mapAll(body, map);
+}
+
+bool Aggregator::classof(const Node* n) {
+    const NodeKind kind = n->getKind();
+    return (kind >= NK_Aggregator && kind < NK_LastAggregator);
 }
 
 Node::NodeVec Aggregator::getChildren() const {

--- a/src/ast/Aggregator.h
+++ b/src/ast/Aggregator.h
@@ -38,7 +38,7 @@ namespace souffle::ast {
  */
 class Aggregator : public Argument {
 public:
-    Aggregator(Own<Argument> expr = {}, VecOwn<Literal> body = {}, SrcLocation loc = {});
+    Aggregator(NodeKind Kind, Own<Argument> expr = {}, VecOwn<Literal> body = {}, SrcLocation loc = {});
 
     /** Return target expression */
     const Argument* getTargetExpression() const {
@@ -58,6 +58,8 @@ public:
     void apply(const NodeMapper& map) override;
 
     virtual std::string getBaseOperatorName() const = 0;
+
+    static bool classof(const Node*);
 
 protected:
     NodeVec getChildren() const override;

--- a/src/ast/AlgebraicDataType.cpp
+++ b/src/ast/AlgebraicDataType.cpp
@@ -16,7 +16,7 @@
 namespace souffle::ast {
 
 AlgebraicDataType::AlgebraicDataType(QualifiedName name, VecOwn<BranchType> branches, SrcLocation loc)
-        : Type(std::move(name), std::move(loc)), branches(std::move(branches)) {
+        : Type(NK_AlgebraicDataType, std::move(name), std::move(loc)), branches(std::move(branches)) {
     assert(!this->branches.empty());
     assert(allValidPtrs(this->branches));
 }
@@ -41,6 +41,10 @@ bool AlgebraicDataType::equal(const Node& node) const {
 
 AlgebraicDataType* AlgebraicDataType::cloning() const {
     return new AlgebraicDataType(getQualifiedName(), clone(branches), getSrcLoc());
+}
+
+bool AlgebraicDataType::classof(const Node* n) {
+    return n->getKind() == NK_AlgebraicDataType;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/AlgebraicDataType.h
+++ b/src/ast/AlgebraicDataType.h
@@ -44,6 +44,8 @@ public:
 
     std::vector<BranchType*> getBranches() const;
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/AliasType.cpp
+++ b/src/ast/AliasType.cpp
@@ -14,7 +14,7 @@
 namespace souffle::ast {
 
 AliasType::AliasType(QualifiedName name, QualifiedName aliasTypeName, SrcLocation loc)
-        : Type(std::move(name), std::move(loc)), aliasType(std::move(aliasTypeName)) {}
+        : Type(NK_AliasType, std::move(name), std::move(loc)), aliasType(std::move(aliasTypeName)) {}
 
 void AliasType::print(std::ostream& os) const {
     os << ".type " << getQualifiedName() << " = " << getAliasType();
@@ -27,6 +27,10 @@ bool AliasType::equal(const Node& node) const {
 
 AliasType* AliasType::cloning() const {
     return new AliasType(getQualifiedName(), getAliasType(), getSrcLoc());
+}
+
+bool AliasType::classof(const Node* n) {
+    return n->getKind() == NK_AliasType;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/AliasType.h
+++ b/src/ast/AliasType.h
@@ -44,6 +44,8 @@ public:
         aliasType = type;
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/Argument.h
+++ b/src/ast/Argument.h
@@ -27,6 +27,11 @@ namespace souffle::ast {
 class Argument : public Node {
 public:
     using Node::Node;
+
+    static bool classof(const Node* n) {
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_Argument && kind < NK_LastArgument);
+    }
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Atom.cpp
+++ b/src/ast/Atom.cpp
@@ -69,5 +69,4 @@ bool Atom::classof(const Node* n) {
     return n->getKind() == NK_Atom;
 }
 
-
 }  // namespace souffle::ast

--- a/src/ast/Atom.cpp
+++ b/src/ast/Atom.cpp
@@ -26,7 +26,7 @@ namespace souffle::ast {
  * e.g., parent(x,y), !parent(x,y), ...
  */
 Atom::Atom(QualifiedName name, VecOwn<Argument> args, SrcLocation loc)
-        : Literal(std::move(loc)), name(std::move(name)), arguments(std::move(args)) {
+        : Literal(NK_Atom, std::move(loc)), name(std::move(name)), arguments(std::move(args)) {
     assert(allValidPtrs(arguments));
 }
 
@@ -64,5 +64,10 @@ bool Atom::equal(const Node& node) const {
 Atom* Atom::cloning() const {
     return new Atom(name, clone(arguments), getSrcLoc());
 }
+
+bool Atom::classof(const Node* n) {
+    return n->getKind() == NK_Atom;
+}
+
 
 }  // namespace souffle::ast

--- a/src/ast/Atom.h
+++ b/src/ast/Atom.h
@@ -60,6 +60,8 @@ public:
 
     void apply(const NodeMapper& map) override;
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/Attribute.cpp
+++ b/src/ast/Attribute.cpp
@@ -14,10 +14,11 @@
 namespace souffle::ast {
 
 Attribute::Attribute(std::string n, QualifiedName t, SrcLocation loc)
-        : Node(std::move(loc)), name(std::move(n)), typeName(std::move(t)), isLattice(false) {}
+        : Node(NK_Attribute, std::move(loc)), name(std::move(n)), typeName(std::move(t)), isLattice(false) {}
 
 Attribute::Attribute(std::string n, QualifiedName t, bool isLattice, SrcLocation loc)
-        : Node(std::move(loc)), name(std::move(n)), typeName(std::move(t)), isLattice(isLattice) {}
+        : Node(NK_Attribute, std::move(loc)), name(std::move(n)), typeName(std::move(t)),
+          isLattice(isLattice) {}
 
 void Attribute::setTypeName(QualifiedName name) {
     typeName = std::move(name);
@@ -37,6 +38,14 @@ bool Attribute::equal(const Node& node) const {
 
 Attribute* Attribute::cloning() const {
     return new Attribute(name, typeName, isLattice, getSrcLoc());
+}
+
+bool Attribute::classof(const Node* n) {
+    return n->getKind() == NK_Attribute;
+}
+
+bool Attribute::getIsLattice() const {
+    return isLattice;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Attribute.h
+++ b/src/ast/Attribute.h
@@ -50,9 +50,9 @@ public:
     /** Set type name */
     void setTypeName(QualifiedName name);
 
-    bool getIsLattice() const {
-        return isLattice;
-    }
+    bool getIsLattice() const;
+
+    static bool classof(const Node*);
 
 protected:
     void print(std::ostream& os) const override;

--- a/src/ast/BinaryConstraint.cpp
+++ b/src/ast/BinaryConstraint.cpp
@@ -15,7 +15,8 @@
 namespace souffle::ast {
 
 BinaryConstraint::BinaryConstraint(BinaryConstraintOp o, Own<Argument> ls, Own<Argument> rs, SrcLocation loc)
-        : Constraint(NK_BinaryConstraint, std::move(loc)), operation(o), lhs(std::move(ls)), rhs(std::move(rs)) {
+        : Constraint(NK_BinaryConstraint, std::move(loc)), operation(o), lhs(std::move(ls)),
+          rhs(std::move(rs)) {
     assert(lhs != nullptr);
     assert(rhs != nullptr);
 }

--- a/src/ast/BinaryConstraint.cpp
+++ b/src/ast/BinaryConstraint.cpp
@@ -15,7 +15,7 @@
 namespace souffle::ast {
 
 BinaryConstraint::BinaryConstraint(BinaryConstraintOp o, Own<Argument> ls, Own<Argument> rs, SrcLocation loc)
-        : Constraint(std::move(loc)), operation(o), lhs(std::move(ls)), rhs(std::move(rs)) {
+        : Constraint(NK_BinaryConstraint, std::move(loc)), operation(o), lhs(std::move(ls)), rhs(std::move(rs)) {
     assert(lhs != nullptr);
     assert(rhs != nullptr);
 }
@@ -44,6 +44,10 @@ bool BinaryConstraint::equal(const Node& node) const {
 
 BinaryConstraint* BinaryConstraint::cloning() const {
     return new BinaryConstraint(operation, clone(lhs), clone(rhs), getSrcLoc());
+}
+
+bool BinaryConstraint::classof(const Node* n) {
+    return n->getKind() == NK_BinaryConstraint;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/BinaryConstraint.h
+++ b/src/ast/BinaryConstraint.h
@@ -61,6 +61,8 @@ public:
 
     void apply(const NodeMapper& map) override;
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/BooleanConstraint.cpp
+++ b/src/ast/BooleanConstraint.cpp
@@ -24,7 +24,7 @@ namespace souffle::ast {
  * Boolean constraint representing either the 'true' or the 'false' value
  */
 BooleanConstraint::BooleanConstraint(bool truthValue, SrcLocation loc)
-        : Constraint(std::move(loc)), truthValue(truthValue) {}
+        : Constraint(NK_BooleanConstraint, std::move(loc)), truthValue(truthValue) {}
 
 void BooleanConstraint::print(std::ostream& os) const {
     os << (truthValue ? "true" : "false");
@@ -37,6 +37,10 @@ bool BooleanConstraint::equal(const Node& node) const {
 
 BooleanConstraint* BooleanConstraint::cloning() const {
     return new BooleanConstraint(truthValue, getSrcLoc());
+}
+
+bool BooleanConstraint::classof(const Node* n) {
+    return n->getKind() == NK_BooleanConstraint;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/BooleanConstraint.h
+++ b/src/ast/BooleanConstraint.h
@@ -45,6 +45,8 @@ public:
         truthValue = value;
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/BranchInit.cpp
+++ b/src/ast/BranchInit.cpp
@@ -18,7 +18,7 @@
 namespace souffle::ast {
 
 BranchInit::BranchInit(QualifiedName name, VecOwn<Argument> args, SrcLocation loc)
-        : Term(std::move(args), std::move(loc)), name(std::move(name)) {}
+        : Term(NK_BranchInit, std::move(args), std::move(loc)), name(std::move(name)) {}
 
 void BranchInit::print(std::ostream& os) const {
     os << tfm::format("$%s(%s)", name, join(args, ", "));
@@ -33,4 +33,7 @@ BranchInit* BranchInit::cloning() const {
     return new BranchInit(name, clone(args), getSrcLoc());
 }
 
+bool BranchInit::classof(const Node* n) {
+    return n->getKind() == NK_BranchInit;
+}
 }  // namespace souffle::ast

--- a/src/ast/BranchInit.h
+++ b/src/ast/BranchInit.h
@@ -49,6 +49,8 @@ public:
         this->name = name;
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/BranchType.cpp
+++ b/src/ast/BranchType.cpp
@@ -16,7 +16,7 @@
 namespace souffle::ast {
 
 BranchType::BranchType(QualifiedName name, VecOwn<Attribute> fields, SrcLocation loc)
-        : Node(std::move(loc)), name(std::move(name)), fields(std::move(fields)) {
+        : Node(NK_BranchType, std::move(loc)), name(std::move(name)), fields(std::move(fields)) {
     assert(allValidPtrs(this->fields));
 }
 
@@ -34,6 +34,10 @@ BranchType* BranchType::cloning() const {
 
 void BranchType::setFieldType(std::size_t idx, QualifiedName type) {
     fields.at(idx)->setTypeName(std::move(type));
+}
+
+bool BranchType::classof(const Node* n) {
+    return n->getKind() == NK_BranchType;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/BranchType.h
+++ b/src/ast/BranchType.h
@@ -58,6 +58,8 @@ public:
     /** Set field type */
     void setFieldType(std::size_t idx, QualifiedName type);
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/Clause.cpp
+++ b/src/ast/Clause.cpp
@@ -17,13 +17,17 @@
 
 namespace souffle::ast {
 
-Clause::Clause(Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan, SrcLocation loc)
-        : Node(std::move(loc)), head(std::move(head)), bodyLiterals(std::move(bodyLiterals)),
+Clause::Clause(NodeKind kind, Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan, SrcLocation loc)
+        : Node(kind, std::move(loc)), head(std::move(head)), bodyLiterals(std::move(bodyLiterals)),
           plan(std::move(plan)) {
     assert(this->head != nullptr);
     assert(allValidPtrs(this->bodyLiterals));
+    assert(kind >= NK_Clause && kind < NK_LastClause);
     // Execution plan can be null
 }
+
+Clause::Clause(Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan, SrcLocation loc)
+        : Clause(NK_Clause, std::move(head), std::move(bodyLiterals), std::move(plan), std::move(loc)) {}
 
 Clause::Clause(Own<Atom> head, SrcLocation loc) : Clause(std::move(head), {}, {}, std::move(loc)) {}
 
@@ -95,6 +99,11 @@ Clause* Clause::cloneHead() const {
         myClone->setExecutionPlan(clone(getExecutionPlan()));
     }
     return myClone;
+}
+
+bool Clause::classof(const Node* n) {
+    const NodeKind kind = n->getKind();
+    return (kind >= NK_Clause && kind < NK_LastClause);
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Clause.cpp
+++ b/src/ast/Clause.cpp
@@ -17,7 +17,8 @@
 
 namespace souffle::ast {
 
-Clause::Clause(NodeKind kind, Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan, SrcLocation loc)
+Clause::Clause(
+        NodeKind kind, Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan, SrcLocation loc)
         : Node(kind, std::move(loc)), head(std::move(head)), bodyLiterals(std::move(bodyLiterals)),
           plan(std::move(plan)) {
     assert(this->head != nullptr);

--- a/src/ast/Clause.h
+++ b/src/ast/Clause.h
@@ -37,6 +37,9 @@ namespace souffle::ast {
  */
 class Clause : public Node {
 public:
+    Clause(NodeKind kind, Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan = {},
+            SrcLocation loc = {});
+
     Clause(Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan = {}, SrcLocation loc = {});
 
     Clause(Own<Atom> head, SrcLocation loc = {});
@@ -80,6 +83,8 @@ public:
     virtual Clause* cloneHead() const;
 
     void apply(const NodeMapper& map) override;
+
+    static bool classof(const Node*);
 
 protected:
     void print(std::ostream& os) const override;

--- a/src/ast/Component.cpp
+++ b/src/ast/Component.cpp
@@ -16,6 +16,9 @@
 #include <utility>
 
 namespace souffle::ast {
+
+Component::Component(SrcLocation loc) : Node(NK_Component, loc) {}
+
 void Component::setComponentType(Own<ComponentType> other) {
     assert(other != nullptr);
     componentType = std::move(other);
@@ -171,6 +174,10 @@ Component* Component::cloning() const {
     res->directives = clone(directives);
     res->overrideRules = overrideRules;
     return res;
+}
+
+bool Component::classof(const Node* n) {
+    return n->getKind() == NK_Component;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Component.h
+++ b/src/ast/Component.h
@@ -45,6 +45,8 @@ namespace souffle::ast {
  */
 class Component : public Node {
 public:
+    Component(SrcLocation loc = {});
+
     /** Get component type */
     const ComponentType* getComponentType() const {
         return componentType.get();
@@ -114,6 +116,8 @@ public:
     }
 
     void apply(const NodeMapper& mapper) override;
+
+    static bool classof(const Node*);
 
 protected:
     void print(std::ostream& os) const override;

--- a/src/ast/ComponentInit.cpp
+++ b/src/ast/ComponentInit.cpp
@@ -15,7 +15,7 @@
 namespace souffle::ast {
 
 ComponentInit::ComponentInit(std::string name, Own<ComponentType> type, SrcLocation loc)
-        : Node(std::move(loc)), instanceName(std::move(name)), componentType(std::move(type)) {
+        : Node(NK_ComponentInit, std::move(loc)), instanceName(std::move(name)), componentType(std::move(type)) {
     assert(componentType);
 }
 
@@ -48,4 +48,9 @@ bool ComponentInit::equal(const Node& node) const {
 ComponentInit* ComponentInit::cloning() const {
     return new ComponentInit(instanceName, clone(componentType), getSrcLoc());
 }
+
+bool ComponentInit::classof(const Node* n) {
+    return n->getKind() == NK_ComponentInit;
+}
+
 }  // namespace souffle::ast

--- a/src/ast/ComponentInit.cpp
+++ b/src/ast/ComponentInit.cpp
@@ -15,7 +15,8 @@
 namespace souffle::ast {
 
 ComponentInit::ComponentInit(std::string name, Own<ComponentType> type, SrcLocation loc)
-        : Node(NK_ComponentInit, std::move(loc)), instanceName(std::move(name)), componentType(std::move(type)) {
+        : Node(NK_ComponentInit, std::move(loc)), instanceName(std::move(name)),
+          componentType(std::move(type)) {
     assert(componentType);
 }
 

--- a/src/ast/ComponentInit.h
+++ b/src/ast/ComponentInit.h
@@ -55,6 +55,8 @@ public:
 
     void apply(const NodeMapper& mapper) override;
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/ComponentType.cpp
+++ b/src/ast/ComponentType.cpp
@@ -15,7 +15,7 @@
 namespace souffle::ast {
 
 ComponentType::ComponentType(std::string name, std::vector<QualifiedName> params, SrcLocation loc)
-        : Node(std::move(loc)), name(std::move(name)), typeParams(std::move(params)) {}
+        : Node(NK_ComponentType, std::move(loc)), name(std::move(name)), typeParams(std::move(params)) {}
 
 void ComponentType::print(std::ostream& os) const {
     os << name;
@@ -32,5 +32,10 @@ bool ComponentType::equal(const Node& node) const {
 ComponentType* ComponentType::cloning() const {
     return new ComponentType(name, typeParams, getSrcLoc());
 }
+
+bool ComponentType::classof(const Node* n) {
+    return n->getKind() == NK_ComponentType;
+}
+
 
 }  // namespace souffle::ast

--- a/src/ast/ComponentType.cpp
+++ b/src/ast/ComponentType.cpp
@@ -37,5 +37,4 @@ bool ComponentType::classof(const Node* n) {
     return n->getKind() == NK_ComponentType;
 }
 
-
 }  // namespace souffle::ast

--- a/src/ast/ComponentType.h
+++ b/src/ast/ComponentType.h
@@ -56,6 +56,8 @@ public:
         typeParams = params;
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/Constant.cpp
+++ b/src/ast/Constant.cpp
@@ -12,8 +12,10 @@
 #include <utility>
 
 namespace souffle::ast {
-Constant::Constant(std::string value, SrcLocation loc)
-        : Argument(std::move(loc)), constant(std::move(value)){};
+Constant::Constant(NodeKind kind, std::string value, SrcLocation loc)
+        : Argument(kind, std::move(loc)), constant(std::move(value)) {
+    assert(kind >= NK_Constant && kind < NK_LastConstant);
+};
 
 void Constant::print(std::ostream& os) const {
     os << getConstant();
@@ -23,5 +25,11 @@ bool Constant::equal(const Node& node) const {
     const auto& other = asAssert<Constant>(node);
     return constant == other.constant;
 }
+
+bool Constant::classof(const Node* n) {
+    const NodeKind kind = n->getKind();
+    return (kind >= NK_Constant && kind < NK_LastConstant);
+}
+
 
 }  // namespace souffle::ast

--- a/src/ast/Constant.cpp
+++ b/src/ast/Constant.cpp
@@ -31,5 +31,4 @@ bool Constant::classof(const Node* n) {
     return (kind >= NK_Constant && kind < NK_LastConstant);
 }
 
-
 }  // namespace souffle::ast

--- a/src/ast/Constant.h
+++ b/src/ast/Constant.h
@@ -34,8 +34,10 @@ public:
         return constant;
     }
 
+    static bool classof(const Node*);
+
 protected:
-    Constant(std::string value, SrcLocation loc = {});
+    Constant(NodeKind kind, std::string value, SrcLocation loc = {});
 
     void print(std::ostream& os) const override;
 

--- a/src/ast/Constraint.h
+++ b/src/ast/Constraint.h
@@ -27,6 +27,15 @@ namespace souffle::ast {
 class Constraint : public Literal {
 public:
     using Literal::Literal;
+
+    Constraint(NodeKind kind, SrcLocation loc = {}) : Literal(kind, loc) {
+        assert(kind >= NK_Constraint && kind < NK_LastConstraint);
+    }
+
+    static bool classof(const Node* n) {
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_Constraint && kind < NK_LastConstraint);
+    }
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Counter.cpp
+++ b/src/ast/Counter.cpp
@@ -11,12 +11,18 @@
 
 namespace souffle::ast {
 
+Counter::Counter(SrcLocation loc) : Argument(NK_Counter, std::move(loc)) {}
+
 void Counter::print(std::ostream& os) const {
     os << "$";
 }
 
 Counter* Counter::cloning() const {
     return new Counter(getSrcLoc());
+}
+
+bool Counter::classof(const Node* n) {
+    return n->getKind() == NK_Counter;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Counter.h
+++ b/src/ast/Counter.h
@@ -29,6 +29,10 @@ class Counter : public Argument {
 public:
     using Argument::Argument;
 
+    Counter(SrcLocation = {});
+
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/Directive.cpp
+++ b/src/ast/Directive.cpp
@@ -26,7 +26,7 @@ std::ostream& operator<<(std::ostream& os, DirectiveType e) {
 }
 
 Directive::Directive(DirectiveType type, QualifiedName name, SrcLocation loc)
-        : Node(std::move(loc)), type(type), name(std::move(name)) {}
+        : Node(NK_Directive, std::move(loc)), type(type), name(std::move(name)) {}
 
 void Directive::setQualifiedName(QualifiedName name) {
     this->name = std::move(name);
@@ -54,6 +54,10 @@ Directive* Directive::cloning() const {
     auto res = new Directive(type, name, getSrcLoc());
     res->parameters = parameters;
     return res;
+}
+
+bool Directive::classof(const Node* n) {
+    return n->getKind() == NK_Directive;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Directive.h
+++ b/src/ast/Directive.h
@@ -75,6 +75,8 @@ public:
         return parameters;
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/ExecutionOrder.cpp
+++ b/src/ast/ExecutionOrder.cpp
@@ -15,7 +15,7 @@
 namespace souffle::ast {
 
 ExecutionOrder::ExecutionOrder(ExecOrder order, SrcLocation loc)
-        : Node(std::move(loc)), order(std::move(order)) {}
+        : Node(NK_ExecutionOrder, std::move(loc)), order(std::move(order)) {}
 
 void ExecutionOrder::print(std::ostream& out) const {
     out << "(" << join(order) << ")";
@@ -28,6 +28,10 @@ bool ExecutionOrder::equal(const Node& node) const {
 
 ExecutionOrder* ExecutionOrder::cloning() const {
     return new ExecutionOrder(order, getSrcLoc());
+}
+
+bool ExecutionOrder::classof(const Node* n) {
+    return n->getKind() == NK_ExecutionOrder;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/ExecutionOrder.h
+++ b/src/ast/ExecutionOrder.h
@@ -39,6 +39,8 @@ public:
         return order;
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& out) const override;
 

--- a/src/ast/ExecutionPlan.cpp
+++ b/src/ast/ExecutionPlan.cpp
@@ -16,6 +16,8 @@
 
 namespace souffle::ast {
 
+ExecutionPlan::ExecutionPlan(SrcLocation loc) : Node(NK_ExecutionPlan, std::move(loc)) {}
+
 /** Set execution order for a given rule version */
 void ExecutionPlan::setOrderFor(std::size_t version, Own<ExecutionOrder> plan) {
     assert(plan != nullptr);
@@ -62,4 +64,9 @@ ExecutionPlan* ExecutionPlan::cloning() const {
     }
     return res.release();
 }
+
+bool ExecutionPlan::classof(const Node* n) {
+    return n->getKind() == NK_ExecutionPlan;
+}
+
 }  // namespace souffle::ast

--- a/src/ast/ExecutionPlan.h
+++ b/src/ast/ExecutionPlan.h
@@ -39,6 +39,8 @@ class ExecutionPlan : public Node {
 public:
     using Node::Node;
 
+    ExecutionPlan(SrcLocation = {});
+
     /** Set execution order for a given rule version */
     void setOrderFor(std::size_t version, Own<ExecutionOrder> plan);
 
@@ -48,6 +50,8 @@ public:
     void apply(const NodeMapper& map) override;
 
     NodeVec getChildren() const override;
+
+    static bool classof(const Node*);
 
 protected:
     void print(std::ostream& out) const override;

--- a/src/ast/FunctionalConstraint.cpp
+++ b/src/ast/FunctionalConstraint.cpp
@@ -18,11 +18,12 @@
 namespace souffle::ast {
 
 FunctionalConstraint::FunctionalConstraint(VecOwn<Variable> keys, SrcLocation loc)
-        : Constraint(std::move(loc)), keys(std::move(keys)) {
+        : Constraint(NK_FunctionalConstraint, std::move(loc)), keys(std::move(keys)) {
     assert(allValidPtrs(this->keys));
 }
 
-FunctionalConstraint::FunctionalConstraint(Own<Variable> key, SrcLocation loc) : Constraint(std::move(loc)) {
+FunctionalConstraint::FunctionalConstraint(Own<Variable> key, SrcLocation loc)
+        : Constraint(NK_FunctionalConstraint, std::move(loc)) {
     assert(key != nullptr);
     keys.push_back(std::move(key));
 }
@@ -67,6 +68,10 @@ bool FunctionalConstraint::equivalentConstraint(const FunctionalConstraint& othe
 
 FunctionalConstraint* FunctionalConstraint::cloning() const {
     return new FunctionalConstraint(clone(keys), getSrcLoc());
+}
+
+bool FunctionalConstraint::classof(const Node* n) {
+    return n->getKind() == NK_FunctionalConstraint;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/FunctionalConstraint.h
+++ b/src/ast/FunctionalConstraint.h
@@ -56,6 +56,8 @@ public:
 
     bool equivalentConstraint(const FunctionalConstraint& other) const;
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/Functor.h
+++ b/src/ast/Functor.h
@@ -28,6 +28,12 @@ namespace souffle::ast {
 class Functor : public Term {
 protected:
     using Term::Term;
+
+    Functor(NodeKind kind, SrcLocation loc = {}) : Term(kind, loc) {
+        assert(kind > NK_FirstFunctor && kind < NK_LastFunctor);
+    }
+
+    static bool classof(const Node*);
 };
 
 }  // namespace souffle::ast

--- a/src/ast/FunctorDeclaration.cpp
+++ b/src/ast/FunctorDeclaration.cpp
@@ -20,7 +20,7 @@ namespace souffle::ast {
 
 FunctorDeclaration::FunctorDeclaration(
         std::string name, VecOwn<Attribute> params, Own<Attribute> returnType, bool stateful, SrcLocation loc)
-        : Node(std::move(loc)), name(std::move(name)), params(std::move(params)),
+        : Node(NK_FunctorDeclaration, std::move(loc)), name(std::move(name)), params(std::move(params)),
           returnType(std::move(returnType)), stateful(stateful) {
     assert(this->name.length() > 0 && "functor name is empty");
     assert(allValidPtrs(this->params));
@@ -46,6 +46,10 @@ bool FunctorDeclaration::equal(const Node& node) const {
 
 FunctorDeclaration* FunctorDeclaration::cloning() const {
     return new FunctorDeclaration(name, clone(params), clone(returnType), stateful, getSrcLoc());
+}
+
+bool FunctorDeclaration::classof(const Node* n) {
+    return n->getKind() == NK_FunctorDeclaration;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/FunctorDeclaration.h
+++ b/src/ast/FunctorDeclaration.h
@@ -64,6 +64,8 @@ public:
         return stateful;
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& out) const override;
 

--- a/src/ast/IntrinsicAggregator.cpp
+++ b/src/ast/IntrinsicAggregator.cpp
@@ -19,7 +19,7 @@
 namespace souffle::ast {
 IntrinsicAggregator::IntrinsicAggregator(
         AggregateOp baseOperator, Own<Argument> expr, VecOwn<Literal> body, SrcLocation loc)
-        : Aggregator(std::move(expr), std::move(body), std::move(loc)), baseOperator(baseOperator) {}
+        : Aggregator(NK_IntrinsicAggregator, std::move(expr), std::move(body), std::move(loc)), baseOperator(baseOperator) {}
 
 void IntrinsicAggregator::print(std::ostream& os) const {
     os << baseOperator;
@@ -37,6 +37,10 @@ bool IntrinsicAggregator::equal(const Node& node) const {
 
 IntrinsicAggregator* IntrinsicAggregator::cloning() const {
     return new IntrinsicAggregator(baseOperator, clone(targetExpression), clone(body), getSrcLoc());
+}
+
+bool IntrinsicAggregator::classof(const Node* n) {
+    return n->getKind() == NK_IntrinsicAggregator;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/IntrinsicAggregator.cpp
+++ b/src/ast/IntrinsicAggregator.cpp
@@ -19,7 +19,8 @@
 namespace souffle::ast {
 IntrinsicAggregator::IntrinsicAggregator(
         AggregateOp baseOperator, Own<Argument> expr, VecOwn<Literal> body, SrcLocation loc)
-        : Aggregator(NK_IntrinsicAggregator, std::move(expr), std::move(body), std::move(loc)), baseOperator(baseOperator) {}
+        : Aggregator(NK_IntrinsicAggregator, std::move(expr), std::move(body), std::move(loc)),
+          baseOperator(baseOperator) {}
 
 void IntrinsicAggregator::print(std::ostream& os) const {
     os << baseOperator;

--- a/src/ast/IntrinsicAggregator.h
+++ b/src/ast/IntrinsicAggregator.h
@@ -53,6 +53,8 @@ public:
         return s.str();
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/IntrinsicFunctor.cpp
+++ b/src/ast/IntrinsicFunctor.cpp
@@ -16,7 +16,7 @@
 namespace souffle::ast {
 
 IntrinsicFunctor::IntrinsicFunctor(std::string op, VecOwn<Argument> args, SrcLocation loc)
-        : Functor(std::move(args), std::move(loc)), function(std::move(op)) {}
+        : Functor(NK_IntrinsicFunctor, std::move(args), std::move(loc)), function(std::move(op)) {}
 
 void IntrinsicFunctor::print(std::ostream& os) const {
     if (isInfixFunctorOp(function)) {
@@ -39,6 +39,10 @@ bool IntrinsicFunctor::equal(const Node& node) const {
 
 IntrinsicFunctor* IntrinsicFunctor::cloning() const {
     return new IntrinsicFunctor(function, clone(args), getSrcLoc());
+}
+
+bool IntrinsicFunctor::classof(const Node* n) {
+    return n->getKind() == NK_IntrinsicFunctor;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/IntrinsicFunctor.h
+++ b/src/ast/IntrinsicFunctor.h
@@ -34,11 +34,11 @@ class IntrinsicFunctor : public Functor {
 public:
     template <typename... Operands>
     IntrinsicFunctor(std::string op, Operands&&... operands)
-            : Functor(std::forward<Operands>(operands)...), function(std::move(op)) {}
+            : Functor(NK_IntrinsicFunctor, std::forward<Operands>(operands)...), function(std::move(op)) {}
 
     template <typename... Operands>
     IntrinsicFunctor(SrcLocation loc, std::string op, Operands&&... operands)
-            : Functor(std::move(loc), std::forward<Operands>(operands)...), function(std::move(op)) {}
+            : Functor(NK_IntrinsicFunctor, std::move(loc), std::forward<Operands>(operands)...), function(std::move(op)) {}
 
     IntrinsicFunctor(std::string op, VecOwn<Argument> args, SrcLocation loc = {});
 
@@ -51,6 +51,8 @@ public:
     void setFunction(std::string functor) {
         function = std::move(functor);
     }
+
+    static bool classof(const Node*);
 
 protected:
     void print(std::ostream& os) const override;

--- a/src/ast/IntrinsicFunctor.h
+++ b/src/ast/IntrinsicFunctor.h
@@ -38,7 +38,8 @@ public:
 
     template <typename... Operands>
     IntrinsicFunctor(SrcLocation loc, std::string op, Operands&&... operands)
-            : Functor(NK_IntrinsicFunctor, std::move(loc), std::forward<Operands>(operands)...), function(std::move(op)) {}
+            : Functor(NK_IntrinsicFunctor, std::move(loc), std::forward<Operands>(operands)...),
+              function(std::move(op)) {}
 
     IntrinsicFunctor(std::string op, VecOwn<Argument> args, SrcLocation loc = {});
 

--- a/src/ast/IterationCounter.cpp
+++ b/src/ast/IterationCounter.cpp
@@ -11,12 +11,18 @@
 
 namespace souffle::ast {
 
+IterationCounter::IterationCounter(SrcLocation loc) : Argument(NK_IterationCounter, loc) {}
+
 void IterationCounter::print(std::ostream& os) const {
     os << "recursive_iteration_cnt()";
 }
 
 IterationCounter* IterationCounter::cloning() const {
     return new IterationCounter(getSrcLoc());
+}
+
+bool IterationCounter::classof(const Node* n) {
+    return n->getKind() == NK_IterationCounter;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/IterationCounter.h
+++ b/src/ast/IterationCounter.h
@@ -27,7 +27,9 @@ namespace souffle::ast {
  */
 class IterationCounter : public Argument {
 public:
-    using Argument::Argument;
+    IterationCounter(SrcLocation loc = {});
+
+    static bool classof(const Node*);
 
 protected:
     void print(std::ostream& os) const override;

--- a/src/ast/Lattice.cpp
+++ b/src/ast/Lattice.cpp
@@ -36,7 +36,7 @@ std::string latticeOperatorToString(const LatticeOperator op) {
 }
 
 Lattice::Lattice(QualifiedName name, std::map<LatticeOperator, Own<ast::Argument>> ops, SrcLocation loc)
-        : Node(std::move(loc)), name(std::move(name)), operators(std::move(ops)) {}
+        : Node(NK_Lattice, std::move(loc)), name(std::move(name)), operators(std::move(ops)) {}
 
 void Lattice::setQualifiedName(QualifiedName name) {
     this->name = std::move(name);
@@ -102,6 +102,10 @@ bool Lattice::equal(const Node& node) const {
 
 Lattice* Lattice::cloning() const {
     return new Lattice(getQualifiedName(), clone(operators), getSrcLoc());
+}
+
+bool Lattice::classof(const Node* n) {
+    return n->getKind() == NK_Lattice;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Lattice.h
+++ b/src/ast/Lattice.h
@@ -59,6 +59,8 @@ public:
     const ast::Argument* getBottom() const;
     const ast::Argument* getTop() const;
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/Literal.h
+++ b/src/ast/Literal.h
@@ -30,6 +30,15 @@ namespace souffle::ast {
 class Literal : public Node {
 public:
     using Node::Node;
+
+    explicit Literal(NodeKind kind, SrcLocation loc = {}) : Node(kind, loc) {
+        assert(kind >= NK_Literal && kind < NK_LastLiteral);
+    }
+
+    static bool classof(const Node* n) {
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_Literal && kind < NK_LastLiteral);
+    }
 };
 
 }  // namespace souffle::ast

--- a/src/ast/Negation.cpp
+++ b/src/ast/Negation.cpp
@@ -14,7 +14,8 @@
 
 namespace souffle::ast {
 
-Negation::Negation(Own<Atom> atom, SrcLocation loc) : Literal(std::move(loc)), atom(std::move(atom)) {
+Negation::Negation(Own<Atom> atom, SrcLocation loc)
+        : Literal(NK_Negation, std::move(loc)), atom(std::move(atom)) {
     assert(this->atom != nullptr);
 }
 
@@ -37,6 +38,10 @@ bool Negation::equal(const Node& node) const {
 
 Negation* Negation::cloning() const {
     return new Negation(clone(atom), getSrcLoc());
+}
+
+bool Negation::classof(const Node* n) {
+    return n->getKind() == NK_Negation;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Negation.h
+++ b/src/ast/Negation.h
@@ -43,6 +43,8 @@ public:
 
     void apply(const NodeMapper& map) override;
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/NilConstant.cpp
+++ b/src/ast/NilConstant.cpp
@@ -10,10 +10,14 @@
 
 namespace souffle::ast {
 
-NilConstant::NilConstant(SrcLocation loc) : Constant("nil", std::move(loc)) {}
+NilConstant::NilConstant(SrcLocation loc) : Constant(NK_NilConstant, "nil", std::move(loc)) {}
 
 NilConstant* NilConstant::cloning() const {
     return new NilConstant(getSrcLoc());
+}
+
+bool NilConstant::classof(const Node* n) {
+    return n->getKind() == NK_NilConstant;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/NilConstant.h
+++ b/src/ast/NilConstant.h
@@ -31,6 +31,8 @@ class NilConstant : public Constant {
 public:
     NilConstant(SrcLocation loc = {});
 
+    static bool classof(const Node*);
+
 private:
     NilConstant* cloning() const override;
 };

--- a/src/ast/Node.cpp
+++ b/src/ast/Node.cpp
@@ -10,7 +10,7 @@
 #include <utility>
 
 namespace souffle::ast {
-Node::Node(SrcLocation loc) : location(std::move(loc)) {}
+Node::Node(NodeKind kind, SrcLocation loc) : Kind(kind), location(std::move(loc)) {}
 
 /** Set source location for the Node */
 void Node::setSrcLoc(SrcLocation l) {
@@ -52,6 +52,22 @@ bool Node::equal(const Node&) const {
 
 Node::NodeVec Node::getChildren() const {
     return {};
+}
+
+Node::NodeKind Node::getKind() const {
+    return Kind;
+}
+
+const SrcLocation& Node::getSrcLoc() const {
+    return location;
+}
+
+std::string Node::extloc() const {
+    return location.extloc();
+}
+
+bool Node::operator!=(const Node& other) const {
+    return !(*this == other);
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Node.h
+++ b/src/ast/Node.h
@@ -52,7 +52,6 @@ struct ConstCaster {
  */
 class Node {
 public:
-    // clang-format: off
     /// LLVM-style RTTI
     ///
     /// Each class under the ast::Node hierarchy must appear here and must implement
@@ -73,6 +72,7 @@ public:
     ///   NK_LastT
     ///
     ///
+    // clang-format off
     enum NodeKind {
         NK_NONE,
         NK_Argument,
@@ -142,12 +142,11 @@ public:
             NK_UnionType,
         NK_LastType,
     };
-    // clang-format: on
+    // clang-format on
 private:
     const NodeKind Kind;
 
 public:
-
     explicit Node(NodeKind K, SrcLocation loc = {});
     virtual ~Node() = default;
     // Make sure we don't accidentally copy/slice

--- a/src/ast/Node.h
+++ b/src/ast/Node.h
@@ -52,32 +52,124 @@ struct ConstCaster {
  */
 class Node {
 public:
-    Node(SrcLocation loc = {});
+    // clang-format: off
+    /// LLVM-style RTTI
+    ///
+    /// Each class under the ast::Node hierarchy must appear here and must implement
+    /// `static bool classof(const Node*)`.
+    ///
+    /// When class T is final, we must provide a single enum:
+    ///
+    ///   ...
+    ///   NK_T,
+    ///   ...
+    ///
+    /// When class T is non-final, we must provide enums like this:
+    ///
+    ///   NK_T,
+    ///     NK_Child1,
+    ///     ...
+    ///     NK_ChildN,
+    ///   NK_LastT
+    ///
+    ///
+    enum NodeKind {
+        NK_NONE,
+        NK_Argument,
+            NK_Constant,
+                NK_NilConstant,
+                NK_NumericConstant,
+                NK_StringConstant,
+            NK_LastConstant,
+
+            NK_Counter,
+            NK_ExecutionOrder,
+            NK_ExecutionPlan,
+            NK_IterationCounter,
+
+            NK_Aggregator,
+                NK_IntrinsicAggregator,
+                NK_UserDefinedAggregator,
+            NK_LastAggregator,
+
+            NK_Term,
+                NK_BranchInit,
+                NK_FirstFunctor,
+                    NK_IntrinsicFunctor,
+                    NK_UserDefinedFunctor,
+                NK_LastFunctor,
+                NK_RecordInit,
+            NK_LastTerm,
+
+            NK_UnnamedVariable,
+            NK_Variable,
+            NK_TypeCast,
+        NK_LastArgument,
+
+        NK_Attribute,
+        NK_BranchType,
+        NK_Clause,
+          NK_SubsumptiveClause,
+        NK_LastClause,
+        NK_Component,
+        NK_ComponentInit,
+        NK_ComponentType,
+        NK_Directive,
+        NK_FunctorDeclaration,
+        NK_Lattice,
+
+        NK_Literal,
+            NK_Atom,
+
+            NK_Constraint,
+                NK_BinaryConstraint,
+                NK_BooleanConstraint,
+                NK_FunctionalConstraint,
+            NK_LastConstraint,
+
+            NK_Negation,
+        NK_LastLiteral,
+
+        NK_Pragma,
+        NK_Program,
+        NK_Relation,
+
+        NK_Type,
+            NK_AlgebraicDataType,
+            NK_AliasType,
+            NK_RecordType,
+            NK_SubsetType,
+            NK_UnionType,
+        NK_LastType,
+    };
+    // clang-format: on
+private:
+    const NodeKind Kind;
+
+public:
+
+    explicit Node(NodeKind K, SrcLocation loc = {});
     virtual ~Node() = default;
     // Make sure we don't accidentally copy/slice
     Node(Node const&) = delete;
     Node& operator=(Node const&) = delete;
 
+    NodeKind getKind() const;
+
     /** Return source location of the Node */
-    const SrcLocation& getSrcLoc() const {
-        return location;
-    }
+    const SrcLocation& getSrcLoc() const;
 
     /** Set source location for the Node */
     void setSrcLoc(SrcLocation l);
 
     /** Return source location of the syntactic element */
-    std::string extloc() const {
-        return location.extloc();
-    }
+    std::string extloc() const;
 
     /** Equivalence check for two AST nodes */
     bool operator==(const Node& other) const;
 
     /** Inequality check for two AST nodes */
-    bool operator!=(const Node& other) const {
-        return !(*this == other);
-    }
+    bool operator!=(const Node& other) const;
 
     /** Create a clone (i.e. deep copy) of this node */
     Own<Node> cloneImpl() const;

--- a/src/ast/NumericConstant.cpp
+++ b/src/ast/NumericConstant.cpp
@@ -13,13 +13,13 @@
 
 namespace souffle::ast {
 
-NumericConstant::NumericConstant(RamSigned value) : Constant(std::to_string(value)), fixedType(Type::Int) {}
+NumericConstant::NumericConstant(RamSigned value) : Constant(NK_NumericConstant, std::to_string(value)), fixedType(Type::Int) {}
 
 NumericConstant::NumericConstant(std::string constant, SrcLocation loc)
-        : Constant(std::move(constant), std::move(loc)) {}
+        : Constant(NK_NumericConstant, std::move(constant), std::move(loc)) {}
 
 NumericConstant::NumericConstant(std::string constant, std::optional<Type> fixedType, SrcLocation loc)
-        : Constant(std::move(constant), std::move(loc)), fixedType(fixedType) {}
+        : Constant(NK_NumericConstant, std::move(constant), std::move(loc)), fixedType(fixedType) {}
 
 bool NumericConstant::equal(const Node& node) const {
     const auto& other = asAssert<NumericConstant>(node);
@@ -28,6 +28,10 @@ bool NumericConstant::equal(const Node& node) const {
 
 NumericConstant* NumericConstant::cloning() const {
     return new NumericConstant(getConstant(), getFixedType(), getSrcLoc());
+}
+
+bool NumericConstant::classof(const Node* n) {
+    return n->getKind() == NK_NumericConstant;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/NumericConstant.cpp
+++ b/src/ast/NumericConstant.cpp
@@ -13,7 +13,8 @@
 
 namespace souffle::ast {
 
-NumericConstant::NumericConstant(RamSigned value) : Constant(NK_NumericConstant, std::to_string(value)), fixedType(Type::Int) {}
+NumericConstant::NumericConstant(RamSigned value)
+        : Constant(NK_NumericConstant, std::to_string(value)), fixedType(Type::Int) {}
 
 NumericConstant::NumericConstant(std::string constant, SrcLocation loc)
         : Constant(NK_NumericConstant, std::move(constant), std::move(loc)) {}

--- a/src/ast/NumericConstant.h
+++ b/src/ast/NumericConstant.h
@@ -45,6 +45,8 @@ public:
         return fixedType;
     }
 
+    static bool classof(const Node*);
+
 private:
     bool equal(const Node& node) const override;
 

--- a/src/ast/Pragma.cpp
+++ b/src/ast/Pragma.cpp
@@ -14,7 +14,7 @@
 namespace souffle::ast {
 
 Pragma::Pragma(std::string key, std::string value, SrcLocation loc)
-        : Node(std::move(loc)), key(std::move(key)), value(std::move(value)) {}
+        : Node(NK_Pragma, std::move(loc)), key(std::move(key)), value(std::move(value)) {}
 
 void Pragma::print(std::ostream& os) const {
     os << ".pragma " << key << " " << value << "\n";
@@ -27,6 +27,10 @@ bool Pragma::equal(const Node& node) const {
 
 Pragma* Pragma::cloning() const {
     return new Pragma(key, value, getSrcLoc());
+}
+
+bool Pragma::classof(const Node* n) {
+    return n->getKind() == NK_Pragma;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Pragma.h
+++ b/src/ast/Pragma.h
@@ -37,6 +37,8 @@ public:
         return std::make_pair(key, value);
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/Program.cpp
+++ b/src/ast/Program.cpp
@@ -110,6 +110,8 @@ namespace souffle::ast {
 
 using souffle::clone;
 
+Program::Program() : Node(NK_Program) {}
+
 Program::RelationInfo clone(Program::RelationInfo const& x) {
     return {clone(x.decls), clone(x.clauses), clone(x.directives)};
 }
@@ -328,6 +330,10 @@ Program* Program::cloning() const {
     res->functors = clone(functors);
     res->relations = clone(relations);
     return res;
+}
+
+bool Program::classof(const Node* n) {
+    return n->getKind() == NK_Program;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Program.h
+++ b/src/ast/Program.h
@@ -88,6 +88,8 @@ public:
 
     using RelationInfoMap = OrderedQualifiedNameMap<RelationInfo>;
 
+    Program();
+
     RelationInfoMap& getRelationInfo() {
         return relations;
     }
@@ -219,6 +221,8 @@ public:
     void clearComponents();
 
     void apply(const NodeMapper& map) override;
+
+    static bool classof(const Node*);
 
 protected:
     void print(std::ostream& os) const override;

--- a/src/ast/RecordInit.cpp
+++ b/src/ast/RecordInit.cpp
@@ -14,7 +14,7 @@
 
 namespace souffle::ast {
 RecordInit::RecordInit(VecOwn<Argument> operands, SrcLocation loc)
-        : Term(std::move(operands), std::move(loc)) {}
+        : Term(NK_RecordInit, std::move(operands), std::move(loc)) {}
 
 void RecordInit::print(std::ostream& os) const {
     os << "[" << join(args) << "]";
@@ -23,4 +23,9 @@ void RecordInit::print(std::ostream& os) const {
 RecordInit* RecordInit::cloning() const {
     return new RecordInit(clone(args), getSrcLoc());
 }
+
+bool RecordInit::classof(const Node* n) {
+    return n->getKind() == NK_RecordInit;
+}
+
 }  // namespace souffle::ast

--- a/src/ast/RecordInit.h
+++ b/src/ast/RecordInit.h
@@ -32,6 +32,8 @@ class RecordInit : public Term {
 public:
     RecordInit(VecOwn<Argument> operands = {}, SrcLocation loc = {});
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/RecordType.cpp
+++ b/src/ast/RecordType.cpp
@@ -17,7 +17,7 @@
 
 namespace souffle::ast {
 RecordType::RecordType(QualifiedName name, VecOwn<Attribute> fields, SrcLocation loc)
-        : Type(std::move(name), std::move(loc)), fields(std::move(fields)) {
+        : Type(NK_RecordType, std::move(name), std::move(loc)), fields(std::move(fields)) {
     assert(allValidPtrs(this->fields));
 }
 
@@ -44,6 +44,10 @@ bool RecordType::equal(const Node& node) const {
 
 RecordType* RecordType::cloning() const {
     return new RecordType(getQualifiedName(), clone(fields), getSrcLoc());
+}
+
+bool RecordType::classof(const Node* n) {
+    return n->getKind() == NK_RecordType;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/RecordType.h
+++ b/src/ast/RecordType.h
@@ -45,6 +45,8 @@ public:
     /** Set field type */
     void setFieldType(std::size_t idx, QualifiedName type);
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/Relation.cpp
+++ b/src/ast/Relation.cpp
@@ -17,7 +17,10 @@
 
 namespace souffle::ast {
 
-Relation::Relation(QualifiedName name, SrcLocation loc) : Node(std::move(loc)), name(std::move(name)) {}
+Relation::Relation(SrcLocation loc) : Node(NK_Relation, loc) {}
+
+Relation::Relation(QualifiedName name, SrcLocation loc)
+        : Node(NK_Relation, std::move(loc)), name(std::move(name)) {}
 
 void Relation::setQualifiedName(QualifiedName n) {
     name = std::move(n);
@@ -48,6 +51,10 @@ std::vector<FunctionalConstraint*> Relation::getFunctionalDependencies() const {
 
 void Relation::apply(const NodeMapper& map) {
     mapAll(attributes, map);
+}
+
+bool Relation::classof(const Node* n) {
+    return n->getKind() == NK_Relation;
 }
 
 Node::NodeVec Relation::getChildren() const {

--- a/src/ast/Relation.h
+++ b/src/ast/Relation.h
@@ -35,7 +35,7 @@ namespace souffle::ast {
  */
 class Relation : public Node {
 public:
-    Relation() = default;
+    Relation(SrcLocation loc = {});
     Relation(QualifiedName name, SrcLocation loc = {});
 
     /** Get qualified relation name */
@@ -113,6 +113,8 @@ public:
     std::optional<QualifiedName> getIsDeltaDebug() const {
         return isDeltaDebug;
     }
+
+    static bool classof(const Node*);
 
 protected:
     void print(std::ostream& os) const override;

--- a/src/ast/StringConstant.cpp
+++ b/src/ast/StringConstant.cpp
@@ -13,7 +13,7 @@
 namespace souffle::ast {
 
 StringConstant::StringConstant(std::string value, SrcLocation loc)
-        : Constant(std::move(value), std::move(loc)) {}
+        : Constant(NK_StringConstant, std::move(value), std::move(loc)) {}
 
 void StringConstant::print(std::ostream& os) const {
     os << "\"" << getConstant() << "\"";
@@ -22,5 +22,10 @@ void StringConstant::print(std::ostream& os) const {
 StringConstant* StringConstant::cloning() const {
     return new StringConstant(getConstant(), getSrcLoc());
 }
+
+bool StringConstant::classof(const Node* n) {
+    return n->getKind() == NK_StringConstant;
+}
+
 
 }  // namespace souffle::ast

--- a/src/ast/StringConstant.cpp
+++ b/src/ast/StringConstant.cpp
@@ -27,5 +27,4 @@ bool StringConstant::classof(const Node* n) {
     return n->getKind() == NK_StringConstant;
 }
 
-
 }  // namespace souffle::ast

--- a/src/ast/StringConstant.h
+++ b/src/ast/StringConstant.h
@@ -31,6 +31,8 @@ class StringConstant : public Constant {
 public:
     explicit StringConstant(std::string value, SrcLocation loc = {});
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/SubsetType.cpp
+++ b/src/ast/SubsetType.cpp
@@ -14,7 +14,7 @@
 namespace souffle::ast {
 
 SubsetType::SubsetType(QualifiedName name, QualifiedName baseTypeName, SrcLocation loc)
-        : Type(std::move(name), std::move(loc)), baseType(std::move(baseTypeName)) {}
+        : Type(NK_SubsetType, std::move(name), std::move(loc)), baseType(std::move(baseTypeName)) {}
 
 void SubsetType::print(std::ostream& os) const {
     os << ".type " << getQualifiedName() << " <: " << getBaseType();
@@ -27,6 +27,10 @@ bool SubsetType::equal(const Node& node) const {
 
 SubsetType* SubsetType::cloning() const {
     return new SubsetType(getQualifiedName(), getBaseType(), getSrcLoc());
+}
+
+bool SubsetType::classof(const Node* n) {
+    return n->getKind() == NK_SubsetType;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/SubsetType.h
+++ b/src/ast/SubsetType.h
@@ -44,6 +44,8 @@ public:
         baseType = type;
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/SubsumptiveClause.cpp
+++ b/src/ast/SubsumptiveClause.cpp
@@ -19,7 +19,8 @@ namespace souffle::ast {
 
 SubsumptiveClause::SubsumptiveClause(
         Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan, SrcLocation loc)
-        : Clause(NK_SubsumptiveClause, std::move(head), std::move(bodyLiterals), std::move(plan), std::move(loc)) {}
+        : Clause(NK_SubsumptiveClause, std::move(head), std::move(bodyLiterals), std::move(plan),
+                  std::move(loc)) {}
 
 SubsumptiveClause::SubsumptiveClause(Own<Atom> head, SrcLocation loc)
         : SubsumptiveClause(std::move(head), {}, {}, std::move(loc)) {}

--- a/src/ast/SubsumptiveClause.cpp
+++ b/src/ast/SubsumptiveClause.cpp
@@ -19,7 +19,7 @@ namespace souffle::ast {
 
 SubsumptiveClause::SubsumptiveClause(
         Own<Atom> head, VecOwn<Literal> bodyLiterals, Own<ExecutionPlan> plan, SrcLocation loc)
-        : Clause(std::move(head), std::move(bodyLiterals), std::move(plan), std::move(loc)) {}
+        : Clause(NK_SubsumptiveClause, std::move(head), std::move(bodyLiterals), std::move(plan), std::move(loc)) {}
 
 SubsumptiveClause::SubsumptiveClause(Own<Atom> head, SrcLocation loc)
         : SubsumptiveClause(std::move(head), {}, {}, std::move(loc)) {}
@@ -59,6 +59,10 @@ Clause* SubsumptiveClause::cloneHead() const {
         myClone->setExecutionPlan(clone(getExecutionPlan()));
     }
     return myClone;
+}
+
+bool SubsumptiveClause::classof(const Node* n) {
+    return n->getKind() == NK_SubsumptiveClause;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/SubsumptiveClause.h
+++ b/src/ast/SubsumptiveClause.h
@@ -49,6 +49,8 @@ public:
 
     Clause* cloneHead() const override;
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/Term.cpp
+++ b/src/ast/Term.cpp
@@ -14,8 +14,9 @@
 
 namespace souffle::ast {
 
-Term::Term(VecOwn<Argument> operands, SrcLocation loc) : Argument(std::move(loc)), args(std::move(operands)) {
+Term::Term(NodeKind kind, VecOwn<Argument> operands, SrcLocation loc) : Argument(kind, std::move(loc)), args(std::move(operands)) {
     assert(allValidPtrs(args));
+    assert(kind >= NK_Term && kind < NK_LastTerm);
 }
 
 std::vector<Argument*> Term::getArguments() const {
@@ -41,6 +42,11 @@ void Term::apply(const NodeMapper& map) {
 bool Term::equal(const Node& node) const {
     const auto& other = asAssert<Term>(node);
     return equal_targets(args, other.args);
+}
+
+bool Term::classof(const Node* n) {
+    const NodeKind kind = n->getKind();
+    return (kind >= NK_Term && kind < NK_LastTerm);
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Term.cpp
+++ b/src/ast/Term.cpp
@@ -14,7 +14,8 @@
 
 namespace souffle::ast {
 
-Term::Term(NodeKind kind, VecOwn<Argument> operands, SrcLocation loc) : Argument(kind, std::move(loc)), args(std::move(operands)) {
+Term::Term(NodeKind kind, VecOwn<Argument> operands, SrcLocation loc)
+        : Argument(kind, std::move(loc)), args(std::move(operands)) {
     assert(allValidPtrs(args));
     assert(kind >= NK_Term && kind < NK_LastTerm);
 }

--- a/src/ast/Term.h
+++ b/src/ast/Term.h
@@ -32,13 +32,13 @@ namespace souffle::ast {
 class Term : public Argument {
 protected:
     template <typename... Operands>
-    Term(Operands&&... operands) : Term({}, std::forward<Operands>(operands)...) {}
+    Term(NodeKind kind, Operands&&... operands) : Term(kind, {}, std::forward<Operands>(operands)...) {}
 
     template <typename... Operands>
-    Term(SrcLocation loc, Operands&&... operands)
-            : Term(asVec(std::forward<Operands>(operands)...), std::move(loc)) {}
+    Term(NodeKind kind, SrcLocation loc, Operands&&... operands)
+            : Term(kind, asVec(std::forward<Operands>(operands)...), std::move(loc)) {}
 
-    Term(VecOwn<Argument> operands, SrcLocation loc = {});
+    Term(NodeKind kind, VecOwn<Argument> operands, SrcLocation loc = {});
 
 public:
     /** Get arguments */
@@ -50,6 +50,8 @@ public:
     void apply(const NodeMapper& map) override;
 
     bool equal(const Node& node) const override;
+
+    static bool classof(const Node*);
 
 private:
     NodeVec getChildren() const override;

--- a/src/ast/Type.cpp
+++ b/src/ast/Type.cpp
@@ -11,8 +11,9 @@
 
 namespace souffle::ast {
 
-Type::Type(NodeKind kind, QualifiedName name, SrcLocation loc) : Node(kind, std::move(loc)), name(std::move(name)) {
-  assert(kind > NK_Type && kind < NK_LastType);
+Type::Type(NodeKind kind, QualifiedName name, SrcLocation loc)
+        : Node(kind, std::move(loc)), name(std::move(name)) {
+    assert(kind > NK_Type && kind < NK_LastType);
 }
 
 void Type::setQualifiedName(QualifiedName name) {

--- a/src/ast/Type.cpp
+++ b/src/ast/Type.cpp
@@ -11,10 +11,17 @@
 
 namespace souffle::ast {
 
-Type::Type(QualifiedName name, SrcLocation loc) : Node(std::move(loc)), name(std::move(name)) {}
+Type::Type(NodeKind kind, QualifiedName name, SrcLocation loc) : Node(kind, std::move(loc)), name(std::move(name)) {
+  assert(kind > NK_Type && kind < NK_LastType);
+}
 
 void Type::setQualifiedName(QualifiedName name) {
     this->name = std::move(name);
+}
+
+bool Type::classof(const Node* n) {
+    const NodeKind kind = n->getKind();
+    return (kind >= NK_Type && kind < NK_LastType);
 }
 
 }  // namespace souffle::ast

--- a/src/ast/Type.h
+++ b/src/ast/Type.h
@@ -28,7 +28,7 @@ namespace souffle::ast {
  */
 class Type : public Node {
 public:
-    Type(QualifiedName name = {}, SrcLocation loc = {});
+    Type(NodeKind kind, QualifiedName name = {}, SrcLocation loc = {});
 
     /** Return type name */
     const QualifiedName& getQualifiedName() const {
@@ -37,6 +37,8 @@ public:
 
     /** Set type name */
     void setQualifiedName(QualifiedName name);
+
+    static bool classof(const Node*);
 
 private:
     /** type name */

--- a/src/ast/TypeCast.cpp
+++ b/src/ast/TypeCast.cpp
@@ -17,7 +17,7 @@
 namespace souffle::ast {
 
 TypeCast::TypeCast(Own<Argument> value, QualifiedName type, SrcLocation loc)
-        : Argument(std::move(loc)), value(std::move(value)), type(std::move(type)) {
+        : Argument(NK_TypeCast, std::move(loc)), value(std::move(value)), type(std::move(type)) {
     assert(this->value != nullptr);
 }
 
@@ -47,4 +47,9 @@ bool TypeCast::equal(const Node& node) const {
 TypeCast* TypeCast::cloning() const {
     return new TypeCast(clone(value), type, getSrcLoc());
 }
+
+bool TypeCast::classof(const Node* n) {
+    return n->getKind() == NK_TypeCast;
+}
+
 }  // namespace souffle::ast

--- a/src/ast/TypeCast.h
+++ b/src/ast/TypeCast.h
@@ -47,6 +47,8 @@ public:
 
     void apply(const NodeMapper& map) override;
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/UnionType.cpp
+++ b/src/ast/UnionType.cpp
@@ -14,7 +14,7 @@
 
 namespace souffle::ast {
 UnionType::UnionType(QualifiedName name, std::vector<QualifiedName> types, SrcLocation loc)
-        : Type(std::move(name), std::move(loc)), types(std::move(types)) {}
+        : Type(NK_UnionType, std::move(name), std::move(loc)), types(std::move(types)) {}
 
 void UnionType::add(QualifiedName type) {
     types.push_back(std::move(type));
@@ -35,6 +35,10 @@ bool UnionType::equal(const Node& node) const {
 
 UnionType* UnionType::cloning() const {
     return new UnionType(getQualifiedName(), types, getSrcLoc());
+}
+
+bool UnionType::classof(const Node* n) {
+    return n->getKind() == NK_UnionType;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/UnionType.h
+++ b/src/ast/UnionType.h
@@ -55,6 +55,8 @@ public:
     /** Set type */
     void setType(std::size_t idx, QualifiedName type);
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/UnnamedVariable.cpp
+++ b/src/ast/UnnamedVariable.cpp
@@ -11,12 +11,18 @@
 
 namespace souffle::ast {
 
+UnnamedVariable::UnnamedVariable(SrcLocation loc) : Argument(NK_UnnamedVariable, loc) {}
+
 void UnnamedVariable::print(std::ostream& os) const {
     os << "_";
 }
 
 UnnamedVariable* UnnamedVariable::cloning() const {
     return new UnnamedVariable(getSrcLoc());
+}
+
+bool UnnamedVariable::classof(const Node* n) {
+    return n->getKind() == NK_UnnamedVariable;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/UnnamedVariable.h
+++ b/src/ast/UnnamedVariable.h
@@ -29,6 +29,10 @@ class UnnamedVariable : public Argument {
 public:
     using Argument::Argument;
 
+    UnnamedVariable(SrcLocation loc = {});
+
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/UserDefinedAggregator.cpp
+++ b/src/ast/UserDefinedAggregator.cpp
@@ -19,7 +19,7 @@
 namespace souffle::ast {
 UserDefinedAggregator::UserDefinedAggregator(
         std::string name, Own<Argument> init, Own<Argument> expr, VecOwn<Literal> body, SrcLocation loc)
-        : Aggregator(std::move(expr), std::move(body), std::move(loc)), name(name),
+        : Aggregator(NK_UserDefinedAggregator, std::move(expr), std::move(body), std::move(loc)), name(name),
           initValue(std::move(init)) {}
 
 void UserDefinedAggregator::apply(const NodeMapper& map) {
@@ -51,6 +51,10 @@ bool UserDefinedAggregator::equal(const Node& node) const {
 UserDefinedAggregator* UserDefinedAggregator::cloning() const {
     return new UserDefinedAggregator(
             name, clone(initValue), clone(targetExpression), clone(body), getSrcLoc());
+}
+
+bool UserDefinedAggregator::classof(const Node* n) {
+    return n->getKind() == NK_UserDefinedAggregator;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/UserDefinedAggregator.h
+++ b/src/ast/UserDefinedAggregator.h
@@ -52,6 +52,8 @@ public:
 
     void apply(const NodeMapper& map) override;
 
+    static bool classof(const Node*);
+
 protected:
     NodeVec getChildren() const override;
 

--- a/src/ast/UserDefinedFunctor.cpp
+++ b/src/ast/UserDefinedFunctor.cpp
@@ -16,10 +16,12 @@
 
 namespace souffle::ast {
 
-UserDefinedFunctor::UserDefinedFunctor(std::string name) : Functor({}, {}), name(std::move(name)){};
+UserDefinedFunctor::UserDefinedFunctor(std::string name)
+        : Functor(NK_UserDefinedFunctor, {}, {}), name(std::move(name)) {}
 
-UserDefinedFunctor::UserDefinedFunctor(std::string name, VecOwn<Argument> args, SrcLocation loc)
-        : Functor(std::move(args), std::move(loc)), name(std::move(name)) {}
+UserDefinedFunctor::UserDefinedFunctor(
+        std::string name, VecOwn<Argument> args, SrcLocation loc)
+        : Functor(NK_UserDefinedFunctor, std::move(args), std::move(loc)), name(std::move(name)) {}
 
 void UserDefinedFunctor::print(std::ostream& os) const {
     os << '@' << name << "(" << join(args) << ")";
@@ -32,6 +34,10 @@ bool UserDefinedFunctor::equal(const Node& node) const {
 
 UserDefinedFunctor* UserDefinedFunctor::cloning() const {
     return new UserDefinedFunctor(name, clone(args), getSrcLoc());
+}
+
+bool UserDefinedFunctor::classof(const Node* n) {
+    return n->getKind() == NK_UserDefinedFunctor;
 }
 
 }  // namespace souffle::ast

--- a/src/ast/UserDefinedFunctor.cpp
+++ b/src/ast/UserDefinedFunctor.cpp
@@ -19,8 +19,7 @@ namespace souffle::ast {
 UserDefinedFunctor::UserDefinedFunctor(std::string name)
         : Functor(NK_UserDefinedFunctor, {}, {}), name(std::move(name)) {}
 
-UserDefinedFunctor::UserDefinedFunctor(
-        std::string name, VecOwn<Argument> args, SrcLocation loc)
+UserDefinedFunctor::UserDefinedFunctor(std::string name, VecOwn<Argument> args, SrcLocation loc)
         : Functor(NK_UserDefinedFunctor, std::move(args), std::move(loc)), name(std::move(name)) {}
 
 void UserDefinedFunctor::print(std::ostream& os) const {

--- a/src/ast/UserDefinedFunctor.h
+++ b/src/ast/UserDefinedFunctor.h
@@ -40,6 +40,8 @@ public:
         return name;
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/Variable.cpp
+++ b/src/ast/Variable.cpp
@@ -12,7 +12,8 @@
 #include <utility>
 
 namespace souffle::ast {
-Variable::Variable(std::string name, SrcLocation loc) : Argument(std::move(loc)), name(std::move(name)) {}
+Variable::Variable(std::string name, SrcLocation loc)
+        : Argument(NK_Variable, std::move(loc)), name(std::move(name)) {}
 
 void Variable::setName(std::string name) {
     this->name = std::move(name);
@@ -30,4 +31,9 @@ bool Variable::equal(const Node& node) const {
 Variable* Variable::cloning() const {
     return new Variable(name, getSrcLoc());
 }
+
+bool Variable::classof(const Node* n) {
+    return n->getKind() == NK_Variable;
+}
+
 }  // namespace souffle::ast

--- a/src/ast/Variable.h
+++ b/src/ast/Variable.h
@@ -39,6 +39,8 @@ public:
         return name;
     }
 
+    static bool classof(const Node*);
+
 protected:
     void print(std::ostream& os) const override;
 

--- a/src/ast/analysis/RelationSchedule.cpp
+++ b/src/ast/analysis/RelationSchedule.cpp
@@ -78,7 +78,7 @@ std::vector<RelationSet> RelationScheduleAnalysis::computeRelationExpirySchedule
     std::size_t numSCCs = topsortSCCGraphAnalysis->order().size();
 
     /* Alive set for each step */
-    std::vector<RelationSet> alive(numSCCs);
+    std::vector<UnorderedRelationSet> alive(numSCCs);
     /* Resize expired relations sets */
     relationExpirySchedule.resize(numSCCs);
 

--- a/src/ast/analysis/typesystem/TypeSystem.h
+++ b/src/ast/analysis/typesystem/TypeSystem.h
@@ -51,8 +51,8 @@ class TypeEnvironment;
  */
 class Type {
 public:
-    // clang-format:off
     /// LLVM-style no-RTTI dynamic cast
+    // clang-format off
     enum TypeKind {
       TK_ConstantType,
       TK_SubsetType,
@@ -63,7 +63,7 @@ public:
       TK_RecordType,
       TK_AlgebraicDataType
     };
-    // clang-format:on
+    // clang-format on
 
     Type(const Type& other) = delete;
 
@@ -172,7 +172,6 @@ public:
             : Type(kind, environment, name), baseType(base) {}
 
 protected:
-
     SubsetType(const TypeEnvironment& environment, const QualifiedName& name, const Type& base)
             : SubsetType(TK_SubsetType, environment, name, base) {}
 

--- a/src/ast/analysis/typesystem/TypeSystem.h
+++ b/src/ast/analysis/typesystem/TypeSystem.h
@@ -51,6 +51,20 @@ class TypeEnvironment;
  */
 class Type {
 public:
+    // clang-format:off
+    /// LLVM-style no-RTTI dynamic cast
+    enum TypeKind {
+      TK_ConstantType,
+      TK_SubsetType,
+        TK_PrimitiveType,
+      TK_LastSubsetType,
+      TK_AliasType,
+      TK_UnionType,
+      TK_RecordType,
+      TK_AlgebraicDataType
+    };
+    // clang-format:on
+
     Type(const Type& other) = delete;
 
     virtual ~Type() = default;
@@ -88,10 +102,18 @@ public:
         return t.print(out), out;
     }
 
+    TypeKind getKind() const {
+        return kind;
+    }
+
+private:
+    const TypeKind kind;
+
 protected:
-    Type(const TypeEnvironment& environment, QualifiedName name,
+    explicit Type(TypeKind tyKind, const TypeEnvironment& environment, QualifiedName name,
             std::optional<QualifiedName> maybePrettyName = std::nullopt)
-            : environment(environment), name(std::move(name)), maybePrettyName(std::move(maybePrettyName)) {}
+            : kind(tyKind), environment(environment), name(std::move(name)),
+              maybePrettyName(std::move(maybePrettyName)) {}
 
     /** Type environment of type */
     const TypeEnvironment& environment;
@@ -113,7 +135,12 @@ protected:
 class ConstantType : public Type {
     ConstantType(const TypeEnvironment& environment, const QualifiedName& name,
             std::optional<QualifiedName> maybePrettyName = std::nullopt)
-            : Type(environment, name, std::move(maybePrettyName)) {}
+            : Type(TK_ConstantType, environment, name, std::move(maybePrettyName)) {}
+
+public:
+    static bool classof(const Type* t) {
+        return t->getKind() == TK_ConstantType;
+    }
 
 private:
     friend class TypeEnvironment;
@@ -129,7 +156,7 @@ private:
  *
  * where T is a type.
  */
-class SubsetType : virtual public Type {
+class SubsetType : public Type {
 public:
     void print(std::ostream& out) const override;
 
@@ -137,9 +164,17 @@ public:
         return baseType;
     }
 
+    static bool classof(const Type* t) {
+        return t->getKind() >= TK_SubsetType && t->getKind() < TK_LastSubsetType;
+    }
+
+    SubsetType(TypeKind kind, const TypeEnvironment& environment, const QualifiedName& name, const Type& base)
+            : Type(kind, environment, name), baseType(base) {}
+
 protected:
+
     SubsetType(const TypeEnvironment& environment, const QualifiedName& name, const Type& base)
-            : Type(environment, name), baseType(base){};
+            : SubsetType(TK_SubsetType, environment, name, base) {}
 
 private:
     friend class TypeEnvironment;
@@ -166,9 +201,13 @@ public:
         return aliasType;
     }
 
+    static bool classof(const Type* t) {
+        return t->getKind() == TK_AliasType;
+    }
+
 protected:
     AliasType(const TypeEnvironment& environment, const QualifiedName& name, const Type& alias)
-            : Type(environment, name), aliasType(alias){};
+            : Type(TK_AliasType, environment, name), aliasType(alias){};
 
 private:
     friend class TypeEnvironment;
@@ -194,9 +233,13 @@ public:
         out << name;
     }
 
+    static bool classof(const Type* t) {
+        return t->getKind() == TK_PrimitiveType;
+    }
+
 protected:
     PrimitiveType(const TypeEnvironment& environment, const QualifiedName& name, const ConstantType& base)
-            : Type(environment, name), SubsetType(environment, name, base) {}
+            : SubsetType(TK_PrimitiveType, environment, name, base) {}
 
 private:
     friend class TypeEnvironment;
@@ -225,10 +268,14 @@ public:
 
     void print(std::ostream& out) const override;
 
+    static bool classof(const Type* t) {
+        return t->getKind() == TK_UnionType;
+    }
+
 protected:
     UnionType(const TypeEnvironment& environment, const QualifiedName& name,
             std::vector<const Type*> elementTypes = {})
-            : Type(environment, name), elementTypes(std::move(elementTypes)) {}
+            : Type(TK_UnionType, environment, name), elementTypes(std::move(elementTypes)) {}
 
 private:
     friend class TypeEnvironment;
@@ -259,10 +306,14 @@ public:
 
     void print(std::ostream& out) const override;
 
+    static bool classof(const Type* t) {
+        return t->getKind() == TK_RecordType;
+    }
+
 protected:
     RecordType(const TypeEnvironment& environment, const QualifiedName& name,
             const std::vector<const Type*> fields = {})
-            : Type(environment, name), fields(fields) {}
+            : Type(TK_RecordType, environment, name), fields(fields) {}
 
 private:
     friend class TypeEnvironment;
@@ -327,8 +378,13 @@ public:
         return branches;
     }
 
+    static bool classof(const Type* t) {
+        return t->getKind() == TK_AlgebraicDataType;
+    }
+
 protected:
-    AlgebraicDataType(const TypeEnvironment& env, QualifiedName name) : Type(env, std::move(name)) {}
+    AlgebraicDataType(const TypeEnvironment& env, QualifiedName name)
+            : Type(TK_AlgebraicDataType, env, std::move(name)) {}
 
 private:
     friend class TypeEnvironment;

--- a/src/include/souffle/utility/DynamicCasting.h
+++ b/src/include/souffle/utility/DynamicCasting.h
@@ -30,50 +30,113 @@ namespace souffle {
 class AllowCrossCast {};
 
 namespace detail {
+
+/// Tels if A is a valid cross-cast option
 template <typename A>
 constexpr bool is_valid_cross_cast_option = std::is_same_v<A, void> || std::is_same_v<A, AllowCrossCast>;
+
+/// Tells if there is a function `To::classof(From*)`
+template <typename From, typename To, typename = void>
+struct has_classof : std::false_type {};
+
+template <typename From, typename To>
+struct has_classof<From, To, std::void_t<decltype(remove_cvref_t<To>::classof(std::declval<From*>()))>>
+        : std::true_type {};
 }
 
-/**
- * Helpers for `dynamic_cast`ing without having to specify redundant type qualifiers.
- * e.g. `as<AstLiteral>(p)` instead of `as<AstLiteral>(p)`.
- */
-template <typename B, typename CastType = void, typename A,
+/// Takes a non-null pointer and return whether it is pointing to a derived class of `To`.
+template <typename To, typename CastType = void, typename From,
         typename = std::enable_if_t<detail::is_valid_cross_cast_option<CastType>>>
-auto as(A* x) {
-    if constexpr (!std::is_same_v<CastType, AllowCrossCast> &&
-                  !std::is_base_of_v<std::remove_const_t<B>, std::remove_const_t<A>>) {
-        static_assert(std::is_base_of_v<std::remove_const_t<A>, std::remove_const_t<B>>,
+inline bool isA(From* p) noexcept {
+    if constexpr (detail::has_classof<From, To>::value) {
+        // use classof when available
+        return remove_cvref_t<To>::classof(p);
+    } else {
+        // fallback to dynamic_cast
+        return dynamic_cast<std::add_pointer_t<copy_const<From, To>>>(p) != nullptr;
+    }
+}
+
+/// forward isA when From is not a pointer
+template <typename To, typename CastType = void, typename From,
+        typename = std::enable_if_t<detail::is_valid_cross_cast_option<CastType>>,
+        typename = std::enable_if_t<std::is_same_v<CastType, AllowCrossCast> || std::is_base_of_v<From, To>>,
+        typename = std::enable_if_t<std::is_class_v<From> && !is_pointer_like<From>>>
+inline bool isA(From& p) noexcept {
+    return isA<To>(&p);
+}
+
+/// forward isA when From is supposed to be a unique or shared pointer
+template <typename To, typename CastType = void, typename From, typename = std::enable_if_t<is_pointer_like<From>>>
+inline bool isA(const From& p) noexcept {
+    return isA<To, CastType>(p.get());
+}
+
+/// Takes a non-null pointer and dynamic-cast to `To`.
+///
+/// Leverage `To::classof` when available to avoid costly `dynamic_cast`.
+template <typename To, typename CastType = void, typename From,
+        typename = std::enable_if_t<detail::is_valid_cross_cast_option<CastType>>>
+inline auto as(From* p) noexcept {
+    using ToClass = remove_cvref_t<To>;
+    using FromClass = remove_cvref_t<From>;
+    if constexpr (std::is_base_of_v<ToClass, FromClass>) {
+        // trivial conversion from pointer to derived class to pointer to base class
+        return static_cast<std::add_pointer_t<copy_const<From, ToClass>>>(p);
+    } else if constexpr (std::is_base_of_v<FromClass, ToClass> && can_static_cast<FromClass*, ToClass*>::value) {
+        // cast using isA when converting from pointer to non-virtual base class to pointer to derived class
+        using ResultType = remove_cvref_t<To>;
+        return isA<ResultType>(p) ? static_cast<std::add_pointer_t<copy_const<From, ToClass>>>(p) : nullptr;
+    } else if constexpr (std::is_same_v<CastType, AllowCrossCast> ||
+                         !can_static_cast<FromClass*, ToClass*>::value) {
+        // dynamic cast when converting across type hierarchies or
+        // converting from pointer to virtual base class to pointer to derived class
+        return dynamic_cast<std::add_pointer_t<copy_const<From, ToClass>>>(p);
+    } else {
+        // cross-hierarchy dynamic cast not allowed unless CastType = AllowCrossCast
+        static_assert(std::is_base_of_v<FromClass,ToClass>,
                 "`as<B, A>` does not allow cross-type dyn casts. "
                 "(i.e. `as<B, A>` where `B <: A` is not true.) "
                 "Such a cast is likely a mistake or typo.");
     }
-    return dynamic_cast<copy_const<A, B>*>(x);
 }
 
-template <typename B, typename CastType = void, typename A,
-        typename = std::enable_if_t<std::is_same_v<CastType, AllowCrossCast> || std::is_base_of_v<A, B>>,
-        typename = std::enable_if_t<std::is_class_v<A> && !is_pointer_like<A>>>
-auto as(A& x) {
-    return as<B, CastType>(&x);
+/// Takes a possibly null pointer and dynamic-cast to `To`.
+template <typename To, typename CastType = void, typename From,
+        typename = std::enable_if_t<detail::is_valid_cross_cast_option<CastType>>>
+inline auto as_or_null(From* p) noexcept {
+    using ToClass = remove_cvref_t<To>;
+    if (p == nullptr) {
+        return static_cast<std::add_pointer_t<copy_const<From, ToClass>>>(nullptr);
+    }
+    return as<To, CastType, From>(p);
 }
 
-template <typename B, typename CastType = void, typename A, typename = std::enable_if_t<is_pointer_like<A>>>
-auto as(const A& x) {
-    return as<B, CastType>(x.get());
+template <typename To, typename CastType = void, typename From,
+        typename = std::enable_if_t<detail::is_valid_cross_cast_option<CastType>>,
+        typename = std::enable_if_t<std::is_same_v<CastType, AllowCrossCast> || std::is_base_of_v<From, To>>,
+        typename = std::enable_if_t<std::is_class_v<From> && !is_pointer_like<From>>>
+inline auto as(From& x) {
+    return as<To, CastType>(&x);
 }
 
-template <typename B, typename CastType = void, typename A>
-auto as(const std::reference_wrapper<A>& x) {
-    return as<B, CastType>(x.get());
+template <typename To, typename CastType = void, typename From>
+inline auto as(const std::unique_ptr<From>& x) {
+    return as<To, CastType>(x.get());
 }
+
+template <typename To, typename CastType = void, typename From>
+inline auto as(const std::reference_wrapper<From>& x) {
+    return as<To, CastType>(x.get());
+}
+
 
 /**
  * Down-casts and checks the cast has succeeded
  */
-template <typename B, typename CastType = void, typename A>
-auto& asAssert(A&& a) {
-    auto* cast = as<B, CastType>(std::forward<A>(a));
+template <typename To, typename CastType = void, typename From>
+auto& asAssert(From&& a) {
+    auto* cast = as<To, CastType>(std::forward<From>(a));
     assert(cast && "Invalid cast");
     return *cast;
 }
@@ -92,13 +155,13 @@ Own<B> UNSAFE_cast(Own<A> x) {
     }
 }
 
-/**
- * Checks if the object of type Source can be casted to type Destination.
- */
-template <typename B, typename CastType = void, typename A>
-// [[deprecated("Use `as` and implicit boolean conversion instead.")]]
-bool isA(A&& src) {
-    return as<B, CastType>(std::forward<A>(src));
-}
+///**
+// * Checks if the object of type Source can be casted to type Destination.
+// */
+//template <typename B, typename CastType = void, typename A>
+//// [[deprecated("Use `as` and implicit boolean conversion instead.")]]
+//bool isA(A&& src) {
+//    return as<B, CastType>(std::forward<A>(src));
+//}
 
 }  // namespace souffle

--- a/src/include/souffle/utility/Types.h
+++ b/src/include/souffle/utility/Types.h
@@ -164,6 +164,7 @@ struct can_static_cast<From, To, std::void_t<decltype(static_cast<To>(std::declv
 // that, however, cannot be static_casted to its derived class.
 template <typename Base, typename Derived>
 struct is_virtual_base_of
-        : std::conjunction<std::is_base_of<Base, Derived>, std::negation<can_static_cast<Base*, Derived*>>> {};
+        : std::conjunction<std::is_base_of<Base, Derived>, std::negation<can_static_cast<Base*, Derived*>>> {
+};
 
 }  // namespace souffle

--- a/src/include/souffle/utility/Types.h
+++ b/src/include/souffle/utility/Types.h
@@ -152,4 +152,18 @@ constexpr bool is_set = detail::is_set<A>::value;
 template <typename A>
 constexpr bool unhandled_dispatch_type = !std::is_same_v<A, A>;
 
+// Tells if we can static_cast<From,To>
+template <typename From, typename To, typename = void>
+struct can_static_cast : std::false_type {};
+
+template <typename From, typename To>
+struct can_static_cast<From, To, std::void_t<decltype(static_cast<To>(std::declval<From>()))>>
+        : std::true_type {};
+
+// A virtual base is first and foremost a base,
+// that, however, cannot be static_casted to its derived class.
+template <typename Base, typename Derived>
+struct is_virtual_base_of
+        : std::conjunction<std::is_base_of<Base, Derived>, std::negation<can_static_cast<Base*, Derived*>>> {};
+
 }  // namespace souffle

--- a/src/ram/AbstractAggregate.h
+++ b/src/ram/AbstractAggregate.h
@@ -14,13 +14,10 @@
 
 #pragma once
 
-#include "AggregateOp.h"
 #include "ram/Aggregator.h"
 #include "ram/Condition.h"
 #include "ram/Expression.h"
-#include "ram/IntrinsicAggregator.h"
 #include "ram/Node.h"
-#include "ram/UserDefinedAggregator.h"
 #include "souffle/utility/ContainerUtil.h"
 #include "souffle/utility/MiscUtil.h"
 #include <cassert>

--- a/src/ram/AbstractConditional.h
+++ b/src/ram/AbstractConditional.h
@@ -46,13 +46,14 @@ public:
         condition = map(std::move(condition));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_AbstractConditional && kind < NK_LastAbstractConditional);
     }
 
 protected:
-    AbstractConditional(NodeKind kind, Own<Condition> cond, Own<Operation> nested, std::string profileText = "")
+    AbstractConditional(
+            NodeKind kind, Own<Condition> cond, Own<Operation> nested, std::string profileText = "")
             : NestedOperation(kind, std::move(nested), std::move(profileText)), condition(std::move(cond)) {
         assert(condition != nullptr && "Condition is a null-pointer");
         assert(kind >= NK_AbstractConditional && kind < NK_LastAbstractConditional);

--- a/src/ram/AbstractConditional.h
+++ b/src/ram/AbstractConditional.h
@@ -33,11 +33,6 @@ namespace souffle::ram {
  */
 class AbstractConditional : public NestedOperation {
 public:
-    AbstractConditional(Own<Condition> cond, Own<Operation> nested, std::string profileText = "")
-            : NestedOperation(std::move(nested), std::move(profileText)), condition(std::move(cond)) {
-        assert(condition != nullptr && "Condition is a null-pointer");
-    }
-
     AbstractConditional* cloning() const override = 0;
 
     /** @brief Get condition that must be satisfied */
@@ -51,7 +46,18 @@ public:
         condition = map(std::move(condition));
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_AbstractConditional && kind < NK_LastAbstractConditional);
+    }
+
 protected:
+    AbstractConditional(NodeKind kind, Own<Condition> cond, Own<Operation> nested, std::string profileText = "")
+            : NestedOperation(kind, std::move(nested), std::move(profileText)), condition(std::move(cond)) {
+        assert(condition != nullptr && "Condition is a null-pointer");
+        assert(kind >= NK_AbstractConditional && kind < NK_LastAbstractConditional);
+    }
+
     bool equal(const Node& node) const override {
         const auto& other = asAssert<AbstractConditional>(node);
         return NestedOperation::equal(node) && equal_ptr(condition, other.condition);

--- a/src/ram/AbstractExistenceCheck.h
+++ b/src/ram/AbstractExistenceCheck.h
@@ -39,11 +39,6 @@ namespace souffle::ram {
  */
 class AbstractExistenceCheck : public Condition {
 public:
-    AbstractExistenceCheck(std::string rel, VecOwn<Expression> vals)
-            : relation(std::move(rel)), values(std::move(vals)) {
-        assert(allValidPtrs(values));
-    }
-
     /** @brief Get relation */
     const std::string& getRelation() const {
         return relation;
@@ -64,7 +59,18 @@ public:
         }
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_AbstractExistenceCheck && kind < NK_LastAbstractExistenceCheck);
+    }
+
 protected:
+    AbstractExistenceCheck(NodeKind kind, std::string rel, VecOwn<Expression> vals)
+            : Condition(kind), relation(std::move(rel)), values(std::move(vals)) {
+        assert(allValidPtrs(values));
+        assert(kind >= NK_AbstractExistenceCheck && kind < NK_LastAbstractExistenceCheck);
+    }
+
     void print(std::ostream& os) const override {
         os << "(" << join(values, ",") << ") IN " << relation;
     }

--- a/src/ram/AbstractExistenceCheck.h
+++ b/src/ram/AbstractExistenceCheck.h
@@ -59,7 +59,7 @@ public:
         }
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_AbstractExistenceCheck && kind < NK_LastAbstractExistenceCheck);
     }

--- a/src/ram/AbstractOperator.h
+++ b/src/ram/AbstractOperator.h
@@ -44,13 +44,14 @@ public:
         }
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_AbstractOperator && kind < NK_LastAbstractOperator);
     }
 
 protected:
-    explicit AbstractOperator(NodeKind kind, VecOwn<Expression> args) : Expression(kind), arguments(std::move(args)) {
+    explicit AbstractOperator(NodeKind kind, VecOwn<Expression> args)
+            : Expression(kind), arguments(std::move(args)) {
         assert(allValidPtrs(arguments));
         assert(kind >= NK_AbstractOperator && kind < NK_LastAbstractOperator);
     }

--- a/src/ram/AbstractOperator.h
+++ b/src/ram/AbstractOperator.h
@@ -33,10 +33,6 @@ namespace souffle::ram {
  */
 class AbstractOperator : public Expression {
 public:
-    explicit AbstractOperator(VecOwn<Expression> args) : arguments(std::move(args)) {
-        assert(allValidPtrs(arguments));
-    }
-
     /** @brief Get argument values */
     std::vector<Expression*> getArguments() const {
         return toPtrVector(arguments);
@@ -48,7 +44,17 @@ public:
         }
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_AbstractOperator && kind < NK_LastAbstractOperator);
+    }
+
 protected:
+    explicit AbstractOperator(NodeKind kind, VecOwn<Expression> args) : Expression(kind), arguments(std::move(args)) {
+        assert(allValidPtrs(arguments));
+        assert(kind >= NK_AbstractOperator && kind < NK_LastAbstractOperator);
+    }
+
     bool equal(const Node& node) const override {
         const auto& other = asAssert<AbstractOperator>(node);
         return equal_targets(arguments, other.arguments);

--- a/src/ram/Aggregate.h
+++ b/src/ram/Aggregate.h
@@ -49,13 +49,13 @@ class Aggregate : public RelationOperation, public AbstractAggregate {
 public:
     Aggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
             Own<Condition> condition, std::size_t ident)
-            : RelationOperation(rel, ident, std::move(nested)),
-              AbstractAggregate(std::move(fun), std::move(expression), std::move(condition)) {}
+            : Aggregate(NK_Aggregate, std::move(nested), std::move(fun), rel, std::move(expression),
+                std::move(condition), ident) {}
 
     ~Aggregate() override = default;
 
     Aggregate* cloning() const override {
-        return new Aggregate(clone(getOperation()), clone(function), relation, clone(expression),
+        return new Aggregate(NK_Aggregate, clone(getOperation()), clone(function), relation, clone(expression),
                 clone(condition), getTupleId());
     }
 
@@ -65,7 +65,19 @@ public:
         expression = map(std::move(expression));
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_Aggregate && kind < NK_LastAggregate);
+    }
+
 protected:
+    Aggregate(NodeKind kind, Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
+            Own<Condition> condition, std::size_t ident)
+            : RelationOperation(kind, rel, ident, std::move(nested)),
+              AbstractAggregate(std::move(fun), std::move(expression), std::move(condition)) {
+                assert(kind >= NK_Aggregate && kind < NK_LastAggregate);
+              }
+
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
         os << "t" << getTupleId() << ".0 = ";

--- a/src/ram/Aggregate.h
+++ b/src/ram/Aggregate.h
@@ -50,13 +50,13 @@ public:
     Aggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
             Own<Condition> condition, std::size_t ident)
             : Aggregate(NK_Aggregate, std::move(nested), std::move(fun), rel, std::move(expression),
-                std::move(condition), ident) {}
+                      std::move(condition), ident) {}
 
     ~Aggregate() override = default;
 
     Aggregate* cloning() const override {
-        return new Aggregate(NK_Aggregate, clone(getOperation()), clone(function), relation, clone(expression),
-                clone(condition), getTupleId());
+        return new Aggregate(NK_Aggregate, clone(getOperation()), clone(function), relation,
+                clone(expression), clone(condition), getTupleId());
     }
 
     void apply(const NodeMapper& map) override {
@@ -65,18 +65,18 @@ public:
         expression = map(std::move(expression));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_Aggregate && kind < NK_LastAggregate);
     }
 
 protected:
-    Aggregate(NodeKind kind, Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
-            Own<Condition> condition, std::size_t ident)
+    Aggregate(NodeKind kind, Own<Operation> nested, Own<Aggregator> fun, std::string rel,
+            Own<Expression> expression, Own<Condition> condition, std::size_t ident)
             : RelationOperation(kind, rel, ident, std::move(nested)),
               AbstractAggregate(std::move(fun), std::move(expression), std::move(condition)) {
-                assert(kind >= NK_Aggregate && kind < NK_LastAggregate);
-              }
+        assert(kind >= NK_Aggregate && kind < NK_LastAggregate);
+    }
 
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);

--- a/src/ram/Assign.h
+++ b/src/ram/Assign.h
@@ -38,7 +38,7 @@ namespace souffle::ram {
 class Assign : public Statement {
 public:
     Assign(Own<Variable> v, Own<Expression> e, bool init)
-            : variable(std::move(v)), value(std::move(e)), init(init) {
+            : Statement(NK_Assign), variable(std::move(v)), value(std::move(e)), init(init) {
         assert(variable != nullptr && "variable is a null-pointer");
         assert(value != nullptr && "value is a null-pointer");
     }
@@ -64,6 +64,10 @@ public:
     void apply(const NodeMapper& map) override {
         variable = map(std::move(variable));
         value = map(std::move(value));
+    }
+
+    static bool classof(const Node* n) {
+        return n->getKind() == NK_Assign;
     }
 
 protected:

--- a/src/ram/AutoIncrement.h
+++ b/src/ram/AutoIncrement.h
@@ -29,8 +29,14 @@ namespace souffle::ram {
  */
 class AutoIncrement : public Expression {
 public:
+    AutoIncrement() : Expression(NK_AutoIncrement) {}
+
     AutoIncrement* cloning() const override {
         return new AutoIncrement();
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_AutoIncrement;
     }
 
 protected:

--- a/src/ram/AutoIncrement.h
+++ b/src/ram/AutoIncrement.h
@@ -35,7 +35,7 @@ public:
         return new AutoIncrement();
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_AutoIncrement;
     }
 

--- a/src/ram/BinRelationStatement.h
+++ b/src/ram/BinRelationStatement.h
@@ -36,7 +36,8 @@ namespace souffle::ram {
  */
 class BinRelationStatement : public Statement {
 public:
-    BinRelationStatement(std::string f, std::string s) : first(std::move(f)), second(std::move(s)) {}
+    BinRelationStatement(std::string f, std::string s) : 
+    BinRelationStatement(NK_BinRelationStatement, std::move(f), std::move(s)) {}
 
     /** @brief Get first relation */
     const std::string& getFirstRelation() const {
@@ -48,7 +49,16 @@ public:
         return second;
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_BinRelationStatement && kind < NK_LastBinRelationStatement);
+    }
+
 protected:
+    BinRelationStatement(NodeKind kind, std::string f, std::string s) : Statement(kind), first(std::move(f)), second(std::move(s)) {
+        assert(kind >= NK_BinRelationStatement && kind < NK_LastBinRelationStatement);
+    }
+
     bool equal(const Node& node) const override {
         const auto& other = asAssert<BinRelationStatement>(node);
         return first == other.first && second == other.second;

--- a/src/ram/BinRelationStatement.h
+++ b/src/ram/BinRelationStatement.h
@@ -36,8 +36,8 @@ namespace souffle::ram {
  */
 class BinRelationStatement : public Statement {
 public:
-    BinRelationStatement(std::string f, std::string s) : 
-    BinRelationStatement(NK_BinRelationStatement, std::move(f), std::move(s)) {}
+    BinRelationStatement(std::string f, std::string s)
+            : BinRelationStatement(NK_BinRelationStatement, std::move(f), std::move(s)) {}
 
     /** @brief Get first relation */
     const std::string& getFirstRelation() const {
@@ -49,13 +49,14 @@ public:
         return second;
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_BinRelationStatement && kind < NK_LastBinRelationStatement);
     }
 
 protected:
-    BinRelationStatement(NodeKind kind, std::string f, std::string s) : Statement(kind), first(std::move(f)), second(std::move(s)) {
+    BinRelationStatement(NodeKind kind, std::string f, std::string s)
+            : Statement(kind), first(std::move(f)), second(std::move(s)) {
         assert(kind >= NK_BinRelationStatement && kind < NK_LastBinRelationStatement);
     }
 

--- a/src/ram/Break.h
+++ b/src/ram/Break.h
@@ -51,7 +51,7 @@ public:
         return new Break(clone(condition), clone(getOperation()), getProfileText());
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Break;
     }
 

--- a/src/ram/Break.h
+++ b/src/ram/Break.h
@@ -45,10 +45,14 @@ namespace souffle::ram {
 class Break : public AbstractConditional {
 public:
     Break(Own<Condition> cond, Own<Operation> nested, std::string profileText = "")
-            : AbstractConditional(std::move(cond), std::move(nested), std::move(profileText)) {}
+            : AbstractConditional(NK_Break, std::move(cond), std::move(nested), std::move(profileText)) {}
 
     Break* cloning() const override {
         return new Break(clone(condition), clone(getOperation()), getProfileText());
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Break;
     }
 
 protected:

--- a/src/ram/Call.h
+++ b/src/ram/Call.h
@@ -38,7 +38,7 @@ namespace souffle::ram {
 
 class Call : public Statement {
 public:
-    Call(std::string name) : name(std::move(name)) {}
+    Call(std::string name) : Statement(NK_Call), name(std::move(name)) {}
 
     /** @brief Get call name */
     const std::string& getName() const {
@@ -47,6 +47,10 @@ public:
 
     Call* cloning() const override {
         return new Call(name);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Call;
     }
 
 protected:

--- a/src/ram/Call.h
+++ b/src/ram/Call.h
@@ -49,7 +49,7 @@ public:
         return new Call(name);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Call;
     }
 

--- a/src/ram/Clear.h
+++ b/src/ram/Clear.h
@@ -48,7 +48,7 @@ public:
         return new Clear(relation);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Clear;
     }
 

--- a/src/ram/Clear.h
+++ b/src/ram/Clear.h
@@ -42,10 +42,14 @@ namespace souffle::ram {
 
 class Clear : public RelationStatement {
 public:
-    Clear(std::string rel) : RelationStatement(rel) {}
+    Clear(std::string rel) : RelationStatement(NK_Clear, rel) {}
 
     Clear* cloning() const override {
         return new Clear(relation);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Clear;
     }
 
 protected:

--- a/src/ram/Condition.h
+++ b/src/ram/Condition.h
@@ -36,7 +36,7 @@ protected:
 public:
     Condition* cloning() const override = 0;
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_Condition && kind < NK_LastCondition);
     }

--- a/src/ram/Condition.h
+++ b/src/ram/Condition.h
@@ -26,8 +26,20 @@ namespace souffle::ram {
  * @brief Abstract class for conditions and boolean values in RAM
  */
 class Condition : public Node {
+protected:
+    using Node::Node;
+
+    Condition(NodeKind kind) : Node(kind) {
+        assert(kind >= NK_Condition && kind < NK_LastCondition);
+    }
+
 public:
     Condition* cloning() const override = 0;
+
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_Condition && kind < NK_LastCondition);
+    }
 };
 
 }  // namespace souffle::ram

--- a/src/ram/Conjunction.h
+++ b/src/ram/Conjunction.h
@@ -45,7 +45,8 @@ namespace souffle::ram {
  */
 class Conjunction : public Condition {
 public:
-    Conjunction(Own<Condition> l, Own<Condition> r) : Condition(NK_Conjunction), lhs(std::move(l)), rhs(std::move(r)) {
+    Conjunction(Own<Condition> l, Own<Condition> r)
+            : Condition(NK_Conjunction), lhs(std::move(l)), rhs(std::move(r)) {
         assert(lhs != nullptr && "left-hand side of conjunction is a nullptr");
         assert(rhs != nullptr && "right-hand side of conjunction is a nullptr");
     }
@@ -69,7 +70,7 @@ public:
         rhs = map(std::move(rhs));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Conjunction;
     }
 

--- a/src/ram/Conjunction.h
+++ b/src/ram/Conjunction.h
@@ -45,7 +45,7 @@ namespace souffle::ram {
  */
 class Conjunction : public Condition {
 public:
-    Conjunction(Own<Condition> l, Own<Condition> r) : lhs(std::move(l)), rhs(std::move(r)) {
+    Conjunction(Own<Condition> l, Own<Condition> r) : Condition(NK_Conjunction), lhs(std::move(l)), rhs(std::move(r)) {
         assert(lhs != nullptr && "left-hand side of conjunction is a nullptr");
         assert(rhs != nullptr && "right-hand side of conjunction is a nullptr");
     }
@@ -67,6 +67,10 @@ public:
     void apply(const NodeMapper& map) override {
         lhs = map(std::move(lhs));
         rhs = map(std::move(rhs));
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Conjunction;
     }
 
 protected:

--- a/src/ram/Constraint.h
+++ b/src/ram/Constraint.h
@@ -47,7 +47,7 @@ namespace souffle::ram {
 class Constraint : public Condition {
 public:
     Constraint(BinaryConstraintOp op, Own<Expression> l, Own<Expression> r)
-            : op(op), lhs(std::move(l)), rhs(std::move(r)) {
+            : Condition(NK_Constraint), op(op), lhs(std::move(l)), rhs(std::move(r)) {
         assert(lhs != nullptr && "left-hand side of constraint is a null-pointer");
         assert(rhs != nullptr && "right-hand side of constraint is a null-pointer");
     }
@@ -74,6 +74,10 @@ public:
     void apply(const NodeMapper& map) override {
         lhs = map(std::move(lhs));
         rhs = map(std::move(rhs));
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Constraint;
     }
 
 protected:

--- a/src/ram/Constraint.h
+++ b/src/ram/Constraint.h
@@ -76,7 +76,7 @@ public:
         rhs = map(std::move(rhs));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Constraint;
     }
 

--- a/src/ram/DebugInfo.h
+++ b/src/ram/DebugInfo.h
@@ -41,7 +41,7 @@ namespace souffle::ram {
  */
 class DebugInfo : public Statement, public AbstractLog {
 public:
-    DebugInfo(Own<Statement> stmt, std::string msg) : AbstractLog(std::move(stmt), std::move(msg)) {}
+    DebugInfo(Own<Statement> stmt, std::string msg) : Statement(NK_DebugInfo), AbstractLog(std::move(stmt), std::move(msg)) {}
 
     DebugInfo* cloning() const override {
         return new DebugInfo(clone(statement), message);
@@ -49,6 +49,10 @@ public:
 
     void apply(const NodeMapper& map) override {
         AbstractLog::apply(map);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_DebugInfo;
     }
 
 protected:

--- a/src/ram/DebugInfo.h
+++ b/src/ram/DebugInfo.h
@@ -41,7 +41,8 @@ namespace souffle::ram {
  */
 class DebugInfo : public Statement, public AbstractLog {
 public:
-    DebugInfo(Own<Statement> stmt, std::string msg) : Statement(NK_DebugInfo), AbstractLog(std::move(stmt), std::move(msg)) {}
+    DebugInfo(Own<Statement> stmt, std::string msg)
+            : Statement(NK_DebugInfo), AbstractLog(std::move(stmt), std::move(msg)) {}
 
     DebugInfo* cloning() const override {
         return new DebugInfo(clone(statement), message);
@@ -51,7 +52,7 @@ public:
         AbstractLog::apply(map);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_DebugInfo;
     }
 

--- a/src/ram/EmptinessCheck.h
+++ b/src/ram/EmptinessCheck.h
@@ -44,7 +44,7 @@ namespace souffle::ram {
  */
 class EmptinessCheck : public Condition {
 public:
-    EmptinessCheck(std::string rel) : relation(std::move(rel)) {}
+    EmptinessCheck(std::string rel) : Condition(NK_EmptinessCheck), relation(std::move(rel)) {}
 
     /** @brief Get relation */
     const std::string& getRelation() const {
@@ -53,6 +53,10 @@ public:
 
     EmptinessCheck* cloning() const override {
         return new EmptinessCheck(relation);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_EmptinessCheck;
     }
 
 protected:

--- a/src/ram/EmptinessCheck.h
+++ b/src/ram/EmptinessCheck.h
@@ -55,7 +55,7 @@ public:
         return new EmptinessCheck(relation);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_EmptinessCheck;
     }
 

--- a/src/ram/Erase.h
+++ b/src/ram/Erase.h
@@ -84,7 +84,7 @@ public:
         }
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Erase;
     }
 

--- a/src/ram/Erase.h
+++ b/src/ram/Erase.h
@@ -46,8 +46,8 @@ namespace souffle::ram {
 class Erase : public Operation {
 public:
     Erase(std::string rel, VecOwn<Expression> expressions)
-            : relation(std::move(rel)), expressions(std::move(expressions)) {
-        for (auto const& expr : expressions) {
+            : Operation(NK_Erase), relation(std::move(rel)), expressions(std::move(expressions)) {
+        for ([[maybe_unused]] auto const& expr : expressions) {
             assert(expr != nullptr && "Expression is a null-pointer");
         }
     }
@@ -82,6 +82,10 @@ public:
         for (auto& expr : expressions) {
             expr = map(std::move(expr));
         }
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Erase;
     }
 
 protected:

--- a/src/ram/EstimateJoinSize.h
+++ b/src/ram/EstimateJoinSize.h
@@ -50,7 +50,8 @@ class EstimateJoinSize : public RelationStatement {
 public:
     EstimateJoinSize(std::string rel, const std::set<std::size_t>& columns,
             const std::map<std::size_t, const ram::Expression*>& keyToConstants, bool isRecursive)
-            : RelationStatement(NK_EstimateJoinSize, rel), keyColumns(columns), recursiveRelation(isRecursive) {
+            : RelationStatement(NK_EstimateJoinSize, rel), keyColumns(columns),
+              recursiveRelation(isRecursive) {
         // copy the constants over
         for (auto [k, constant] : keyToConstants) {
             auto clonedConstant = clone(constant);
@@ -75,7 +76,7 @@ public:
         return new EstimateJoinSize(relation, keyColumns, constantsMap, recursiveRelation);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_EstimateJoinSize;
     }
 

--- a/src/ram/EstimateJoinSize.h
+++ b/src/ram/EstimateJoinSize.h
@@ -50,7 +50,7 @@ class EstimateJoinSize : public RelationStatement {
 public:
     EstimateJoinSize(std::string rel, const std::set<std::size_t>& columns,
             const std::map<std::size_t, const ram::Expression*>& keyToConstants, bool isRecursive)
-            : RelationStatement(rel), keyColumns(columns), recursiveRelation(isRecursive) {
+            : RelationStatement(NK_EstimateJoinSize, rel), keyColumns(columns), recursiveRelation(isRecursive) {
         // copy the constants over
         for (auto [k, constant] : keyToConstants) {
             auto clonedConstant = clone(constant);
@@ -73,6 +73,10 @@ public:
 
     EstimateJoinSize* cloning() const override {
         return new EstimateJoinSize(relation, keyColumns, constantsMap, recursiveRelation);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_EstimateJoinSize;
     }
 
 protected:

--- a/src/ram/ExistenceCheck.h
+++ b/src/ram/ExistenceCheck.h
@@ -41,7 +41,8 @@ namespace souffle::ram {
  */
 class ExistenceCheck : public AbstractExistenceCheck {
 public:
-    ExistenceCheck(std::string rel, VecOwn<Expression> vals) : AbstractExistenceCheck(NK_ExistenceCheck, rel, std::move(vals)) {}
+    ExistenceCheck(std::string rel, VecOwn<Expression> vals)
+            : AbstractExistenceCheck(NK_ExistenceCheck, rel, std::move(vals)) {}
 
     ExistenceCheck* cloning() const override {
         VecOwn<Expression> newValues;
@@ -51,7 +52,7 @@ public:
         return new ExistenceCheck(relation, std::move(newValues));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == Node::NK_ExistenceCheck;
     }
 };

--- a/src/ram/ExistenceCheck.h
+++ b/src/ram/ExistenceCheck.h
@@ -41,7 +41,7 @@ namespace souffle::ram {
  */
 class ExistenceCheck : public AbstractExistenceCheck {
 public:
-    ExistenceCheck(std::string rel, VecOwn<Expression> vals) : AbstractExistenceCheck(rel, std::move(vals)) {}
+    ExistenceCheck(std::string rel, VecOwn<Expression> vals) : AbstractExistenceCheck(NK_ExistenceCheck, rel, std::move(vals)) {}
 
     ExistenceCheck* cloning() const override {
         VecOwn<Expression> newValues;
@@ -49,6 +49,10 @@ public:
             newValues.emplace_back(cur->cloning());
         }
         return new ExistenceCheck(relation, std::move(newValues));
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == Node::NK_ExistenceCheck;
     }
 };
 

--- a/src/ram/Exit.h
+++ b/src/ram/Exit.h
@@ -42,7 +42,7 @@ namespace souffle::ram {
  */
 class Exit : public Statement {
 public:
-    Exit(Own<Condition> c) : condition(std::move(c)) {
+    Exit(Own<Condition> c) : Statement(NK_Exit), condition(std::move(c)) {
         assert(condition && "condition is a nullptr");
     }
 
@@ -57,6 +57,10 @@ public:
 
     void apply(const NodeMapper& map) override {
         condition = map(std::move(condition));
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Exit;
     }
 
 protected:

--- a/src/ram/Exit.h
+++ b/src/ram/Exit.h
@@ -59,7 +59,7 @@ public:
         condition = map(std::move(condition));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Exit;
     }
 

--- a/src/ram/Expression.h
+++ b/src/ram/Expression.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "ram/Node.h"
+#include <cassert>
 
 namespace souffle::ram {
 
@@ -25,7 +26,19 @@ namespace souffle::ram {
  * @brief Abstract class for describing scalar values in RAM
  */
 class Expression : public Node {
+protected:
+    using Node::Node;
+
+    explicit Expression(NodeKind kind) : Node(kind) {
+        assert(kind >= NK_Expression && kind < NK_LastExpression);
+    }
+
 public:
+    static bool classof(const Node* n) {
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_Expression && kind < NK_LastExpression);
+    }
+
     Expression* cloning() const override = 0;
 };
 

--- a/src/ram/False.h
+++ b/src/ram/False.h
@@ -30,8 +30,14 @@ namespace souffle::ram {
  */
 class False : public Condition {
 public:
+    False() : Condition(NK_False){}
+
     False* cloning() const override {
         return new False();
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_False;
     }
 
 protected:

--- a/src/ram/False.h
+++ b/src/ram/False.h
@@ -30,13 +30,13 @@ namespace souffle::ram {
  */
 class False : public Condition {
 public:
-    False() : Condition(NK_False){}
+    False() : Condition(NK_False) {}
 
     False* cloning() const override {
         return new False();
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_False;
     }
 

--- a/src/ram/Filter.h
+++ b/src/ram/Filter.h
@@ -45,10 +45,14 @@ namespace souffle::ram {
 class Filter : public AbstractConditional {
 public:
     Filter(Own<Condition> cond, Own<Operation> nested, std::string profileText = "")
-            : AbstractConditional(std::move(cond), std::move(nested), std::move(profileText)) {}
+            : AbstractConditional(NK_Filter, std::move(cond), std::move(nested), std::move(profileText)) {}
 
     Filter* cloning() const override {
         return new Filter(clone(condition), clone(getOperation()), getProfileText());
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Filter;
     }
 
 protected:

--- a/src/ram/Filter.h
+++ b/src/ram/Filter.h
@@ -51,7 +51,7 @@ public:
         return new Filter(clone(condition), clone(getOperation()), getProfileText());
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Filter;
     }
 

--- a/src/ram/FloatConstant.h
+++ b/src/ram/FloatConstant.h
@@ -33,7 +33,7 @@ namespace souffle::ram {
  */
 class FloatConstant : public NumericConstant {
 public:
-    explicit FloatConstant(RamFloat val) : NumericConstant(ramBitCast(val)) {}
+    explicit FloatConstant(RamFloat val) : NumericConstant(NK_FloatConstant, ramBitCast(val)) {}
 
     /** @brief Get value of the constant. */
     RamFloat getValue() const {
@@ -43,6 +43,10 @@ public:
     /** Create cloning */
     FloatConstant* cloning() const override {
         return new FloatConstant(getValue());
+    }
+
+    static bool classof(const Node* n) {
+        return n->getKind() == NK_FloatConstant;
     }
 
 protected:

--- a/src/ram/GuardedInsert.h
+++ b/src/ram/GuardedInsert.h
@@ -67,7 +67,7 @@ public:
         condition = map(std::move(condition));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_GuardedInsert;
     }
 

--- a/src/ram/GuardedInsert.h
+++ b/src/ram/GuardedInsert.h
@@ -44,7 +44,7 @@ namespace souffle::ram {
 class GuardedInsert : public Insert {
 public:
     GuardedInsert(std::string rel, VecOwn<Expression> expressions, Own<Condition> condition = mk<True>())
-            : Insert(rel, std::move(expressions)), condition(std::move(condition)) {}
+            : Insert(NK_GuardedInsert, rel, std::move(expressions)), condition(std::move(condition)) {}
 
     /** @brief Get guarded condition */
     const Condition* getCondition() const {
@@ -65,6 +65,10 @@ public:
             expr = map(std::move(expr));
         }
         condition = map(std::move(condition));
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_GuardedInsert;
     }
 
 protected:

--- a/src/ram/IO.h
+++ b/src/ram/IO.h
@@ -54,7 +54,7 @@ public:
         return new IO(relation, directives);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_IO;
     }
 

--- a/src/ram/IO.h
+++ b/src/ram/IO.h
@@ -38,7 +38,7 @@ namespace souffle::ram {
 class IO : public RelationStatement {
 public:
     IO(std::string rel, std::map<std::string, std::string> directives)
-            : RelationStatement(rel), directives(std::move(directives)) {}
+            : RelationStatement(NK_IO, rel), directives(std::move(directives)) {}
 
     /** @brief get I/O directives */
     const std::map<std::string, std::string>& getDirectives() const {
@@ -52,6 +52,10 @@ public:
 
     IO* cloning() const override {
         return new IO(relation, directives);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_IO;
     }
 
 protected:

--- a/src/ram/IfExists.h
+++ b/src/ram/IfExists.h
@@ -53,8 +53,7 @@ class IfExists : public RelationOperation, public AbstractIfExists {
 public:
     IfExists(std::string rel, std::size_t ident, Own<Condition> cond, Own<Operation> nested,
             std::string profileText = "")
-            : RelationOperation(rel, ident, std::move(nested), std::move(profileText)),
-              AbstractIfExists(std::move(cond)) {}
+            : IfExists(NK_IfExists, rel, ident, clone(cond), clone(nested), profileText) {}
 
     void apply(const NodeMapper& map) override {
         RelationOperation::apply(map);
@@ -62,11 +61,21 @@ public:
     }
 
     IfExists* cloning() const override {
-        return new IfExists(
+        return new IfExists(NK_IfExists,
                 relation, getTupleId(), clone(condition), clone(getOperation()), getProfileText());
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_IfExists && kind < NK_LastIfExists);
+    }
+
 protected:
+    IfExists(NodeKind kind, std::string rel, std::size_t ident, Own<Condition> cond, Own<Operation> nested,
+            std::string profileText = "")
+            : RelationOperation(kind, rel, ident, std::move(nested), std::move(profileText)),
+              AbstractIfExists(std::move(cond)) {}
+
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
         os << "IF EXISTS t" << getTupleId();

--- a/src/ram/IfExists.h
+++ b/src/ram/IfExists.h
@@ -61,11 +61,11 @@ public:
     }
 
     IfExists* cloning() const override {
-        return new IfExists(NK_IfExists,
-                relation, getTupleId(), clone(condition), clone(getOperation()), getProfileText());
+        return new IfExists(NK_IfExists, relation, getTupleId(), clone(condition), clone(getOperation()),
+                getProfileText());
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_IfExists && kind < NK_LastIfExists);
     }

--- a/src/ram/IndexAggregate.h
+++ b/src/ram/IndexAggregate.h
@@ -48,7 +48,7 @@ public:
     IndexAggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
             Own<Condition> condition, RamPattern queryPattern, std::size_t ident)
             : IndexAggregate(NK_IndexAggregate, std::move(nested), std::move(fun), rel, std::move(expression),
-                std::move(condition), std::move(queryPattern), ident) {}
+                      std::move(condition), std::move(queryPattern), ident) {}
 
     IndexAggregate* cloning() const override {
         RamPattern pattern;
@@ -58,8 +58,8 @@ public:
         for (const auto& i : queryPattern.second) {
             pattern.second.emplace_back(i->cloning());
         }
-        return new IndexAggregate(NK_IndexAggregate, clone(getOperation()), clone(function), relation, clone(expression),
-                clone(condition), std::move(pattern), getTupleId());
+        return new IndexAggregate(NK_IndexAggregate, clone(getOperation()), clone(function), relation,
+                clone(expression), clone(condition), std::move(pattern), getTupleId());
     }
 
     void apply(const NodeMapper& map) override {
@@ -68,18 +68,18 @@ public:
         expression = map(std::move(expression));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_IndexAggregate && kind < NK_LastIndexAggregate);
     }
 
 protected:
-    IndexAggregate(NodeKind kind, Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
-            Own<Condition> condition, RamPattern queryPattern, std::size_t ident)
+    IndexAggregate(NodeKind kind, Own<Operation> nested, Own<Aggregator> fun, std::string rel,
+            Own<Expression> expression, Own<Condition> condition, RamPattern queryPattern, std::size_t ident)
             : IndexOperation(kind, rel, ident, std::move(queryPattern), std::move(nested)),
               AbstractAggregate(std::move(fun), std::move(expression), std::move(condition)) {
-                        assert(kind >= NK_IndexAggregate && kind < NK_LastIndexAggregate);
-              }
+        assert(kind >= NK_IndexAggregate && kind < NK_LastIndexAggregate);
+    }
 
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);

--- a/src/ram/IndexIfExists.h
+++ b/src/ram/IndexIfExists.h
@@ -54,8 +54,8 @@ class IndexIfExists : public IndexOperation, public AbstractIfExists {
 public:
     IndexIfExists(std::string rel, std::size_t ident, Own<Condition> cond, RamPattern queryPattern,
             Own<Operation> nested, std::string profileText = "")
-            : IndexIfExists(NK_IndexIfExists, rel, ident, std::move(cond), std::move(queryPattern), std::move(nested), profileText) {}
-
+            : IndexIfExists(NK_IndexIfExists, rel, ident, std::move(cond), std::move(queryPattern),
+                      std::move(nested), profileText) {}
 
     void apply(const NodeMapper& map) override {
         RelationOperation::apply(map);
@@ -76,19 +76,21 @@ public:
         for (const auto& i : queryPattern.second) {
             resQueryPattern.second.emplace_back(i->cloning());
         }
-        auto* res = new IndexIfExists(NK_IndexIfExists, relation, getTupleId(), clone(condition), std::move(resQueryPattern),
-                clone(getOperation()), getProfileText());
+        auto* res = new IndexIfExists(NK_IndexIfExists, relation, getTupleId(), clone(condition),
+                std::move(resQueryPattern), clone(getOperation()), getProfileText());
         return res;
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
-        return (kind >= NK_IndexIfExists && kind < NK_LastIndexIfExists);    }
+        return (kind >= NK_IndexIfExists && kind < NK_LastIndexIfExists);
+    }
 
 protected:
-    IndexIfExists(NodeKind kind, std::string rel, std::size_t ident, Own<Condition> cond, RamPattern queryPattern,
-            Own<Operation> nested, std::string profileText = "")
-            : IndexOperation(kind, rel, ident, std::move(queryPattern), std::move(nested), std::move(profileText)),
+    IndexIfExists(NodeKind kind, std::string rel, std::size_t ident, Own<Condition> cond,
+            RamPattern queryPattern, Own<Operation> nested, std::string profileText = "")
+            : IndexOperation(
+                      kind, rel, ident, std::move(queryPattern), std::move(nested), std::move(profileText)),
               AbstractIfExists(std::move(cond)) {
         assert(getRangePattern().first.size() == getRangePattern().second.size() && "Arity mismatch");
         assert(kind >= NK_IndexIfExists && kind < NK_LastIndexIfExists);

--- a/src/ram/IndexOperation.h
+++ b/src/ram/IndexOperation.h
@@ -45,7 +45,7 @@ public:
     IndexOperation(std::string rel, std::size_t ident, RamPattern queryPattern, Own<Operation> nested,
             std::string profileText = "")
             : IndexOperation(NK_IndexOperation, std::move(rel), ident, std::move(queryPattern),
-                std::move(nested), std::move(profileText)) {}
+                      std::move(nested), std::move(profileText)) {}
 
     /**
      * @brief Get range pattern
@@ -76,8 +76,8 @@ public:
         for (const auto& i : queryPattern.second) {
             resQueryPattern.second.emplace_back(i->cloning());
         }
-        return new IndexOperation(NK_IndexOperation,
-                relation, getTupleId(), std::move(resQueryPattern), clone(getOperation()), getProfileText());
+        return new IndexOperation(NK_IndexOperation, relation, getTupleId(), std::move(resQueryPattern),
+                clone(getOperation()), getProfileText());
     }
 
     /** @brief Helper method for printing */
@@ -125,14 +125,14 @@ public:
         }
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_IndexOperation && kind < NK_LastIndexOperation);
     }
 
 protected:
-    IndexOperation(NodeKind kind, std::string rel, std::size_t ident, RamPattern queryPattern, Own<Operation> nested,
-            std::string profileText = "")
+    IndexOperation(NodeKind kind, std::string rel, std::size_t ident, RamPattern queryPattern,
+            Own<Operation> nested, std::string profileText = "")
             : RelationOperation(kind, rel, ident, std::move(nested), std::move(profileText)),
               queryPattern(std::move(queryPattern)) {
         assert(queryPattern.first.size() == queryPattern.second.size() && "Arity mismatch");

--- a/src/ram/IndexScan.h
+++ b/src/ram/IndexScan.h
@@ -49,9 +49,8 @@ class IndexScan : public IndexOperation {
 public:
     IndexScan(std::string rel, std::size_t ident, RamPattern queryPattern, Own<Operation> nested,
             std::string profileText = "")
-            : IndexScan(NK_IndexScan, rel, ident, std::move(queryPattern), 
-                std::move(nested), std::move(profileText)) {
-    }
+            : IndexScan(NK_IndexScan, rel, ident, std::move(queryPattern), std::move(nested),
+                      std::move(profileText)) {}
 
     IndexScan* cloning() const override {
         RamPattern resQueryPattern;
@@ -61,20 +60,20 @@ public:
         for (const auto& i : queryPattern.second) {
             resQueryPattern.second.emplace_back(i->cloning());
         }
-        return new IndexScan(NK_IndexScan,
-                relation, getTupleId(), std::move(resQueryPattern), clone(getOperation()), getProfileText());
+        return new IndexScan(NK_IndexScan, relation, getTupleId(), std::move(resQueryPattern),
+                clone(getOperation()), getProfileText());
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_IndexScan && kind < NK_LastIndexScan);
     }
 
 protected:
-    IndexScan(NodeKind kind, std::string rel, std::size_t ident, RamPattern queryPattern, Own<Operation> nested,
-            std::string profileText = "")
-            : IndexOperation(kind, rel, ident, std::move(queryPattern),
-                std::move(nested), std::move(profileText)) {
+    IndexScan(NodeKind kind, std::string rel, std::size_t ident, RamPattern queryPattern,
+            Own<Operation> nested, std::string profileText = "")
+            : IndexOperation(
+                      kind, rel, ident, std::move(queryPattern), std::move(nested), std::move(profileText)) {
         assert(kind >= NK_IndexScan && kind < NK_LastIndexScan);
     }
 

--- a/src/ram/IndexScan.h
+++ b/src/ram/IndexScan.h
@@ -49,7 +49,8 @@ class IndexScan : public IndexOperation {
 public:
     IndexScan(std::string rel, std::size_t ident, RamPattern queryPattern, Own<Operation> nested,
             std::string profileText = "")
-            : IndexOperation(rel, ident, std::move(queryPattern), std::move(nested), std::move(profileText)) {
+            : IndexScan(NK_IndexScan, rel, ident, std::move(queryPattern), 
+                std::move(nested), std::move(profileText)) {
     }
 
     IndexScan* cloning() const override {
@@ -60,11 +61,23 @@ public:
         for (const auto& i : queryPattern.second) {
             resQueryPattern.second.emplace_back(i->cloning());
         }
-        return new IndexScan(
+        return new IndexScan(NK_IndexScan,
                 relation, getTupleId(), std::move(resQueryPattern), clone(getOperation()), getProfileText());
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_IndexScan && kind < NK_LastIndexScan);
+    }
+
 protected:
+    IndexScan(NodeKind kind, std::string rel, std::size_t ident, RamPattern queryPattern, Own<Operation> nested,
+            std::string profileText = "")
+            : IndexOperation(kind, rel, ident, std::move(queryPattern),
+                std::move(nested), std::move(profileText)) {
+        assert(kind >= NK_IndexScan && kind < NK_LastIndexScan);
+    }
+
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
         os << "FOR t" << getTupleId() << " IN " << relation;

--- a/src/ram/Insert.h
+++ b/src/ram/Insert.h
@@ -45,8 +45,7 @@ namespace souffle::ram {
 class Insert : public Operation {
 public:
     Insert(std::string rel, VecOwn<Expression> expressions)
-            : Insert(NK_Insert, std::move(rel), std::move(expressions)) {
-    }
+            : Insert(NK_Insert, std::move(rel), std::move(expressions)) {}
 
     /** @brief Get relation */
     const std::string& getRelation() const {
@@ -72,7 +71,7 @@ public:
         }
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_Insert && kind < NK_LastInsert);
     }

--- a/src/ram/Insert.h
+++ b/src/ram/Insert.h
@@ -45,8 +45,7 @@ namespace souffle::ram {
 class Insert : public Operation {
 public:
     Insert(std::string rel, VecOwn<Expression> expressions)
-            : relation(std::move(rel)), expressions(std::move(expressions)) {
-        assert(allValidPtrs(expressions));
+            : Insert(NK_Insert, std::move(rel), std::move(expressions)) {
     }
 
     /** @brief Get relation */
@@ -64,7 +63,7 @@ public:
         for (auto& expr : expressions) {
             newValues.emplace_back(expr->cloning());
         }
-        return new Insert(relation, std::move(newValues));
+        return new Insert(NK_Insert, relation, std::move(newValues));
     }
 
     void apply(const NodeMapper& map) override {
@@ -73,7 +72,18 @@ public:
         }
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_Insert && kind < NK_LastInsert);
+    }
+
 protected:
+    Insert(NodeKind kind, std::string rel, VecOwn<Expression> expressions)
+            : Operation(kind), relation(std::move(rel)), expressions(std::move(expressions)) {
+        assert(allValidPtrs(expressions));
+        assert(kind >= NK_Insert && kind < NK_LastInsert);
+    }
+
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
         os << "INSERT (" << join(expressions, ", ", print_deref<Own<Expression>>()) << ") INTO " << relation

--- a/src/ram/IntrinsicOperator.h
+++ b/src/ram/IntrinsicOperator.h
@@ -37,10 +37,10 @@ namespace souffle::ram {
 class IntrinsicOperator : public AbstractOperator {
 public:
     template <typename... Args>
-    IntrinsicOperator(FunctorOp op, Args... args) : AbstractOperator({std::move(args)...}), operation(op) {}
+    IntrinsicOperator(FunctorOp op, Args... args) : AbstractOperator(NK_IntrinsicOperator, {std::move(args)...}), operation(op) {}
 
     IntrinsicOperator(FunctorOp op, VecOwn<Expression> args)
-            : AbstractOperator(std::move(args)), operation(op) {}
+            : AbstractOperator(NK_IntrinsicOperator, std::move(args)), operation(op) {}
 
     /** @brief Get operator symbol */
     FunctorOp getOperator() const {
@@ -53,6 +53,10 @@ public:
             argsCopy.emplace_back(arg->cloning());
         }
         return new IntrinsicOperator(operation, std::move(argsCopy));
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_IntrinsicOperator;
     }
 
 protected:

--- a/src/ram/IntrinsicOperator.h
+++ b/src/ram/IntrinsicOperator.h
@@ -37,7 +37,8 @@ namespace souffle::ram {
 class IntrinsicOperator : public AbstractOperator {
 public:
     template <typename... Args>
-    IntrinsicOperator(FunctorOp op, Args... args) : AbstractOperator(NK_IntrinsicOperator, {std::move(args)...}), operation(op) {}
+    IntrinsicOperator(FunctorOp op, Args... args)
+            : AbstractOperator(NK_IntrinsicOperator, {std::move(args)...}), operation(op) {}
 
     IntrinsicOperator(FunctorOp op, VecOwn<Expression> args)
             : AbstractOperator(NK_IntrinsicOperator, std::move(args)), operation(op) {}
@@ -55,7 +56,7 @@ public:
         return new IntrinsicOperator(operation, std::move(argsCopy));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_IntrinsicOperator;
     }
 

--- a/src/ram/ListStatement.h
+++ b/src/ram/ListStatement.h
@@ -55,7 +55,7 @@ public:
         }
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_ListStatement && kind < NK_LastListStatement);
     }
@@ -65,7 +65,8 @@ protected:
         assert(kind >= NK_ListStatement && kind < NK_LastListStatement);
     }
 
-    ListStatement(NodeKind kind, VecOwn<Statement> statements) : Statement(kind), statements(std::move(statements)) {
+    ListStatement(NodeKind kind, VecOwn<Statement> statements)
+            : Statement(kind), statements(std::move(statements)) {
         assert(kind >= NK_ListStatement && kind < NK_LastListStatement);
     }
 

--- a/src/ram/ListStatement.h
+++ b/src/ram/ListStatement.h
@@ -31,11 +31,12 @@ namespace souffle::ram {
  */
 class ListStatement : public Statement {
 public:
-    ListStatement() = default;
-    ListStatement(VecOwn<Statement> statements) : statements(std::move(statements)) {}
+    ListStatement() : Statement(NK_ListStatement) {}
+
+    ListStatement(VecOwn<Statement> statements) : ListStatement(NK_ListStatement, std::move(statements)) {}
 
     template <typename... Stmts>
-    ListStatement(Own<Stmts>&&... stmts) {
+    ListStatement(NodeKind kind, Own<Stmts>&&... stmts) : Statement(kind) {
         Own<Statement> tmp[] = {std::move(stmts)...};
         for (auto& cur : tmp) {
             assert(cur.get() != nullptr && "statement is a null-pointer");
@@ -54,7 +55,20 @@ public:
         }
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_ListStatement && kind < NK_LastListStatement);
+    }
+
 protected:
+    ListStatement(NodeKind kind) : Statement(kind), statements() {
+        assert(kind >= NK_ListStatement && kind < NK_LastListStatement);
+    }
+
+    ListStatement(NodeKind kind, VecOwn<Statement> statements) : Statement(kind), statements(std::move(statements)) {
+        assert(kind >= NK_ListStatement && kind < NK_LastListStatement);
+    }
+
     bool equal(const Node& node) const override {
         const auto& other = asAssert<ListStatement>(node);
         return equal_targets(statements, other.statements);

--- a/src/ram/LogRelationTimer.h
+++ b/src/ram/LogRelationTimer.h
@@ -50,7 +50,8 @@ namespace souffle::ram {
 class LogRelationTimer : public RelationStatement, public AbstractLog {
 public:
     LogRelationTimer(Own<Statement> stmt, std::string msg, std::string relRef)
-            : RelationStatement(NK_LogRelationTimer, std::move(relRef)), AbstractLog(std::move(stmt), std::move(msg)) {}
+            : RelationStatement(NK_LogRelationTimer, std::move(relRef)),
+              AbstractLog(std::move(stmt), std::move(msg)) {}
 
     LogRelationTimer* cloning() const override {
         return new LogRelationTimer(clone(statement), message, relation);
@@ -61,7 +62,7 @@ public:
         AbstractLog::apply(map);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_LogRelationTimer;
     }
 

--- a/src/ram/LogRelationTimer.h
+++ b/src/ram/LogRelationTimer.h
@@ -50,7 +50,7 @@ namespace souffle::ram {
 class LogRelationTimer : public RelationStatement, public AbstractLog {
 public:
     LogRelationTimer(Own<Statement> stmt, std::string msg, std::string relRef)
-            : RelationStatement(std::move(relRef)), AbstractLog(std::move(stmt), std::move(msg)) {}
+            : RelationStatement(NK_LogRelationTimer, std::move(relRef)), AbstractLog(std::move(stmt), std::move(msg)) {}
 
     LogRelationTimer* cloning() const override {
         return new LogRelationTimer(clone(statement), message, relation);
@@ -59,6 +59,10 @@ public:
     void apply(const NodeMapper& map) override {
         RelationStatement::apply(map);
         AbstractLog::apply(map);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_LogRelationTimer;
     }
 
 protected:

--- a/src/ram/LogSize.h
+++ b/src/ram/LogSize.h
@@ -33,7 +33,7 @@ namespace souffle::ram {
  */
 class LogSize : public RelationStatement {
 public:
-    LogSize(std::string rel, std::string message) : RelationStatement(rel), message(std::move(message)) {}
+    LogSize(std::string rel, std::string message) : RelationStatement(NK_LogSize, rel), message(std::move(message)) {}
 
     /** @brief Get logging message */
     const std::string& getMessage() const {
@@ -42,6 +42,10 @@ public:
 
     LogSize* cloning() const override {
         return new LogSize(relation, message);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_LogSize;
     }
 
 protected:

--- a/src/ram/LogSize.h
+++ b/src/ram/LogSize.h
@@ -33,7 +33,8 @@ namespace souffle::ram {
  */
 class LogSize : public RelationStatement {
 public:
-    LogSize(std::string rel, std::string message) : RelationStatement(NK_LogSize, rel), message(std::move(message)) {}
+    LogSize(std::string rel, std::string message)
+            : RelationStatement(NK_LogSize, rel), message(std::move(message)) {}
 
     /** @brief Get logging message */
     const std::string& getMessage() const {
@@ -44,7 +45,7 @@ public:
         return new LogSize(relation, message);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_LogSize;
     }
 

--- a/src/ram/LogTimer.h
+++ b/src/ram/LogTimer.h
@@ -49,7 +49,8 @@ namespace souffle::ram {
  */
 class LogTimer : public Statement, public AbstractLog {
 public:
-    LogTimer(Own<Statement> stmt, std::string msg) : Statement(NK_LogTimer), AbstractLog(std::move(stmt), std::move(msg)) {}
+    LogTimer(Own<Statement> stmt, std::string msg)
+            : Statement(NK_LogTimer), AbstractLog(std::move(stmt), std::move(msg)) {}
 
     LogTimer* cloning() const override {
         return new LogTimer(clone(statement), message);
@@ -59,7 +60,7 @@ public:
         AbstractLog::apply(map);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_LogTimer;
     }
 

--- a/src/ram/LogTimer.h
+++ b/src/ram/LogTimer.h
@@ -49,7 +49,7 @@ namespace souffle::ram {
  */
 class LogTimer : public Statement, public AbstractLog {
 public:
-    LogTimer(Own<Statement> stmt, std::string msg) : AbstractLog(std::move(stmt), std::move(msg)) {}
+    LogTimer(Own<Statement> stmt, std::string msg) : Statement(NK_LogTimer), AbstractLog(std::move(stmt), std::move(msg)) {}
 
     LogTimer* cloning() const override {
         return new LogTimer(clone(statement), message);
@@ -57,6 +57,10 @@ public:
 
     void apply(const NodeMapper& map) override {
         AbstractLog::apply(map);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_LogTimer;
     }
 
 protected:

--- a/src/ram/Loop.h
+++ b/src/ram/Loop.h
@@ -59,7 +59,7 @@ public:
         body = map(std::move(body));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Loop;
     }
 

--- a/src/ram/Loop.h
+++ b/src/ram/Loop.h
@@ -42,7 +42,7 @@ namespace souffle::ram {
  */
 class Loop : public Statement {
 public:
-    Loop(Own<Statement> b) : body(std::move(b)) {
+    Loop(Own<Statement> b) : Statement(NK_Loop), body(std::move(b)) {
         assert(body != nullptr && "Loop body is a null-pointer");
     }
 
@@ -57,6 +57,10 @@ public:
 
     void apply(const NodeMapper& map) override {
         body = map(std::move(body));
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Loop;
     }
 
 protected:

--- a/src/ram/MergeExtend.h
+++ b/src/ram/MergeExtend.h
@@ -36,7 +36,8 @@ namespace souffle::ram {
  */
 class MergeExtend : public BinRelationStatement {
 public:
-    MergeExtend(std::string tRef, const std::string& sRef) : BinRelationStatement(NK_MergeExtend, sRef, tRef) {}
+    MergeExtend(std::string tRef, const std::string& sRef)
+            : BinRelationStatement(NK_MergeExtend, sRef, tRef) {}
 
     /** @brief Get source relation */
     const std::string& getSourceRelation() const {
@@ -53,7 +54,7 @@ public:
         return res;
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_MergeExtend;
     }
 

--- a/src/ram/MergeExtend.h
+++ b/src/ram/MergeExtend.h
@@ -36,7 +36,7 @@ namespace souffle::ram {
  */
 class MergeExtend : public BinRelationStatement {
 public:
-    MergeExtend(std::string tRef, const std::string& sRef) : BinRelationStatement(sRef, tRef) {}
+    MergeExtend(std::string tRef, const std::string& sRef) : BinRelationStatement(NK_MergeExtend, sRef, tRef) {}
 
     /** @brief Get source relation */
     const std::string& getSourceRelation() const {
@@ -51,6 +51,10 @@ public:
     MergeExtend* cloning() const override {
         auto* res = new MergeExtend(second, first);
         return res;
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_MergeExtend;
     }
 
 protected:

--- a/src/ram/Negation.h
+++ b/src/ram/Negation.h
@@ -57,7 +57,7 @@ public:
         operand = map(std::move(operand));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Negation;
     }
 

--- a/src/ram/Negation.h
+++ b/src/ram/Negation.h
@@ -40,7 +40,7 @@ namespace souffle::ram {
  */
 class Negation : public Condition {
 public:
-    Negation(Own<Condition> op) : operand(std::move(op)) {
+    Negation(Own<Condition> op) : Condition(NK_Negation), operand(std::move(op)) {
         assert(operand != nullptr && "operand of negation is a null-pointer");
     }
 
@@ -55,6 +55,10 @@ public:
 
     void apply(const NodeMapper& map) override {
         operand = map(std::move(operand));
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Negation;
     }
 
 protected:

--- a/src/ram/NestedIntrinsicOperator.h
+++ b/src/ram/NestedIntrinsicOperator.h
@@ -58,7 +58,8 @@ class NestedIntrinsicOperator : public TupleOperation {
 public:
     NestedIntrinsicOperator(
             NestedIntrinsicOp op, VecOwn<Expression> args, Own<Operation> nested, std::size_t ident)
-            : TupleOperation(NK_NestedIntrinsicOperator, ident, std::move(nested)), args(std::move(args)), op(op) {}
+            : TupleOperation(NK_NestedIntrinsicOperator, ident, std::move(nested)), args(std::move(args)),
+              op(op) {}
 
     NestedIntrinsicOp getFunction() const {
         return op;
@@ -79,7 +80,7 @@ public:
         }
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_NestedIntrinsicOperator;
     }
 

--- a/src/ram/NestedIntrinsicOperator.h
+++ b/src/ram/NestedIntrinsicOperator.h
@@ -58,7 +58,7 @@ class NestedIntrinsicOperator : public TupleOperation {
 public:
     NestedIntrinsicOperator(
             NestedIntrinsicOp op, VecOwn<Expression> args, Own<Operation> nested, std::size_t ident)
-            : TupleOperation(ident, std::move(nested)), args(std::move(args)), op(op) {}
+            : TupleOperation(NK_NestedIntrinsicOperator, ident, std::move(nested)), args(std::move(args)), op(op) {}
 
     NestedIntrinsicOp getFunction() const {
         return op;
@@ -77,6 +77,10 @@ public:
         for (auto&& x : args) {
             x = map(std::move(x));
         }
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_NestedIntrinsicOperator;
     }
 
 protected:

--- a/src/ram/NestedOperation.h
+++ b/src/ram/NestedOperation.h
@@ -46,11 +46,6 @@ namespace souffle::ram {
  */
 class NestedOperation : public Operation {
 public:
-    NestedOperation(Own<Operation> nested, std::string profileText = "")
-            : nestedOperation(std::move(nested)), profileText(std::move(profileText)) {
-        assert(nestedOperation != nullptr);
-    }
-
     NestedOperation* cloning() const override = 0;
 
     /** @brief Get nested operation */
@@ -67,7 +62,18 @@ public:
         nestedOperation = map(std::move(nestedOperation));
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_NestedOperation && kind < NK_LastNestedOperation);
+    }
+
 protected:
+    NestedOperation(NodeKind kind, Own<Operation> nested, std::string profileText = "")
+            : Operation(kind), nestedOperation(std::move(nested)), profileText(std::move(profileText)) {
+        assert(nestedOperation != nullptr);
+        assert(kind >= NK_NestedOperation && kind < NK_LastNestedOperation);
+    }
+
     void print(std::ostream& os, int tabpos) const override {
         Operation::print(nestedOperation.get(), os, tabpos);
     }

--- a/src/ram/NestedOperation.h
+++ b/src/ram/NestedOperation.h
@@ -62,7 +62,7 @@ public:
         nestedOperation = map(std::move(nestedOperation));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_NestedOperation && kind < NK_LastNestedOperation);
     }

--- a/src/ram/Node.cpp
+++ b/src/ram/Node.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 namespace souffle::ram {
+Node::Node(NodeKind kind) : Kind(kind) {}
 
 void Node::rewrite(const Node* oldNode, Own<Node> newNode) {
     assert(oldNode != nullptr && "old node is a null-pointer");
@@ -45,6 +46,10 @@ Node::ConstChildNodes Node::getChildNodes() const {
 
 Node::ChildNodes Node::getChildNodes() {
     return ChildNodes(getChildren(), detail::ConstCaster());
+}
+
+Node::NodeKind Node::getKind() const {
+    return Kind;
 }
 
 }  // namespace souffle::ram

--- a/src/ram/Node.h
+++ b/src/ram/Node.h
@@ -57,7 +57,6 @@ protected:
     using NodeVec = std::vector<Node const*>;  // std::reference_wrapper<Node const>>;
 
 public:
-    // clang-format: off
     /// LLVM-style RTTI
     ///
     /// Each class under the ram::Node hierarchy must appear here and must implement
@@ -78,6 +77,7 @@ public:
     ///   NK_LastT
     ///
     ///
+    // clang-format off
     enum NodeKind {
         NK_NONE,
         NK_Condition,
@@ -199,7 +199,7 @@ public:
 
         NK_LastStatement,
     };
-    // clang-format: on
+    // clang-format on
 private:
     const NodeKind Kind;
 

--- a/src/ram/Node.h
+++ b/src/ram/Node.h
@@ -57,10 +57,159 @@ protected:
     using NodeVec = std::vector<Node const*>;  // std::reference_wrapper<Node const>>;
 
 public:
-    Node() = default;
-    Node(Node const&) = delete;
+    // clang-format: off
+    /// LLVM-style RTTI
+    ///
+    /// Each class under the ram::Node hierarchy must appear here and must implement
+    /// `static bool classof(const Node*)`.
+    ///
+    /// When class T is final, we must provide a single enum:
+    ///
+    ///   ...
+    ///   NK_T,
+    ///   ...
+    ///
+    /// When class T is non-final, we must provide enums like this:
+    ///
+    ///   NK_T,
+    ///     NK_Child1,
+    ///     ...
+    ///     NK_ChildN,
+    ///   NK_LastT
+    ///
+    ///
+    enum NodeKind {
+        NK_NONE,
+        NK_Condition,
+            NK_AbstractExistenceCheck, //Abstract Class
+                NK_ExistenceCheck,
+                NK_ProvenanceExistenceCheck,
+            NK_LastAbstractExistenceCheck,
+
+            NK_Conjunction,
+            NK_Constraint,
+            NK_EmptinessCheck,
+            NK_False,
+            NK_Negation,
+            NK_True,
+        NK_LastCondition,
+
+        NK_Expression,
+            NK_AbstractOperator,
+                NK_IntrinsicOperator,
+                NK_UserDefinedOperator,
+            NK_LastAbstractOperator,
+
+            NK_AutoIncrement,
+            NK_NumericConstant,
+                NK_FloatConstant,
+                NK_SignedConstant,
+                NK_UnsignedConstant,
+            NK_LastNumericConstant,
+
+            NK_PackRecord,
+            NK_RelationSize,
+            NK_SubroutineArgument,
+            NK_StringConstant,
+            NK_TupleElement,
+            NK_UndefValue,
+            NK_Variable,
+        NK_LastExpression,
+
+        NK_Operation,
+            NK_Erase,
+            NK_Insert,
+                NK_GuardedInsert,
+            NK_LastInsert,
+
+            NK_NestedOperation,
+                NK_AbstractConditional,
+                    NK_Break,
+                    NK_Filter,
+                NK_LastAbstractConditional,
+
+                NK_TupleOperation,
+                    NK_RelationOperation,
+                        NK_Aggregate,
+                            NK_ParallelAggregate,
+                        NK_LastAggregate,
+
+                        NK_IfExists,
+                            NK_ParallelIfExists,
+                        NK_LastIfExists,
+
+                        NK_IndexOperation,
+                            NK_IndexAggregate,
+                                NK_ParallelIndexAggregate,
+                            NK_LastIndexAggregate,
+
+                            NK_IndexIfExists,
+                                NK_ParallelIndexIfExists,
+                            NK_LastIndexIfExists,
+
+                            NK_IndexScan,
+                                NK_ParallelIndexScan,
+                            NK_LastIndexScan,
+                        NK_LastIndexOperation,
+
+                        NK_Scan,
+                            NK_ParallelScan,
+                        NK_LastScan,
+
+                    NK_LastRelationOperation,
+
+                    NK_UnpackRecord,
+                    NK_NestedIntrinsicOperator,
+                NK_LastTupleOperation,
+
+            NK_LastNestedOperation,
+
+            NK_Project,
+            NK_SubroutineReturn,
+        NK_LastOperation,
+
+        NK_Program,
+        NK_Relation,
+        NK_Statement,
+            NK_Assign,
+
+            NK_BinRelationStatement,
+                NK_MergeExtend,
+                NK_Swap,
+            NK_LastBinRelationStatement,
+
+            NK_Call,
+            NK_DebugInfo,
+            NK_Exit,
+            NK_ListStatement,
+                NK_Parallel,
+                NK_Sequence,
+            NK_LastListStatement,
+
+            NK_LogTimer,
+            NK_Loop,
+            NK_Query,
+            NK_RelationStatement,
+                NK_Clear,
+                NK_EstimateJoinSize,
+                NK_IO,
+                NK_LogRelationTimer,
+                NK_LogSize,
+            NK_LastRelationStatement,
+
+        NK_LastStatement,
+    };
+    // clang-format: on
+private:
+    const NodeKind Kind;
+
+public:
+    explicit Node(NodeKind K);
     virtual ~Node() = default;
+    Node(Node const&) = delete;
     Node& operator=(Node const&) = delete;
+
+    NodeKind getKind() const;
 
     /**
      * @brief Equivalence check for two RAM nodes

--- a/src/ram/NumericConstant.h
+++ b/src/ram/NumericConstant.h
@@ -35,8 +35,15 @@ public:
         return constant;
     }
 
+    static bool classof(const Node* n) {
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_NumericConstant && kind < NK_LastNumericConstant);
+    }
+
 protected:
-    explicit NumericConstant(RamDomain constant) : constant(constant) {}
+    explicit NumericConstant(NodeKind kind, RamDomain constant) : Expression(kind), constant(constant) {
+        assert(kind >= NK_NumericConstant && kind < NK_LastNumericConstant);
+    }
 
     bool equal(const Node& node) const override {
         const auto& other = asAssert<NumericConstant>(node);

--- a/src/ram/Operation.h
+++ b/src/ram/Operation.h
@@ -29,10 +29,10 @@ class Operation : public Node {
 public:
     Operation* cloning() const override = 0;
 
-static bool classof(const Node* n){
-    const NodeKind kind = n->getKind();
-    return (kind >= NK_Operation && kind < NK_LastOperation);
-}
+    static bool classof(const Node* n) {
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_Operation && kind < NK_LastOperation);
+    }
 
 protected:
     Operation(NodeKind kind) : Node(kind) {

--- a/src/ram/Operation.h
+++ b/src/ram/Operation.h
@@ -29,7 +29,16 @@ class Operation : public Node {
 public:
     Operation* cloning() const override = 0;
 
+static bool classof(const Node* n){
+    const NodeKind kind = n->getKind();
+    return (kind >= NK_Operation && kind < NK_LastOperation);
+}
+
 protected:
+    Operation(NodeKind kind) : Node(kind) {
+        assert(kind >= NK_Operation && kind < NK_LastOperation);
+    }
+
     void print(std::ostream& os) const override {
         print(os, 0);
     }

--- a/src/ram/PackRecord.h
+++ b/src/ram/PackRecord.h
@@ -35,7 +35,7 @@ namespace souffle::ram {
  */
 class PackRecord : public Expression {
 public:
-    PackRecord(VecOwn<Expression> args) : arguments(std::move(args)) {
+    PackRecord(VecOwn<Expression> args) : Expression(NK_PackRecord), arguments(std::move(args)) {
         assert(allValidPtrs(arguments));
     }
 
@@ -56,6 +56,10 @@ public:
         for (auto& arg : arguments) {
             arg = map(std::move(arg));
         }
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_PackRecord;
     }
 
 protected:

--- a/src/ram/PackRecord.h
+++ b/src/ram/PackRecord.h
@@ -58,7 +58,7 @@ public:
         }
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_PackRecord;
     }
 

--- a/src/ram/Parallel.h
+++ b/src/ram/Parallel.h
@@ -58,7 +58,7 @@ public:
         return res;
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Parallel;
     }
 

--- a/src/ram/Parallel.h
+++ b/src/ram/Parallel.h
@@ -44,11 +44,11 @@ namespace souffle::ram {
  */
 class Parallel : public ListStatement {
 public:
-    Parallel(VecOwn<Statement> statements) : ListStatement(std::move(statements)) {}
-    Parallel() : ListStatement() {}
+    Parallel(VecOwn<Statement> statements) : ListStatement(NK_Parallel, std::move(statements)) {}
+    Parallel() : ListStatement(NK_Parallel) {}
     template <typename... Stmts>
     Parallel(Own<Statement> first, Own<Stmts>... rest)
-            : ListStatement(std::move(first), std::move(rest)...) {}
+            : ListStatement(NK_Parallel, std::move(first), std::move(rest)...) {}
 
     Parallel* cloning() const override {
         auto* res = new Parallel();
@@ -56,6 +56,10 @@ public:
             res->statements.push_back(clone(cur));
         }
         return res;
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Parallel;
     }
 
 protected:

--- a/src/ram/ParallelAggregate.h
+++ b/src/ram/ParallelAggregate.h
@@ -50,15 +50,15 @@ class ParallelAggregate : public Aggregate, public AbstractParallel {
 public:
     ParallelAggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
             Own<Condition> condition, std::size_t ident)
-            : Aggregate(NK_ParallelAggregate, std::move(nested), std::move(fun), rel, std::move(expression), std::move(condition),
-                      ident) {}
+            : Aggregate(NK_ParallelAggregate, std::move(nested), std::move(fun), rel, std::move(expression),
+                      std::move(condition), ident) {}
 
     ParallelAggregate* cloning() const override {
         return new ParallelAggregate(clone(getOperation()), clone(function), relation, clone(expression),
                 clone(condition), identifier);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_ParallelAggregate;
     }
 

--- a/src/ram/ParallelAggregate.h
+++ b/src/ram/ParallelAggregate.h
@@ -50,12 +50,16 @@ class ParallelAggregate : public Aggregate, public AbstractParallel {
 public:
     ParallelAggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
             Own<Condition> condition, std::size_t ident)
-            : Aggregate(std::move(nested), std::move(fun), rel, std::move(expression), std::move(condition),
+            : Aggregate(NK_ParallelAggregate, std::move(nested), std::move(fun), rel, std::move(expression), std::move(condition),
                       ident) {}
 
     ParallelAggregate* cloning() const override {
         return new ParallelAggregate(clone(getOperation()), clone(function), relation, clone(expression),
                 clone(condition), identifier);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_ParallelAggregate;
     }
 
 protected:

--- a/src/ram/ParallelIfExists.h
+++ b/src/ram/ParallelIfExists.h
@@ -55,7 +55,7 @@ public:
                 relation, getTupleId(), clone(condition), clone(getOperation()), getProfileText());
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_ParallelIfExists;
     }
 

--- a/src/ram/ParallelIfExists.h
+++ b/src/ram/ParallelIfExists.h
@@ -48,11 +48,15 @@ class ParallelIfExists : public IfExists, public AbstractParallel {
 public:
     ParallelIfExists(std::string rel, std::size_t ident, Own<Condition> cond, Own<Operation> nested,
             std::string profileText = "")
-            : IfExists(rel, ident, std::move(cond), std::move(nested), profileText) {}
+            : IfExists(NK_ParallelIfExists, rel, ident, std::move(cond), std::move(nested), profileText) {}
 
     ParallelIfExists* cloning() const override {
         return new ParallelIfExists(
                 relation, getTupleId(), clone(condition), clone(getOperation()), getProfileText());
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_ParallelIfExists;
     }
 
 protected:

--- a/src/ram/ParallelIndexAggregate.h
+++ b/src/ram/ParallelIndexAggregate.h
@@ -49,7 +49,7 @@ class ParallelIndexAggregate : public IndexAggregate, public AbstractParallel {
 public:
     ParallelIndexAggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel,
             Own<Expression> expression, Own<Condition> condition, RamPattern queryPattern, std::size_t ident)
-            : IndexAggregate(std::move(nested), std::move(fun), rel, std::move(expression),
+            : IndexAggregate(NK_ParallelIndexAggregate, std::move(nested), std::move(fun), rel, std::move(expression),
                       std::move(condition), std::move(queryPattern), ident) {}
 
     ParallelIndexAggregate* cloning() const override {
@@ -62,6 +62,10 @@ public:
         }
         return new ParallelIndexAggregate(clone(getOperation()), clone(function), relation, clone(expression),
                 clone(condition), std::move(pattern), getTupleId());
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_ParallelIndexAggregate;
     }
 
 protected:

--- a/src/ram/ParallelIndexAggregate.h
+++ b/src/ram/ParallelIndexAggregate.h
@@ -49,8 +49,8 @@ class ParallelIndexAggregate : public IndexAggregate, public AbstractParallel {
 public:
     ParallelIndexAggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel,
             Own<Expression> expression, Own<Condition> condition, RamPattern queryPattern, std::size_t ident)
-            : IndexAggregate(NK_ParallelIndexAggregate, std::move(nested), std::move(fun), rel, std::move(expression),
-                      std::move(condition), std::move(queryPattern), ident) {}
+            : IndexAggregate(NK_ParallelIndexAggregate, std::move(nested), std::move(fun), rel,
+                      std::move(expression), std::move(condition), std::move(queryPattern), ident) {}
 
     ParallelIndexAggregate* cloning() const override {
         RamPattern pattern;
@@ -64,7 +64,7 @@ public:
                 clone(condition), std::move(pattern), getTupleId());
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_ParallelIndexAggregate;
     }
 

--- a/src/ram/ParallelIndexIfExists.h
+++ b/src/ram/ParallelIndexIfExists.h
@@ -55,7 +55,7 @@ class ParallelIndexIfExists : public IndexIfExists, public AbstractParallel {
 public:
     ParallelIndexIfExists(std::string rel, std::size_t ident, Own<Condition> cond, RamPattern queryPattern,
             Own<Operation> nested, std::string profileText = "")
-            : IndexIfExists(
+            : IndexIfExists(NK_ParallelIndexIfExists,
                       rel, ident, std::move(cond), std::move(queryPattern), std::move(nested), profileText) {}
 
     ParallelIndexIfExists* cloning() const override {
@@ -69,6 +69,10 @@ public:
         auto* res = new ParallelIndexIfExists(relation, getTupleId(), clone(condition),
                 std::move(resQueryPattern), clone(getOperation()), getProfileText());
         return res;
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_ParallelIndexIfExists;
     }
 
 protected:

--- a/src/ram/ParallelIndexIfExists.h
+++ b/src/ram/ParallelIndexIfExists.h
@@ -55,8 +55,8 @@ class ParallelIndexIfExists : public IndexIfExists, public AbstractParallel {
 public:
     ParallelIndexIfExists(std::string rel, std::size_t ident, Own<Condition> cond, RamPattern queryPattern,
             Own<Operation> nested, std::string profileText = "")
-            : IndexIfExists(NK_ParallelIndexIfExists,
-                      rel, ident, std::move(cond), std::move(queryPattern), std::move(nested), profileText) {}
+            : IndexIfExists(NK_ParallelIndexIfExists, rel, ident, std::move(cond), std::move(queryPattern),
+                      std::move(nested), profileText) {}
 
     ParallelIndexIfExists* cloning() const override {
         RamPattern resQueryPattern;
@@ -71,7 +71,7 @@ public:
         return res;
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_ParallelIndexIfExists;
     }
 

--- a/src/ram/ParallelIndexScan.h
+++ b/src/ram/ParallelIndexScan.h
@@ -54,7 +54,7 @@ class ParallelIndexScan : public IndexScan, public AbstractParallel {
 public:
     ParallelIndexScan(std::string rel, std::size_t ident, RamPattern queryPattern, Own<Operation> nested,
             std::string profileText = "")
-            : IndexScan(rel, ident, std::move(queryPattern), std::move(nested), profileText) {}
+            : IndexScan(NK_ParallelIndexScan, rel, ident, std::move(queryPattern), std::move(nested), profileText) {}
 
     ParallelIndexScan* cloning() const override {
         RamPattern resQueryPattern;
@@ -66,6 +66,10 @@ public:
         }
         return new ParallelIndexScan(
                 relation, getTupleId(), std::move(resQueryPattern), clone(getOperation()), getProfileText());
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_ParallelIndexScan;
     }
 
 protected:

--- a/src/ram/ParallelIndexScan.h
+++ b/src/ram/ParallelIndexScan.h
@@ -54,7 +54,8 @@ class ParallelIndexScan : public IndexScan, public AbstractParallel {
 public:
     ParallelIndexScan(std::string rel, std::size_t ident, RamPattern queryPattern, Own<Operation> nested,
             std::string profileText = "")
-            : IndexScan(NK_ParallelIndexScan, rel, ident, std::move(queryPattern), std::move(nested), profileText) {}
+            : IndexScan(NK_ParallelIndexScan, rel, ident, std::move(queryPattern), std::move(nested),
+                      profileText) {}
 
     ParallelIndexScan* cloning() const override {
         RamPattern resQueryPattern;
@@ -68,7 +69,7 @@ public:
                 relation, getTupleId(), std::move(resQueryPattern), clone(getOperation()), getProfileText());
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_ParallelIndexScan;
     }
 

--- a/src/ram/ParallelScan.h
+++ b/src/ram/ParallelScan.h
@@ -52,8 +52,7 @@ public:
         return new ParallelScan(relation, getTupleId(), clone(getOperation()), getProfileText());
     }
 
-
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_ParallelScan;
     }
 

--- a/src/ram/ParallelScan.h
+++ b/src/ram/ParallelScan.h
@@ -46,10 +46,15 @@ namespace souffle::ram {
 class ParallelScan : public Scan, public AbstractParallel {
 public:
     ParallelScan(std::string rel, std::size_t ident, Own<Operation> nested, std::string profileText = "")
-            : Scan(rel, ident, std::move(nested), profileText) {}
+            : Scan(NK_ParallelScan, rel, ident, std::move(nested), profileText) {}
 
     ParallelScan* cloning() const override {
         return new ParallelScan(relation, getTupleId(), clone(getOperation()), getProfileText());
+    }
+
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_ParallelScan;
     }
 
 protected:

--- a/src/ram/Program.h
+++ b/src/ram/Program.h
@@ -49,7 +49,7 @@ namespace souffle::ram {
  */
 class Program : public Node {
 private:
-    Program() : Node(NK_Program) {};
+    Program() : Node(NK_Program){};
 
 public:
     Program(VecOwn<Relation> rels, Own<Statement> main, std::map<std::string, Own<Statement>> subs)
@@ -106,7 +106,7 @@ public:
         }
     }
 
-    static bool classof(const Node*n) {
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Program;
     }
 

--- a/src/ram/Program.h
+++ b/src/ram/Program.h
@@ -49,11 +49,12 @@ namespace souffle::ram {
  */
 class Program : public Node {
 private:
-    Program() = default;
+    Program() : Node(NK_Program) {};
 
 public:
     Program(VecOwn<Relation> rels, Own<Statement> main, std::map<std::string, Own<Statement>> subs)
-            : relations(std::move(rels)), main(std::move(main)), subroutines(std::move(subs)) {
+            : Node(NK_Program), relations(std::move(rels)), main(std::move(main)),
+              subroutines(std::move(subs)) {
         assert(this->main != nullptr && "Main program is a null-pointer");
         assert(allValidPtrs(relations));
         assert(allValidPtrs(makeTransformRange(subroutines, [](auto&& kv) { return kv.second.get(); })));
@@ -103,6 +104,10 @@ public:
         for (auto& sub : subroutines) {
             sub.second = map(std::move(sub.second));
         }
+    }
+
+    static bool classof(const Node*n) {
+        return n->getKind() == NK_Program;
     }
 
 protected:

--- a/src/ram/ProvenanceExistenceCheck.h
+++ b/src/ram/ProvenanceExistenceCheck.h
@@ -45,9 +45,9 @@ public:
         return new ProvenanceExistenceCheck(relation, std::move(newValues));
     }
 
-static bool classof(const Node* n){
-    return n->getKind() == Node::NK_ProvenanceExistenceCheck;
-}
+    static bool classof(const Node* n) {
+        return n->getKind() == Node::NK_ProvenanceExistenceCheck;
+    }
 
 protected:
     void print(std::ostream& os) const override {

--- a/src/ram/ProvenanceExistenceCheck.h
+++ b/src/ram/ProvenanceExistenceCheck.h
@@ -35,7 +35,7 @@ namespace souffle::ram {
 class ProvenanceExistenceCheck : public AbstractExistenceCheck {
 public:
     ProvenanceExistenceCheck(std::string rel, VecOwn<Expression> vals)
-            : AbstractExistenceCheck(rel, std::move(vals)) {}
+            : AbstractExistenceCheck(NK_ProvenanceExistenceCheck, rel, std::move(vals)) {}
 
     ProvenanceExistenceCheck* cloning() const override {
         VecOwn<Expression> newValues;
@@ -44,6 +44,10 @@ public:
         }
         return new ProvenanceExistenceCheck(relation, std::move(newValues));
     }
+
+static bool classof(const Node* n){
+    return n->getKind() == Node::NK_ProvenanceExistenceCheck;
+}
 
 protected:
     void print(std::ostream& os) const override {

--- a/src/ram/Query.h
+++ b/src/ram/Query.h
@@ -45,7 +45,7 @@ namespace souffle::ram {
  */
 class Query : public Statement {
 public:
-    Query(Own<Operation> o) : operation(std::move(o)) {
+    Query(Own<Operation> o) : Statement(NK_Query), operation(std::move(o)) {
         assert(operation && "operation is a nullptr");
     }
 
@@ -60,6 +60,10 @@ public:
 
     void apply(const NodeMapper& map) override {
         operation = map(std::move(operation));
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Query;
     }
 
 protected:

--- a/src/ram/Query.h
+++ b/src/ram/Query.h
@@ -62,7 +62,7 @@ public:
         operation = map(std::move(operation));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Query;
     }
 

--- a/src/ram/Relation.h
+++ b/src/ram/Relation.h
@@ -39,7 +39,7 @@ public:
     Relation(std::string name, std::size_t arity, std::size_t auxiliaryArity,
             std::vector<std::string> attributeNames, std::vector<std::string> attributeTypes,
             RelationRepresentation representation)
-            : representation(representation), name(std::move(name)), arity(arity),
+            : Node(NK_Relation), representation(representation), name(std::move(name)), arity(arity),
               auxiliaryArity(auxiliaryArity), attributeNames(std::move(attributeNames)),
               attributeTypes(std::move(attributeTypes)) {
         assert(this->attributeNames.size() == arity && "arity mismatch for attributes");
@@ -97,6 +97,10 @@ public:
 
     Relation* cloning() const override {
         return new Relation(name, arity, auxiliaryArity, attributeNames, attributeTypes, representation);
+    }
+
+    static bool classof(const Node* n) {
+        return n->getKind() == NK_Relation;
     }
 
 protected:

--- a/src/ram/RelationOperation.h
+++ b/src/ram/RelationOperation.h
@@ -36,14 +36,19 @@ namespace souffle::ram {
  */
 class RelationOperation : public TupleOperation {
 public:
-    RelationOperation(std::string rel, std::size_t ident, Own<Operation> nested, std::string profileText = "")
-            : TupleOperation(ident, std::move(nested), std::move(profileText)), relation(std::move(rel)) {}
+    RelationOperation(NodeKind kind, std::string rel, std::size_t ident, Own<Operation> nested, std::string profileText = "")
+            : TupleOperation(kind, ident, std::move(nested), std::move(profileText)), relation(std::move(rel)) {}
 
     RelationOperation* cloning() const override = 0;
 
     /** @brief Get search relation */
     const std::string& getRelation() const {
         return relation;
+    }
+
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_RelationOperation && kind < NK_LastRelationOperation);
     }
 
 protected:

--- a/src/ram/RelationOperation.h
+++ b/src/ram/RelationOperation.h
@@ -36,8 +36,10 @@ namespace souffle::ram {
  */
 class RelationOperation : public TupleOperation {
 public:
-    RelationOperation(NodeKind kind, std::string rel, std::size_t ident, Own<Operation> nested, std::string profileText = "")
-            : TupleOperation(kind, ident, std::move(nested), std::move(profileText)), relation(std::move(rel)) {}
+    RelationOperation(NodeKind kind, std::string rel, std::size_t ident, Own<Operation> nested,
+            std::string profileText = "")
+            : TupleOperation(kind, ident, std::move(nested), std::move(profileText)),
+              relation(std::move(rel)) {}
 
     RelationOperation* cloning() const override = 0;
 
@@ -46,7 +48,7 @@ public:
         return relation;
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_RelationOperation && kind < NK_LastRelationOperation);
     }

--- a/src/ram/RelationSize.h
+++ b/src/ram/RelationSize.h
@@ -41,7 +41,7 @@ namespace souffle::ram {
  */
 class RelationSize : public Expression {
 public:
-    RelationSize(std::string rel) : relation(std::move(rel)) {}
+    RelationSize(std::string rel) : Expression(NK_RelationSize), relation(std::move(rel)) {}
 
     /** @brief Get relation */
     const std::string getRelation() const {
@@ -50,6 +50,10 @@ public:
 
     RelationSize* cloning() const override {
         return new RelationSize(relation);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_RelationSize;
     }
 
 protected:

--- a/src/ram/RelationSize.h
+++ b/src/ram/RelationSize.h
@@ -52,7 +52,7 @@ public:
         return new RelationSize(relation);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_RelationSize;
     }
 

--- a/src/ram/RelationStatement.h
+++ b/src/ram/RelationStatement.h
@@ -39,7 +39,7 @@ public:
         return relation;
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_RelationStatement && kind < NK_LastRelationStatement);
     }

--- a/src/ram/RelationStatement.h
+++ b/src/ram/RelationStatement.h
@@ -32,14 +32,23 @@ namespace souffle::ram {
  */
 class RelationStatement : public Statement {
 public:
-    RelationStatement(std::string rel) : relation(std::move(rel)) {}
+    RelationStatement(std::string rel) : RelationStatement(NK_RelationStatement, std::move(rel)) {}
 
     /** @brief Get RAM relation */
     const std::string& getRelation() const {
         return relation;
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_RelationStatement && kind < NK_LastRelationStatement);
+    }
+
 protected:
+    RelationStatement(NodeKind kind, std::string rel) : Statement(kind), relation(std::move(rel)) {
+        assert(kind >= NK_RelationStatement && kind < NK_LastRelationStatement);
+    }
+
     bool equal(const Node& node) const override {
         const auto& other = asAssert<RelationStatement>(node);
         return relation == other.relation;

--- a/src/ram/Scan.h
+++ b/src/ram/Scan.h
@@ -49,13 +49,14 @@ public:
         return new Scan(NK_Scan, relation, getTupleId(), clone(getOperation()), getProfileText());
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_Scan && kind < NK_LastScan);
     }
 
 protected:
-    Scan(NodeKind kind, std::string rel, std::size_t ident, Own<Operation> nested, std::string profileText = "")
+    Scan(NodeKind kind, std::string rel, std::size_t ident, Own<Operation> nested,
+            std::string profileText = "")
             : RelationOperation(kind, rel, ident, std::move(nested), std::move(profileText)) {
         assert(kind >= NK_Scan && kind < NK_LastScan);
     }

--- a/src/ram/Scan.h
+++ b/src/ram/Scan.h
@@ -43,13 +43,23 @@ namespace souffle::ram {
 class Scan : public RelationOperation {
 public:
     Scan(std::string rel, std::size_t ident, Own<Operation> nested, std::string profileText = "")
-            : RelationOperation(rel, ident, std::move(nested), std::move(profileText)) {}
+            : Scan(NK_Scan, rel, ident, std::move(nested), std::move(profileText)) {}
 
     Scan* cloning() const override {
-        return new Scan(relation, getTupleId(), clone(getOperation()), getProfileText());
+        return new Scan(NK_Scan, relation, getTupleId(), clone(getOperation()), getProfileText());
+    }
+
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_Scan && kind < NK_LastScan);
     }
 
 protected:
+    Scan(NodeKind kind, std::string rel, std::size_t ident, Own<Operation> nested, std::string profileText = "")
+            : RelationOperation(kind, rel, ident, std::move(nested), std::move(profileText)) {
+        assert(kind >= NK_Scan && kind < NK_LastScan);
+    }
+
     void print(std::ostream& os, int tabpos) const override {
         os << times(" ", tabpos);
         os << "FOR t" << getTupleId();

--- a/src/ram/Sequence.h
+++ b/src/ram/Sequence.h
@@ -17,6 +17,7 @@
 #include "ram/ListStatement.h"
 #include "ram/Statement.h"
 #include "souffle/utility/MiscUtil.h"
+#include "souffle/utility/Types.h"
 #include <memory>
 #include <ostream>
 #include <utility>
@@ -32,11 +33,11 @@ namespace souffle::ram {
  */
 class Sequence : public ListStatement {
 public:
-    Sequence(VecOwn<Statement> statements) : ListStatement(std::move(statements)) {}
-    Sequence() : ListStatement() {}
+    Sequence(VecOwn<Statement> statements) : ListStatement(NK_Sequence, std::move(statements)) {}
+    Sequence() : ListStatement(NK_Sequence) {}
     template <typename... Stmts>
     Sequence(Own<Statement> first, Own<Stmts>... rest)
-            : ListStatement(std::move(first), std::move(rest)...) {}
+            : ListStatement(NK_Sequence, std::move(first), std::move(rest)...) {}
 
     Sequence* cloning() const override {
         auto* res = new Sequence();
@@ -44,6 +45,10 @@ public:
             res->statements.push_back(clone(cur));
         }
         return res;
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Sequence;
     }
 
 protected:

--- a/src/ram/Sequence.h
+++ b/src/ram/Sequence.h
@@ -47,7 +47,7 @@ public:
         return res;
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Sequence;
     }
 

--- a/src/ram/SignedConstant.h
+++ b/src/ram/SignedConstant.h
@@ -33,7 +33,7 @@ namespace souffle::ram {
  */
 class SignedConstant : public NumericConstant {
 public:
-    explicit SignedConstant(RamDomain val) : NumericConstant(val) {}
+    explicit SignedConstant(RamDomain val) : NumericConstant(NK_SignedConstant, val) {}
 
     /** @brief Get value of the constant. */
     RamDomain getValue() const {
@@ -43,6 +43,10 @@ public:
     /** Create cloning */
     SignedConstant* cloning() const override {
         return new SignedConstant(getValue());
+    }
+
+    static bool classof(const Node* n) {
+        return n->getKind() == NK_SignedConstant;
     }
 
 protected:

--- a/src/ram/Statement.h
+++ b/src/ram/Statement.h
@@ -31,7 +31,16 @@ class Statement : public Node {
 public:
     Statement* cloning() const override = 0;
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_Statement && kind < NK_LastStatement);
+    }
+
 protected:
+    Statement(NodeKind kind) : Node(kind) {
+        assert(kind > NK_Statement && kind < NK_LastStatement);
+    }
+
     void print(std::ostream& os) const override {
         print(os, 0);
     }

--- a/src/ram/Statement.h
+++ b/src/ram/Statement.h
@@ -31,7 +31,7 @@ class Statement : public Node {
 public:
     Statement* cloning() const override = 0;
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_Statement && kind < NK_LastStatement);
     }

--- a/src/ram/StringConstant.h
+++ b/src/ram/StringConstant.h
@@ -31,7 +31,7 @@ namespace souffle::ram {
  */
 class StringConstant : public Expression {
 public:
-    StringConstant(std::string constant) : constant(constant) {}
+    StringConstant(std::string constant) : Expression(NK_StringConstant), constant(constant) {}
 
     /** @brief Get constant */
     const std::string& getConstant() const {
@@ -40,6 +40,10 @@ public:
 
     StringConstant* cloning() const override {
         return new StringConstant(constant);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_StringConstant;
     }
 
 protected:

--- a/src/ram/StringConstant.h
+++ b/src/ram/StringConstant.h
@@ -42,7 +42,7 @@ public:
         return new StringConstant(constant);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_StringConstant;
     }
 

--- a/src/ram/SubroutineArgument.h
+++ b/src/ram/SubroutineArgument.h
@@ -34,7 +34,7 @@ namespace souffle::ram {
  */
 class SubroutineArgument : public Expression {
 public:
-    SubroutineArgument(std::size_t number) : number(number) {}
+    SubroutineArgument(std::size_t number) : Expression(NK_SubroutineArgument), number(number) {}
 
     /** @brief Get argument */
     std::size_t getArgument() const {
@@ -43,6 +43,10 @@ public:
 
     SubroutineArgument* cloning() const override {
         return new SubroutineArgument(number);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_SubroutineArgument;
     }
 
 protected:

--- a/src/ram/SubroutineArgument.h
+++ b/src/ram/SubroutineArgument.h
@@ -45,7 +45,7 @@ public:
         return new SubroutineArgument(number);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_SubroutineArgument;
     }
 

--- a/src/ram/SubroutineReturn.h
+++ b/src/ram/SubroutineReturn.h
@@ -41,7 +41,7 @@ namespace souffle::ram {
  */
 class SubroutineReturn : public Operation {
 public:
-    SubroutineReturn(VecOwn<Expression> vals) : expressions(std::move(vals)) {
+    SubroutineReturn(VecOwn<Expression> vals) : Operation(NK_SubroutineReturn), expressions(std::move(vals)) {
         assert(allValidPtrs(expressions));
     }
 
@@ -62,6 +62,10 @@ public:
         for (auto& expr : expressions) {
             expr = map(std::move(expr));
         }
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_SubroutineReturn;
     }
 
 protected:

--- a/src/ram/SubroutineReturn.h
+++ b/src/ram/SubroutineReturn.h
@@ -64,7 +64,7 @@ public:
         }
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_SubroutineReturn;
     }
 

--- a/src/ram/Swap.h
+++ b/src/ram/Swap.h
@@ -44,7 +44,7 @@ public:
         return new Swap(first, second);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_Swap;
     }
 

--- a/src/ram/Swap.h
+++ b/src/ram/Swap.h
@@ -38,10 +38,14 @@ namespace souffle::ram {
  */
 class Swap : public BinRelationStatement {
 public:
-    Swap(std::string f, std::string s) : BinRelationStatement(f, s) {}
+    Swap(std::string f, std::string s) : BinRelationStatement(NK_Swap, f, s) {}
 
     Swap* cloning() const override {
         return new Swap(first, second);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_Swap;
     }
 
 protected:

--- a/src/ram/True.h
+++ b/src/ram/True.h
@@ -30,13 +30,13 @@ namespace souffle::ram {
  */
 class True : public Condition {
 public:
-    True() : Condition(NK_True){}
+    True() : Condition(NK_True) {}
 
     True* cloning() const override {
         return new True();
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_True;
     }
 

--- a/src/ram/True.h
+++ b/src/ram/True.h
@@ -30,8 +30,14 @@ namespace souffle::ram {
  */
 class True : public Condition {
 public:
+    True() : Condition(NK_True){}
+
     True* cloning() const override {
         return new True();
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_True;
     }
 
 protected:

--- a/src/ram/TupleElement.h
+++ b/src/ram/TupleElement.h
@@ -36,7 +36,8 @@ namespace souffle::ram {
  */
 class TupleElement : public Expression {
 public:
-    TupleElement(std::size_t ident, std::size_t elem) : Expression(NK_TupleElement), identifier(ident), element(elem) {}
+    TupleElement(std::size_t ident, std::size_t elem)
+            : Expression(NK_TupleElement), identifier(ident), element(elem) {}
 
     /** @brief Get identifier */
     std::size_t getTupleId() const {
@@ -52,7 +53,7 @@ public:
         return new TupleElement(identifier, element);
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_TupleElement;
     }
 

--- a/src/ram/TupleElement.h
+++ b/src/ram/TupleElement.h
@@ -36,7 +36,7 @@ namespace souffle::ram {
  */
 class TupleElement : public Expression {
 public:
-    TupleElement(std::size_t ident, std::size_t elem) : identifier(ident), element(elem) {}
+    TupleElement(std::size_t ident, std::size_t elem) : Expression(NK_TupleElement), identifier(ident), element(elem) {}
 
     /** @brief Get identifier */
     std::size_t getTupleId() const {
@@ -50,6 +50,10 @@ public:
 
     TupleElement* cloning() const override {
         return new TupleElement(identifier, element);
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_TupleElement;
     }
 
 protected:

--- a/src/ram/TupleOperation.h
+++ b/src/ram/TupleOperation.h
@@ -32,7 +32,7 @@ namespace souffle::ram {
 class TupleOperation : public NestedOperation {
 public:
     TupleOperation(std::size_t ident, Own<Operation> nested, std::string profileText = "")
-            : NestedOperation(std::move(nested), std::move(profileText)), identifier(ident) {}
+            : TupleOperation(NK_TupleOperation, ident, std::move(nested), std::move(profileText)) {}
 
     TupleOperation* cloning() const override = 0;
 
@@ -46,7 +46,17 @@ public:
         identifier = id;
     }
 
+    static bool classof(const Node* n){
+        const NodeKind kind = n->getKind();
+        return (kind >= NK_TupleOperation && kind < NK_LastTupleOperation);
+    }
+
 protected:
+    TupleOperation(NodeKind kind, std::size_t ident, Own<Operation> nested, std::string profileText = "")
+            : NestedOperation(kind, std::move(nested), std::move(profileText)), identifier(ident) {
+        assert(kind > NK_TupleOperation && kind < NK_LastTupleOperation);
+    }
+
     bool equal(const Node& node) const override {
         const auto& other = asAssert<TupleOperation>(node);
         return NestedOperation::equal(other) && identifier == other.identifier;

--- a/src/ram/TupleOperation.h
+++ b/src/ram/TupleOperation.h
@@ -46,7 +46,7 @@ public:
         identifier = id;
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         const NodeKind kind = n->getKind();
         return (kind >= NK_TupleOperation && kind < NK_LastTupleOperation);
     }

--- a/src/ram/UndefValue.h
+++ b/src/ram/UndefValue.h
@@ -29,8 +29,14 @@ namespace souffle::ram {
  */
 class UndefValue : public Expression {
 public:
+    UndefValue() : Expression(NK_UndefValue) {}
+
     UndefValue* cloning() const override {
         return new UndefValue();
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_UndefValue;
     }
 
 protected:

--- a/src/ram/UndefValue.h
+++ b/src/ram/UndefValue.h
@@ -35,7 +35,7 @@ public:
         return new UndefValue();
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_UndefValue;
     }
 

--- a/src/ram/UnpackRecord.h
+++ b/src/ram/UnpackRecord.h
@@ -46,7 +46,8 @@ namespace souffle::ram {
 class UnpackRecord : public TupleOperation {
 public:
     UnpackRecord(Own<Operation> nested, std::size_t ident, Own<Expression> expr, std::size_t arity)
-            : TupleOperation(NK_UnpackRecord, ident, std::move(nested)), expression(std::move(expr)), arity(arity) {
+            : TupleOperation(NK_UnpackRecord, ident, std::move(nested)), expression(std::move(expr)),
+              arity(arity) {
         assert(expression != nullptr && "Expression is a null-pointer");
     }
 
@@ -70,7 +71,7 @@ public:
         expression = map(std::move(expression));
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_UnpackRecord;
     }
 

--- a/src/ram/UnpackRecord.h
+++ b/src/ram/UnpackRecord.h
@@ -46,7 +46,7 @@ namespace souffle::ram {
 class UnpackRecord : public TupleOperation {
 public:
     UnpackRecord(Own<Operation> nested, std::size_t ident, Own<Expression> expr, std::size_t arity)
-            : TupleOperation(ident, std::move(nested)), expression(std::move(expr)), arity(arity) {
+            : TupleOperation(NK_UnpackRecord, ident, std::move(nested)), expression(std::move(expr)), arity(arity) {
         assert(expression != nullptr && "Expression is a null-pointer");
     }
 
@@ -68,6 +68,10 @@ public:
     void apply(const NodeMapper& map) override {
         TupleOperation::apply(map);
         expression = map(std::move(expression));
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_UnpackRecord;
     }
 
 protected:

--- a/src/ram/UnsignedConstant.h
+++ b/src/ram/UnsignedConstant.h
@@ -33,7 +33,7 @@ namespace souffle::ram {
  */
 class UnsignedConstant : public NumericConstant {
 public:
-    explicit UnsignedConstant(RamUnsigned val) : NumericConstant(ramBitCast(val)) {}
+    explicit UnsignedConstant(RamUnsigned val) : NumericConstant(NK_UnsignedConstant, ramBitCast(val)) {}
 
     /** @brief Get value of the constant. */
     RamUnsigned getValue() const {
@@ -43,6 +43,10 @@ public:
     /** Create cloning */
     UnsignedConstant* cloning() const override {
         return new UnsignedConstant(getValue());
+    }
+
+    static bool classof(const Node* n) {
+        return n->getKind() == NK_UnsignedConstant;
     }
 
 protected:

--- a/src/ram/UserDefinedOperator.h
+++ b/src/ram/UserDefinedOperator.h
@@ -39,7 +39,7 @@ class UserDefinedOperator : public AbstractOperator {
 public:
     UserDefinedOperator(std::string n, std::vector<TypeAttribute> argsTypes, TypeAttribute returnType,
             bool stateful, VecOwn<Expression> args)
-            : AbstractOperator(std::move(args)), name(std::move(n)), argsTypes(std::move(argsTypes)),
+            : AbstractOperator(NK_UserDefinedOperator, std::move(args)), name(std::move(n)), argsTypes(std::move(argsTypes)),
               returnType(returnType), stateful(stateful) {
         assert(argsTypes.size() == args.size());
     }
@@ -71,6 +71,10 @@ public:
             res->arguments.emplace_back(arg);
         }
         return res;
+    }
+
+    static bool classof(const Node* n){
+        return n->getKind() == NK_UserDefinedOperator;
     }
 
 protected:

--- a/src/ram/UserDefinedOperator.h
+++ b/src/ram/UserDefinedOperator.h
@@ -39,8 +39,8 @@ class UserDefinedOperator : public AbstractOperator {
 public:
     UserDefinedOperator(std::string n, std::vector<TypeAttribute> argsTypes, TypeAttribute returnType,
             bool stateful, VecOwn<Expression> args)
-            : AbstractOperator(NK_UserDefinedOperator, std::move(args)), name(std::move(n)), argsTypes(std::move(argsTypes)),
-              returnType(returnType), stateful(stateful) {
+            : AbstractOperator(NK_UserDefinedOperator, std::move(args)), name(std::move(n)),
+              argsTypes(std::move(argsTypes)), returnType(returnType), stateful(stateful) {
         assert(argsTypes.size() == args.size());
     }
 
@@ -73,7 +73,7 @@ public:
         return res;
     }
 
-    static bool classof(const Node* n){
+    static bool classof(const Node* n) {
         return n->getKind() == NK_UserDefinedOperator;
     }
 

--- a/src/ram/Variable.h
+++ b/src/ram/Variable.h
@@ -32,7 +32,7 @@ namespace souffle::ram {
  */
 class Variable : public Expression {
 public:
-    explicit Variable(const std::string name) : name(name) {}
+    explicit Variable(const std::string name) : Expression(NK_Variable), name(name) {}
 
     /** @brief Get value of the constant. */
     const std::string getName() const {
@@ -42,6 +42,10 @@ public:
     /** Create cloning */
     Variable* cloning() const override {
         return new Variable(getName());
+    }
+
+    static bool classof(const Node* n) {
+        return n->getKind() == NK_Variable;
     }
 
 protected:

--- a/src/synthesiser/Synthesiser.cpp
+++ b/src/synthesiser/Synthesiser.cpp
@@ -46,6 +46,7 @@
 #include "ram/IndexIfExists.h"
 #include "ram/IndexScan.h"
 #include "ram/Insert.h"
+#include "ram/IntrinsicAggregator.h"
 #include "ram/IntrinsicOperator.h"
 #include "ram/LogRelationTimer.h"
 #include "ram/LogSize.h"


### PR DESCRIPTION
Dynamic cast have a significant performance impact on Souffle AST/RAM pipelines.

* non-RTTI dynamic cast for the ast::Node hierarchy
* non-RTTI dynamic cast for the ast::analysis::Type hierarchy
* non-RTTI dynamic cast for the ram::Node hierarchy