### PR TITLE
fix `apply` on user-defined aggregate `init`

### DIFF
--- a/src/ast/UserDefinedAggregator.cpp
+++ b/src/ast/UserDefinedAggregator.cpp
@@ -34,10 +34,9 @@ Node::NodeVec UserDefinedAggregator::getChildren() const {
 }
 
 void UserDefinedAggregator::print(std::ostream& os) const {
-    os << "@" << name;
-    os << " init: " << *initValue;
+    os << "@@" << name << " " << *initValue;
     if (targetExpression) {
-        os << " " << *targetExpression;
+        os << ", " << *targetExpression;
     }
     os << " : { " << join(body) << " }";
 }

--- a/src/ram/Aggregate.h
+++ b/src/ram/Aggregate.h
@@ -63,6 +63,7 @@ public:
         RelationOperation::apply(map);
         condition = map(std::move(condition));
         expression = map(std::move(expression));
+        function->apply(map);
     }
 
     static bool classof(const Node* n) {

--- a/src/ram/Aggregator.h
+++ b/src/ram/Aggregator.h
@@ -45,6 +45,8 @@ public:
         return {};
     }
 
+    virtual void apply(const NodeMapper&) {}
+
     /**
      * @brief Create a cloning (i.e. deep copy) of this node
      */

--- a/src/ram/IndexAggregate.h
+++ b/src/ram/IndexAggregate.h
@@ -66,6 +66,7 @@ public:
         IndexOperation::apply(map);
         condition = map(std::move(condition));
         expression = map(std::move(expression));
+        function->apply(map);
     }
 
     static bool classof(const Node* n) {

--- a/src/ram/UserDefinedAggregator.h
+++ b/src/ram/UserDefinedAggregator.h
@@ -77,6 +77,10 @@ public:
         os << name << " INIT " << *initValue << " ";
     }
 
+    void apply(const NodeMapper& map) override {
+        initValue = map(std::move(initValue));
+    }
+
 protected:
     /** Aggregation function */
     const std::string name;


### PR DESCRIPTION
The `init` expression of user-define aggregates was never handed-over to `apply`'s `mapper`.

One visible issue is that the `TupleId` transformer would not update the tuple of the `init` expression while shuffling tuple identifiers. That would then result in the `init` expression peeking data in the wrong tuple during execution of the RAM program.