### PR TITLE
make interpreter's `Conjunction` a `Compound` node

### DIFF
--- a/src/interpreter/Engine.cpp
+++ b/src/interpreter/Engine.cpp
@@ -979,7 +979,12 @@ RamDomain Engine::execute(const Node* node, Context& ctxt) {
         ESAC(False)
 
         CASE(Conjunction)
-            return execute(shadow.getLhs(), ctxt) && execute(shadow.getRhs(), ctxt);
+            for (const auto& child : shadow.getChildren()) {
+                if (!execute(child.get(), ctxt)) {
+                    return false;
+                }
+            }
+            return true;
         ESAC(Conjunction)
 
         CASE(Negation)

--- a/src/interpreter/Node.h
+++ b/src/interpreter/Node.h
@@ -578,9 +578,12 @@ class False : public Node {
 
 /**
  * @class Conjunction
+ *
+ * It's a compound node so that conjunctions with hundreds of terms
+ * do not overflow the engine stack with left/right recursion.
  */
-class Conjunction : public BinaryNode {
-    using BinaryNode::BinaryNode;
+class Conjunction : public CompoundNode {
+    using CompoundNode::CompoundNode;
 };
 
 /**


### PR DESCRIPTION
Conjunctions with hundreds of terms would otherwise overflow the engine stack with left/right recursion.
The issue has been observed in `Debug` build with ~200 terms.