### PR TITLE
Do not treat warnings as errors when using MSVC.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -235,7 +235,7 @@ set_target_properties(compiled PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if (NOT MSVC)
   target_compile_options(libsouffle PUBLIC -Wall -Wextra -fwrapv)
 else ()
-  target_compile_options(libsouffle PUBLIC /W3 /WX)
+  target_compile_options(libsouffle PUBLIC /W3)
 endif ()
 
 target_compile_options(compiled PUBLIC "")


### PR DESCRIPTION
Similar motivation to https://github.com/souffle-lang/souffle/pull/2299 . Warnings as errors is a fragile construct, the e.g., the build can break due to a compiler update.