### PR TITLE
Fix some clang tidy warnings

### DIFF
--- a/src/ast/Constraint.h
+++ b/src/ast/Constraint.h
@@ -28,7 +28,7 @@ class Constraint : public Literal {
 public:
     using Literal::Literal;
 
-    Constraint(NodeKind kind, SrcLocation loc = {}) : Literal(kind, loc) {
+    Constraint(NodeKind kind, SrcLocation loc = {}) : Literal(kind, std::move(loc)) {
         assert(kind >= NK_Constraint && kind < NK_LastConstraint);
     }
 

--- a/src/ast/Functor.h
+++ b/src/ast/Functor.h
@@ -29,7 +29,7 @@ class Functor : public Term {
 protected:
     using Term::Term;
 
-    Functor(NodeKind kind, SrcLocation loc = {}) : Term(kind, loc) {
+    Functor(NodeKind kind, SrcLocation loc = {}) : Term(kind, std::move(loc)) {
         assert(kind > NK_FirstFunctor && kind < NK_LastFunctor);
     }
 

--- a/src/ast/Lattice.cpp
+++ b/src/ast/Lattice.cpp
@@ -42,7 +42,7 @@ void Lattice::setQualifiedName(QualifiedName name) {
     this->name = std::move(name);
 }
 
-const std::map<LatticeOperator, const ast::Argument*> Lattice::getOperators() const {
+std::map<LatticeOperator, const ast::Argument*> Lattice::getOperators() const {
     std::map<LatticeOperator, const ast::Argument*> ops;
     for (const auto& [op, arg] : operators) {
         ops.emplace(std::make_pair(op, arg.get()));

--- a/src/ast/Lattice.h
+++ b/src/ast/Lattice.h
@@ -47,7 +47,7 @@ public:
     /** Set type name */
     void setQualifiedName(QualifiedName name);
 
-    const std::map<LatticeOperator, const ast::Argument*> getOperators() const;
+    std::map<LatticeOperator, const ast::Argument*> getOperators() const;
 
     bool hasGlb() const;
     bool hasLub() const;

--- a/src/ast/Literal.h
+++ b/src/ast/Literal.h
@@ -31,7 +31,7 @@ class Literal : public Node {
 public:
     using Node::Node;
 
-    explicit Literal(NodeKind kind, SrcLocation loc = {}) : Node(kind, loc) {
+    explicit Literal(NodeKind kind, SrcLocation loc = {}) : Node(kind, std::move(loc)) {
         assert(kind >= NK_Literal && kind < NK_LastLiteral);
     }
 

--- a/src/ast/UnnamedVariable.cpp
+++ b/src/ast/UnnamedVariable.cpp
@@ -11,7 +11,7 @@
 
 namespace souffle::ast {
 
-UnnamedVariable::UnnamedVariable(SrcLocation loc) : Argument(NK_UnnamedVariable, loc) {}
+UnnamedVariable::UnnamedVariable(SrcLocation loc) : Argument(NK_UnnamedVariable, std::move(loc)) {}
 
 void UnnamedVariable::print(std::ostream& os) const {
     os << "_";

--- a/src/ast/UserDefinedAggregator.cpp
+++ b/src/ast/UserDefinedAggregator.cpp
@@ -19,7 +19,7 @@
 namespace souffle::ast {
 UserDefinedAggregator::UserDefinedAggregator(
         std::string name, Own<Argument> init, Own<Argument> expr, VecOwn<Literal> body, SrcLocation loc)
-        : Aggregator(NK_UserDefinedAggregator, std::move(expr), std::move(body), std::move(loc)), name(name),
+        : Aggregator(NK_UserDefinedAggregator, std::move(expr), std::move(body), std::move(loc)), name(std::move(name)),
           initValue(std::move(init)) {}
 
 void UserDefinedAggregator::apply(const NodeMapper& map) {

--- a/src/ast/UserDefinedAggregator.cpp
+++ b/src/ast/UserDefinedAggregator.cpp
@@ -19,8 +19,8 @@
 namespace souffle::ast {
 UserDefinedAggregator::UserDefinedAggregator(
         std::string name, Own<Argument> init, Own<Argument> expr, VecOwn<Literal> body, SrcLocation loc)
-        : Aggregator(NK_UserDefinedAggregator, std::move(expr), std::move(body), std::move(loc)), name(std::move(name)),
-          initValue(std::move(init)) {}
+        : Aggregator(NK_UserDefinedAggregator, std::move(expr), std::move(body), std::move(loc)),
+          name(std::move(name)), initValue(std::move(init)) {}
 
 void UserDefinedAggregator::apply(const NodeMapper& map) {
     Aggregator::apply(map);

--- a/src/ast/analysis/Aggregate.cpp
+++ b/src/ast/analysis/Aggregate.cpp
@@ -105,7 +105,7 @@ std::set<std::string> getWitnessVariables(
     M update;
     aggregatorlessClause->apply(update);
     auto groundingAtom = mk<Atom>(QualifiedName::fromString("+grounding_atom"));
-    for (std::string variableName : update.getAggregatorVariables()) {
+    for (const std::string& variableName : update.getAggregatorVariables()) {
         groundingAtom->addArgument(mk<Variable>(variableName));
     }
     aggregatorlessClause->addToBody(std::move(groundingAtom));
@@ -163,7 +163,7 @@ std::set<std::string> getVariablesOutsideAggregate(const Clause& clause, const A
     return variablesOutsideAggregate;
 }
 
-std::string findUniqueVariableName(const Clause& clause, std::string base) {
+std::string findUniqueVariableName(const Clause& clause, const std::string& base) {
     std::set<std::string> variablesInClause;
     visit(clause, [&](const Variable& v) { variablesInClause.insert(v.getName()); });
     int varNum = 0;
@@ -174,7 +174,7 @@ std::string findUniqueVariableName(const Clause& clause, std::string base) {
     return candidate;
 }
 
-std::string findUniqueRelationName(const Program& program, std::string base) {
+std::string findUniqueRelationName(const Program& program, const std::string& base) {
     int counter = 0;
     auto candidate = base;
     while (program.getRelation(QualifiedName::fromString(candidate)) != nullptr) {
@@ -331,7 +331,7 @@ std::set<std::string> getInjectedVariables(
     tweakedClause->apply(update);
     // the update will now tell us which variables we need to ground!
     auto groundingAtom = mk<Atom>(QualifiedName::fromString("+grounding_atom"));
-    for (std::string variableName : update.getAggregatorVariables()) {
+    for (const std::string& variableName : update.getAggregatorVariables()) {
         groundingAtom->addArgument(mk<Variable>(variableName));
     }
     // add the newly created grounding atom to the body

--- a/src/ast/analysis/Aggregate.h
+++ b/src/ast/analysis/Aggregate.h
@@ -50,12 +50,12 @@ std::set<std::string> getVariablesOutsideAggregate(const Clause& clause, const A
  *  Find a new relation name. I use this when I create new relations either for
  *  aggregate bodies or singleton aggregates.
  **/
-std::string findUniqueRelationName(const Program& program, std::string base);
+std::string findUniqueRelationName(const Program& program, const std::string& base);
 /**
  * Find a variable name using base to form a string like base1
  * Use this when you need to limit the scope of a variable to the inside of an aggregate.
  **/
-std::string findUniqueVariableName(const Clause& clause, std::string base);
+std::string findUniqueVariableName(const Clause& clause, const std::string& base);
 /**
  *  Given an aggregate and a clause, we find all the variables that have been
  *  injected into the aggregate.

--- a/src/ast/analysis/IOType.h
+++ b/src/ast/analysis/IOType.h
@@ -60,8 +60,8 @@ public:
         auto iter = limitSize.find(relation);
         if (iter != limitSize.end()) {
             return (*iter).second;
-        } else
-            return 0;
+        }
+        return 0;
     }
 
     bool isIO(const Relation* relation) const {

--- a/src/ast/analysis/typesystem/TypeSystem.h
+++ b/src/ast/analysis/typesystem/TypeSystem.h
@@ -311,8 +311,8 @@ public:
 
 protected:
     RecordType(const TypeEnvironment& environment, const QualifiedName& name,
-            const std::vector<const Type*> fields = {})
-            : Type(TK_RecordType, environment, name), fields(fields) {}
+            std::vector<const Type*> fields = {})
+            : Type(TK_RecordType, environment, name), fields(std::move(fields)) {}
 
 private:
     friend class TypeEnvironment;

--- a/src/ast2ram/utility/ValueIndex.cpp
+++ b/src/ast2ram/utility/ValueIndex.cpp
@@ -42,7 +42,7 @@ void ValueIndex::addVarReference(std::string varName, const Location& l) {
 }
 
 void ValueIndex::addVarReference(std::string varName, std::size_t ident, std::size_t pos) {
-    addVarReference(varName, Location({ident, pos}));
+    addVarReference(std::move(varName), Location({ident, pos}));
 }
 
 bool ValueIndex::isDefined(const std::string& varName) const {

--- a/src/include/souffle/RecordTable.h
+++ b/src/include/souffle/RecordTable.h
@@ -26,7 +26,7 @@ namespace souffle {
 /** The interface of any Record Table. */
 class RecordTable {
 public:
-    virtual ~RecordTable() {}
+    virtual ~RecordTable() = default;
 
     virtual void setNumLanes(const std::size_t NumLanes) = 0;
 

--- a/src/include/souffle/SouffleInterface.h
+++ b/src/include/souffle/SouffleInterface.h
@@ -172,7 +172,7 @@ public:
         /**
          * Move constructor.
          *
-         * The new iterator now has ownerhsip of the iterator base.
+         * The new iterator now has ownership of the iterator base.
          *
          * @param arg lvalue reference to an iterator object
          */
@@ -215,7 +215,7 @@ public:
             return *this;
         }
 
-        iterator& operator=(iterator&& o) {
+        iterator& operator=(iterator&& o) noexcept {
             iter.swap(o.iter);
             return *this;
         }
@@ -845,9 +845,8 @@ public:
         auto it = relationMap.find(name);
         if (it != relationMap.end()) {
             return (*it).second;
-        } else {
-            return nullptr;
         }
+        return nullptr;
     };
 
     /**
@@ -1137,9 +1136,8 @@ public:
         ProgramFactory* factory = find(name);
         if (factory != nullptr) {
             return factory->newInstance();
-        } else {
-            return nullptr;
         }
+        return nullptr;
     }
 };
 }  // namespace souffle

--- a/src/include/souffle/SymbolTable.h
+++ b/src/include/souffle/SymbolTable.h
@@ -26,7 +26,7 @@ namespace souffle {
 /** Interface of a generic SymbolTable iterator. */
 class SymbolTableIteratorInterface {
 public:
-    virtual ~SymbolTableIteratorInterface() {}
+    virtual ~SymbolTableIteratorInterface() = default;
 
     virtual const std::pair<const std::string, const std::size_t>& get() const = 0;
 
@@ -44,7 +44,7 @@ public:
  */
 class SymbolTable {
 public:
-    virtual ~SymbolTable() {}
+    virtual ~SymbolTable() = default;
 
     /**
      * @brief Iterator on a symbol table.
@@ -61,7 +61,7 @@ public:
 
         Iterator(const Iterator& it) : impl(it.impl->copy()) {}
 
-        Iterator(Iterator&& it) : impl(std::move(it.impl)) {}
+        Iterator(Iterator&& it) noexcept : impl(std::move(it.impl)) {}
 
         reference operator*() const {
             return impl->get();

--- a/src/include/souffle/datastructure/BTree.h
+++ b/src/include/souffle/datastructure/BTree.h
@@ -207,7 +207,7 @@ protected:
             }
 
             // copy child nodes recursively
-            auto* ires = (inner_node*)res;
+            auto* ires = static_cast<inner_node*>(res);
             for (size_type i = 0; i <= this->numElements; ++i) {
                 ires->children[i] = this->getChild(i)->clone();
                 ires->children[i]->parent = res;
@@ -634,7 +634,7 @@ protected:
             }
 
             // move bigger keys one forward
-            for (int i = static_cast<int>(this->numElements) - 1; i >= (int)pos; --i) {
+            for (int i = static_cast<int>(this->numElements) - 1; i >= static_cast<int>(pos); --i) {
                 keys[i + 1] = keys[i];
                 getChildren()[i + 2] = getChildren()[i + 1];
                 ++getChildren()[i + 2]->position;
@@ -660,7 +660,7 @@ protected:
          */
         void printTree(std::ostream& out, const std::string& prefix) const {
             // print the header
-            out << prefix << "@" << this << "[" << ((int)(this->position)) << "] - "
+            out << prefix << "@" << this << "[" << static_cast<int>(this->position) << "] - "
                 << (this->inner ? "i" : "") << "node : " << this->numElements << "/" << maxKeys << " [";
 
             // print the keys
@@ -806,7 +806,7 @@ protected:
                         std::cout << "Parent reference invalid!\n";
                         std::cout << "   Node:     " << this << "\n";
                         std::cout << "   Parent:   " << this->parent << "\n";
-                        std::cout << "   Position: " << ((int)this->position) << "\n";
+                        std::cout << "   Position: " << static_cast<int>(this->position) << "\n";
                         valid = false;
                     }
 
@@ -816,7 +816,7 @@ protected:
                         std::cout << "Left parent key not lower bound!\n";
                         std::cout << "   Node:     " << this << "\n";
                         std::cout << "   Parent:   " << this->parent << "\n";
-                        std::cout << "   Position: " << ((int)this->position) << "\n";
+                        std::cout << "   Position: " << static_cast<int>(this->position) << "\n";
                         std::cout << "   Key:   " << (this->parent->keys[this->position]) << "\n";
                         std::cout << "   Lower: " << (keys[0]) << "\n";
                         valid = false;
@@ -829,7 +829,7 @@ protected:
                         std::cout << "Right parent key not lower bound!\n";
                         std::cout << "   Node:     " << this << "\n";
                         std::cout << "   Parent:   " << this->parent << "\n";
-                        std::cout << "   Position: " << ((int)this->position) << "\n";
+                        std::cout << "   Position: " << static_cast<int>(this->position) << "\n";
                         std::cout << "   Key:   " << (this->parent->keys[this->position]) << "\n";
                         std::cout << "   Upper: " << (keys[0]) << "\n";
                         valid = false;
@@ -982,7 +982,7 @@ public:
 
         // prints a textual representation of this iterator to the given stream (mainly for debugging)
         void print(std::ostream& out = std::cout) const {
-            out << cur << "[" << (int)pos << "]";
+            out << cur << "[" << static_cast<int>(pos) << "]";
         }
     };
 
@@ -1075,7 +1075,7 @@ public:
     }
 
     // a move constructor
-    btree(btree&& other)
+    btree(btree&& other) noexcept
             : comp(other.comp), weak_comp(other.weak_comp), root(other.root), leftmost(other.leftmost) {
         other.root = nullptr;
         other.leftmost = nullptr;
@@ -1360,7 +1360,7 @@ public:
                 }
 
                 // insert element in right fragment
-                if (((size_type)idx) > cur->numElements) {
+                if (static_cast<size_type>(idx) > cur->numElements) {
                     // release current lock
                     cur->lock.end_write();
 
@@ -1858,8 +1858,8 @@ public:
         out << "  Size of leaf node:  " << sizeof(leaf_node) << "\n";
         out << "  Size of Key:        " << sizeof(Key) << "\n";
         out << "  max keys / node:  " << node::maxKeys << "\n";
-        out << "  avg keys / node:  " << (size() / (double)nodes) << "\n";
-        out << "  avg filling rate: " << ((size() / (double)nodes) / node::maxKeys) << "\n";
+        out << "  avg keys / node:  " << (size() / static_cast<double>(nodes)) << "\n";
+        out << "  avg filling rate: " << ((size() / static_cast<double>(nodes)) / node::maxKeys) << "\n";
         out << " ---------------------------------\n";
         out << "  insert-hint (hits/misses/total): " << hint_stats.inserts.getHits() << "/"
             << hint_stats.inserts.getMisses() << "/" << hint_stats.inserts.getAccesses() << "\n";
@@ -2061,7 +2061,7 @@ public:
     btree_set(const btree_set& other) : super(other) {}
 
     // A move constructor.
-    btree_set(btree_set&& other) : super(std::move(other)) {}
+    btree_set(btree_set&& other) noexcept : super(std::move(other)) {}
 
 private:
     // A constructor required by the bulk-load facility.
@@ -2123,7 +2123,7 @@ public:
     btree_multiset(const btree_multiset& other) : super(other) {}
 
     // A move constructor.
-    btree_multiset(btree_multiset&& other) : super(std::move(other)) {}
+    btree_multiset(btree_multiset&& other) noexcept : super(std::move(other)) {}
 
 private:
     // A constructor required by the bulk-load facility.

--- a/src/include/souffle/datastructure/BTreeDelete.h
+++ b/src/include/souffle/datastructure/BTreeDelete.h
@@ -210,7 +210,7 @@ protected:
             }
 
             // copy child nodes recursively
-            auto* ires = (inner_node*)res;
+            auto* ires = static_cast<inner_node*>(res);
             for (size_type i = 0; i <= this->numElements; ++i) {
                 ires->children[i] = this->getChild(i)->clone();
                 ires->children[i]->parent = res;
@@ -637,7 +637,7 @@ protected:
             }
 
             // move bigger keys one forward
-            for (int i = static_cast<int>(this->numElements) - 1; i >= (int)pos; --i) {
+            for (int i = static_cast<int>(this->numElements) - 1; i >= static_cast<int>(pos); --i) {
                 keys[i + 1] = keys[i];
                 getChildren()[i + 2] = getChildren()[i + 1];
                 ++getChildren()[i + 2]->position;
@@ -663,7 +663,7 @@ protected:
          */
         void printTree(std::ostream& out, const std::string& prefix) const {
             // print the header
-            out << prefix << "@" << this << "[" << ((int)(this->position)) << "] - "
+            out << prefix << "@" << this << "[" << static_cast<int>(this->position) << "] - "
                 << (this->inner ? "i" : "") << "node : " << this->numElements << "/" << maxKeys << " [";
 
             // print the keys
@@ -809,7 +809,7 @@ protected:
                         std::cout << "Parent reference invalid!\n";
                         std::cout << "   Node:     " << this << "\n";
                         std::cout << "   Parent:   " << this->parent << "\n";
-                        std::cout << "   Position: " << ((int)this->position) << "\n";
+                        std::cout << "   Position: " << static_cast<int>(this->position) << "\n";
                         valid = false;
                     }
 
@@ -819,7 +819,7 @@ protected:
                         std::cout << "Left parent key not lower bound!\n";
                         std::cout << "   Node:     " << this << "\n";
                         std::cout << "   Parent:   " << this->parent << "\n";
-                        std::cout << "   Position: " << ((int)this->position) << "\n";
+                        std::cout << "   Position: " << static_cast<int>(this->position) << "\n";
                         std::cout << "   Key:   " << (this->parent->keys[this->position]) << "\n";
                         std::cout << "   Lower: " << (keys[0]) << "\n";
                         valid = false;
@@ -832,7 +832,7 @@ protected:
                         std::cout << "Right parent key not lower bound!\n";
                         std::cout << "   Node:     " << this << "\n";
                         std::cout << "   Parent:   " << this->parent << "\n";
-                        std::cout << "   Position: " << ((int)this->position) << "\n";
+                        std::cout << "   Position: " << static_cast<int>(this->position) << "\n";
                         std::cout << "   Key:   " << (this->parent->keys[this->position]) << "\n";
                         std::cout << "   Upper: " << (keys[0]) << "\n";
                         valid = false;
@@ -1034,7 +1034,7 @@ public:
 
         // prints a textual representation of this iterator to the given stream (mainly for debugging)
         void print(std::ostream& out = std::cout) const {
-            out << cur << "[" << (int)pos << "]";
+            out << cur << "[" << static_cast<int>(pos) << "]";
         }
     };
 
@@ -1127,7 +1127,7 @@ public:
     }
 
     // a move constructor
-    btree_delete(btree_delete&& other)
+    btree_delete(btree_delete&& other) noexcept
             : comp(other.comp), weak_comp(other.weak_comp), root(other.root), leftmost(other.leftmost) {
         other.root = nullptr;
         other.leftmost = nullptr;
@@ -1413,7 +1413,7 @@ public:
                 }
 
                 // insert element in right fragment
-                if (((size_type)idx) > cur->numElements) {
+                if (static_cast<size_type>(idx) > cur->numElements) {
                     // release current lock
                     cur->lock.end_write();
 
@@ -2419,8 +2419,8 @@ public:
         out << "  Size of leaf node:  " << sizeof(leaf_node) << "\n";
         out << "  Size of Key:        " << sizeof(Key) << "\n";
         out << "  max keys / node:  " << node::maxKeys << "\n";
-        out << "  avg keys / node:  " << (size() / (double)nodes) << "\n";
-        out << "  avg filling rate: " << ((size() / (double)nodes) / node::maxKeys) << "\n";
+        out << "  avg keys / node:  " << (size() / static_cast<double>(nodes)) << "\n";
+        out << "  avg filling rate: " << ((size() / static_cast<double>(nodes)) / node::maxKeys) << "\n";
         out << " ---------------------------------\n";
         out << "  insert-hint (hits/misses/total): " << hint_stats.inserts.getHits() << "/"
             << hint_stats.inserts.getMisses() << "/" << hint_stats.inserts.getAccesses() << "\n";
@@ -2623,7 +2623,7 @@ public:
     btree_delete_set(const btree_delete_set& other) : super(other) {}
 
     // A move constructor.
-    btree_delete_set(btree_delete_set&& other) : super(std::move(other)) {}
+    btree_delete_set(btree_delete_set&& other) noexcept : super(std::move(other)) {}
 
 private:
     // A constructor required by the bulk-load facility.
@@ -2686,7 +2686,7 @@ public:
     btree_delete_multiset(const btree_delete_multiset& other) : super(other) {}
 
     // A move constructor.
-    btree_delete_multiset(btree_delete_multiset&& other) : super(std::move(other)) {}
+    btree_delete_multiset(btree_delete_multiset&& other) noexcept : super(std::move(other)) {}
 
 private:
     // A constructor required by the bulk-load facility.

--- a/src/include/souffle/datastructure/Brie.h
+++ b/src/include/souffle/datastructure/Brie.h
@@ -123,7 +123,7 @@ struct identity {
 template <typename T>
 struct default_merge {
     /**
-     * Merges two values a and b when merging spase maps.
+     * Merges two values a and b when merging sparse maps.
      */
     T operator()(T a, T b) const {
         default_factory<T> def;
@@ -421,7 +421,7 @@ public:
      * takes over ownership of the structure maintained by the
      * handed in array.
      */
-    SparseArray(SparseArray&& other)
+    SparseArray(SparseArray&& other) noexcept
             : unsynced(RootInfo{other.unsynced.root, other.unsynced.levels, other.unsynced.offset,
                       other.unsynced.first, other.unsynced.firstOffset}) {
         other.unsynced.root = nullptr;
@@ -466,7 +466,7 @@ public:
      * An assignment operation taking over ownership
      * from a r-value reference to a sparse array.
      */
-    SparseArray& operator=(SparseArray&& other) {
+    SparseArray& operator=(SparseArray&& other) noexcept {
         // clean this one
         clean();
 

--- a/src/include/souffle/datastructure/ConcurrentFlyweight.h
+++ b/src/include/souffle/datastructure/ConcurrentFlyweight.h
@@ -127,7 +127,7 @@ public:
             NextMaybeUnassignedHandle = That.NextMaybeUnassignedHandle;
         }
 
-        Iterator& operator=(Iterator&& That) {
+        Iterator& operator=(Iterator&& That) noexcept {
             This = That.This;
             Lane = That.Lane;
             Slot = That.Slot;

--- a/src/include/souffle/datastructure/ConcurrentInsertOnlyHashMap.h
+++ b/src/include/souffle/datastructure/ConcurrentInsertOnlyHashMap.h
@@ -95,7 +95,7 @@ public:
 
     class Node {
     public:
-        virtual ~Node() {}
+        virtual ~Node() = default;
         virtual const value_type& value() const = 0;
         virtual const key_type& key() const = 0;
         virtual const mapped_type& mapped() const = 0;
@@ -104,7 +104,7 @@ public:
 private:
     // Each bucket of the hash-map is a linked list.
     struct BucketList : Node {
-        virtual ~BucketList() {}
+        virtual ~BucketList() = default;
 
         BucketList(const Key& K, const T& V, BucketList* N) : Value(K, V), Next(N) {}
 

--- a/src/include/souffle/datastructure/LambdaBTree.h
+++ b/src/include/souffle/datastructure/LambdaBTree.h
@@ -596,7 +596,7 @@ public:
     LambdaBTreeSet(const LambdaBTreeSet& other) : super(other) {}
 
     // A move constructor.
-    LambdaBTreeSet(LambdaBTreeSet&& other) : super(std::move(other)) {}
+    LambdaBTreeSet(LambdaBTreeSet&& other) noexcept : super(std::move(other)) {}
 
 private:
     // A constructor required by the bulk-load facility.

--- a/src/include/souffle/datastructure/RecordTableImpl.h
+++ b/src/include/souffle/datastructure/RecordTableImpl.h
@@ -51,7 +51,7 @@ using SpecializedRecord = std::array<RamDomain, Arity>;
 struct GenericRecordView {
     explicit GenericRecordView(const RamDomain* Data, const std::size_t Arity) : Data(Data), Arity(Arity) {}
     GenericRecordView(const GenericRecordView& Other) : Data(Other.Data), Arity(Other.Arity) {}
-    GenericRecordView(GenericRecordView&& Other) : Data(Other.Data), Arity(Other.Arity) {}
+    GenericRecordView(GenericRecordView&& Other) noexcept : Data(Other.Data), Arity(Other.Arity) {}
 
     const RamDomain* const Data;
     const std::size_t Arity;
@@ -70,7 +70,7 @@ template <std::size_t Arity>
 struct SpecializedRecordView {
     explicit SpecializedRecordView(const RamDomain* Data) : Data(Data) {}
     SpecializedRecordView(const SpecializedRecordView& Other) : Data(Other.Data) {}
-    SpecializedRecordView(SpecializedRecordView&& Other) : Data(Other.Data) {}
+    SpecializedRecordView(SpecializedRecordView&& Other) noexcept : Data(Other.Data) {}
 
     const RamDomain* const Data;
 
@@ -88,7 +88,7 @@ struct SpecializedRecordView {
 struct GenericRecordHash {
     explicit GenericRecordHash(const std::size_t Arity) : Arity(Arity) {}
     GenericRecordHash(const GenericRecordHash& Other) : Arity(Other.Arity) {}
-    GenericRecordHash(GenericRecordHash&& Other) : Arity(Other.Arity) {}
+    GenericRecordHash(GenericRecordHash&& Other) noexcept : Arity(Other.Arity) {}
 
     const std::size_t Arity;
     std::hash<RamDomain> domainHash;
@@ -107,7 +107,7 @@ template <std::size_t Arity>
 struct SpecializedRecordHash {
     explicit SpecializedRecordHash() {}
     SpecializedRecordHash(const SpecializedRecordHash& Other) : DomainHash(Other.DomainHash) {}
-    SpecializedRecordHash(SpecializedRecordHash&& Other) : DomainHash(Other.DomainHash) {}
+    SpecializedRecordHash(SpecializedRecordHash&& Other) noexcept : DomainHash(Other.DomainHash) {}
 
     std::hash<RamDomain> DomainHash;
 
@@ -125,7 +125,7 @@ template <>
 struct SpecializedRecordHash<0> {
     explicit SpecializedRecordHash() {}
     SpecializedRecordHash(const SpecializedRecordHash&) {}
-    SpecializedRecordHash(SpecializedRecordHash&&) {}
+    SpecializedRecordHash(SpecializedRecordHash&&) noexcept {}
 
     template <typename T>
     std::size_t operator()(const T&) const {
@@ -137,7 +137,7 @@ struct SpecializedRecordHash<0> {
 struct GenericRecordEqual {
     explicit GenericRecordEqual(const std::size_t Arity) : Arity(Arity) {}
     GenericRecordEqual(const GenericRecordEqual& Other) : Arity(Other.Arity) {}
-    GenericRecordEqual(GenericRecordEqual&& Other) : Arity(Other.Arity) {}
+    GenericRecordEqual(GenericRecordEqual&& Other) noexcept : Arity(Other.Arity) {}
 
     const std::size_t Arity;
 
@@ -151,7 +151,7 @@ template <std::size_t Arity>
 struct SpecializedRecordEqual {
     explicit SpecializedRecordEqual() {}
     SpecializedRecordEqual(const SpecializedRecordEqual&) {}
-    SpecializedRecordEqual(SpecializedRecordEqual&&) {}
+    SpecializedRecordEqual(SpecializedRecordEqual&&) noexcept {}
 
     template <typename T, typename U>
     bool operator()(const T& A, const U& B) const {
@@ -164,7 +164,7 @@ template <>
 struct SpecializedRecordEqual<0> {
     explicit SpecializedRecordEqual() {}
     SpecializedRecordEqual(const SpecializedRecordEqual&) {}
-    SpecializedRecordEqual(SpecializedRecordEqual&&) {}
+    SpecializedRecordEqual(SpecializedRecordEqual&&) noexcept {}
 
     template <typename T, typename U>
     bool operator()(const T&, const U&) const {
@@ -176,7 +176,7 @@ struct SpecializedRecordEqual<0> {
 struct GenericRecordLess {
     explicit GenericRecordLess(const std::size_t Arity) : Arity(Arity) {}
     GenericRecordLess(const GenericRecordLess& Other) : Arity(Other.Arity) {}
-    GenericRecordLess(GenericRecordLess&& Other) : Arity(Other.Arity) {}
+    GenericRecordLess(GenericRecordLess&& Other) noexcept : Arity(Other.Arity) {}
 
     const std::size_t Arity;
 
@@ -190,7 +190,7 @@ template <std::size_t Arity>
 struct SpecializedRecordLess {
     explicit SpecializedRecordLess() {}
     SpecializedRecordLess(const SpecializedRecordLess&) {}
-    SpecializedRecordLess(SpecializedRecordLess&&) {}
+    SpecializedRecordLess(SpecializedRecordLess&&) noexcept {}
 
     template <typename T, typename U>
     bool operator()(const T& A, const U& B) const {
@@ -203,7 +203,7 @@ template <>
 struct SpecializedRecordLess<0> {
     explicit SpecializedRecordLess() {}
     SpecializedRecordLess(const SpecializedRecordLess&) {}
-    SpecializedRecordLess(SpecializedRecordLess&&) {}
+    SpecializedRecordLess(SpecializedRecordLess&&) noexcept {}
 
     template <typename T, typename U>
     bool operator()(const T&, const U&) const {
@@ -215,7 +215,7 @@ struct SpecializedRecordLess<0> {
 struct GenericRecordCmp {
     explicit GenericRecordCmp(const std::size_t Arity) : Arity(Arity) {}
     GenericRecordCmp(const GenericRecordCmp& Other) : Arity(Other.Arity) {}
-    GenericRecordCmp(GenericRecordCmp&& Other) : Arity(Other.Arity) {}
+    GenericRecordCmp(GenericRecordCmp&& Other) noexcept : Arity(Other.Arity) {}
 
     const std::size_t Arity;
 
@@ -229,7 +229,7 @@ template <std::size_t Arity>
 struct SpecializedRecordCmp {
     explicit SpecializedRecordCmp() {}
     SpecializedRecordCmp(const SpecializedRecordCmp&) {}
-    SpecializedRecordCmp(SpecializedRecordCmp&&) {}
+    SpecializedRecordCmp(SpecializedRecordCmp&&) noexcept {}
 
     template <typename T, typename U>
     bool operator()(const T& A, const U& B) const {
@@ -242,7 +242,7 @@ template <>
 struct SpecializedRecordCmp<0> {
     explicit SpecializedRecordCmp() {}
     SpecializedRecordCmp(const SpecializedRecordCmp&) {}
-    SpecializedRecordCmp(SpecializedRecordCmp&&) {}
+    SpecializedRecordCmp(SpecializedRecordCmp&&) noexcept {}
 
     template <typename T, typename U>
     bool operator()(const T&, const U&) const {
@@ -258,7 +258,7 @@ struct GenericRecordFactory {
 
     explicit GenericRecordFactory(const std::size_t Arity) : Arity(Arity) {}
     GenericRecordFactory(const GenericRecordFactory& Other) : Arity(Other.Arity) {}
-    GenericRecordFactory(GenericRecordFactory&& Other) : Arity(Other.Arity) {}
+    GenericRecordFactory(GenericRecordFactory&& Other) noexcept : Arity(Other.Arity) {}
 
     const std::size_t Arity;
 
@@ -289,7 +289,7 @@ struct SpecializedRecordFactory {
 
     explicit SpecializedRecordFactory() {}
     SpecializedRecordFactory(const SpecializedRecordFactory&) {}
-    SpecializedRecordFactory(SpecializedRecordFactory&&) {}
+    SpecializedRecordFactory(SpecializedRecordFactory&&) noexcept {}
 
     reference replace(reference Place, const SpecializedRecord<Arity>& V) {
         assert(V.size() == Arity);
@@ -318,7 +318,7 @@ struct SpecializedRecordFactory<0> {
 
     explicit SpecializedRecordFactory() {}
     SpecializedRecordFactory(const SpecializedRecordFactory&) {}
-    SpecializedRecordFactory(SpecializedRecordFactory&&) {}
+    SpecializedRecordFactory(SpecializedRecordFactory&&) noexcept {}
 
     reference replace(reference Place, const SpecializedRecord<0>&) {
         return Place;
@@ -338,7 +338,7 @@ struct SpecializedRecordFactory<0> {
 /** @brief Interface of bidirectional mappping between records and record references. */
 class RecordMap {
 public:
-    virtual ~RecordMap() {}
+    virtual ~RecordMap() = default;
     virtual void setNumLanes(const std::size_t NumLanes) = 0;
     virtual RamDomain pack(const std::vector<RamDomain>& Vector) = 0;
     virtual RamDomain pack(const RamDomain* Tuple) = 0;
@@ -361,7 +361,7 @@ public:
                       details::GenericRecordFactory(arity)),
               Arity(arity) {}
 
-    virtual ~GenericRecordMap() {}
+    virtual ~GenericRecordMap() = default;
 
     void setNumLanes(const std::size_t NumLanes) override {
         Base::setNumLanes(NumLanes);
@@ -407,7 +407,7 @@ public:
     SpecializedRecordMap(const std::size_t LaneCount)
             : Base(LaneCount, 8, true, RecordHash(), RecordEqual(), RecordFactory()) {}
 
-    virtual ~SpecializedRecordMap() {}
+    virtual ~SpecializedRecordMap() = default;
 
     void setNumLanes(const std::size_t NumLanes) override {
         Base::setNumLanes(NumLanes);
@@ -453,7 +453,7 @@ class SpecializedRecordMap<0> : public RecordMap {
 public:
     SpecializedRecordMap(const std::size_t /* LaneCount */) {}
 
-    virtual ~SpecializedRecordMap() {}
+    virtual ~SpecializedRecordMap() = default;
 
     void setNumLanes(const std::size_t) override {}
 

--- a/src/include/souffle/utility/ContainerUtil.h
+++ b/src/include/souffle/utility/ContainerUtil.h
@@ -93,7 +93,7 @@ typename C::mapped_type const& getOr(
     if (it != container.end()) {
         return it->second;
     }
-    
+
     return defaultValue;
 }
 

--- a/src/include/souffle/utility/ContainerUtil.h
+++ b/src/include/souffle/utility/ContainerUtil.h
@@ -92,9 +92,9 @@ typename C::mapped_type const& getOr(
 
     if (it != container.end()) {
         return it->second;
-    } else {
-        return defaultValue;
     }
+    
+    return defaultValue;
 }
 
 /**
@@ -258,7 +258,7 @@ bool equal_targets_map(const std::map<Key, Value, Cmp>& a, const std::map<Key, V
 // -------------------------------------------------------------------------------
 template <typename R>
 bool allValidPtrs(R const& range) {
-    return std::all_of(range.begin(), range.end(), [](auto&& p) { return (bool)p; });
+    return std::all_of(range.begin(), range.end(), [](auto&& p) { return static_cast<bool>(p); });
 }
 
 }  // namespace souffle

--- a/src/include/souffle/utility/FileUtil.h
+++ b/src/include/souffle/utility/FileUtil.h
@@ -157,7 +157,9 @@ inline std::string which(const std::string& name) {
 
     // Check for existence of a binary called 'name' in PATH
     while (std::getline(sstr, sub, PATHdelimiter)) {
-        std::string path = sub + pathSeparator + name;
+        std::string path = sub;
+        path += pathSeparator;
+        path += name;
         if ((::realpath(path.c_str(), buf) != nullptr) && isExecutable(path) && !existDir(path)) {
             return buf;
         }
@@ -286,19 +288,18 @@ inline std::string simpleName(const std::string& path) {
  * File extension, with all else removed.
  */
 inline std::string fileExtension(const std::string& path) {
-    std::string name = path;
-    const std::size_t lastDot = name.find_last_of('.');
+    const std::size_t lastDot = path.find_last_of('.');
     // file has no extension
     if (lastDot == std::string::npos) {
         return std::string();
     }
-    const std::size_t lastSlash = name.find_last_of(pathSeparator);
+    const std::size_t lastSlash = path.find_last_of(pathSeparator);
     // last slash occurs after last dot, so no extension
     if (lastSlash != std::string::npos && lastSlash > lastDot) {
         return std::string();
     }
     // last dot after last slash, or no slash
-    return name.substr(lastDot + 1);
+    return path.substr(lastDot + 1);
 }
 
 /**

--- a/src/include/souffle/utility/FunctionalUtil.h
+++ b/src/include/souffle/utility/FunctionalUtil.h
@@ -120,7 +120,7 @@ detail::LambdaFix<F> fix(F f) {
 // -------------------------------------------------------------------------------
 
 namespace detail {
-constexpr auto coerceToBool = [](auto&& x) { return (bool)x; };
+constexpr auto coerceToBool = [](auto&& x) { return static_cast<bool>(x); };
 
 template <typename C, typename F /* : A -> B */>
 auto mapVector(C& xs, F&& f) {

--- a/src/include/souffle/utility/ParallelUtil.h
+++ b/src/include/souffle/utility/ParallelUtil.h
@@ -137,7 +137,7 @@ namespace souffle {
 
 struct SeqConcurrentLanes {
     struct TrivialLock {
-        ~TrivialLock() {}
+        ~TrivialLock() = default;
     };
 
     using lane_id = std::size_t;
@@ -147,7 +147,7 @@ struct SeqConcurrentLanes {
     SeqConcurrentLanes(const SeqConcurrentLanes&) = delete;
     SeqConcurrentLanes(SeqConcurrentLanes&&) = delete;
 
-    virtual ~SeqConcurrentLanes() {}
+    virtual ~SeqConcurrentLanes() = default;
 
     std::size_t lanes() const {
         return 1;
@@ -198,7 +198,7 @@ public:
         Lease(std::mutex& mux) : mux(&mux) {
             mux.lock();
         }
-        Lease(Lease&& other) : mux(other.mux) {
+        Lease(Lease&& other) noexcept : mux(other.mux) {
             other.mux = nullptr;
         }
         Lease(const Lease& other) = delete;
@@ -554,7 +554,7 @@ struct MutexConcurrentLanes {
     MutexConcurrentLanes(const MutexConcurrentLanes&) = delete;
     MutexConcurrentLanes(MutexConcurrentLanes&&) = delete;
 
-    virtual ~MutexConcurrentLanes() {}
+    virtual ~MutexConcurrentLanes() = default;
 
     // Return the number of lanes.
     std::size_t lanes() const {
@@ -565,9 +565,8 @@ struct MutexConcurrentLanes {
     lane_id getLane(std::size_t I) const {
         if (Attribution == lane_attribution::mod_power_of_2) {
             return I & (Size - 1);
-        } else {
-            return I % Size;
         }
+        return I % Size;
     }
 
     /** Change the number of lanes.
@@ -654,9 +653,8 @@ private:
         if ((Sz & (Sz - 1)) == 0) {
             // Sz is a power of 2
             return lane_attribution::mod_power_of_2;
-        } else {
-            return lane_attribution::mod_other;
         }
+        return lane_attribution::mod_other;
     }
 
 protected:

--- a/src/include/souffle/utility/StreamUtil.h
+++ b/src/include/souffle/utility/StreamUtil.h
@@ -47,11 +47,11 @@ namespace souffle {
 // NOTE:        `char`, `signed char`, and `unsigned char` are distinct types.
 namespace stream_write_qualified_char_as_number {
 inline std::ostream& operator<<(std::ostream& os, signed char c) {
-    return os << int(c);
+    return os << static_cast<int>(c);
 }
 
 inline std::ostream& operator<<(std::ostream& os, unsigned char c) {
-    return os << unsigned(c);
+    return os << static_cast<unsigned>(c);
 }
 }  // namespace stream_write_qualified_char_as_number
 

--- a/src/include/souffle/utility/StringUtil.h
+++ b/src/include/souffle/utility/StringUtil.h
@@ -345,7 +345,7 @@ inline std::vector<std::string_view> splitView(std::string_view toSplit, std::st
     for (auto tail = toSplit;;) {
         auto pos = tail.find(delimiter);
         parts.push_back(tail.substr(0, pos));
-        if (pos == tail.npos) break;
+        if (pos == std::string_view::npos) break;
 
         tail = tail.substr(pos + delimLen);
     }

--- a/src/include/souffle/utility/tinyformat.h
+++ b/src/include/souffle/utility/tinyformat.h
@@ -606,13 +606,12 @@ inline bool parseWidthOrPrecision(int& n, const char*& c, bool positionalMode,
 // returned, or the end of string.
 inline const char* printFormatStringLiteral(std::ostream& out, const char* fmt)
 {
-    const char* c = fmt;
-    for (;; ++c) {
+    for (const char* c = fmt;; ++c) {
         if (*c == '\0') {
             out.write(fmt, c - fmt);
             return c;
         }
-        else if (*c == '%') {
+        if (*c == '%') {
             out.write(fmt, c - fmt);
             if (*(c+1) != '%')
                 return c;

--- a/src/interpreter/Node.h
+++ b/src/interpreter/Node.h
@@ -941,7 +941,7 @@ public:
 class Call : public Node {
 public:
     Call(enum NodeType ty, const ram::Node* sdw, std::string subroutineName)
-            : Node(ty, sdw), subroutineName(subroutineName) {}
+            : Node(ty, sdw), subroutineName(std::move(subroutineName)) {}
 
     const std::string& getSubroutineName() const {
         return subroutineName;

--- a/src/parser/SrcLocation.h
+++ b/src/parser/SrcLocation.h
@@ -63,7 +63,7 @@ struct IncludeStack {
     explicit IncludeStack(std::shared_ptr<IncludeStack> parent, Point includePos,
             const std::filesystem::path& physical, const std::string& reported,
             bool reducedConsecutiveNonLeadingWhitespaces = false)
-            : ParentStack(parent), IncludePos(includePos), Physical(physical), Reported(reported),
+            : ParentStack(std::move(parent)), IncludePos(includePos), Physical(physical), Reported(reported),
               ReducedConsecutiveNonLeadingWhitespaces(reducedConsecutiveNonLeadingWhitespaces) {}
 
     /** The parent file. */
@@ -126,7 +126,7 @@ public:
 
 /** Information struct for scanner */
 struct ScannerInfo {
-    ScannerInfo(std::shared_ptr<FileSystem> fs) : FS(fs) {}
+    ScannerInfo(std::shared_ptr<FileSystem> fs) : FS(std::move(fs)) {}
 
     /** Scanner's current location */
     SrcLocation yylloc;

--- a/src/ram/Aggregate.h
+++ b/src/ram/Aggregate.h
@@ -49,7 +49,7 @@ class Aggregate : public RelationOperation, public AbstractAggregate {
 public:
     Aggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
             Own<Condition> condition, std::size_t ident)
-            : Aggregate(NK_Aggregate, std::move(nested), std::move(fun), rel, std::move(expression),
+            : Aggregate(NK_Aggregate, std::move(nested), std::move(fun), std::move(rel), std::move(expression),
                       std::move(condition), ident) {}
 
     ~Aggregate() override = default;
@@ -74,7 +74,7 @@ public:
 protected:
     Aggregate(NodeKind kind, Own<Operation> nested, Own<Aggregator> fun, std::string rel,
             Own<Expression> expression, Own<Condition> condition, std::size_t ident)
-            : RelationOperation(kind, rel, ident, std::move(nested)),
+            : RelationOperation(kind, std::move(rel), ident, std::move(nested)),
               AbstractAggregate(std::move(fun), std::move(expression), std::move(condition)) {
         assert(kind >= NK_Aggregate && kind < NK_LastAggregate);
     }

--- a/src/ram/Aggregate.h
+++ b/src/ram/Aggregate.h
@@ -49,8 +49,8 @@ class Aggregate : public RelationOperation, public AbstractAggregate {
 public:
     Aggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
             Own<Condition> condition, std::size_t ident)
-            : Aggregate(NK_Aggregate, std::move(nested), std::move(fun), std::move(rel), std::move(expression),
-                      std::move(condition), ident) {}
+            : Aggregate(NK_Aggregate, std::move(nested), std::move(fun), std::move(rel),
+                      std::move(expression), std::move(condition), ident) {}
 
     ~Aggregate() override = default;
 

--- a/src/ram/Clear.h
+++ b/src/ram/Clear.h
@@ -42,7 +42,7 @@ namespace souffle::ram {
 
 class Clear : public RelationStatement {
 public:
-    Clear(std::string rel) : RelationStatement(NK_Clear, rel) {}
+    Clear(std::string rel) : RelationStatement(NK_Clear, std::move(rel)) {}
 
     Clear* cloning() const override {
         return new Clear(relation);

--- a/src/ram/EstimateJoinSize.h
+++ b/src/ram/EstimateJoinSize.h
@@ -50,7 +50,7 @@ class EstimateJoinSize : public RelationStatement {
 public:
     EstimateJoinSize(std::string rel, const std::set<std::size_t>& columns,
             const std::map<std::size_t, const ram::Expression*>& keyToConstants, bool isRecursive)
-            : RelationStatement(NK_EstimateJoinSize, rel), keyColumns(columns),
+            : RelationStatement(NK_EstimateJoinSize, std::move(rel)), keyColumns(columns),
               recursiveRelation(isRecursive) {
         // copy the constants over
         for (auto [k, constant] : keyToConstants) {

--- a/src/ram/IO.h
+++ b/src/ram/IO.h
@@ -38,7 +38,7 @@ namespace souffle::ram {
 class IO : public RelationStatement {
 public:
     IO(std::string rel, std::map<std::string, std::string> directives)
-            : RelationStatement(NK_IO, rel), directives(std::move(directives)) {}
+            : RelationStatement(NK_IO, std::move(rel)), directives(std::move(directives)) {}
 
     /** @brief get I/O directives */
     const std::map<std::string, std::string>& getDirectives() const {

--- a/src/ram/IfExists.h
+++ b/src/ram/IfExists.h
@@ -53,7 +53,7 @@ class IfExists : public RelationOperation, public AbstractIfExists {
 public:
     IfExists(std::string rel, std::size_t ident, Own<Condition> cond, Own<Operation> nested,
             std::string profileText = "")
-            : IfExists(NK_IfExists, rel, ident, clone(cond), clone(nested), profileText) {}
+            : IfExists(NK_IfExists, std::move(rel), ident, clone(cond), clone(nested), profileText) {}
 
     void apply(const NodeMapper& map) override {
         RelationOperation::apply(map);
@@ -73,7 +73,7 @@ public:
 protected:
     IfExists(NodeKind kind, std::string rel, std::size_t ident, Own<Condition> cond, Own<Operation> nested,
             std::string profileText = "")
-            : RelationOperation(kind, rel, ident, std::move(nested), std::move(profileText)),
+            : RelationOperation(kind, std::move(rel), ident, std::move(nested), std::move(profileText)),
               AbstractIfExists(std::move(cond)) {}
 
     void print(std::ostream& os, int tabpos) const override {

--- a/src/ram/IndexAggregate.h
+++ b/src/ram/IndexAggregate.h
@@ -47,8 +47,8 @@ class IndexAggregate : public IndexOperation, public AbstractAggregate {
 public:
     IndexAggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
             Own<Condition> condition, RamPattern queryPattern, std::size_t ident)
-            : IndexAggregate(NK_IndexAggregate, std::move(nested), std::move(fun), std::move(rel), std::move(expression),
-                      std::move(condition), std::move(queryPattern), ident) {}
+            : IndexAggregate(NK_IndexAggregate, std::move(nested), std::move(fun), std::move(rel),
+                      std::move(expression), std::move(condition), std::move(queryPattern), ident) {}
 
     IndexAggregate* cloning() const override {
         RamPattern pattern;

--- a/src/ram/IndexAggregate.h
+++ b/src/ram/IndexAggregate.h
@@ -47,7 +47,7 @@ class IndexAggregate : public IndexOperation, public AbstractAggregate {
 public:
     IndexAggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel, Own<Expression> expression,
             Own<Condition> condition, RamPattern queryPattern, std::size_t ident)
-            : IndexAggregate(NK_IndexAggregate, std::move(nested), std::move(fun), rel, std::move(expression),
+            : IndexAggregate(NK_IndexAggregate, std::move(nested), std::move(fun), std::move(rel), std::move(expression),
                       std::move(condition), std::move(queryPattern), ident) {}
 
     IndexAggregate* cloning() const override {
@@ -77,7 +77,7 @@ public:
 protected:
     IndexAggregate(NodeKind kind, Own<Operation> nested, Own<Aggregator> fun, std::string rel,
             Own<Expression> expression, Own<Condition> condition, RamPattern queryPattern, std::size_t ident)
-            : IndexOperation(kind, rel, ident, std::move(queryPattern), std::move(nested)),
+            : IndexOperation(kind, std::move(rel), ident, std::move(queryPattern), std::move(nested)),
               AbstractAggregate(std::move(fun), std::move(expression), std::move(condition)) {
         assert(kind >= NK_IndexAggregate && kind < NK_LastIndexAggregate);
     }

--- a/src/ram/IndexIfExists.h
+++ b/src/ram/IndexIfExists.h
@@ -54,7 +54,7 @@ class IndexIfExists : public IndexOperation, public AbstractIfExists {
 public:
     IndexIfExists(std::string rel, std::size_t ident, Own<Condition> cond, RamPattern queryPattern,
             Own<Operation> nested, std::string profileText = "")
-            : IndexIfExists(NK_IndexIfExists, rel, ident, std::move(cond), std::move(queryPattern),
+            : IndexIfExists(NK_IndexIfExists, std::move(rel), ident, std::move(cond), std::move(queryPattern),
                       std::move(nested), profileText) {}
 
     void apply(const NodeMapper& map) override {
@@ -90,7 +90,7 @@ protected:
     IndexIfExists(NodeKind kind, std::string rel, std::size_t ident, Own<Condition> cond,
             RamPattern queryPattern, Own<Operation> nested, std::string profileText = "")
             : IndexOperation(
-                      kind, rel, ident, std::move(queryPattern), std::move(nested), std::move(profileText)),
+                      kind, std::move(rel), ident, std::move(queryPattern), std::move(nested), std::move(profileText)),
               AbstractIfExists(std::move(cond)) {
         assert(getRangePattern().first.size() == getRangePattern().second.size() && "Arity mismatch");
         assert(kind >= NK_IndexIfExists && kind < NK_LastIndexIfExists);

--- a/src/ram/IndexIfExists.h
+++ b/src/ram/IndexIfExists.h
@@ -89,8 +89,8 @@ public:
 protected:
     IndexIfExists(NodeKind kind, std::string rel, std::size_t ident, Own<Condition> cond,
             RamPattern queryPattern, Own<Operation> nested, std::string profileText = "")
-            : IndexOperation(
-                      kind, std::move(rel), ident, std::move(queryPattern), std::move(nested), std::move(profileText)),
+            : IndexOperation(kind, std::move(rel), ident, std::move(queryPattern), std::move(nested),
+                      std::move(profileText)),
               AbstractIfExists(std::move(cond)) {
         assert(getRangePattern().first.size() == getRangePattern().second.size() && "Arity mismatch");
         assert(kind >= NK_IndexIfExists && kind < NK_LastIndexIfExists);

--- a/src/ram/IndexOperation.h
+++ b/src/ram/IndexOperation.h
@@ -133,7 +133,7 @@ public:
 protected:
     IndexOperation(NodeKind kind, std::string rel, std::size_t ident, RamPattern queryPattern,
             Own<Operation> nested, std::string profileText = "")
-            : RelationOperation(kind, rel, ident, std::move(nested), std::move(profileText)),
+            : RelationOperation(kind, std::move(rel), ident, std::move(nested), std::move(profileText)),
               queryPattern(std::move(queryPattern)) {
         assert(queryPattern.first.size() == queryPattern.second.size() && "Arity mismatch");
         assert(allValidPtrs(queryPattern.first));

--- a/src/ram/IndexScan.h
+++ b/src/ram/IndexScan.h
@@ -49,7 +49,7 @@ class IndexScan : public IndexOperation {
 public:
     IndexScan(std::string rel, std::size_t ident, RamPattern queryPattern, Own<Operation> nested,
             std::string profileText = "")
-            : IndexScan(NK_IndexScan, rel, ident, std::move(queryPattern), std::move(nested),
+            : IndexScan(NK_IndexScan, std::move(rel), ident, std::move(queryPattern), std::move(nested),
                       std::move(profileText)) {}
 
     IndexScan* cloning() const override {
@@ -73,7 +73,7 @@ protected:
     IndexScan(NodeKind kind, std::string rel, std::size_t ident, RamPattern queryPattern,
             Own<Operation> nested, std::string profileText = "")
             : IndexOperation(
-                      kind, rel, ident, std::move(queryPattern), std::move(nested), std::move(profileText)) {
+                      kind, std::move(rel), ident, std::move(queryPattern), std::move(nested), std::move(profileText)) {
         assert(kind >= NK_IndexScan && kind < NK_LastIndexScan);
     }
 

--- a/src/ram/IndexScan.h
+++ b/src/ram/IndexScan.h
@@ -72,8 +72,8 @@ public:
 protected:
     IndexScan(NodeKind kind, std::string rel, std::size_t ident, RamPattern queryPattern,
             Own<Operation> nested, std::string profileText = "")
-            : IndexOperation(
-                      kind, std::move(rel), ident, std::move(queryPattern), std::move(nested), std::move(profileText)) {
+            : IndexOperation(kind, std::move(rel), ident, std::move(queryPattern), std::move(nested),
+                      std::move(profileText)) {
         assert(kind >= NK_IndexScan && kind < NK_LastIndexScan);
     }
 

--- a/src/ram/LogSize.h
+++ b/src/ram/LogSize.h
@@ -34,7 +34,7 @@ namespace souffle::ram {
 class LogSize : public RelationStatement {
 public:
     LogSize(std::string rel, std::string message)
-            : RelationStatement(NK_LogSize, rel), message(std::move(message)) {}
+            : RelationStatement(NK_LogSize, std::move(rel)), message(std::move(message)) {}
 
     /** @brief Get logging message */
     const std::string& getMessage() const {

--- a/src/ram/MergeExtend.h
+++ b/src/ram/MergeExtend.h
@@ -37,7 +37,7 @@ namespace souffle::ram {
 class MergeExtend : public BinRelationStatement {
 public:
     MergeExtend(std::string tRef, const std::string& sRef)
-            : BinRelationStatement(NK_MergeExtend, sRef, tRef) {}
+            : BinRelationStatement(NK_MergeExtend, sRef, std::move(tRef)) {}
 
     /** @brief Get source relation */
     const std::string& getSourceRelation() const {

--- a/src/ram/ParallelIndexAggregate.h
+++ b/src/ram/ParallelIndexAggregate.h
@@ -49,7 +49,7 @@ class ParallelIndexAggregate : public IndexAggregate, public AbstractParallel {
 public:
     ParallelIndexAggregate(Own<Operation> nested, Own<Aggregator> fun, std::string rel,
             Own<Expression> expression, Own<Condition> condition, RamPattern queryPattern, std::size_t ident)
-            : IndexAggregate(NK_ParallelIndexAggregate, std::move(nested), std::move(fun), rel,
+            : IndexAggregate(NK_ParallelIndexAggregate, std::move(nested), std::move(fun), std::move(rel),
                       std::move(expression), std::move(condition), std::move(queryPattern), ident) {}
 
     ParallelIndexAggregate* cloning() const override {

--- a/src/ram/ParallelIndexIfExists.h
+++ b/src/ram/ParallelIndexIfExists.h
@@ -55,7 +55,7 @@ class ParallelIndexIfExists : public IndexIfExists, public AbstractParallel {
 public:
     ParallelIndexIfExists(std::string rel, std::size_t ident, Own<Condition> cond, RamPattern queryPattern,
             Own<Operation> nested, std::string profileText = "")
-            : IndexIfExists(NK_ParallelIndexIfExists, rel, ident, std::move(cond), std::move(queryPattern),
+            : IndexIfExists(NK_ParallelIndexIfExists, std::move(rel), ident, std::move(cond), std::move(queryPattern),
                       std::move(nested), profileText) {}
 
     ParallelIndexIfExists* cloning() const override {

--- a/src/ram/ParallelIndexIfExists.h
+++ b/src/ram/ParallelIndexIfExists.h
@@ -55,8 +55,8 @@ class ParallelIndexIfExists : public IndexIfExists, public AbstractParallel {
 public:
     ParallelIndexIfExists(std::string rel, std::size_t ident, Own<Condition> cond, RamPattern queryPattern,
             Own<Operation> nested, std::string profileText = "")
-            : IndexIfExists(NK_ParallelIndexIfExists, std::move(rel), ident, std::move(cond), std::move(queryPattern),
-                      std::move(nested), profileText) {}
+            : IndexIfExists(NK_ParallelIndexIfExists, std::move(rel), ident, std::move(cond),
+                      std::move(queryPattern), std::move(nested), profileText) {}
 
     ParallelIndexIfExists* cloning() const override {
         RamPattern resQueryPattern;

--- a/src/ram/ParallelScan.h
+++ b/src/ram/ParallelScan.h
@@ -46,7 +46,7 @@ namespace souffle::ram {
 class ParallelScan : public Scan, public AbstractParallel {
 public:
     ParallelScan(std::string rel, std::size_t ident, Own<Operation> nested, std::string profileText = "")
-            : Scan(NK_ParallelScan, rel, ident, std::move(nested), profileText) {}
+            : Scan(NK_ParallelScan, std::move(rel), ident, std::move(nested), profileText) {}
 
     ParallelScan* cloning() const override {
         return new ParallelScan(relation, getTupleId(), clone(getOperation()), getProfileText());

--- a/src/ram/ProvenanceExistenceCheck.h
+++ b/src/ram/ProvenanceExistenceCheck.h
@@ -35,7 +35,7 @@ namespace souffle::ram {
 class ProvenanceExistenceCheck : public AbstractExistenceCheck {
 public:
     ProvenanceExistenceCheck(std::string rel, VecOwn<Expression> vals)
-            : AbstractExistenceCheck(NK_ProvenanceExistenceCheck, rel, std::move(vals)) {}
+            : AbstractExistenceCheck(NK_ProvenanceExistenceCheck, std::move(rel), std::move(vals)) {}
 
     ProvenanceExistenceCheck* cloning() const override {
         VecOwn<Expression> newValues;

--- a/src/ram/Scan.h
+++ b/src/ram/Scan.h
@@ -43,7 +43,7 @@ namespace souffle::ram {
 class Scan : public RelationOperation {
 public:
     Scan(std::string rel, std::size_t ident, Own<Operation> nested, std::string profileText = "")
-            : Scan(NK_Scan, rel, ident, std::move(nested), std::move(profileText)) {}
+            : Scan(NK_Scan, std::move(rel), ident, std::move(nested), std::move(profileText)) {}
 
     Scan* cloning() const override {
         return new Scan(NK_Scan, relation, getTupleId(), clone(getOperation()), getProfileText());
@@ -57,7 +57,7 @@ public:
 protected:
     Scan(NodeKind kind, std::string rel, std::size_t ident, Own<Operation> nested,
             std::string profileText = "")
-            : RelationOperation(kind, rel, ident, std::move(nested), std::move(profileText)) {
+            : RelationOperation(kind, std::move(rel), ident, std::move(nested), std::move(profileText)) {
         assert(kind >= NK_Scan && kind < NK_LastScan);
     }
 

--- a/src/ram/StringConstant.h
+++ b/src/ram/StringConstant.h
@@ -31,7 +31,7 @@ namespace souffle::ram {
  */
 class StringConstant : public Expression {
 public:
-    StringConstant(std::string constant) : Expression(NK_StringConstant), constant(constant) {}
+    StringConstant(std::string constant) : Expression(NK_StringConstant), constant(std::move(constant)) {}
 
     /** @brief Get constant */
     const std::string& getConstant() const {

--- a/src/ram/Swap.h
+++ b/src/ram/Swap.h
@@ -38,7 +38,7 @@ namespace souffle::ram {
  */
 class Swap : public BinRelationStatement {
 public:
-    Swap(std::string f, std::string s) : BinRelationStatement(NK_Swap, f, s) {}
+    Swap(std::string f, std::string s) : BinRelationStatement(NK_Swap, f, std::move(s)) {}
 
     Swap* cloning() const override {
         return new Swap(first, second);

--- a/src/ram/Variable.h
+++ b/src/ram/Variable.h
@@ -32,10 +32,10 @@ namespace souffle::ram {
  */
 class Variable : public Expression {
 public:
-    explicit Variable(const std::string name) : Expression(NK_Variable), name(name) {}
+    explicit Variable(std::string name) : Expression(NK_Variable), name(std::move(name)) {}
 
     /** @brief Get value of the constant. */
-    const std::string getName() const {
+    const std::string& getName() const {
         return name;
     }
 

--- a/src/reports/ErrorReport.h
+++ b/src/reports/ErrorReport.h
@@ -160,7 +160,7 @@ enum class WarnType : std::size_t {
 
 class WarnSet {
 public:
-    WarnSet() : warns(std::bitset<(std::size_t)WarnType::VarAppearsOnce + 1>()) {
+    WarnSet() : warns(std::bitset<static_cast<std::size_t>(WarnType::VarAppearsOnce) + 1>()) {
         this->set();  // default to enabling all warnings
     }
 
@@ -191,7 +191,7 @@ public:
     bool resetStr(const std::string& str);
 
 private:
-    std::bitset<(std::size_t)WarnType::VarAppearsOnce + 1> warns;
+    std::bitset<static_cast<std::size_t>(WarnType::VarAppearsOnce) + 1> warns;
 
     std::optional<WarnType> warnTypeFromString(const std::string& s);
 };


### PR DESCRIPTION
Mostly adding noexcept to some move assignments/ctors so they are utilized by STL. Also adding some std::move calls to avoid certain potentially expensive copies. Some misc fixes/improvements including fixing typos in comments.