### PR TITLE
Fix uninitialized variable warning

### DIFF
--- a/src/ast/transform/InsertLatticeOperations.cpp
+++ b/src/ast/transform/InsertLatticeOperations.cpp
@@ -187,7 +187,7 @@ RuleBody LatticeTransformer::translateNegatedAtom(ast::Atom& atom) {
 
 bool LatticeTransformer::translateClause(
         TranslationUnit& translationUnit, ErrorReport& report, ast::Clause* clause) {
-    bool changed;
+    bool changed = false;
 
     // Set of atoms that are negated in the clause body and contain lattice arguments
     std::set<const ast::Atom*> negatedLatticeAtoms;


### PR DESCRIPTION
The interface/lattice{1,2,3} tests otherwise fail on MSVC in debug mode due to "Run-Time Check Failure #3 - The variable 'changed' is being used without being initialized."