### PR TITLE
Fix unquoted environment variable in check_os.sh

### DIFF
--- a/sh/check_os.sh
+++ b/sh/check_os.sh
@@ -11,7 +11,7 @@ fi
 ID=$(grep -G "^ID_LIKE=" $file | tr a-z A-Z)
 
 #Fedora is special and has no ID_LIKE
-if [ -z $ID ]; then
+if [ -z "$ID" ]; then
     ID=$(grep -G "^ID=" $file | tr a-z A-Z)
 fi
 


### PR DESCRIPTION
CMake failed to setup the build properly, because the environment variable ID was tested in check_os.sh without quoting it. This led to the error `souffle/sh/check_os.sh: line 15: [: too many arguments`. In my case, that variable was to `ID_LIKE="RHEL CENTOS FEDORA"`, which expands to multiple words when done without quoting.
