### PR TITLE
avoid calls to `getArguments()` in interpreter

### DIFF
--- a/src/ram/AbstractOperator.h
+++ b/src/ram/AbstractOperator.h
@@ -38,6 +38,10 @@ public:
         return toPtrVector(arguments);
     }
 
+    std::size_t getNumArgs() const {
+        return arguments.size();
+    }
+
     void apply(const NodeMapper& map) override {
         for (auto& arg : arguments) {
             arg = map(std::move(arg));

--- a/src/ram/NestedIntrinsicOperator.h
+++ b/src/ram/NestedIntrinsicOperator.h
@@ -69,6 +69,10 @@ public:
         return toPtrVector(args);
     }
 
+    std::size_t getNumArgs() const {
+        return args.size();
+    }
+
     NestedIntrinsicOperator* cloning() const override {
         return new NestedIntrinsicOperator(op, clone(args), clone(getOperation()), getTupleId());
     }

--- a/src/ram/PackRecord.h
+++ b/src/ram/PackRecord.h
@@ -44,6 +44,10 @@ public:
         return toPtrVector(arguments);
     }
 
+    std::size_t getNumArgs() const {
+        return arguments.size();
+    }
+
     PackRecord* cloning() const override {
         auto* res = new PackRecord({});
         for (auto& cur : arguments) {

--- a/src/ram/SubroutineReturn.h
+++ b/src/ram/SubroutineReturn.h
@@ -50,6 +50,10 @@ public:
         return toPtrVector(expressions);
     }
 
+    std::size_t getNumValues() const {
+        return expressions.size();
+    }
+
     SubroutineReturn* cloning() const override {
         VecOwn<Expression> newValues;
         for (auto& expr : expressions) {

--- a/src/ram/UserDefinedOperator.h
+++ b/src/ram/UserDefinedOperator.h
@@ -54,6 +54,10 @@ public:
         return argsTypes;
     }
 
+    std::size_t getNumArgs() const {
+        return argsTypes.size();
+    }
+
     /** @brief Get return type */
     TypeAttribute getReturnType() const {
         return returnType;


### PR DESCRIPTION
Avoid calling costly `getArguments()` when the interpreter is only interested by the number of arguments.