### PR TITLE
Apple ARM CI: use default toolchain, export SDKROOT

### DIFF
--- a/sh/setup/install_macos_arm_deps.sh
+++ b/sh/setup/install_macos_arm_deps.sh
@@ -9,13 +9,14 @@ set -x
 
 # Install requirements of MAC OS X
 brew install libtool mcpp swig bison libffi
-brew install gcc@13
-brew link gcc@13
+#brew install gcc@13
+#brew link gcc@13
 
 echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
 echo 'PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig/"' >> $GITHUB_ENV
-echo 'CC=gcc-13' >> $GITHUB_ENV
-echo 'CXX=g++-13' >> $GITHUB_ENV
+#echo 'CC=gcc-13' >> $GITHUB_ENV
+#echo 'CXX=g++-13' >> $GITHUB_ENV
+echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
 
 set +e
 set +x


### PR DESCRIPTION
Recent changes in Github OSX Apple ARM runner image have broken the CI with thousand of compilation errors:

```
/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/time.h:198:67: error: macro "__API_AVAILABLE2" passed 4 arguments, but takes just 3
  198 | __API_AVAILABLE(macosx(10.15), ios(13.0), tvos(13.0), watchos(6.0))
```

Seems related to https://github.com/iains/gcc-14-branch/issues/4

Switching to default xcode toolchain and setting `SDKROOT` fixes the CI issues.