### PR TITLE
Fix incorrect handling of ".include" in identifiers

### DIFF
--- a/src/parser/scanner.ll
+++ b/src/parser/scanner.ll
@@ -153,7 +153,7 @@ WS [ \t\r\v\f]
 ".pragma"/{WS}                        { return yy::parser::make_PRAGMA(yylloc); }
 ".plan"/{WS}                          { return yy::parser::make_PLAN(yylloc); }
 ".lattice"/{WS}                       { return yy::parser::make_LATTICE(yylloc); }
-".include"                            {
+".include"/{WS}                       {
                                         yyinfo.LastIncludeDirectiveLoc = yylloc;
                                         BEGIN(INCLUDE);
                                       }


### PR DESCRIPTION
Souffle's lexer incorrectly recognizes ".include" as a keyword or directive, rather than part of an identifier. 

Updated scanner.ll to ensure ".include" is only treated as a directive when followed by whitespace.