### PR TITLE
chore: bump macos versions used in CI

### DIFF
--- a/.github/workflows/CI-Tests.yml
+++ b/.github/workflows/CI-Tests.yml
@@ -113,15 +113,9 @@ jobs:
       matrix:
         chunk: ${{ fromJSON(needs.Test-Setup.outputs.chunks) }}
 
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
-    - name: Select XCode version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        # Pending https://github.com/actions/runner-images/issues/6350
-        xcode-version: '13.4'
-
     - name: checkout
       uses: actions/checkout@v4
 
@@ -146,14 +140,9 @@ jobs:
       matrix:
         chunk: ${{ fromJSON(needs.Test-Setup.outputs.chunks) }}
 
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
-    - name: Select XCode version
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '15.2'
-
     - name: checkout
       uses: actions/checkout@v4
 

--- a/sh/setup/install_macos_deps.sh
+++ b/sh/setup/install_macos_deps.sh
@@ -9,13 +9,13 @@ set -x
 
 # Install requirements of MAC OS X
 brew install bison libtool mcpp libffi swig
-brew install gcc@10
-brew link gcc@10
+brew install gcc@12
+brew link gcc@12
 
 echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
 echo 'PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig/"' >> $GITHUB_ENV 
-echo 'CC=gcc-10' >> $GITHUB_ENV
-echo 'CXX=g++-10' >> $GITHUB_ENV
+echo 'CC=gcc-12' >> $GITHUB_ENV
+echo 'CXX=g++-12' >> $GITHUB_ENV
 
 set +e
 set +x


### PR DESCRIPTION
The macOS 12 runner image will be removed by December 3rd, 2024 See https://github.com/actions/runner-images/issues/10721