### PR TITLE
chore: fix ci for ubuntu 24 and windows

### DIFF
--- a/.github/workflows/CI-Tests.yml
+++ b/.github/workflows/CI-Tests.yml
@@ -89,7 +89,7 @@ jobs:
 
     - name: create-coverage-report
       if: ${{ matrix.domain == '32bit' }}
-      run: lcov --capture --directory build --output-file coverage.info
+      run: lcov --capture --directory build --output-file coverage.info --ignore-errors mismatch
 
     - name: remove-system-files-from-coverage-report
       if: ${{ matrix.domain == '32bit' }}

--- a/.github/workflows/VS-CI-Tests.yml
+++ b/.github/workflows/VS-CI-Tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Library Dependencies (vcpkg)
       uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: '56954f1db97f38635782d5ad7cdfd45d2731c854'
+        vcpkgGitCommitId: '6f29f12e82a8293156836ad81cc9bf5af41fe836'
 
     - name: Create Build Directory
       working-directory: ${{github.workspace}}

--- a/choco-packages.config
+++ b/choco-packages.config
@@ -3,5 +3,4 @@
   <package id="winflexbison3"/>
   <!-- must use the same version of sqlite as in vcpkg.json -->
   <package id="sqlite" version="3.40.1"/>
-  <package id="cmake" version="3.31.1"/>
 </packages>

--- a/sh/setup/install_ubuntu_deps.sh
+++ b/sh/setup/install_ubuntu_deps.sh
@@ -3,4 +3,4 @@
 # Install Ubuntu dependencies on a Github Action VM
 
 apt-get update -q
-apt-get install -y -q bash-completion bison build-essential clang debhelper default-jdk-headless devscripts doxygen fakeroot flex g++ gdb git graphviz libffi-dev libncurses5-dev libsqlite3-dev libtool make mcpp pkg-config python3-dev sqlite swig zlib1g-dev cmake ruby
+apt-get install -y -q bash-completion bison build-essential clang debhelper default-jdk-headless devscripts doxygen fakeroot flex g++ gdb git graphviz libffi-dev libncurses5-dev libsqlite3-dev libtool make mcpp pkg-config python3-dev sqlite3 swig zlib1g-dev cmake ruby

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,5 +12,5 @@
       "version": "3.40.1"
     }
   ],
-  "builtin-baseline": "56954f1db97f38635782d5ad7cdfd45d2731c854"
+  "builtin-baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836"
 }


### PR DESCRIPTION
CI build on `ubuntu-latest` (24) fails with missing dependency `sqlite`: https://github.com/souffle-lang/souffle/actions/runs/12881721601/job/35912754336#step:4:41

Now use package `sqlite3`.