### PR TITLE
chore: align vcpkg version in `populate-deps.yml`

### DIFF
--- a/.github/workflows/populate-deps.yml
+++ b/.github/workflows/populate-deps.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
             git clone https://github.com/Microsoft/vcpkg.git
             cd vcpkg
-            git checkout 56954f1db97f38635782d5ad7cdfd45d2731c854
+            git checkout 6f29f12e82a8293156836ad81cc9bf5af41fe836
 
     - name: Bootstrap vcpkg
       working-directory: vcpkg


### PR DESCRIPTION
Fix the current error in `populate-deps.yml` workflow: https://github.com/souffle-lang/souffle/actions/runs/12886798125/job/35928156279#step:5:37

The commit hash must match `builtin-baseline` in `vcpkg.json` and `vcpkgGitCommitId` in `.github/workflows/VS-CI-Tests.yml`.