### PR TITLE
chore: releases should publish packages for newer linux distributions

### DIFF
--- a/.github/images/arch-linux/PKGBUILD.in
+++ b/.github/images/arch-linux/PKGBUILD.in
@@ -17,7 +17,7 @@ url="https://github.com/souffle-lang/souffle"
 license=('UPL')
 groups=()
 depends=('mcpp' 'gcc>=8' 'openmp' 'sqlite' 'python3')
-makedepends=('git' 'cmake>=3.15' 'bison>=3.0.4' 'flex' 'libffi' 'ncurses' 'zlib' 'python3')
+makedepends=('git' 'cmake>=3.15' 'bison>=3.6' 'flex' 'libffi' 'ncurses' 'zlib' 'python3')
 optdepends=('bash-completion')
 provides=('souffle')
 conflicts=('souffle-git')
@@ -25,17 +25,17 @@ source=(souffle-${RELEASE_TAG}.tar.gz::https://github.com/${REPO_OWNER}/souffle/
 md5sums=('SKIP')
 
 build() {
-	cd souffle-${pkgver}
-	cmake -S . -B ./build \
-        -DCMAKE_INSTALL_PREFIX=/usr \
-        -DSOUFFLE_GIT=OFF \
-        -DSOUFFLE_VERSION=${pkgver} \
-        -DPACKAGE_VERSION=${pkgver} \
+  cd souffle-${pkgver}
+  cmake -S . -B ./build \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DSOUFFLE_GIT=OFF \
+    -DPACKAGE_VERSION=${pkgver} \
+    -DGIT_PACKAGE_VERSION=${pkgver}
 
-    cmake --build ./build --parallel "$(nproc)"
+  cmake --build ./build --parallel "$(nproc)"
 }
 
 package() {
-	cd souffle-${pkgver}/build
-	make DESTDIR="$pkgdir/" install
+  cd souffle-${pkgver}/build
+  make DESTDIR="$pkgdir/" install
 }

--- a/.github/images/entrypoint.sh
+++ b/.github/images/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -euxo
 
 # Run the build command
 case "$DOMAIN_SIZE" in
@@ -11,6 +12,11 @@ case "$DOMAIN_SIZE" in
     ;;
 esac
 
-
 # Create the package
 cmake --build ./build --parallel "$(nproc)" --target package
+
+# Print version
+./build/src/souffle --version
+
+# Run a few tests for consistency
+cmake --build ./build --target test -- ARGS="-R access1"

--- a/.github/images/fedora-40/Dockerfile
+++ b/.github/images/fedora-40/Dockerfile
@@ -1,0 +1,30 @@
+FROM fedora:40
+
+WORKDIR /souffle
+
+# Install souffle build dependencies
+RUN dnf -y install \
+    autoconf \
+    automake \
+    bash-completion \
+    bison \
+    cmake \
+    doxygen \
+    flex \
+    gcc-c++ \
+    git \
+    libffi-devel \
+    libtool \
+    make \
+    mcpp \
+    ncurses-devel \
+    pkg-config \
+    python39 \
+    rpm-build \
+    sqlite-devel \
+    zlib-devel
+
+# Copy everything into souffle directory
+COPY . .
+
+ENTRYPOINT ["/bin/bash", "-l", "-c", ".github/images/entrypoint.sh"]

--- a/.github/images/fedora-41/Dockerfile
+++ b/.github/images/fedora-41/Dockerfile
@@ -1,0 +1,30 @@
+FROM fedora:41
+
+WORKDIR /souffle
+
+# Install souffle build dependencies
+RUN dnf -y install \
+    autoconf \
+    automake \
+    bash-completion \
+    bison \
+    cmake \
+    doxygen \
+    flex \
+    gcc-c++ \
+    git \
+    libffi-devel \
+    libtool \
+    make \
+    mcpp \
+    ncurses-devel \
+    pkg-config \
+    python39 \
+    rpm-build \
+    sqlite-devel \
+    zlib-devel
+
+# Copy everything into souffle directory
+COPY . .
+
+ENTRYPOINT ["/bin/bash", "-l", "-c", ".github/images/entrypoint.sh"]

--- a/.github/images/oraclelinux-9/Dockerfile
+++ b/.github/images/oraclelinux-9/Dockerfile
@@ -1,0 +1,32 @@
+FROM oraclelinux:9
+
+WORKDIR /souffle
+
+# Install souffle build dependencies
+RUN yum -y install dnf-plugins-core
+RUN dnf config-manager --set-enabled ol9_codeready_builder
+RUN dnf -y install \
+    autoconf \
+    automake \
+    bash-completion \
+    bison \
+    clang \
+    cmake \
+    doxygen \
+    flex \
+    gcc-c++ \
+    git \
+    libffi-devel \
+    libtool \
+    make \
+    ncurses-devel \
+    pkg-config \
+    python39 \
+    rpm-build \
+    sqlite-devel \
+    zlib-devel
+
+# Copy everything into souffle directory
+COPY . .
+
+ENTRYPOINT ["/bin/bash", "-l", "-c", ".github/images/entrypoint.sh"]

--- a/.github/images/ubuntu-2204/Dockerfile
+++ b/.github/images/ubuntu-2204/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /souffle
+
+# Install souffle build dependencies
+RUN apt-get update && \
+apt-get install -y -q bash-completion bison build-essential clang debhelper default-jdk-headless devscripts doxygen fakeroot flex g++ gdb git graphviz libffi-dev libncurses5-dev libsqlite3-dev libtool make mcpp pkg-config python3-dev sqlite swig zlib1g-dev cmake ruby
+
+# Copy everything into souffle directory
+COPY CMakeLists.txt ./CMakeLists.txt
+COPY cmake ./cmake
+COPY debian ./debian
+COPY man ./man
+COPY sh ./sh
+COPY src ./src
+COPY tests ./tests
+COPY utilities ./utilities
+COPY .github/images/entrypoint.sh ./entrypoint.sh
+COPY .git ./.git
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/.github/images/ubuntu-2404/Dockerfile
+++ b/.github/images/ubuntu-2404/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /souffle
+
+# Install souffle build dependencies
+RUN apt-get update && \
+apt-get install -y -q bash-completion bison build-essential clang debhelper default-jdk-headless devscripts doxygen fakeroot flex g++ gdb git graphviz libffi-dev libncurses5-dev libsqlite3-dev libtool make mcpp pkg-config python3-dev sqlite3 swig zlib1g-dev cmake ruby
+
+# Copy everything into souffle directory
+COPY CMakeLists.txt ./CMakeLists.txt
+COPY cmake ./cmake
+COPY debian ./debian
+COPY man ./man
+COPY sh ./sh
+COPY src ./src
+COPY tests ./tests
+COPY utilities ./utilities
+COPY .github/images/entrypoint.sh ./entrypoint.sh
+COPY .git ./.git
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/.github/scripts/updatePPA.sh
+++ b/.github/scripts/updatePPA.sh
@@ -62,17 +62,17 @@ git add .
 git commit -m "Added fedora rpm files for $SOUFFLE_TAG"
 
 ## oraclelinux
-mkdir -p $TMPDIR/ppa/ol/8/x86_64
+mkdir -p $TMPDIR/ppa/ol/9/x86_64
 cd $TMPDIR/ppa/ol
 
-for i in $DEBPATH/*oracle*8*/*rpm
+for i in $DEBPATH/*oracle*9*/*rpm
 do
     rpm --addsign $i
 done
 
-cp $DEBPATH/*oracle*8*/*rpm 8/x86_64/
+cp $DEBPATH/*oracle*9*/*rpm 9/x86_64/
 
-createrepo 8/x86_64
+createrepo 9/x86_64
 
 git add .
 git commit -m "Added oraclelinux rpm files for $SOUFFLE_TAG"

--- a/.github/workflows/CI-Tests.yml
+++ b/.github/workflows/CI-Tests.yml
@@ -32,6 +32,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          fetch-tags: true
       - id: set-test-ids
         uses: ./.github/actions/set-test-ids
         with:
@@ -55,6 +58,9 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        fetch-tags: true
 
     - name: install-lcov
       if: ${{ matrix.domain == '32bit' }}
@@ -118,6 +124,9 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        fetch-tags: true
 
     - name: install-deps
       run: sh/setup/install_macos_deps.sh
@@ -145,6 +154,9 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        fetch-tags: true
 
     - name: install-deps
       run: sh/setup/install_macos_arm_deps.sh
@@ -173,6 +185,9 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        fetch-tags: true
 
     - name: install-deps
       run: sudo sh/setup/install_ubuntu_deps.sh
@@ -199,7 +214,8 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        fetch-depth: 1
+        fetch-tags: true
 
     - name: install-lcov
       run: sudo apt-get update && sudo apt-get install lcov

--- a/.github/workflows/VS-CI-Tests.yml
+++ b/.github/workflows/VS-CI-Tests.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        fetch-tags: true
 
     - name: Dependencies Cache
       uses: actions/cache@v3

--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -9,15 +9,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - release: ubuntu-2004
+          - release: ubuntu-2204
             extension: ".deb"
-            OS-name: "ubuntu/focal"
-          - release: oraclelinux-8
+            OS-name: "ubuntu/jammy"
+          - release: ubuntu-2404
+            extension: ".deb"
+            OS-name: "ubuntu/noble"
+          - release: oraclelinux-9
             extension: ".rpm"
-            OS-name: "el/8"
+            OS-name: "ol/9"
           - release: fedora-39
             extension: ".rpm"
             OS-name: "fedora/39"
+          - release: fedora-40
+            extension: ".rpm"
+            OS-name: "fedora/40"
+          - release: fedora-41
+            extension: ".rpm"
+            OS-name: "fedora/41"
 
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +39,7 @@ jobs:
         run: docker build . -f ./.github/images/${{ matrix.release }}/Dockerfile  -t package_builder
 
       - name: Packaging
-        run: docker run -e DOMAIN_SIZE="64bit" --name container -t package_builder 
+        run: docker run -e DOMAIN_SIZE="64bit" --name container -t package_builder
 
       - name: Extract
         id: extract_pkg
@@ -44,11 +53,11 @@ jobs:
         run: cp build/${{ steps.extract_pkg.outputs.pkg_name }} build/${{ steps.extract_pkg.outputs.artifact_name }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.extract_pkg.outputs.artifact_name }}
           path: build/${{ steps.extract_pkg.outputs.artifact_name }}
-      
+
   Arch-Package-Build:
     runs-on: ubuntu-latest
     steps:
@@ -60,14 +69,14 @@ jobs:
       - name: Prepare
         id: prepare
         run: |-
-          echo "release_tag=$(git describe --tags --always | sed "s/-.*$//")" >> $GITHUB_OUTPUT
+          echo "release_tag=$(git describe --tags --always | sed 's/-.*$//')" >> $GITHUB_OUTPUT
 
       - name: Build Container
         run: docker build ./.github/images/arch-linux/ -t package_builder
 
       - name: Packaging
         run: >
-          docker run 
+          docker run
           -e RELEASE_TAG=${{ steps.prepare.outputs.release_tag }}
           -e REPO_OWNER=${{ github.repository_owner }}
           --name container
@@ -98,14 +107,14 @@ jobs:
           git push
 
 
-  Upload-Release-Assests:
+  Upload-Release-Assets:
     needs: CPack-Package-Build
     if: ${{ always() }}
 
     runs-on: ubuntu-latest
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ./downloads
 
@@ -116,8 +125,8 @@ jobs:
           cd result && 
           sha512sum * > sha512sum.txt
 
-      - name: Upload Release Assests
-        uses: softprops/action-gh-release@v1
+      - name: Upload Release Assets
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             result/*
@@ -135,7 +144,7 @@ jobs:
           clean: false
 
       - name: Download All Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ./downloads
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ if (SOUFFLE_GIT)
         # If building from a shallow clone where tag is not available.
         if (NOT ${PACKAGE_VERSION} MATCHES "^[0-9.]+$")
             message(WARNING "Cannot find a valid tag: cmake project version will be incomplete")
+            set(PACKAGE_VERSION "")
         endif()
 
         message(STATUS "Package version ${PACKAGE_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,39 +14,49 @@ include(CMakeDependentOption)
 
 option(SOUFFLE_GIT "Enable/Disable git completion" ON)
 
-if (SOUFFLE_GIT) 
+if (SOUFFLE_GIT)
     find_package(Git REQUIRED)
 
-    # PACKAGE_VERSION is the full tag with git hash
+    # GIT_TAGNAME identifies the current commit, it is closest tag in the
+    # branch, possibly followed by number of additionnal commits and
+    # abbreviated hash
     execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --always
                     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                     RESULT_VARIABLE GIT_RESULT
-                    OUTPUT_VARIABLE GIT_PACKAGE_VERSION)
-                    # FIXME: Use in cmake 3.19 or later
-                    # COMMAND_ERROR_IS_FATAL ANY)
+                    OUTPUT_VARIABLE GIT_TAGNAME)
+
+    # GIT_CLOSEST_TAG is the closest tag in the branch
+    execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --always --abbrev=0
+                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                    RESULT_VARIABLE GIT_RESULT
+                    OUTPUT_VARIABLE GIT_CLOSEST_TAG)
 
     # Figure out the version number, depends on whether building from the git repo
     if (NOT GIT_RESULT EQUAL 0)
         # Not building from a git clone
         message(WARNING "Unable to find git repository: version number will be incomplete")
-        set(PACKAGE_VERSION "UNKNOWN")
-        set(SOUFFLE_VERSION "")
+        set(GIT_PACKAGE_VERSION "UNKNOWN")
+        set(PACKAGE_VERSION "")
     else()
-        string(REGEX REPLACE "\n$" "" PACKAGE_VERSION "${GIT_PACKAGE_VERSION}")
-        message(STATUS "Building souffle version ${PACKAGE_VERSION}")
+        string(REGEX REPLACE "\n$" "" GIT_PACKAGE_VERSION "${GIT_TAGNAME}")
+        message(STATUS "Building souffle version ${GIT_PACKAGE_VERSION}")
 
-        # SOUFFLE_VERSION only includes the major/minor triplet
-        string(REGEX REPLACE "-.*$" "" SOUFFLE_VERSION "${PACKAGE_VERSION}")
+        string(REGEX REPLACE "\n$" "" GIT_CLOSEST_TAG "${GIT_CLOSEST_TAG}")
+        # remove leading 'v' in tag if any
+        string(REGEX REPLACE "^v" "" PACKAGE_VERSION "${GIT_CLOSEST_TAG}")
+        # remove trailing '-something' in tag
+        string(REGEX REPLACE "-.*$" "" PACKAGE_VERSION "${PACKAGE_VERSION}")
 
         # If building from a shallow clone where tag is not available.
-        if (NOT ${SOUFFLE_VERSION} MATCHES "^[0-9.]+$")
+        if (NOT ${PACKAGE_VERSION} MATCHES "^[0-9.]+$")
             message(WARNING "Cannot find a valid tag: cmake project version will be incomplete")
-            set (SOUFFLE_VERSION "")
         endif()
+
+        message(STATUS "Package version ${PACKAGE_VERSION}")
     endif()
 endif()
 
-project(souffle VERSION "${SOUFFLE_VERSION}"
+project(souffle VERSION "${PACKAGE_VERSION}"
                 DESCRIPTION "A datalog compiler"
                 LANGUAGES CXX)
 include(CTest)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ domain-specific language for analysis problems.
 
 ## How to get Soufflé
 
-Use git to obtain the source code of Soufflé.
+If you are using Ubuntu, Fedora or Oracle Linux, get a packaged version from the [Releases section](https://github.com/souffle-lang/souffle/releases).
+
+Or use `git` to obtain the source code of Soufflé.
 
     $ git clone https://github.com/souffle-lang/souffle.git
 
@@ -59,7 +61,7 @@ Alternatively, please add the following line to the start of your source-code:
 .pragma "legacy"
 ```
 
-## Issues and Discussions 
+## Issues and Discussions
 
 Use either the [issue list](https://github.com/souffle-lang/souffle/issues) for
 

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -2,4 +2,5 @@
 
 namespace souffle {
 constexpr char const* PACKAGE_VERSION = "${PACKAGE_VERSION}";
+constexpr char const* GIT_PACKAGE_VERSION = "${GIT_PACKAGE_VERSION}";
 }

--- a/src/MainDriver.cpp
+++ b/src/MainDriver.cpp
@@ -612,7 +612,7 @@ std::string versionFooter() {
     footer << "----------------------------------------------------------------------------" << std::endl;
     footer << "Version: " << packageVersion();
     if (strlen(gitPackageVersion()) > 0) {
-      footer << " (" << gitPackageVersion() << ")";
+        footer << " (" << gitPackageVersion() << ")";
     }
     footer << std::endl;
     footer << "Word size: " << ramDomainSizeInBits() << " bits" << std::endl;

--- a/src/MainDriver.cpp
+++ b/src/MainDriver.cpp
@@ -599,6 +599,10 @@ const char* packageVersion() {
     return PACKAGE_VERSION;
 }
 
+const char* gitPackageVersion() {
+    return GIT_PACKAGE_VERSION;
+}
+
 std::size_t ramDomainSizeInBits() {
     return RAM_DOMAIN_SIZE;
 }
@@ -606,7 +610,11 @@ std::size_t ramDomainSizeInBits() {
 std::string versionFooter() {
     std::stringstream footer;
     footer << "----------------------------------------------------------------------------" << std::endl;
-    footer << "Version: " << packageVersion() << std::endl;
+    footer << "Version: " << packageVersion();
+    if (strlen(gitPackageVersion()) > 0) {
+      footer << " (" << gitPackageVersion() << ")";
+    }
+    footer << std::endl;
     footer << "Word size: " << ramDomainSizeInBits() << " bits" << std::endl;
     footer << "Options enabled:";
 #ifdef USE_LIBFFI
@@ -626,7 +634,7 @@ std::string versionFooter() {
 #endif
     footer << std::endl;
     footer << "----------------------------------------------------------------------------" << std::endl;
-    footer << "Copyright (c) 2016-22 The Souffle Developers." << std::endl;
+    footer << "Copyright (c) 2016-25 The Souffle Developers." << std::endl;
     footer << "Copyright (c) 2013-16 Oracle and/or its affiliates." << std::endl;
     footer << "All rights reserved." << std::endl;
     footer << "============================================================================" << std::endl;

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -14,7 +14,7 @@
  *
  ***********************************************************************/
 %skeleton "lalr1.cc"
-%require "3.2"
+%require "3.6"
 
 %defines
 %define api.token.constructor


### PR DESCRIPTION
The packages produced by the publication of a new release were targeting outdated linux distributions.

With this change, the following distributions are supported:
- Ubuntu 22.04, Ubuntu 24.04 (`deb`)
- Fedora 39, Fedora 40, Fedora 41 (`rpm`)
- Oracle Linux 9 (`rpm`)

Due to dependencies minimum requirements, packages for older distributions will not be provided.

Related issues:
https://github.com/souffle-lang/souffle/issues/2505
https://github.com/souffle-lang/souffle/issues/1462