### PR TITLE
Subprocess.h: use vector instead of dynamically-sized VLA

### DIFF
--- a/src/include/souffle/utility/SubProcess.h
+++ b/src/include/souffle/utility/SubProcess.h
@@ -195,9 +195,8 @@ std::optional<detail::LinuxWaitStatus> execute(
     std::unique_ptr<std::pair<char const*, char const*>[]> envp_temp =
             std::make_unique<std::pair<char const*, char const*>[]>(envp.size());
     auto argv_ptr = go(argv_temp.get(), argv, [](auto&& x) { return x.c_str(); });
-    auto envp_ptr = go(envp_temp.get(), envp, [](auto&& kv) {
-        return std::pair{kv.first, kv.second.c_str()};
-    });
+    auto envp_ptr =
+            go(envp_temp.get(), envp, [](auto&& kv) { return std::pair{kv.first, kv.second.c_str()}; });
     return souffle::execute(program, argv_ptr, envp_ptr);
 }
 

--- a/src/include/souffle/utility/SubProcess.h
+++ b/src/include/souffle/utility/SubProcess.h
@@ -78,12 +78,12 @@ std::optional<detail::LinuxWaitStatus> execute(
                 if (::setenv(k, v, 1)) detail::perrorExit("setenv");
             }
 
-            char* argv_temp[argv.size() + 2];
+            std::vector<char*> argv_temp(argv.size() + 2);
             argv_temp[0] = const_cast<char*>(program.c_str());
-            std::copy_n(argv.data(), argv.size(), const_cast<char const**>(argv_temp) + 1);
+            std::copy_n(argv.data(), argv.size(), const_cast<char const**>(argv_temp.data()) + 1);
             argv_temp[argv.size() + 1] = nullptr;
 
-            ::execvp(program.c_str(), argv_temp);
+            ::execvp(program.c_str(), argv_temp.data());
             std::exit(EC::cannot_execute);
         }
 


### PR DESCRIPTION
addresses warning present in recent clang versions (i was using clang 19).
```cpp
souffle> /tmp/nix-build-souffle-2.4.1.drv-0/source/src/include/souffle/utility/SubProcess.h:81:29: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
souffle>    81 |             char* argv_temp[argv.size() + 2];
souffle>       |                             ^~~~~~~~~~~~~~~
souffle> /tmp/nix-build-souffle-2.4.1.drv-0/source/src/include/souffle/utility/SubProcess.h:201:21: note: in instantiation of function template specialization 'souffle::execute<tcb::span<std::pair<const char *, const char *>> &, void>' requested here
souffle>   201 |     return souffle::execute(program, argv_ptr, envp_ptr);
souffle>       |                     ^
souffle> /tmp/nix-build-souffle-2.4.1.drv-0/source/src/MainDriver.cpp:165:17: note: in instantiation of function template specialization 'souffle::execute<std::map<const char *, std::string> &, void>' requested here
souffle>   165 |     auto exit = execute(binaryFilename, {}, env);
souffle>       |                 ^
souffle> /tmp/nix-build-souffle-2.4.1.drv-0/source/src/include/souffle/utility/span.h:473:56: note: function parameter 'argv' with unknown value cannot be used in a constant expression
souffle>   473 |     constexpr size_type size() const noexcept { return storage_.size; }
souffle>       |                                                        ^
souffle> /tmp/nix-build-souffle-2.4.1.drv-0/source/src/include/souffle/utility/SubProcess.h:81:29: note: in call to 'argv.size()'
souffle>    81 |             char* argv_temp[argv.size() + 2];
souffle>       |                             ^~~~~~~~~~~
souffle> /tmp/nix-build-souffle-2.4.1.drv-0/source/src/include/souffle/utility/SubProcess.h:67:61: note: declared here
souffle>    67 |         std::string const& program, span<char const* const> argv = {}, Envp&& envp = {}) {
souffle>       |                                                             ^
```

the VLA warnings have always existed but were recently added to the Wall group: https://ddanilov.me/default-non-standard-features/