### PR TITLE
chore: upload code style patch as CI artifact

### DIFF
--- a/.github/workflows/CI-Tests.yml
+++ b/.github/workflows/CI-Tests.yml
@@ -8,18 +8,6 @@ on:
       - 'master'
 
 jobs:
-  Code-Style:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 2
-
-    - name: clang-format
-      run: sh/run_test_format.sh
-
   Test-Setup:
     name: Test-Setup
     runs-on: ubuntu-latest

--- a/.github/workflows/Guidelines.yml
+++ b/.github/workflows/Guidelines.yml
@@ -1,0 +1,34 @@
+name: Guidelines
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  Code-Style:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+
+    - name: clang-format
+      id: clang-format
+      run: sh/run_test_format.sh
+
+    - name: format patch
+      if: ${{ failure() }}
+      run: git diff > reformat.patch
+
+    - name: upload-full-clang-format-config
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: reformat.patch
+        path: reformat.patch
+


### PR DESCRIPTION
We have code formatting diffs quite frequently, sometimes unrelated to the changes we push. That's  because the version of `clang-format` evolves in the github action runners and sometimes they do not produce the same reformatting as the previous version.

I suggest to upload the `clang-format` diff as an artifact of the CI. So anyone can apply the patch to fix formatting issues, regardless of the `clang-format` version they use during development.

Also move code style checks to a new `Guidelines` workflow.