### PR TITLE
Fix segfault on malformed subproof commands

### DIFF
--- a/src/include/souffle/provenance/Explain.h
+++ b/src/include/souffle/provenance/Explain.h
@@ -109,6 +109,10 @@ public:
                 return true;
             }
             query = parseTuple(command[1]);
+            if (query.second.size() == 0) {
+                printError("Usage: subproof relation_name(<label>)\n");
+                return true;
+            }
             label = std::stoi(query.second[0]);
             printTree(prov.explainSubproof(query.first, label, ExplainConfig::getExplainConfig().depthLimit));
         } else if (command[0] == "explainnegation") {


### PR DESCRIPTION
Make sure that parseTuple()'s result contains an argument value before passing it to stoi().

To reproduce the crash:
```
$ touch /tmp/blank.dl
$ souffle -t explain /tmp/blank.dl 
Explain is invoked.
Enter command > subproof asd(x)
Segmentation fault (core dumped)
```