### PR TITLE
Handle some uncaught exceptions in explain mode

### DIFF
--- a/src/include/souffle/provenance/Explain.h
+++ b/src/include/souffle/provenance/Explain.h
@@ -149,10 +149,16 @@ public:
             printInfo(rules);
 
             printPrompt("Pick a rule number: ");
+            int ruleNum = 0;
+            try {
+                ruleNum = stoi(getInput());
+            } catch (std::exception& e) {
+                printError("Invalid rule number\n");
+                return true;
+            }
 
             try {
-                std::string ruleNum = getInput();
-                auto variables = prov.explainNegationGetVariables(query.first, query.second, std::stoi(ruleNum));
+                auto variables = prov.explainNegationGetVariables(query.first, query.second, ruleNum);
                 
                 // @ and @non_matching are special sentinel values returned by ExplainProvenance
                 if (variables.size() == 1 && variables[0] == "@") {
@@ -172,7 +178,7 @@ public:
                     varValues[var] = getInput();
                 }
 
-                printTree(prov.explainNegation(query.first, std::stoi(ruleNum), query.second, varValues));
+                printTree(prov.explainNegation(query.first, ruleNum, query.second, varValues));
             } catch(const ValueReadException& e) {
                 printError(tfm::format("%s\n", e.what()));
                 return true;

--- a/src/include/souffle/provenance/ExplainProvenance.h
+++ b/src/include/souffle/provenance/ExplainProvenance.h
@@ -35,6 +35,11 @@
 namespace souffle {
 class TreeNode;
 
+class ValueReadException : public std::runtime_error {
+public:
+    ValueReadException(const std::string& what_arg) : std::runtime_error(what_arg) {}
+};
+
 /** Equivalence class for variables in query command */
 class Equivalence {
 public:
@@ -240,7 +245,8 @@ protected:
     }
 
     RamDomain valueRead(const char type, const std::string& value) const {
-        switch (type) {
+        try {
+            switch (type) {
             case 'i': return ramBitCast(RamSignedFromString(value));
             case 'u': return ramBitCast(RamUnsignedFromString(value));
             case 'f': return ramBitCast(RamFloatFromString(value));
@@ -249,6 +255,11 @@ protected:
                 return symTable.encode(value.substr(1, value.size() - 2));
             case 'r': fatal("not implemented");
             default: fatal("unhandled type attr code");
+            }
+        } catch (const std::invalid_argument& e) {
+            throw ValueReadException(tfm::format("Invalid argument %s for type '%c'", value, type));
+        } catch (const std::out_of_range& e) {
+            throw ValueReadException(tfm::format("Out of range value %s for type '%c'", value, type));
         }
     }
 };


### PR DESCRIPTION
Explain mode passes some user input directly to stoi() and friends, which makes it crash on user errors/typos.

For example:
```---------------
path
===============
1	2
1	3
1	4
1	5
2	3
2	4
2	5
3	4
3	5
4	5
===============

Explain is invoked.
Enter command > explain path("asd", 123)
stoll
*CRASH*

Explain is invoked.
Enter command > explainnegation path(1,6)
1: path(x,y) :- 
   edge(x,y).

2: path(x,z) :- 
   edge(x,y),
   path(y,z).

Pick a rule number: xcvb
stoi
*CRASH*
```

And with this patch:
```Explain is invoked.
Enter command > explain path(1,"Asd")
Invalid argument "Asd" for type 'i'
Enter command > explainnegation path(1,6)
1: path(x,y) :- 
   edge(x,y).

2: path(x,z) :- 
   edge(x,y),
   path(y,z).

Pick a rule number: asd
Invalid rule number
Enter command > 
```