### PR TITLE
fix: replace copy assignment of atomic with store/load in Index

### DIFF
--- a/src/interpreter/Index.h
+++ b/src/interpreter/Index.h
@@ -420,7 +420,7 @@ public:
     }
 
     void insert(const Index& src) {
-        data = src.data;
+        data.store(src.data.load());
     }
 
     bool contains(const Tuple& /* t */) const {


### PR DESCRIPTION
In C++11 and later, std::atomic's copy assignment operator was explicitly deleted.

Tested with Clang 19.