### PR TITLE
Fix name of InsertLatticeOperations.h

### DIFF
--- a/src/ast/transform/InsertLatticeOperations.h
+++ b/src/ast/transform/InsertLatticeOperations.h
@@ -31,7 +31,7 @@ namespace souffle::ast::transform {
 class LatticeTransformer : public Transformer {
 public:
     std::string getName() const override {
-        return "InlineRelationsTransformer";
+        return "LatticeTransformer";
     }
 
 private:


### PR DESCRIPTION
I just noticed that there is probably a copy and paste error in `InsertLatticeOperations.h`. It uses the same name as `InlineRelations`. 