### PR TITLE
make mcpp optional for fedora builds. use version string to differenti…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,12 @@ if (CHECK_OS_RESULT EQUAL 0)
       # --------------------------------------------------
 
       # Specifying runtime dependencies
-      set(CPACK_RPM_PACKAGE_REQUIRES "gcc-c++ >= 8, libffi, libffi-devel, ncurses-devel, sqlite-devel, mcpp, zlib-devel, python3")
+      if (CHECK_OS_OUTPUT MATCHES "42")
+        # fedora versions >= 42 no longer have mcpp
+        set(CPACK_RPM_PACKAGE_REQUIRES "gcc-c++ >= 8, libffi, libffi-devel, ncurses-devel, sqlite-devel, zlib-devel, python3")
+      else()
+        set(CPACK_RPM_PACKAGE_REQUIRES "gcc-c++ >= 8, libffi, libffi-devel, ncurses-devel, sqlite-devel, mcpp, zlib-devel, python3")
+      endif()
 
       # Note: By default automatic dependency detection is enabled by rpm generator.
       # SET(CPACK_RPM_PACKAGE_AUTOREQPROV "no")

--- a/sh/check_os.sh
+++ b/sh/check_os.sh
@@ -9,10 +9,18 @@ else
 fi
 
 ID=$(grep -G "^ID_LIKE=" $file | tr a-z A-Z)
+VERSION=$(grep -G "^VERSION_ID=" $file | tr a-z A-Z)
+
 
 #Fedora is special and has no ID_LIKE
 if [ -z "$ID" ]; then
     ID=$(grep -G "^ID=" $file | tr a-z A-Z)
 fi
 
+if [ -z "$VERSION" ]; then
+    VERSION=$(grep -G "^VERSION=" $file | tr a-z A-Z)
+fi
+
+
 echo $ID
+echo $VERSION


### PR DESCRIPTION
…iate cmake behaviour.

This is an alternative to #2554 to solve #2553 that adds a version number to the `check_os` script and uses that to differentiate behaviour.

This PR is better for repeatability, as the build does not depend on the system setup, but needs to be maintained with the proper version numbers.

The other PR is better for compatibility, but also allows earlier fedora versions to create non-mcpp packages if it isn't installed in the first place.