### PR TITLE
Use without-rowid tables to reduce disk space use

### DIFF
--- a/src/include/souffle/io/WriteStreamSQLite.h
+++ b/src/include/souffle/io/WriteStreamSQLite.h
@@ -199,11 +199,11 @@ private:
     void createRelationTable() {
         std::stringstream createTableText;
         createTableText << "CREATE TABLE IF NOT EXISTS '_" << relationName << "' (";
-        // 8 bytes per datum worst case + 1 byte per datum in header + 1 byte header length < ~1/20 DB page (4096 bytes)
-        // size See https://sqlite.org/withoutrowid.html#when_to_use_without_rowid and
+        // 8 bytes per datum worst case + 1 byte per datum in header + 1 byte header length < ~1/20 DB page
+        // (4096 bytes) size See https://sqlite.org/withoutrowid.html#when_to_use_without_rowid and
         // https://sqlite.org/fileformat2.html#record_format for justification
-        // 22*9+1 = 199 < 200 
-        bool shouldUseWithoutRowid = (arity>0 && arity<23);
+        // 22*9+1 = 199 < 200
+        bool shouldUseWithoutRowid = (arity > 0 && arity < 23);
         if (arity > 0) {
             createTableText << "'0' INTEGER";
             for (unsigned int i = 1; i < arity; i++) {


### PR DESCRIPTION
This small change cuts the amount of database metadata in half.
See [the SQLite page](https://sqlite.org/withoutrowid.html) for other benefits.