### PR TITLE
chore: update Intel MacOS image to `macos-15-intel`

### DIFF
--- a/.github/workflows/CI-Tests.yml
+++ b/.github/workflows/CI-Tests.yml
@@ -111,7 +111,8 @@ jobs:
       matrix:
         chunk: ${{ fromJSON(needs.Test-Setup.outputs.chunks) }}
 
-    runs-on: macos-13
+    # macos-15-intel is the last supported image based on intel CPU
+    runs-on: macos-15-intel
 
     steps:
     - name: checkout


### PR DESCRIPTION
Github's `macos-13` is now deprecated, see https://github.com/actions/runner-images/issues/13046