### PR TITLE
ci(windows): Disable vcpkg binary caching

### DIFF
--- a/.github/workflows/VS-CI-Tests.yml
+++ b/.github/workflows/VS-CI-Tests.yml
@@ -26,7 +26,7 @@ jobs:
         fetch-tags: true
 
     - name: Dependencies Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
         cache-name: cache-chocolatey
       with:
@@ -53,6 +53,8 @@ jobs:
         mkdir build
 
     - name: Configure Build
+      env:
+        VCPKG_BINARY_SOURCES: clear
       working-directory: ${{github.workspace}}
       run: |
         $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."


### PR DESCRIPTION
Fix CI on windows.

Relates to issue https://github.com/microsoft/vcpkg/issues/45073