### PR TITLE
Fix optimistic locking under weak memory ordering

### DIFF
--- a/.github/workflows/CI-Tests.yml
+++ b/.github/workflows/CI-Tests.yml
@@ -157,8 +157,7 @@ jobs:
     - name: cmake-test-64bit
       uses: ./.github/actions/cmake-test
       with:
-        # disable openmp on ARM architecture, see souffle-lang/souffle#2476
-        cmake-flags: -DSOUFFLE_DOMAIN_64BIT=ON -DSOUFFLE_USE_OPENMP=OFF
+        cmake-flags: -DSOUFFLE_DOMAIN_64BIT=ON
         n-chunks: ${{ needs.Test-Setup.outputs.n-chunks }}
         chunk: ${{ matrix.chunk }}
 

--- a/sh/setup/install_macos_arm_deps.sh
+++ b/sh/setup/install_macos_arm_deps.sh
@@ -8,15 +8,13 @@ set -e
 set -x
 
 # Install requirements of MAC OS X
-brew install libtool mcpp swig bison libffi
-#brew install gcc@13
-#brew link gcc@13
+brew install libtool mcpp swig bison libffi gcc@15
 
-echo "/usr/local/opt/bison/bin:$PATH" >> $GITHUB_PATH
-echo 'PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig/"' >> $GITHUB_ENV
-#echo 'CC=gcc-13' >> $GITHUB_ENV
-#echo 'CXX=g++-13' >> $GITHUB_ENV
-echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
+echo "PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig" >> "$GITHUB_ENV"
+echo "CC=$(brew --prefix gcc@15)/bin/gcc-15" >> "$GITHUB_ENV"
+echo "CXX=$(brew --prefix gcc@15)/bin/g++-15" >> "$GITHUB_ENV"
+echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> "$GITHUB_ENV"
 
 set +e
 set +x

--- a/src/include/souffle/datastructure/BTree.h
+++ b/src/include/souffle/datastructure/BTree.h
@@ -1241,6 +1241,12 @@ public:
 
                 // get next pointer
                 auto next = cur->getChild(idx);
+                if (next == nullptr) {
+                    if (cur->lock.validate(cur_lease)) {
+                        assert(false && "B-tree inner node has null child");
+                    }
+                    return insert(k, hints);
+                }
 
                 // get lease on next level
                 auto next_lease = next->lock.start_read();

--- a/src/include/souffle/datastructure/BTree.h
+++ b/src/include/souffle/datastructure/BTree.h
@@ -1026,7 +1026,7 @@ protected:
     node* volatile root;
 
     // a lock to synchronize update operations on the root pointer
-    lock_type root_lock;
+    mutable lock_type root_lock;
 #else
     // a pointer to the root node of this tree
     node* root;
@@ -1574,6 +1574,91 @@ public:
      * referencing its position. If not found, an end-iterator will be returned.
      */
     iterator find(const Key& k, operation_hints& hints) const {
+#ifdef IS_PARALLEL
+        node* cur = nullptr;
+        lock_type::Lease cur_lease;
+
+        auto checkHints = [&](node* last_find_end) {
+            if (!last_find_end) return false;
+
+            auto hint_lease = last_find_end->lock.start_read();
+            if (!covers(last_find_end, k)) return false;
+            if (!last_find_end->lock.validate(hint_lease)) return false;
+
+            cur = last_find_end;
+            cur_lease = hint_lease;
+            return true;
+        };
+
+        // test last location searched (temporal locality)
+        if (hints.last_find_end.any(checkHints)) {
+            // register it as a hit
+            hint_stats.contains.addHit();
+        } else {
+            // register it as a miss
+            hint_stats.contains.addMiss();
+        }
+
+        if (!cur) {
+            do {
+                auto root_lease = root_lock.start_read();
+                cur = root;
+
+                if (cur == nullptr) {
+                    if (root_lock.end_read(root_lease)) {
+                        return end();
+                    }
+                    continue;
+                }
+
+                cur_lease = cur->lock.start_read();
+
+                if (root_lock.end_read(root_lease)) {
+                    break;
+                }
+            } while (true);
+        }
+
+        while (true) {
+            auto a = &(cur->keys[0]);
+            auto b = &(cur->keys[cur->numElements]);
+
+            auto pos = search(k, a, b, comp);
+
+            if (pos < b && equal(*pos, k)) {
+                if (!cur->lock.validate(cur_lease)) {
+                    return find(k, hints);
+                }
+                hints.last_find_end.access(cur);
+                return iterator(cur, static_cast<field_index_type>(pos - a));
+            }
+
+            if (!cur->inner) {
+                if (!cur->lock.validate(cur_lease)) {
+                    return find(k, hints);
+                }
+                hints.last_find_end.access(cur);
+                return end();
+            }
+
+            // continue search in child node
+            auto next = cur->getChild(pos - a);
+            if (next == nullptr) {
+                if (cur->lock.validate(cur_lease)) {
+                    assert(false && "B-tree inner node has null child");
+                }
+                return find(k, hints);
+            }
+
+            auto next_lease = next->lock.start_read();
+            if (!cur->lock.end_read(cur_lease)) {
+                return find(k, hints);
+            }
+
+            cur = next;
+            cur_lease = next_lease;
+        }
+#else
         if (empty()) {
             return end();
         }
@@ -1617,6 +1702,7 @@ public:
             // continue search in child node
             cur = cur->getChild(pos - a);
         }
+#endif
     }
 
     /**

--- a/src/include/souffle/datastructure/BTreeDelete.h
+++ b/src/include/souffle/datastructure/BTreeDelete.h
@@ -1294,6 +1294,12 @@ public:
 
                 // get next pointer
                 auto next = cur->getChild(idx);
+                if (next == nullptr) {
+                    if (cur->lock.validate(cur_lease)) {
+                        assert(false && "B-tree inner node has null child");
+                    }
+                    return insert(k, hints);
+                }
 
                 // get lease on next level
                 auto next_lease = next->lock.start_read();

--- a/src/include/souffle/datastructure/LambdaBTree.h
+++ b/src/include/souffle/datastructure/LambdaBTree.h
@@ -198,6 +198,12 @@ public:
 
                 // get next pointer
                 auto next = cur->getChild(idx);
+                if (next == nullptr) {
+                    if (cur->lock.validate(cur_lease)) {
+                        assert(false && "B-tree inner node has null child");
+                    }
+                    return insert(k, hints, f);
+                }
 
                 // get lease on next level
                 auto next_lease = next->lock.start_read();

--- a/src/include/souffle/utility/ParallelUtil.h
+++ b/src/include/souffle/utility/ParallelUtil.h
@@ -444,7 +444,7 @@ public:
     bool validate(const Lease& lease) {
         // check whether version number has changed in the mean-while
         std::atomic_thread_fence(std::memory_order_acquire);
-        return lease.version == version.load(std::memory_order_relaxed);
+        return lease.version == version.load(std::memory_order_acquire);
     }
 
     /**
@@ -466,14 +466,14 @@ public:
         detail::Waiter wait;
 
         // set last bit => make it odd
-        auto v = version.fetch_or(0x1, std::memory_order_acquire);
+        auto v = version.fetch_or(0x1, std::memory_order_acq_rel);
 
         // check for concurrent writes
         while ((v & 0x1) == 1) {
             // wait for a moment
             wait();
             // get an updated version
-            v = version.fetch_or(0x1, std::memory_order_acquire);
+            v = version.fetch_or(0x1, std::memory_order_acq_rel);
         }
 
         // done
@@ -486,7 +486,7 @@ public:
      * @return true if write permission has been granted, false otherwise.
      */
     bool try_start_write() {
-        auto v = version.fetch_or(0x1, std::memory_order_acquire);
+        auto v = version.fetch_or(0x1, std::memory_order_acq_rel);
         return !(v & 0x1);
     }
 
@@ -499,7 +499,7 @@ public:
      *      be granted, false otherwise.
      */
     bool try_upgrade_to_write(const Lease& lease) {
-        auto v = version.fetch_or(0x1, std::memory_order_acquire);
+        auto v = version.fetch_or(0x1, std::memory_order_acq_rel);
 
         // check whether write privileges have been gained
         if (v & 0x1) return false;  // there is another writer already
@@ -539,7 +539,7 @@ public:
      * @return true if so, false otherwise
      */
     bool is_write_locked() const {
-        return version & 0x1;
+        return version.load(std::memory_order_relaxed) & 0x1;
     }
 };
 


### PR DESCRIPTION
Reproduced the crash described in #2476 on Apple Mac mini M2 on macOS Sequoia 15.6.

Test `cprog4` only use b-tree, no symbol table nor record table, so the issue is definitely not in `ConcurrentFlyweight` as proposed in the issue description.

I built `souffle` and `cprog4` in `RelWithDebugInfo` mode. Then run `cprog4` in a loop until it crashed and created a core dump:

```sh
# enable core dumps
ulimit -c unlimited
sudo sysctl -w kern.coredump=1
sudo sysctl -w kern.corefile="$PWD/core.%P"

# build cprog4
souffle "-D" "." "-F" "tests/evaluation/cprog4/facts" "tests/evaluation/cprog4/cprog4.dl" -o cprog4 -j 8 -v

# rerun the g++ command printed by the previous command, adding '-g' at the end
/opt/homebrew/bin/g++-15 ... -g

# sign with debugging entitlement
/usr/libexec/PlistBuddy -c \
  "Add :com.apple.security.get-task-allow bool true" \
  debug.entitlements
codesign -s - -f --entitlements debug.entitlements ./cprog4

# SOUFFLE_ALLOW_SIGNALS=1 prevents souffle from handling signals 
while SOUFFLE_ALLOW_SIGNALS=1 ./cprog4 -j 16 "-D" "-" "-F" tests/evaluation/cprog4 ; do
  date
done

# after a core.PID file is produced:
lldb cprog4 -core core.PID
```

With `lldb` pointing to the crashing location in `BTree.h` I used gpt-5.5 to investigate possible concurrency issues in Souffle's b-tree and optimistic RW lock implementations, under the assumption of aarch64 weak memory consistency. It created a first fix.

Then I found a similar sporadic crash in `test_binary_relation`, again `lldb` helped me pinpointing the exact location of the crash in the `btree::find` function and gpt-5.5 created a second fix.

Both fixes were validated on the same Apple Mac mini M2.

Fix #2476