### PR TITLE
Update CI to work with new images

### DIFF
--- a/.github/actions/cmake-test/action.yml
+++ b/.github/actions/cmake-test/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: setup-env
       run: |

--- a/.github/workflows/CI-Tests.yml
+++ b/.github/workflows/CI-Tests.yml
@@ -23,7 +23,7 @@ jobs:
       chunks: ${{ steps.set-test-ids.outputs.chunks }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           fetch-tags: true
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 1
         fetch-tags: true
@@ -116,7 +116,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 1
         fetch-tags: true
@@ -146,7 +146,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 1
         fetch-tags: true
@@ -177,7 +177,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 1
         fetch-tags: true
@@ -205,7 +205,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 1
         fetch-tags: true

--- a/.github/workflows/CI-Tests.yml
+++ b/.github/workflows/CI-Tests.yml
@@ -95,7 +95,7 @@ jobs:
 
     - name: upload-coverage-artifact
       if: ${{ matrix.domain == '32bit' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-${{ matrix.domain }}-${{ matrix.chunk }}
         path: coverage.info
@@ -214,7 +214,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install lcov
 
     - name: download-coverage-artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
 
     - name: merge-coverage-report
       run: lcov $(for i in coverage-*-*/coverage.info; do echo -a $i; done) --output-file coverage.info

--- a/.github/workflows/Guidelines.yml
+++ b/.github/workflows/Guidelines.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 2
 
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 2
     - name: Install ninja-build tool

--- a/.github/workflows/Guidelines.yml
+++ b/.github/workflows/Guidelines.yml
@@ -48,8 +48,6 @@ jobs:
       uses: actions/checkout@v7
       with:
         fetch-depth: 2
-    - name: Install ninja-build tool
-      uses: seanmiddleditch/gha-setup-ninja@v6
     - name: Install dependencies
       run: sudo sh/setup/install_ubuntu_deps.sh
     - name: generate with Ninja

--- a/.github/workflows/Guidelines.yml
+++ b/.github/workflows/Guidelines.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: upload-full-clang-format-config
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: reformat.patch
         path: reformat.patch

--- a/.github/workflows/VS-CI-Tests.yml
+++ b/.github/workflows/VS-CI-Tests.yml
@@ -60,7 +60,7 @@ jobs:
         $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
         Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
         refreshenv
-        cmake -S . -B build -G "Visual Studio 17 2022" -A x64 "-DCMAKE_TOOLCHAIN_FILE=${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=/bigobj -DSOUFFLE_DOMAIN_64BIT=ON -DCMAKE_FIND_LIBRARY_PREFIXES=";lib" -DCMAKE_FIND_LIBRARY_SUFFIXES=".lib;.dll" -DSOUFFLE_USE_CURSES=OFF -DSOUFFLE_USE_ZLIB=ON -DSOUFFLE_USE_SQLITE=ON -DCMAKE_FIND_DEBUG_MODE=FALSE -DSOUFFLE_BASH_COMPLETION=OFF
+        cmake -S . -B build -G "Visual Studio 18 2026" -A x64 "-DCMAKE_TOOLCHAIN_FILE=${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=/bigobj -DSOUFFLE_DOMAIN_64BIT=ON -DCMAKE_FIND_LIBRARY_PREFIXES=";lib" -DCMAKE_FIND_LIBRARY_SUFFIXES=".lib;.dll" -DSOUFFLE_USE_CURSES=OFF -DSOUFFLE_USE_ZLIB=ON -DSOUFFLE_USE_SQLITE=ON -DCMAKE_FIND_DEBUG_MODE=FALSE -DSOUFFLE_BASH_COMPLETION=OFF
 
     - name: Build
       working-directory: ${{github.workspace}}
@@ -71,13 +71,13 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: cmd
       run: |
-        pushd "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build" & call vcvars64.bat & popd
+        pushd "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build" & call vcvars64.bat & popd
         ctest --output-on-failure --build-config Release --progress -j4 -L interpreted
 
     - name: Check others
       working-directory: ${{github.workspace}}/build
       shell: cmd
       run: |
-        pushd "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build" & call vcvars64.bat & popd
+        pushd "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build" & call vcvars64.bat & popd
         ctest --output-on-failure --build-config Release --progress -j2 -LE interpreted
 

--- a/.github/workflows/VS-CI-Tests.yml
+++ b/.github/workflows/VS-CI-Tests.yml
@@ -20,7 +20,7 @@ jobs:
   Windows-CMake-MSVC:
     runs-on: windows-2025
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 1
         fetch-tags: true

--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           clean: false

--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -59,7 +59,7 @@ jobs:
         run: cp build/${{ steps.extract_pkg.outputs.pkg_name }} build/${{ steps.extract_pkg.outputs.artifact_name }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.extract_pkg.outputs.artifact_name }}
           path: build/${{ steps.extract_pkg.outputs.artifact_name }}
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ./downloads
 
@@ -150,7 +150,7 @@ jobs:
           clean: false
 
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ./downloads
 

--- a/.github/workflows/populate-deps.yml
+++ b/.github/workflows/populate-deps.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
 


### PR DESCRIPTION
The GitHub runner for Windows has a new Visual Studio version which breaks the CI. This PR updates the expected location accordingly.

The GitHub actions used (checkout and upload/download artifacts)still work, but will break or change soon, so I've updated them to newer versions (that also claim improved security).